### PR TITLE
Fix Policheck issues: replace non-inclusive terminology

### DIFF
--- a/src/winml/modelkit/analyze/analyzer.py
+++ b/src/winml/modelkit/analyze/analyzer.py
@@ -238,10 +238,10 @@ class AnalysisResult:
                 continue
 
             # Collect BLACK patterns (errors)
-            error_patterns.extend(ep_support.classification.get(SupportLevel.BLACK, []))
+            error_patterns.extend(ep_support.classification.get(SupportLevel.UNSUPPORTED, []))
 
             # Collect GRAY patterns (warnings)
-            warning_patterns.extend(ep_support.classification.get(SupportLevel.GRAY, []))
+            warning_patterns.extend(ep_support.classification.get(SupportLevel.PARTIAL, []))
 
             # Collect information items
             information_list.extend(ep_support.information)
@@ -276,7 +276,7 @@ class AnalysisResult:
                 If None, returns unsupported operators for all EPs in results.
 
         Returns:
-            list[str]: List of BLACK or GRAY classified operator names
+            list[str]: List of UNSUPPORTED or PARTIAL classified operator names
 
         Example:
             >>> result = analyzer.analyze(
@@ -298,13 +298,13 @@ class AnalysisResult:
                 continue
 
             # Collect from classification
-            unsupported.extend(ep_support.classification.get(SupportLevel.GRAY, []))
-            unsupported.extend(ep_support.classification.get(SupportLevel.BLACK, []))
+            unsupported.extend(ep_support.classification.get(SupportLevel.PARTIAL, []))
+            unsupported.extend(ep_support.classification.get(SupportLevel.UNSUPPORTED, []))
 
         return unsupported
 
     def get_optimization_opportunities(self, ep: str | None = None) -> list[Action]:
-        """Get actions for patterns that could be optimized (BLACK or GRAY status).
+        """Get actions for patterns that could be optimized (UNSUPPORTED or PARTIAL status).
 
         Args:
             ep: Optional execution provider to filter by (e.g., "QNNExecutionProvider").
@@ -516,7 +516,7 @@ class ONNXStaticAnalyzer:
             run_unknown_op: Whether to run unknown operators on the local machine
                 if possible. Default: True
             save_node_types: Set of node types to save for further analysis
-                (e.g., {"gray", "black"}). Default: None (save nothing)
+                (e.g., {"partial", "unsupported"}). Default: None (save nothing)
 
         Returns:
             AnalysisResult: Analysis result wrapper containing:
@@ -623,7 +623,7 @@ class ONNXStaticAnalyzer:
             run_unknown_op: Whether to run unknown operators on local machine
                 if possible. Default: True
             save_node_types: Set of node types to save for further analysis
-                (e.g., {"gray", "black"}). Default: None (save nothing)
+                (e.g., {"partial", "unsupported"}). Default: None (save nothing)
 
         Returns:
             AnalysisResult: Analysis result wrapper with output

--- a/src/winml/modelkit/analyze/console_writer.py
+++ b/src/winml/modelkit/analyze/console_writer.py
@@ -231,10 +231,10 @@ class StaticAnalyzerConsoleWriter:
         self.console.print(f"\n   {self._bold('Support Classification:')}")
 
         classification_info = [
-            (SupportLevel.WHITE, "✅", "Fully Supported", "green"),
-            (SupportLevel.GRAY, "⚠️ ", "Partial Support", "yellow"),
+            (SupportLevel.SUPPORTED, "✅", "Fully Supported", "green"),
+            (SupportLevel.PARTIAL, "⚠️ ", "Partial Support", "yellow"),
             (SupportLevel.UNKNOWN, "❓", "Unknown Support", "blue"),
-            (SupportLevel.BLACK, "⛔", "Not Supported", "red"),
+            (SupportLevel.UNSUPPORTED, "⛔", "Not Supported", "red"),
         ]
 
         for level, icon, label, color in classification_info:
@@ -251,14 +251,14 @@ class StaticAnalyzerConsoleWriter:
 
                 self.console.print(f"   {icon} {label:20s}: {count_str} operator types ({pct_str})")
 
-                # Show operators - expand WHITE level, show samples for others
+                # Show operators - expand SUPPORTED level, show samples for others
                 if count > 0:
-                    if level == SupportLevel.WHITE:
+                    if level == SupportLevel.SUPPORTED:
                         # Expand all fully supported operators
                         for op in operators:
                             self.console.print(f"      • {self._bright_green(op)}")
                     else:
-                        # Show all operators for non-white levels
+                        # Show all operators for non-supported levels
                         for op in operators:
                             self.console.print(f"      • {self._dim(op)}")
 
@@ -469,15 +469,15 @@ class StaticAnalyzerConsoleWriter:
         supported_platforms = sum(1 for r in analysis.results if r.runtime_support)
         total_platforms = len(analysis.results)
 
-        # Check if unsupported platforms only have unknown nodes (no black/gray)
+        # Check if unsupported platforms only have unknown nodes (no unsupported/partial)
         unsupported_results = [r for r in analysis.results if not r.runtime_support]
         has_only_unknown = False
         if unsupported_results:
-            # Check if there are NO black or gray issues (only unknown/white)
+            # Check if there are NO unsupported or partial issues (only unknown/supported)
             # Use .get() to handle missing keys and check for non-empty lists
             has_only_unknown = all(
-                not r.classification.get(SupportLevel.BLACK, [])
-                and not r.classification.get(SupportLevel.GRAY, [])
+                not r.classification.get(SupportLevel.UNSUPPORTED, [])
+                and not r.classification.get(SupportLevel.PARTIAL, [])
                 for r in unsupported_results
             )
 
@@ -511,7 +511,7 @@ class StaticAnalyzerConsoleWriter:
                 issue_counts = {
                     level: len(ops)
                     for level, ops in ep_result.classification.items()
-                    if level != SupportLevel.WHITE
+                    if level != SupportLevel.SUPPORTED
                 }
 
                 if any(issue_counts.values()):

--- a/src/winml/modelkit/analyze/core/information_engine.py
+++ b/src/winml/modelkit/analyze/core/information_engine.py
@@ -268,15 +268,15 @@ class InformationEngine:
             classification = runtime_result.result.classification
             reason = runtime_result.result.reason
 
-            # Skip WHITE patterns (no action needed) and patterns with alternatives
-            if classification == SupportLevel.WHITE or runtime_result.alternatives:
+            # Skip SUPPORTED patterns (no action needed) and patterns with alternatives
+            if classification == SupportLevel.SUPPORTED or runtime_result.alternatives:
                 continue
 
             # For failed/unknown operators, query doc checker for detailed constraint info
             doc_check_reason = None
             if self._doc_checker and classification in [
-                SupportLevel.BLACK,
-                SupportLevel.GRAY,
+                SupportLevel.UNSUPPORTED,
+                SupportLevel.PARTIAL,
                 SupportLevel.UNKNOWN,
             ]:
                 doc_check_reason = self._query_doc_constraints(runtime_result, pattern_id)
@@ -298,7 +298,7 @@ class InformationEngine:
             count = len(runtime_results)
             actions: list[Action] = []
 
-            if classification == SupportLevel.GRAY:
+            if classification == SupportLevel.PARTIAL:
                 # Partial support - optional optimization
                 if count == 1:
                     if reason:
@@ -327,7 +327,7 @@ class InformationEngine:
                 #     pattern_from_id=pattern_id,
                 #     pattern_to_id="",
                 #     level=ActionLevel.OPTIONAL,
-                #     status=SupportLevel.GRAY,
+                #     status=SupportLevel.PARTIAL,
                 #     details=(
                 #         f"Pattern '{pattern_id}' has partial support. "
                 #         f"Consider optimizing the input for better runtime performance. "
@@ -336,10 +336,10 @@ class InformationEngine:
                 # )
                 # actions.append(action)
                 logger.debug(
-                    "Operator %s: GRAY (partial support) - %d instances", pattern_id, count
+                    "Operator %s: PARTIAL (partial support) - %d instances", pattern_id, count
                 )
 
-            elif classification == SupportLevel.BLACK:
+            elif classification == SupportLevel.UNSUPPORTED:
                 # Not supported - required action
                 if count == 1:
                     if reason:
@@ -537,29 +537,29 @@ class InformationEngine:
             tuple: (ActionLevel, SupportLevel or None)
 
         Logic:
-            - BLACK → WHITE/GRAY: REQUIRED
-            - BLACK → UNKNOWN: WARNING
-            - GRAY → WHITE: REQUIRED
-            - UNKNOWN → WHITE/GRAY: OPTIONAL
+            - UNSUPPORTED → SUPPORTED/PARTIAL: REQUIRED
+            - UNSUPPORTED → UNKNOWN: WARNING
+            - PARTIAL → SUPPORTED: REQUIRED
+            - UNKNOWN → SUPPORTED/PARTIAL: OPTIONAL
             - Otherwise: No action recommended
         """
-        if current_classification == SupportLevel.BLACK:
-            if alternative_classification == SupportLevel.WHITE:
-                return ActionLevel.REQUIRED, SupportLevel.WHITE
-            if alternative_classification == SupportLevel.GRAY:
-                return ActionLevel.REQUIRED, SupportLevel.GRAY
+        if current_classification == SupportLevel.UNSUPPORTED:
+            if alternative_classification == SupportLevel.SUPPORTED:
+                return ActionLevel.REQUIRED, SupportLevel.SUPPORTED
+            if alternative_classification == SupportLevel.PARTIAL:
+                return ActionLevel.REQUIRED, SupportLevel.PARTIAL
             if alternative_classification == SupportLevel.UNKNOWN:
                 return ActionLevel.WARNING, None
 
         if (
-            current_classification == SupportLevel.GRAY
-            and alternative_classification == SupportLevel.WHITE
+            current_classification == SupportLevel.PARTIAL
+            and alternative_classification == SupportLevel.SUPPORTED
         ):
-            return ActionLevel.REQUIRED, SupportLevel.WHITE
+            return ActionLevel.REQUIRED, SupportLevel.SUPPORTED
 
         if current_classification == SupportLevel.UNKNOWN and alternative_classification in (
-            SupportLevel.WHITE,
-            SupportLevel.GRAY,
+            SupportLevel.SUPPORTED,
+            SupportLevel.PARTIAL,
         ):
             return ActionLevel.OPTIONAL, alternative_classification
 
@@ -596,7 +596,7 @@ class InformationEngine:
 
         # Generate details based on level and status
         if level == ActionLevel.REQUIRED:
-            if status == SupportLevel.WHITE:
+            if status == SupportLevel.SUPPORTED:
                 details = (
                     f"Pattern '{pattern_from_id}' is not supported. "
                     f"Replace '{pattern_from_id}' with '{pattern_to_id}'"
@@ -606,7 +606,7 @@ class InformationEngine:
                         f" ({alt_type} alternative). "
                         f"Alternative '{pattern_to_id}' ({alt_type}) is fully supported."
                     )
-            elif status == SupportLevel.GRAY:
+            elif status == SupportLevel.PARTIAL:
                 details = (
                     f"Pattern '{pattern_from_id}' is not supported. "
                     f"Replace '{pattern_from_id}' with '{pattern_to_id}'"
@@ -624,7 +624,7 @@ class InformationEngine:
 
         elif level == ActionLevel.OPTIONAL:
             status_text = (
-                "fully supported" if status == SupportLevel.WHITE else "partially supported"
+                "fully supported" if status == SupportLevel.SUPPORTED else "partially supported"
             )
             current_status = "unknown support status" if status else "partial support"
             details = (
@@ -636,7 +636,7 @@ class InformationEngine:
                     f" ({alt_type} alternative, {status_text}). "
                     f"Alternative '{pattern_to_id}' ({alt_type}) is {status_text}"
                 )
-                if status == SupportLevel.WHITE:
+                if status == SupportLevel.SUPPORTED:
                     details += " and may improve performance."
                 details += "."
 
@@ -782,31 +782,31 @@ class InformationEngine:
             # (all instances of the same pattern should have same alternatives)
             representative = runtime_results[0]
 
-            # WHITE patterns with no alternatives don't need information
-            if classification == SupportLevel.WHITE and not representative.alternatives:
+            # SUPPORTED patterns with no alternatives don't need information
+            if classification == SupportLevel.SUPPORTED and not representative.alternatives:
                 continue
 
             # Generate explanation with count
             if count == 1:
-                if classification == SupportLevel.WHITE:
+                if classification == SupportLevel.SUPPORTED:
                     explanation = f"Pattern '{pattern_id}' is fully supported"
-                elif classification == SupportLevel.GRAY:
+                elif classification == SupportLevel.PARTIAL:
                     explanation = (
                         f"Pattern '{pattern_id}' has partial support (compiles but not optimized)"
                     )
-                elif classification == SupportLevel.BLACK:
+                elif classification == SupportLevel.UNSUPPORTED:
                     explanation = f"Pattern '{pattern_id}' is not supported"
                 else:  # UNKNOWN
                     explanation = f"Pattern '{pattern_id}' has unknown support status"
             else:
-                if classification == SupportLevel.WHITE:
+                if classification == SupportLevel.SUPPORTED:
                     explanation = f"{count} instances of pattern '{pattern_id}' are fully supported"
-                elif classification == SupportLevel.GRAY:
+                elif classification == SupportLevel.PARTIAL:
                     explanation = (
                         f"{count} instances of pattern '{pattern_id}' have partial support "
                         f"(compile but not optimized)"
                     )
-                elif classification == SupportLevel.BLACK:
+                elif classification == SupportLevel.UNSUPPORTED:
                     explanation = f"{count} instances of pattern '{pattern_id}' are not supported"
                 else:  # UNKNOWN
                     explanation = (
@@ -977,16 +977,16 @@ class InformationEngine:
         pattern_id = pattern_runtime.pattern_id
         classification = pattern_runtime.result.classification
 
-        # WHITE patterns with no alternatives don't need information
-        if classification == SupportLevel.WHITE and not pattern_runtime.alternatives:
+        # SUPPORTED patterns with no alternatives don't need information
+        if classification == SupportLevel.SUPPORTED and not pattern_runtime.alternatives:
             return None
 
         # Generate explanation based on classification
-        if classification == SupportLevel.WHITE:
+        if classification == SupportLevel.SUPPORTED:
             explanation = f"Pattern '{pattern_id}' is fully supported"
-        elif classification == SupportLevel.GRAY:
+        elif classification == SupportLevel.PARTIAL:
             explanation = f"Pattern '{pattern_id}' has partial support (compiles but not optimized)"
-        elif classification == SupportLevel.BLACK:
+        elif classification == SupportLevel.UNSUPPORTED:
             explanation = f"Pattern '{pattern_id}' is not supported"
         else:  # UNKNOWN
             explanation = f"Pattern '{pattern_id}' has unknown support status"
@@ -1061,8 +1061,8 @@ class InformationEngine:
             )
             actions.append(action)
 
-        # If no alternatives found but pattern is BLACK, add warning
-        if classification == SupportLevel.BLACK and not actions:
+        # If no alternatives found but pattern is UNSUPPORTED, add warning
+        if classification == SupportLevel.UNSUPPORTED and not actions:
             reason = pattern_runtime.result.reason
             action = self._create_action(
                 pattern_from_id=pattern_id,

--- a/src/winml/modelkit/analyze/core/output_aggregator.py
+++ b/src/winml/modelkit/analyze/core/output_aggregator.py
@@ -165,9 +165,9 @@ class OutputAggregator:
 
         # Classify patterns by support level
         classification: dict[SupportLevel, list[str]] = {
-            SupportLevel.WHITE: [],
-            SupportLevel.GRAY: [],
-            SupportLevel.BLACK: [],
+            SupportLevel.SUPPORTED: [],
+            SupportLevel.PARTIAL: [],
+            SupportLevel.UNSUPPORTED: [],
             SupportLevel.UNKNOWN: [],
         }
 
@@ -180,34 +180,34 @@ class OutputAggregator:
                 classification[support_level].append(pattern_runtime.pattern_id)
 
         # Determine overall runtime support
-        # Support is False if any patterns are BLACK, True otherwise
-        has_black_or_gray = (
-            len(classification[SupportLevel.BLACK])
+        # Support is False if any patterns are UNSUPPORTED, True otherwise
+        has_unsupported_or_partial = (
+            len(classification[SupportLevel.UNSUPPORTED])
             + len(classification[SupportLevel.UNKNOWN])
-            + len(classification[SupportLevel.GRAY])
+            + len(classification[SupportLevel.PARTIAL])
             > 0
         )
-        runtime_support = not has_black_or_gray
+        runtime_support = not has_unsupported_or_partial
 
-        # Check if BLACK patterns exist (blocking errors)
-        has_black = len(classification[SupportLevel.BLACK]) > 0
+        # Check if UNSUPPORTED patterns exist (blocking errors)
+        has_unsupported = len(classification[SupportLevel.UNSUPPORTED]) > 0
 
-        # Check if GRAY patterns exist (warnings/optimizations)
-        has_gray = len(classification[SupportLevel.GRAY]) > 0
+        # Check if PARTIAL patterns exist (warnings/optimizations)
+        has_partial = len(classification[SupportLevel.PARTIAL]) > 0
 
         if not check_results:
             # No check results available
             logger.warning("No check results for EP %s", ep_type)
             runtime_support = False
-            has_black = False
-            has_gray = False
+            has_unsupported = False
+            has_partial = False
 
         logger.debug(
-            "EP %s classification: WHITE=%d, GRAY=%d, BLACK=%d, UNKNOWN=%d",
+            "EP %s classification: SUPPORTED=%d, PARTIAL=%d, UNSUPPORTED=%d, UNKNOWN=%d",
             ep_type,
-            len(classification[SupportLevel.WHITE]),
-            len(classification[SupportLevel.GRAY]),
-            len(classification[SupportLevel.BLACK]),
+            len(classification[SupportLevel.SUPPORTED]),
+            len(classification[SupportLevel.PARTIAL]),
+            len(classification[SupportLevel.UNSUPPORTED]),
             len(classification[SupportLevel.UNKNOWN]),
         )
 
@@ -219,8 +219,8 @@ class OutputAggregator:
             ep_version=ep_version,
             driver_version=driver_version,
             runtime_support=runtime_support,
-            has_errors=has_black,
-            has_warnings=has_gray,
+            has_errors=has_unsupported,
+            has_warnings=has_partial,
             classification=classification,
             information=information_list,
         )

--- a/src/winml/modelkit/analyze/core/runtime_checker_query.py
+++ b/src/winml/modelkit/analyze/core/runtime_checker_query.py
@@ -974,7 +974,7 @@ class RuntimeCheckerQuery:
             pattern_match: Pattern match result for the node.
             node_tags: Collected tags for the node.
             fallback_reason: The original reason rules were not found.
-            save_node_types: Set of node types to save (e.g., {"gray", "black"}).
+            save_node_types: Set of node types to save (e.g., {"partial", "unsupported"}).
             conditions: Conditions for the local check.
 
         Returns:
@@ -1064,11 +1064,11 @@ class RuntimeCheckerQuery:
 
         if not compile_success:
             _save_types = save_node_types or set()
-            is_black = "black" in _save_types and not run_success
-            is_gray = "gray" in _save_types and run_success
-            if is_black or is_gray:
+            is_unsupported = "unsupported" in _save_types and not run_success
+            is_partial = "partial" in _save_types and run_success
+            if is_unsupported or is_partial:
                 self._save_failed_node(
-                    node, model, conditions, name_suffix="black" if is_black else "gray"
+                    node, model, conditions, name_suffix="unsupported" if is_unsupported else "partial"
                 )
 
         result = RuntimeTestResult(
@@ -1284,7 +1284,7 @@ class RuntimeCheckerQuery:
             node: ONNX node to check.
             for_debug: If True, include detailed debug information in results.
             run_unknown_op: If True, attempt local EP check for unknown ops.
-            save_node_types: Set of node types to save (e.g., {"gray", "black"}).
+            save_node_types: Set of node types to save (e.g., {"partial", "unsupported"}).
 
         Returns:
             PatternRuntime with check results.
@@ -1638,16 +1638,16 @@ class RuntimeCheckerQuery:
 
         if not compile_result:
             _save_types = save_node_types or set()
-            is_black = "black" in _save_types and not run_result
-            is_gray = "gray" in _save_types and run_result
-            if is_black or is_gray:
+            is_unsupported = "unsupported" in _save_types and not run_result
+            is_partial = "partial" in _save_types and run_result
+            if is_unsupported or is_partial:
                 node_model = self._build_single_node_model(node, op_domain, opset_version)
                 # TODO: Need to use match_keys to filter conditions
                 self._save_failed_node(
                     node,
                     node_model,
                     make_hashable(conditions),
-                    name_suffix="black" if is_black else "gray",
+                    name_suffix="unsupported" if is_unsupported else "partial",
                 )
 
         return PatternRuntime(

--- a/src/winml/modelkit/analyze/models/runtime_checks.py
+++ b/src/winml/modelkit/analyze/models/runtime_checks.py
@@ -61,17 +61,17 @@ class RuntimeTestResult(BaseModel):
 
         Returns:
             SupportLevel.UNKNOWN if no_data=True
-            SupportLevel.WHITE if compile=True and run=True
-            SupportLevel.GRAY if compile=False and run=True
-            SupportLevel.BLACK if compile=False and run=False
+            SupportLevel.SUPPORTED if compile=True and run=True
+            SupportLevel.PARTIAL if compile=False and run=True
+            SupportLevel.UNSUPPORTED if compile=False and run=False
         """
         if self.no_data:
             return SupportLevel.UNKNOWN
         if self.compile and self.run:
-            return SupportLevel.WHITE
+            return SupportLevel.SUPPORTED
         if not self.compile and self.run:
-            return SupportLevel.GRAY
-        return SupportLevel.BLACK
+            return SupportLevel.PARTIAL
+        return SupportLevel.UNSUPPORTED
 
 
 class PatternAlternative(BaseModel):

--- a/src/winml/modelkit/analyze/models/support_level.py
+++ b/src/winml/modelkit/analyze/models/support_level.py
@@ -10,7 +10,7 @@ from enum import Enum
 class SupportLevel(str, Enum):
     """Support level classification."""
 
-    WHITE = "white"
-    GRAY = "gray"
-    BLACK = "black"
+    SUPPORTED = "supported"
+    PARTIAL = "partial"
+    UNSUPPORTED = "unsupported"
     UNKNOWN = "unknown"

--- a/src/winml/modelkit/commands/analyze.py
+++ b/src/winml/modelkit/commands/analyze.py
@@ -67,9 +67,9 @@ logger = logging.getLogger(__name__)
 @click.option(  # type: ignore[misc]
     "--save-node",
     multiple=True,
-    type=click.Choice(["gray", "black"], case_sensitive=False),
+    type=click.Choice(["partial", "unsupported"], case_sensitive=False),
     help="Save specific node types for further analysis. Can be specified multiple times "
-    "(e.g., --save-node gray --save-node black).",
+    "(e.g., --save-node partial --save-node unsupported).",
 )
 def analyze(
     model: Path,

--- a/src/winml/modelkit/core/onnx_node_tagger.py
+++ b/src/winml/modelkit/core/onnx_node_tagger.py
@@ -6,13 +6,13 @@
 
 This module implements the corrected tagging strategy:
 1. NO HARDCODED LOGIC - all model/operation info extracted dynamically
-2. Operation types only added if whitelisted
+2. Operation types only added if on the supportedlist
 3. Operation-based fallback is optional
 4. Root fallback always uses clean root module tag
 
 CARDINAL RULES:
 - MUST-001: NO HARDCODED LOGIC - works with any model
-- MUST-002: TORCH.NN FILTERING - only whitelist operations
+- MUST-002: TORCH.NN FILTERING - only supportedlist operations
 - MUST-003: UNIVERSAL DESIGN - architecture-agnostic
 """
 
@@ -32,9 +32,9 @@ class ONNXNodeTagger:
     NO HARDCODED LOGIC - extracts all model information dynamically.
     """
 
-    # Whitelisted operation types that can be added to tags
+    # Supportedlist operation types that can be added to tags
     # These are fundamental ONNX operations that provide semantic value
-    WHITELISTED_OPERATIONS: ClassVar[set[str]] = {
+    SUPPORTEDLIST_OPERATIONS: ClassVar[set[str]] = {
         "MatMul",
         "Gemm",  # Matrix operations
         "LayerNormalization",  # Normalization

--- a/src/winml/modelkit/core/universal_hierarchy_exporter.py
+++ b/src/winml/modelkit/core/universal_hierarchy_exporter.py
@@ -9,7 +9,7 @@ This is a clean, new implementation that follows all CARDINAL RULES and requirem
 
 CARDINAL RULES:
 - MUST-001: NO HARDCODED LOGIC - Universal PyTorch principles only
-- MUST-002: TORCH.NN FILTERING - Filter most torch.nn except whitelist
+- MUST-002: TORCH.NN FILTERING - Filter most torch.nn except supportedlist
 - MUST-003: UNIVERSAL DESIGN - Must work with ANY PyTorch model
 
 REQUIREMENTS:
@@ -44,7 +44,7 @@ class UniversalHierarchyExporter:
 
     Follows all CARDINAL RULES:
     - NO HARDCODED LOGIC: Works with any PyTorch model
-    - TORCH.NN FILTERING: Filters torch.nn modules except whitelist
+    - TORCH.NN FILTERING: Filters torch.nn modules except supportedlist
     - UNIVERSAL DESIGN: Architecture-agnostic approach
     """
 

--- a/src/winml/modelkit/pattern/op_input_gen/normalization_input_generator.py
+++ b/src/winml/modelkit/pattern/op_input_gen/normalization_input_generator.py
@@ -387,7 +387,7 @@ class LayerNormalizationInputGenerator(NormalizationInputGenerator):
                 combinations.append(
                     {
                         "X": InputShapeConstraint(shape),
-                        "Scale": scale,  # Note: capital S
+                        "Scale": scale,  # Note: uppercase S
                         "B": bias,
                         "axis": axis,
                     }

--- a/tests/mock_data/analyze/output.json
+++ b/tests/mock_data/analyze/output.json
@@ -24,15 +24,15 @@
       "driver_version": "2.10.0",
       "runtime_support": true,
       "classification": {
-        "white": [
+        "supported": [
           "Conv",
           "Relu",
           "MaxPool",
           "Add",
           "BatchNormalization"
         ],
-        "gray": [],
-        "black": []
+        "partial": [],
+        "unsupported": []
       },
       "information": [],
       "pattern_support": {
@@ -57,16 +57,16 @@
       "driver_version": "2023.1",
       "runtime_support": false,
       "classification": {
-        "white": [
+        "supported": [
           "Conv",
           "Relu",
           "MaxPool",
           "Add"
         ],
-        "gray": [
+        "partial": [
           "BatchNormalization"
         ],
-        "black": []
+        "unsupported": []
       },
       "information": [
         {
@@ -77,7 +77,7 @@
               "pattern_to_id": "SUBGRAPH/FusedBatchNorm",
               "type": "optional",
               "action": "Enable BatchNorm fusion in model optimization",
-              "status": "white",
+              "status": "supported",
               "details": "BatchNormalization can be optimized by fusing with Conv operator for better performance"
             }
           ],
@@ -113,15 +113,15 @@
       "driver_version": "6.0.0",
       "runtime_support": true,
       "classification": {
-        "white": [
+        "supported": [
           "Conv",
           "Relu",
           "MaxPool",
           "Add",
           "BatchNormalization"
         ],
-        "gray": [],
-        "black": []
+        "partial": [],
+        "unsupported": []
       },
       "information": [],
       "pattern_support": {}

--- a/tests/unit/analyze/core/test_information_engine.py
+++ b/tests/unit/analyze/core/test_information_engine.py
@@ -500,11 +500,11 @@ class TestInformationEngineProcessPatternWithAlternatives:
         assert info is not None
         assert info.actions is not None
         assert len(info.actions) == 1
-        # BLACK → GRAY is still REQUIRED (improvement from not working to partial support)
+        # UNSUPPORTED → PARTIAL is still REQUIRED (improvement from not working to partial support)
         assert info.actions[0].level == ActionLevel.REQUIRED
         assert (
             "partial support" in info.actions[0].details.lower()
-            or "gray" in info.actions[0].details.lower()
+            or "partial" in info.actions[0].details.lower()
         )
 
     def test_gray_to_white_alternative_optional_action(
@@ -526,7 +526,7 @@ class TestInformationEngineProcessPatternWithAlternatives:
         assert len(info.actions) == 1
         # GRAY → WHITE is REQUIRED (improvement from partial to full support)
         assert info.actions[0].level == ActionLevel.REQUIRED
-        assert info.actions[0].status == SupportLevel.WHITE
+        assert info.actions[0].status == SupportLevel.SUPPORTED
 
     def test_white_with_no_alternatives_returns_none(
         self, white_runtime_result: PatternRuntime, simple_model: ONNXModel, test_device: str
@@ -570,7 +570,7 @@ class TestInformationEngineExtractActions:
         assert action.pattern_from_id == "SUBGRAPH/old_pattern"
         assert action.pattern_to_id == "OP/ai.onnx/Conv"
         assert action.level == ActionLevel.REQUIRED
-        assert action.status == SupportLevel.WHITE
+        assert action.status == SupportLevel.SUPPORTED
         assert "equivalent" in action.details.lower()
 
     def test_extract_actions_gray_to_white(
@@ -591,7 +591,7 @@ class TestInformationEngineExtractActions:
         action = actions[0]
         # GRAY → WHITE is REQUIRED (improvement)
         assert action.level == ActionLevel.REQUIRED
-        assert action.status == SupportLevel.WHITE
+        assert action.status == SupportLevel.SUPPORTED
 
     def test_extract_actions_no_improvement_alternatives(
         self, simple_model: ONNXModel, test_device: str

--- a/tests/unit/analyze/core/test_output_aggregator.py
+++ b/tests/unit/analyze/core/test_output_aggregator.py
@@ -91,7 +91,7 @@ def sample_information() -> dict[str, list[Information]]:
         pattern_to_id="OP/ai.onnx/LeakyRelu",
         level=ActionLevel.REQUIRED,
         action="Replace Relu with LeakyRelu",
-        status=SupportLevel.WHITE,
+        status=SupportLevel.SUPPORTED,
         details="Relu is not supported, use LeakyRelu instead",
     )
 
@@ -266,7 +266,7 @@ class TestOutputAggregatorBuildEPSupport:
         assert isinstance(ihv_support, EPSupport)
         assert ihv_support.ihv_type == IHVType.QC
         assert ihv_support.runtime_support is True
-        assert len(ihv_support.classification[SupportLevel.WHITE]) == 1
+        assert len(ihv_support.classification[SupportLevel.SUPPORTED]) == 1
 
     def test_build_ep_support_classifies_white(self) -> None:
         """Test WHITE classification for fully supported patterns."""
@@ -285,9 +285,9 @@ class TestOutputAggregatorBuildEPSupport:
             ep_type="QNNExecutionProvider",
         )
 
-        assert "OP/ai.onnx/Conv" in ihv_support.classification[SupportLevel.WHITE]
-        assert len(ihv_support.classification[SupportLevel.GRAY]) == 0
-        assert len(ihv_support.classification[SupportLevel.BLACK]) == 0
+        assert "OP/ai.onnx/Conv" in ihv_support.classification[SupportLevel.SUPPORTED]
+        assert len(ihv_support.classification[SupportLevel.PARTIAL]) == 0
+        assert len(ihv_support.classification[SupportLevel.UNSUPPORTED]) == 0
         assert ihv_support.runtime_support is True
 
     def test_build_ep_support_classifies_gray(self) -> None:
@@ -325,7 +325,7 @@ class TestOutputAggregatorBuildEPSupport:
             ep_type="QNNExecutionProvider",
         )
 
-        assert "OP/ai.onnx/Custom" in ihv_support.classification[SupportLevel.BLACK]
+        assert "OP/ai.onnx/Custom" in ihv_support.classification[SupportLevel.UNSUPPORTED]
         assert ihv_support.runtime_support is False
 
     def test_build_ep_support_deduplicates_patterns(self) -> None:
@@ -351,7 +351,7 @@ class TestOutputAggregatorBuildEPSupport:
         )
 
         # Should only appear once in classification
-        assert ihv_support.classification[SupportLevel.WHITE].count("OP/ai.onnx/Conv") == 1
+        assert ihv_support.classification[SupportLevel.SUPPORTED].count("OP/ai.onnx/Conv") == 1
 
     def test_build_ep_support_runtime_support_false_with_black(self) -> None:
         """Test runtime_support is False when BLACK patterns present."""
@@ -501,8 +501,8 @@ class TestOutputAggregatorIntegration:
 
         ihv_support = output.results[0]
         assert ihv_support.ihv_type == IHVType.QC
-        assert len(ihv_support.classification[SupportLevel.WHITE]) == 1
-        assert len(ihv_support.classification[SupportLevel.BLACK]) == 1
+        assert len(ihv_support.classification[SupportLevel.SUPPORTED]) == 1
+        assert len(ihv_support.classification[SupportLevel.UNSUPPORTED]) == 1
         assert len(ihv_support.information) == 1
 
     def test_full_workflow_multiple_ihv(self, sample_metadata: ModelStats) -> None:

--- a/tests/unit/analyze/core/test_rule_loader_suffix.py
+++ b/tests/unit/analyze/core/test_rule_loader_suffix.py
@@ -127,7 +127,7 @@ class TestRuleLoaderSuffixFiltering:
                         "pattern_to_id": "OP/ai.onnx/Relu",
                         "level": "required",
                         "action": "Replace",
-                        "status": "white",
+                        "status": "supported",
                         "details": "Replace with Relu",
                         "enabled": True,
                     },
@@ -136,7 +136,7 @@ class TestRuleLoaderSuffixFiltering:
                         "pattern_to_id": "OP/ai.onnx/Mul",
                         "level": "optional",
                         "action": "Consider",
-                        "status": "gray",
+                        "status": "partial",
                         "details": "Consider replacement",
                         "enabled": False,  # This should be filtered
                     },
@@ -185,7 +185,7 @@ class TestRuleLoaderBackwardCompatibility:
                         "pattern_to_id": "OP/ai.onnx/QLinearConv",
                         "level": "required",
                         "action": "Replace with quantized version",
-                        "status": "black",
+                        "status": "unsupported",
                         "details": "Conv requires quantization",
                     }
                 ],

--- a/tests/unit/analyze/models/test_information.py
+++ b/tests/unit/analyze/models/test_information.py
@@ -30,14 +30,14 @@ class TestActionValidation:
             pattern_from_id="SUBGRAPH/GELU_Erf",
             pattern_to_id="SUBGRAPH/GELU_Tanh",
             level=ActionLevel.REQUIRED,
-            status=SupportLevel.WHITE,
+            status=SupportLevel.SUPPORTED,
             details="Use Tanh-based GELU for better hardware support",
         )
 
         assert action.pattern_from_id == "SUBGRAPH/GELU_Erf"
         assert action.pattern_to_id == "SUBGRAPH/GELU_Tanh"
         assert action.level == ActionLevel.REQUIRED
-        assert action.status == SupportLevel.WHITE
+        assert action.status == SupportLevel.SUPPORTED
 
     def test_action_level_enum_values(self):
         """Test that ActionLevel enum values are accepted."""
@@ -46,14 +46,14 @@ class TestActionValidation:
                 pattern_from_id="OP/ai.onnx/Conv",
                 pattern_to_id="OP/com.microsoft/FusedConv",
                 level=level,
-                status=SupportLevel.WHITE,
+                status=SupportLevel.SUPPORTED,
                 details="Test details",
             )
             assert action.level == level
 
     def test_support_level_enum_values(self):
         """Test that SupportLevel enum values are accepted for status."""
-        for status in [SupportLevel.WHITE, SupportLevel.GRAY, SupportLevel.BLACK]:
+        for status in [SupportLevel.SUPPORTED, SupportLevel.PARTIAL, SupportLevel.UNSUPPORTED]:
             action = Action(
                 pattern_from_id="OP/ai.onnx/Conv",
                 pattern_to_id="OP/com.microsoft/FusedConv",
@@ -109,7 +109,7 @@ class TestInformationValidation:
             pattern_from_id="SUBGRAPH/GELU_Erf",
             pattern_to_id="SUBGRAPH/GELU_Tanh",
             level=ActionLevel.REQUIRED,
-            status=SupportLevel.WHITE,
+            status=SupportLevel.SUPPORTED,
             details="Tanh-based GELU has better hardware support",
         )
 
@@ -163,7 +163,7 @@ class TestInformationValidation:
             pattern_from_id="OP/ai.onnx/Conv",
             pattern_to_id="OP/com.microsoft/FusedConv",
             level=ActionLevel.REQUIRED,
-            status=SupportLevel.WHITE,
+            status=SupportLevel.SUPPORTED,
             details=("FusedConv combines convolution and activation for better performance"),
         )
 
@@ -181,24 +181,24 @@ class TestInformationValidation:
 class TestInformationIntegrationScenarios:
     """Test Information integration scenarios."""
 
-    def test_required_action_whitelist(self):
-        """Test required action that improves to whitelist."""
+    def test_required_action_supportedlist(self):
+        """Test required action that improves to supportedlist."""
         action = Action(
             pattern_from_id="SUBGRAPH/GELU_Erf",
             pattern_to_id="OP/ai.onnx/Gelu",
             level=ActionLevel.REQUIRED,
-            status=SupportLevel.WHITE,
+            status=SupportLevel.SUPPORTED,
             details="Native Gelu operator is fully supported",
         )
 
         info = Information(
             actions=[action],
-            explanation="Erf-based GELU pattern is blacklisted on this hardware",
+            explanation="Erf-based GELU pattern is unsupported on this hardware",
             pattern_id="SUBGRAPH/GELU_Erf",
         )
 
         assert info.actions[0].level == ActionLevel.REQUIRED
-        assert info.actions[0].status == SupportLevel.WHITE
+        assert info.actions[0].status == SupportLevel.SUPPORTED
 
     def test_optional_action_performance_hint(self):
         """Test optional action for performance optimization."""
@@ -206,7 +206,7 @@ class TestInformationIntegrationScenarios:
             pattern_from_id="OP/ai.onnx/Conv",
             pattern_to_id="OP/com.microsoft/FusedConv",
             level=ActionLevel.OPTIONAL,
-            status=SupportLevel.WHITE,
+            status=SupportLevel.SUPPORTED,
             details="FusedConv can improve inference speed by 20%",
         )
 
@@ -217,15 +217,15 @@ class TestInformationIntegrationScenarios:
         )
 
         assert info.actions[0].level == ActionLevel.OPTIONAL
-        assert info.actions[0].status == SupportLevel.WHITE
+        assert info.actions[0].status == SupportLevel.SUPPORTED
 
-    def test_warning_action_graylist(self):
+    def test_warning_action_partiallist(self):
         """Test warning action for potential issues."""
         action = Action(
             pattern_from_id="OP/ai.onnx/DynamicQuantizeLinear",
             pattern_to_id="OP/ai.onnx/QuantizeLinear",
             level=ActionLevel.WARNING,
-            status=SupportLevel.GRAY,
+            status=SupportLevel.PARTIAL,
             details="Dynamic quantization may have accuracy issues on this hardware",
         )
 
@@ -236,7 +236,7 @@ class TestInformationIntegrationScenarios:
         )
 
         assert info.actions[0].level == ActionLevel.WARNING
-        assert info.actions[0].status == SupportLevel.GRAY
+        assert info.actions[0].status == SupportLevel.PARTIAL
 
     def test_multiple_pattern_transformation(self):
         """Test action involving complex pattern transformation."""
@@ -244,7 +244,7 @@ class TestInformationIntegrationScenarios:
             pattern_from_id="SUBGRAPH/LayerNormalization",
             pattern_to_id="OP/ai.onnx/LayerNormalization",
             level=ActionLevel.REQUIRED,
-            status=SupportLevel.WHITE,
+            status=SupportLevel.SUPPORTED,
             details="Native LayerNormalization operator provides better performance",
         )
 
@@ -284,7 +284,7 @@ class TestInformationIntegrationScenarios:
             pattern_from_id="SUBGRAPH/GELU_Erf",
             pattern_to_id="OP/ai.onnx/Gelu",
             level=ActionLevel.REQUIRED,
-            status=SupportLevel.WHITE,
+            status=SupportLevel.SUPPORTED,
             details="Native Gelu operator is fully supported",
         )
 
@@ -292,7 +292,7 @@ class TestInformationIntegrationScenarios:
             pattern_from_id="SUBGRAPH/GELU_Erf",
             pattern_to_id="SUBGRAPH/GELU_Tanh",
             level=ActionLevel.OPTIONAL,
-            status=SupportLevel.WHITE,
+            status=SupportLevel.SUPPORTED,
             details="Tanh approximation also works well",
         )
 

--- a/tests/unit/analyze/models/test_output.py
+++ b/tests/unit/analyze/models/test_output.py
@@ -124,9 +124,9 @@ class TestEPSupportValidation:
             ep_type="QNNExecutionProvider",
             runtime_support=True,
             classification={
-                SupportLevel.WHITE: ["Conv_0"],
-                SupportLevel.GRAY: [],
-                SupportLevel.BLACK: [],
+                SupportLevel.SUPPORTED: ["Conv_0"],
+                SupportLevel.PARTIAL: [],
+                SupportLevel.UNSUPPORTED: [],
             },
             has_errors=False,
                     has_warnings=False,
@@ -134,7 +134,7 @@ class TestEPSupportValidation:
 
         assert support.ihv_type == IHVType.QC
         assert support.runtime_support is True
-        assert len(support.classification[SupportLevel.WHITE]) == 1
+        assert len(support.classification[SupportLevel.SUPPORTED]) == 1
 
     def test_optional_version_fields(self):
         """Test that ep_version and driver_version are optional."""
@@ -143,9 +143,9 @@ class TestEPSupportValidation:
             ep_type="OpenVINOExecutionProvider",
             runtime_support=True,
             classification={
-                SupportLevel.WHITE: [],
-                SupportLevel.GRAY: [],
-                SupportLevel.BLACK: [],
+                SupportLevel.SUPPORTED: [],
+                SupportLevel.PARTIAL: [],
+                SupportLevel.UNSUPPORTED: [],
             },
             has_errors=False,
                     has_warnings=False,
@@ -175,9 +175,9 @@ class TestAnalysisOutputValidation:
                     ep_type="QNNExecutionProvider",
                     runtime_support=True,
                     classification={
-                        SupportLevel.WHITE: [],
-                        SupportLevel.GRAY: [],
-                        SupportLevel.BLACK: [],
+                        SupportLevel.SUPPORTED: [],
+                        SupportLevel.PARTIAL: [],
+                        SupportLevel.UNSUPPORTED: [],
                     },
                     has_errors=False,
                     has_warnings=False,
@@ -208,9 +208,9 @@ class TestAnalysisOutputValidation:
                     ep_type="QNNExecutionProvider",
                     runtime_support=True,
                     classification={
-                        SupportLevel.WHITE: [],
-                        SupportLevel.GRAY: [],
-                        SupportLevel.BLACK: [],
+                        SupportLevel.SUPPORTED: [],
+                        SupportLevel.PARTIAL: [],
+                        SupportLevel.UNSUPPORTED: [],
                     },
                     has_errors=False,
                     has_warnings=False,
@@ -220,9 +220,9 @@ class TestAnalysisOutputValidation:
                     ep_type="OpenVINOExecutionProvider",
                     runtime_support=True,
                     classification={
-                        SupportLevel.WHITE: [],
-                        SupportLevel.GRAY: [],
-                        SupportLevel.BLACK: [],
+                        SupportLevel.SUPPORTED: [],
+                        SupportLevel.PARTIAL: [],
+                        SupportLevel.UNSUPPORTED: [],
                     },
                     has_errors=False,
                     has_warnings=False,
@@ -249,9 +249,9 @@ class TestAnalysisOutputValidation:
                         ep_type="QNNExecutionProvider",
                         runtime_support=True,
                         classification={
-                            SupportLevel.WHITE: [],
-                            SupportLevel.GRAY: [],
-                            SupportLevel.BLACK: [],
+                            SupportLevel.SUPPORTED: [],
+                            SupportLevel.PARTIAL: [],
+                            SupportLevel.UNSUPPORTED: [],
                         },
                         has_errors=False,
                     has_warnings=False,
@@ -261,9 +261,9 @@ class TestAnalysisOutputValidation:
                         ep_type="QNNExecutionProvider",
                         runtime_support=True,
                         classification={
-                            SupportLevel.WHITE: [],
-                            SupportLevel.GRAY: [],
-                            SupportLevel.BLACK: [],
+                            SupportLevel.SUPPORTED: [],
+                            SupportLevel.PARTIAL: [],
+                            SupportLevel.UNSUPPORTED: [],
                         },
                         has_errors=False,
                     has_warnings=False,
@@ -290,9 +290,9 @@ class TestAnalysisOutputValidation:
                     ep_type="QNNExecutionProvider",
                     runtime_support=True,
                     classification={
-                        SupportLevel.WHITE: [],
-                        SupportLevel.GRAY: [],
-                        SupportLevel.BLACK: [],
+                        SupportLevel.SUPPORTED: [],
+                        SupportLevel.PARTIAL: [],
+                        SupportLevel.UNSUPPORTED: [],
                     },
                     has_errors=False,
                     has_warnings=False,
@@ -302,9 +302,9 @@ class TestAnalysisOutputValidation:
                     ep_type="OpenVINOExecutionProvider",
                     runtime_support=True,
                     classification={
-                        SupportLevel.WHITE: [],
-                        SupportLevel.GRAY: [],
-                        SupportLevel.BLACK: [],
+                        SupportLevel.SUPPORTED: [],
+                        SupportLevel.PARTIAL: [],
+                        SupportLevel.UNSUPPORTED: [],
                     },
                     has_errors=False,
                     has_warnings=False,
@@ -314,9 +314,9 @@ class TestAnalysisOutputValidation:
                     ep_type="ACEExecutionProvider",
                     runtime_support=True,
                     classification={
-                        SupportLevel.WHITE: [],
-                        SupportLevel.GRAY: [],
-                        SupportLevel.BLACK: [],
+                        SupportLevel.SUPPORTED: [],
+                        SupportLevel.PARTIAL: [],
+                        SupportLevel.UNSUPPORTED: [],
                     },
                     has_errors=False,
                     has_warnings=False,
@@ -343,9 +343,9 @@ class TestAnalysisOutputValidation:
                     ep_type="QNNExecutionProvider",
                     runtime_support=True,
                     classification={
-                        SupportLevel.WHITE: [],
-                        SupportLevel.GRAY: [],
-                        SupportLevel.BLACK: [],
+                        SupportLevel.SUPPORTED: [],
+                        SupportLevel.PARTIAL: [],
+                        SupportLevel.UNSUPPORTED: [],
                     },
                     has_errors=False,
                     has_warnings=False,
@@ -405,9 +405,9 @@ class TestAnalysisOutputValidation:
                     has_errors=False,
                     has_warnings=False,
                     classification={
-                        SupportLevel.WHITE: ["Conv_0"],
-                        SupportLevel.GRAY: [],
-                        SupportLevel.BLACK: [],
+                        SupportLevel.SUPPORTED: ["Conv_0"],
+                        SupportLevel.PARTIAL: [],
+                        SupportLevel.UNSUPPORTED: [],
                     },
                     information=[
                         Information(

--- a/tests/unit/analyze/models/test_rule_loader.py
+++ b/tests/unit/analyze/models/test_rule_loader.py
@@ -117,7 +117,7 @@ class TestRuleLoaderBasicLoading:
                             "pattern_to_id": "OP/ai.onnx/Gelu",
                             "type": "required",
                             "action": "Use native Gelu operator",
-                            "status": "white",
+                            "status": "supported",
                             "details": "Native Gelu is fully supported",
                         }
                     ],

--- a/tests/unit/analyze/models/test_rules.py
+++ b/tests/unit/analyze/models/test_rules.py
@@ -28,37 +28,37 @@ from winml.modelkit.analyze.models.support_level import SupportLevel
 class TestRuntimeTestResultValidation:
     """Test RuntimeTestResult nested model validation."""
 
-    def test_classification_whitelist_compile_true_run_true(self):
-        """Test that compile=True and run=True gives whitelist classification."""
+    def test_classification_supportedlist_compile_true_run_true(self):
+        """Test that compile=True and run=True gives supportedlist classification."""
         result = RuntimeTestResult(
             compile=True,
             run=True,
         )
-        assert result.classification == SupportLevel.WHITE
+        assert result.classification == SupportLevel.SUPPORTED
 
-    def test_classification_graylist_compile_true_run_false(self):
-        """Test that compile=False and run=True gives graylist classification."""
+    def test_classification_partiallist_compile_true_run_false(self):
+        """Test that compile=False and run=True gives partiallist classification."""
         result = RuntimeTestResult(
             compile=False,
             run=True,
         )
-        assert result.classification == SupportLevel.GRAY
+        assert result.classification == SupportLevel.PARTIAL
 
-    def test_classification_blacklist_compile_false(self):
-        """Test that compile=False and run=False gives blacklist classification."""
+    def test_classification_unsupportedlist_compile_false(self):
+        """Test that compile=False and run=False gives unsupportedlist classification."""
         # compile=False, run=False
         result1 = RuntimeTestResult(
             compile=False,
             run=False,
         )
-        assert result1.classification == SupportLevel.BLACK
+        assert result1.classification == SupportLevel.UNSUPPORTED
 
         # compile=False, run=True gives GRAY (fallback to CPU scenario)
         result2 = RuntimeTestResult(
             compile=False,
             run=True,
         )
-        assert result2.classification == SupportLevel.GRAY
+        assert result2.classification == SupportLevel.PARTIAL
 
     def test_reason_optional(self):
         """Test that reason field is optional."""
@@ -353,7 +353,7 @@ class TestRuntimeCheckRuleValidation:
 
         assert rule.pattern_id == "OP/ai.onnx/Conv"
         assert rule.ihv_type == IHVType.QC
-        assert rule.test_result.classification == SupportLevel.WHITE
+        assert rule.test_result.classification == SupportLevel.SUPPORTED
         assert rule.namespace == "ai.onnx"
         assert rule.op_version == 13
 
@@ -361,8 +361,8 @@ class TestRuntimeCheckRuleValidation:
 class TestRuntimeCheckRuleIntegration:
     """Test RuntimeCheckRule integration scenarios."""
 
-    def test_whitelist_rule(self):
-        """Test creating a whitelist rule."""
+    def test_supportedlist_rule(self):
+        """Test creating a supportedlist rule."""
         rule = RuntimeCheckRule(
             pattern_id="OP/ai.onnx/Relu",
             ihv_type=IHVType.QC,
@@ -371,10 +371,10 @@ class TestRuntimeCheckRuleIntegration:
             test_result=RuntimeTestResult(compile=True, run=True),
         )
 
-        assert rule.test_result.classification == SupportLevel.WHITE
+        assert rule.test_result.classification == SupportLevel.SUPPORTED
 
-    def test_graylist_rule(self):
-        """Test creating a graylist rule (compiles but doesn't run)."""
+    def test_partiallist_rule(self):
+        """Test creating a partiallist rule (compiles but doesn't run)."""
         rule = RuntimeCheckRule(
             pattern_id="OP/ai.onnx/CustomOp",
             ihv_type=IHVType.INTEL,
@@ -385,10 +385,10 @@ class TestRuntimeCheckRuleIntegration:
             ),
         )
 
-        assert rule.test_result.classification == SupportLevel.GRAY
+        assert rule.test_result.classification == SupportLevel.PARTIAL
 
-    def test_blacklist_rule(self):
-        """Test creating a blacklist rule (doesn't compile)."""
+    def test_unsupportedlist_rule(self):
+        """Test creating an unsupportedlist rule (doesn't compile)."""
         rule = RuntimeCheckRule(
             pattern_id="OP/ai.onnx/UnsupportedOp",
             ihv_type=IHVType.AMD,
@@ -399,4 +399,4 @@ class TestRuntimeCheckRuleIntegration:
             ),
         )
 
-        assert rule.test_result.classification == SupportLevel.BLACK
+        assert rule.test_result.classification == SupportLevel.UNSUPPORTED

--- a/tests/unit/analyze/test_analyze_onnx.py
+++ b/tests/unit/analyze/test_analyze_onnx.py
@@ -76,9 +76,9 @@ def _make_mock_output(
         has_errors=has_errors,
         has_warnings=has_warnings,
         classification={
-            SupportLevel.WHITE: ["Conv", "Relu"],
-            SupportLevel.GRAY: gray_patterns or [],
-            SupportLevel.BLACK: black_patterns or [],
+            SupportLevel.SUPPORTED: ["Conv", "Relu"],
+            SupportLevel.PARTIAL: gray_patterns or [],
+            SupportLevel.UNSUPPORTED: black_patterns or [],
             SupportLevel.UNKNOWN: [],
         },
         information=information or [],

--- a/tests/unit/analyze/test_analyzer.py
+++ b/tests/unit/analyze/test_analyzer.py
@@ -71,9 +71,9 @@ class TestAnalysisResult:
             has_errors=False,
             has_warnings=False,
             classification={
-                SupportLevel.WHITE: ["Conv", "Relu"],
-                SupportLevel.GRAY: [],
-                SupportLevel.BLACK: [],
+                SupportLevel.SUPPORTED: ["Conv", "Relu"],
+                SupportLevel.PARTIAL: [],
+                SupportLevel.UNSUPPORTED: [],
                 SupportLevel.UNKNOWN: [],
             },
             information=[],
@@ -104,7 +104,7 @@ class TestAnalysisResult:
     def test_is_fully_supported_false_with_black_ops(self, mock_output: AnalysisOutput) -> None:
         """Test is_fully_supported returns False when BLACK ops exist."""
         mock_output.results[0].runtime_support = False
-        mock_output.results[0].classification[SupportLevel.BLACK] = ["Upsample"]
+        mock_output.results[0].classification[SupportLevel.UNSUPPORTED] = ["Upsample"]
 
         result = AnalysisResult(output=mock_output)
         assert result.is_fully_supported() is False
@@ -140,7 +140,7 @@ class TestAnalysisResult:
 
     def test_has_errors_true_with_black(self, mock_output: AnalysisOutput) -> None:
         """Test has_errors returns True when BLACK patterns exist."""
-        mock_output.results[0].classification[SupportLevel.BLACK] = ["Upsample"]
+        mock_output.results[0].classification[SupportLevel.UNSUPPORTED] = ["Upsample"]
         mock_output.results[0].has_errors = True
 
         result = AnalysisResult(output=mock_output)
@@ -178,7 +178,7 @@ class TestAnalysisResult:
 
     def test_has_warnings_true_with_gray(self, mock_output: AnalysisOutput) -> None:
         """Test has_warnings returns True when GRAY patterns exist."""
-        mock_output.results[0].classification[SupportLevel.GRAY] = ["Resize"]
+        mock_output.results[0].classification[SupportLevel.PARTIAL] = ["Resize"]
         mock_output.results[0].has_warnings = True
 
         result = AnalysisResult(output=mock_output)
@@ -224,7 +224,7 @@ class TestAnalysisResult:
 
     def test_get_lint_result_with_errors(self, mock_output: AnalysisOutput) -> None:
         """Test get_lint_result with BLACK patterns (errors)."""
-        mock_output.results[0].classification[SupportLevel.BLACK] = ["Upsample", "NonZero"]
+        mock_output.results[0].classification[SupportLevel.UNSUPPORTED] = ["Upsample", "NonZero"]
         mock_output.results[0].has_errors = True
 
         result = AnalysisResult(output=mock_output)
@@ -241,7 +241,7 @@ class TestAnalysisResult:
 
     def test_get_lint_result_with_warnings(self, mock_output: AnalysisOutput) -> None:
         """Test get_lint_result with GRAY patterns (warnings)."""
-        mock_output.results[0].classification[SupportLevel.GRAY] = ["Resize", "Shape"]
+        mock_output.results[0].classification[SupportLevel.PARTIAL] = ["Resize", "Shape"]
         mock_output.results[0].has_warnings = True
 
         result = AnalysisResult(output=mock_output)
@@ -284,8 +284,8 @@ class TestAnalysisResult:
 
     def test_get_lint_result_comprehensive(self, mock_output: AnalysisOutput) -> None:
         """Test get_lint_result with errors, warnings, and info."""
-        mock_output.results[0].classification[SupportLevel.BLACK] = ["Upsample"]
-        mock_output.results[0].classification[SupportLevel.GRAY] = ["Resize", "Shape"]
+        mock_output.results[0].classification[SupportLevel.UNSUPPORTED] = ["Upsample"]
+        mock_output.results[0].classification[SupportLevel.PARTIAL] = ["Resize", "Shape"]
         mock_output.results[0].has_errors = True
         mock_output.results[0].has_warnings = True
         info1 = Information(
@@ -344,9 +344,9 @@ class TestAnalysisResult:
             has_errors=True,
             has_warnings=False,
             classification={
-                SupportLevel.WHITE: [],
-                SupportLevel.GRAY: [],
-                SupportLevel.BLACK: ["InstanceNorm"],
+                SupportLevel.SUPPORTED: [],
+                SupportLevel.PARTIAL: [],
+                SupportLevel.UNSUPPORTED: ["InstanceNorm"],
                 SupportLevel.UNKNOWN: [],
             },
             information=[],
@@ -386,8 +386,8 @@ class TestAnalysisResult:
         self, mock_output: AnalysisOutput
     ) -> None:
         """Test get_unsupported_operators returns BLACK and GRAY ops."""
-        mock_output.results[0].classification[SupportLevel.BLACK] = ["Upsample"]
-        mock_output.results[0].classification[SupportLevel.GRAY] = ["Resize"]
+        mock_output.results[0].classification[SupportLevel.UNSUPPORTED] = ["Upsample"]
+        mock_output.results[0].classification[SupportLevel.PARTIAL] = ["Resize"]
 
         result = AnalysisResult(output=mock_output)
         unsupported = result.get_unsupported_operators()
@@ -405,9 +405,9 @@ class TestAnalysisResult:
             has_errors=True,
             has_warnings=False,
             classification={
-                SupportLevel.WHITE: [],
-                SupportLevel.GRAY: [],
-                SupportLevel.BLACK: ["Gelu"],
+                SupportLevel.SUPPORTED: [],
+                SupportLevel.PARTIAL: [],
+                SupportLevel.UNSUPPORTED: ["Gelu"],
                 SupportLevel.UNKNOWN: [],
             },
             information=[],
@@ -572,9 +572,9 @@ class TestAnalysisResult:
             has_errors=False,
             has_warnings=False,
             classification={
-                SupportLevel.WHITE: [],
-                SupportLevel.GRAY: [],
-                SupportLevel.BLACK: [],
+                SupportLevel.SUPPORTED: [],
+                SupportLevel.PARTIAL: [],
+                SupportLevel.UNSUPPORTED: [],
                 SupportLevel.UNKNOWN: [],
             },
             information=[
@@ -929,7 +929,7 @@ class TestONNXStaticAnalyzer:
         # Mock PatternRuntime with proper structure
         mock_pattern_runtime = MagicMock()
         mock_pattern_runtime.pattern_id = "OP/Conv"
-        mock_pattern_runtime.result.classification = SupportLevel.WHITE
+        mock_pattern_runtime.result.classification = SupportLevel.SUPPORTED
 
         mock_checker.summary.return_value = {
             "op_runtime_check_result": [mock_pattern_runtime],  # Non-empty


### PR DESCRIPTION
## Summary

- Rename `SupportLevel` enum values: `WHITE`/`GRAY`/`BLACK` → `SUPPORTED`/`PARTIAL`/`UNSUPPORTED` (string values updated accordingly)
- Replace `whitelist`/`blacklist`/`graylist` terminology with `supportedlist`/`partiallist`/`unsupportedlist` across comments, docstrings, and variable names (`WHITELISTED_OPERATIONS` → `SUPPORTEDLIST_OPERATIONS`)
- Update CLI `--save-node` choices from `gray`/`black` to `partial`/`unsupported`
- Reword `capital` → `uppercase` in comment to avoid geopolitical false positive