### PR TITLE
Replace internal paths with public GitHub URLs

### DIFF
--- a/tests/optim/assets/fusionpipe/builders/attention.py
+++ b/tests/optim/assets/fusionpipe/builders/attention.py
@@ -5,9 +5,9 @@
 """Attention pattern builders for FusionPipe testing.
 
 Creates ONNX graphs that match ORT's attention fusion patterns.
-Based on: D:/BYOM/ort/onnxruntime/test/python/transformers/bert_model_generator.py
+Based on: https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/test/python/transformers/bert_model_generator.py
 
-Reference: D:/BYOM/ort/onnxruntime/python/tools/transformers/fusion_attention.py
+Reference: https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/python/tools/transformers/fusion_attention.py
 """
 
 from __future__ import annotations

--- a/tests/optim/assets/fusionpipe/builders/layernorm.py
+++ b/tests/optim/assets/fusionpipe/builders/layernorm.py
@@ -9,7 +9,7 @@ Creates ONNX graphs that match ORT's LayerNorm fusion patterns:
 - FusionSkipLayerNormalization (Add + LayerNorm)
 - FusionSimplifiedLayerNormalization (RMS Normalization)
 
-Reference: D:/BYOM/ort/onnxruntime/python/tools/transformers/fusion_layernorm.py
+Reference: https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/python/tools/transformers/fusion_layernorm.py
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Replace internal development paths with public ORT GitHub URLs in test builder docstrings.