### PR TITLE
Change support_weight, support_activation to qdq_types in QDQParameterConfig

### DIFF
--- a/src/winml/modelkit/pattern/op_input_gen/conv_input_generator.py
+++ b/src/winml/modelkit/pattern/op_input_gen/conv_input_generator.py
@@ -132,7 +132,7 @@ class ConvInputGenerator(OpInputGenerator):
         return {
             "X": QDQParameterConfig(support_activation=True),
             "W": QDQParameterConfig(support_weight=True),
-            "B": QDQParameterConfig(weight_type=dtypes.SupportedONNXType.INT32),
+            "B": QDQParameterConfig(qdq_types=[dtypes.SupportedONNXType.INT32]),
         }
 
 

--- a/src/winml/modelkit/pattern/op_input_gen/matmul_input_generator.py
+++ b/src/winml/modelkit/pattern/op_input_gen/matmul_input_generator.py
@@ -305,5 +305,5 @@ class GemmInputGenerator(OpInputGenerator):
         return {
             "A": QDQParameterConfig(support_activation=True),
             "B": QDQParameterConfig(support_weight=True),
-            "C": QDQParameterConfig(weight_type=dtypes.SupportedONNXType.INT32),
+            "C": QDQParameterConfig(qdq_types=[dtypes.SupportedONNXType.INT32]),
         }

--- a/src/winml/modelkit/pattern/op_input_gen/normalization_input_generator.py
+++ b/src/winml/modelkit/pattern/op_input_gen/normalization_input_generator.py
@@ -335,7 +335,7 @@ class InstanceNormalizationInputGenerator(NormalizationInputGenerator):
         return {
             self.op_input_names[0]: QDQParameterConfig(support_activation=True),
             self.op_input_names[1]: QDQParameterConfig(support_weight=True),
-            self.op_input_names[2]: QDQParameterConfig(weight_type=dtypes.SupportedONNXType.INT32),
+            self.op_input_names[2]: QDQParameterConfig(qdq_types=[dtypes.SupportedONNXType.INT32]),
         }
 
 
@@ -415,7 +415,7 @@ class LayerNormalizationInputGenerator(NormalizationInputGenerator):
         return {
             "X": QDQParameterConfig(support_activation=True),
             "Scale": QDQParameterConfig(support_activation=True, support_weight=True),
-            "B": QDQParameterConfig(weight_type=dtypes.SupportedONNXType.INT32),
+            "B": QDQParameterConfig(qdq_types=[dtypes.SupportedONNXType.INT32]),
         }
 
 

--- a/src/winml/modelkit/pattern/op_input_gen/op_input_gen.py
+++ b/src/winml/modelkit/pattern/op_input_gen/op_input_gen.py
@@ -260,32 +260,23 @@ class QDQParameterConfig:
         support_weight: bool = False,
         support_activation: bool = False,
         support_non_qdq: bool = False,
-        weight_type: dtypes.SupportedONNXType | None = None,
-        activation_type: dtypes.SupportedONNXType | None = None,
+        qdq_types: list[dtypes.SupportedONNXType] | None = None,
     ):
         """Initialize QDQParameterConfig.
 
-        weight_type is not None means support_weight = True.
-        activation_type is not None means support_activation = True.
+        qdq_types, when set, specifies the exact quantization types to yield for this parameter.
+        qdq_types is yielded as a distinct combination.
         """
-        self._support_weight = support_weight
-        self._support_activation = support_activation
-        self.weight_type = weight_type
-        self.activation_type = activation_type
+        self.support_weight = support_weight
+        self.support_activation = support_activation
         self.support_non_qdq = support_non_qdq
-        assert self.support_activation or self.support_weight or self.support_non_qdq, (
-            "At least one of support_weight, support_activation, or support_non_qdq must be True"
-        )
-
-    @property
-    def support_weight(self) -> bool:
-        """Return whether weight quantization is supported."""
-        return self._support_weight or self.weight_type is not None
-
-    @property
-    def support_activation(self) -> bool:
-        """Return whether activation quantization is supported."""
-        return self._support_activation or self.activation_type is not None
+        self.qdq_types = qdq_types
+        assert (
+            self.support_activation
+            or self.support_weight
+            or self.support_non_qdq
+            or self.qdq_types is not None
+        ), "At least one of support_weight, support_activation, support_non_qdq, or qdq_types must be set"
 
 
 class OpInputGenerator(ABC):
@@ -653,13 +644,15 @@ class OpInputGenerator(ABC):
 
         # For each input in the config, collect the possible should_qdq values.
         input_names: list[str] = []
-        input_option_lists: list[list[bool]] = []
+        input_option_lists: list[list[bool | dtypes.SupportedONNXType]] = []
         for input_name, config in expanded_config.items():
             if input_name not in schema_input_names:
                 continue  # output name present in qdq_config; handled below
-            options: list[bool] = []
+            options: list[bool | dtypes.SupportedONNXType] = []
             if config.support_activation or config.support_weight:
                 options.append(True)
+            if config.qdq_types is not None:
+                options.extend(config.qdq_types)
             if config.support_non_qdq:
                 options.append(False)
             input_names.append(input_name)
@@ -1153,21 +1146,26 @@ class OpInputGenerator(ABC):
                 continue
 
             config = qdq_config[input_name]
-            # If neither weight nor activation quantization is supported, treat as
-            # pass-through: no QDQ nodes for this input regardless of is_constant.
-            if not config.support_weight and not config.support_activation:
-                continue
+            should_val = should_qdq_map.get(input_name)
 
-            if is_constant and not config.support_weight:
-                # Config doesn't support this input as weight
-                return
-            if not is_constant and not config.support_activation:
-                # Config doesn't support this input as activation
-                return
-
-            # Determine if we need to iterate over weight/activation types
-            if is_constant and config.support_weight and config.weight_type is None:
-                needs_weight_iteration = True
+            if isinstance(should_val, dtypes.SupportedONNXType):
+                # Specific type from qdq_types — always quantize with this type, skip
+                # weight/activation mode checks since the type is fully determined.
+                pass
+            else:
+                # should_val is True (from support_weight or support_activation)
+                # If neither flag is set, treat as pass-through.
+                if not config.support_weight and not config.support_activation:
+                    continue
+                if is_constant and not config.support_weight:
+                    # Config doesn't support this input as weight
+                    return
+                if not is_constant and not config.support_activation:
+                    # Config doesn't support this input as activation
+                    return
+                # Only need weight iteration when type is not already determined
+                if is_constant and config.support_weight:
+                    needs_weight_iteration = True
 
         # Step 3: Validate input types against qdq_generator.SUPPORT_DQ_OUTPUT_TYPES
         # DQ nodes output the type that the operator expects as input; the original input
@@ -1187,10 +1185,15 @@ class OpInputGenerator(ABC):
             if ta_key not in self.type_annotations:
                 raise ValueError(f"Input '{input_name}' not found in type annotations")
             config = qdq_config[input_name]
-            if not config.support_activation and not config.support_weight:
-                continue  # This input is not quantized, skip type check
-            if should_qdq_map.get(input_name) is False:
+            should_val = should_qdq_map.get(input_name)
+            if should_val is False:
                 continue  # should_qdq_map says no DQ for this input, skip type check
+            if (
+                not config.support_activation
+                and not config.support_weight
+                and not isinstance(should_val, dtypes.SupportedONNXType)
+            ):
+                continue  # This input is not quantized, skip type check
             type_template = self.type_annotations[ta_key]
             annotation = self._apply_type_var_combination(type_template, tags[self.type_vars_key])
             try:
@@ -1251,29 +1254,28 @@ class OpInputGenerator(ABC):
                         continue
 
                     config = qdq_config[input_name]
-                    if not config.support_activation and not config.support_weight:
+                    should_val = should_qdq_map.get(input_name)
+                    if (
+                        not config.support_activation
+                        and not config.support_weight
+                        and not isinstance(should_val, dtypes.SupportedONNXType)
+                    ):
                         qdq_types[input_name] = None  # Pass-through input (support_non_qdq only)
                         new_constant_map[input_name] = (
                             is_constant  # Pass-through input, keep original constant setting
                         )
                         continue
 
-                    if is_constant:
-                        # Use weight type - from config override or iteration
-                        if config.weight_type is not None:
-                            qdq_types[input_name] = config.weight_type
-                        else:
-                            qdq_types[input_name] = dtypes.SupportedONNXType.from_onnx_type(
-                                weight_onnx_type
-                            )
+                    if isinstance(should_val, dtypes.SupportedONNXType):
+                        qdq_types[input_name] = should_val
+                    elif is_constant:
+                        qdq_types[input_name] = dtypes.SupportedONNXType.from_onnx_type(
+                            weight_onnx_type
+                        )
                     else:
-                        # Use activation type - from config override or iteration
-                        if config.activation_type is not None:
-                            qdq_types[input_name] = config.activation_type
-                        else:
-                            qdq_types[input_name] = dtypes.SupportedONNXType.from_onnx_type(
-                                activation_onnx_type
-                            )
+                        qdq_types[input_name] = dtypes.SupportedONNXType.from_onnx_type(
+                            activation_onnx_type
+                        )
 
                 # Infer output types for this combination first
                 output_dtypes = self.infer_output_types(kwargs, tags)
@@ -1815,16 +1817,10 @@ class OpInputGenerator(ABC):
         weight or activation.
         - as weight: the input is from initializer
         - as activation: the input is not from initializer
-        - if the config has weight_type or activation_type, it
-          indicates the input could be quantized as that type.
-          Overwrites the default list.
-        If input names are not in the dict:
-        - if the input name is optional, then when the value is
-          actually provided, we will not generate the model
-          because we don't know what is supported
-        - if the input name is required, then we will not
-          generate the model because we don't know what is
-          supported
+        - if the config has qdq_types, it indicates the input could be quantized as those types. Overwrite the default list
+        If input names are not in the dict
+        - if the input name is optional, then when the value is actually provided, we will not generate the model because we don't know what it is supported
+        - if the input name is required, then we will not generate the model because we don't know what it is supported
         """
         return None
 

--- a/src/winml/modelkit/pattern/op_input_gen/op_input_gen.py
+++ b/src/winml/modelkit/pattern/op_input_gen/op_input_gen.py
@@ -276,7 +276,10 @@ class QDQParameterConfig:
             or self.support_weight
             or self.support_non_qdq
             or self.qdq_types is not None
-        ), "At least one of support_weight, support_activation, support_non_qdq, or qdq_types must be set"
+        ), (
+            "At least one of support_weight, support_activation, "
+            "support_non_qdq, or qdq_types must be set"
+        )
 
 
 class OpInputGenerator(ABC):
@@ -1817,10 +1820,13 @@ class OpInputGenerator(ABC):
         weight or activation.
         - as weight: the input is from initializer
         - as activation: the input is not from initializer
-        - if the config has qdq_types, it indicates the input could be quantized as those types. Overwrite the default list
+        - if the config has qdq_types, it indicates the input could be quantized as those types.
+          Overwrite the default list
         If input names are not in the dict
-        - if the input name is optional, then when the value is actually provided, we will not generate the model because we don't know what it is supported
-        - if the input name is required, then we will not generate the model because we don't know what it is supported
+        - if the input name is optional, then when the value is actually provided, we will not
+          generate the model because we don't know what it is supported
+        - if the input name is required, then we will not generate the model because we don't
+          know what it is supported
         """
         return None
 

--- a/src/winml/modelkit/session/monitor/_pdh.py
+++ b/src/winml/modelkit/session/monitor/_pdh.py
@@ -26,6 +26,7 @@ import sys
 import threading
 import time
 from dataclasses import dataclass, field
+from typing import ClassVar
 
 
 logger = logging.getLogger(__name__)
@@ -55,14 +56,14 @@ _pdh = ctypes.windll.pdh
 # PDH structure definitions
 # ---------------------------------------------------------------------------
 class _PdhFmtDouble(ctypes.Structure):
-    _fields_ = [
+    _fields_: ClassVar = [
         ("CStatus", wintypes.DWORD),
         ("doubleValue", ctypes.c_double),
     ]
 
 
 class _PdhFmtLarge(ctypes.Structure):
-    _fields_ = [
+    _fields_: ClassVar = [
         ("CStatus", wintypes.DWORD),
         ("_padding", wintypes.DWORD),
         ("largeValue", ctypes.c_longlong),
@@ -134,14 +135,10 @@ class PdhQuery:
         """
         pdh_fmt = _PDH_FMT_DOUBLE if fmt == "double" else _PDH_FMT_LARGE
         entry = _CounterEntry(name=name, path=path, fmt=pdh_fmt)
-        status = _pdh.PdhAddEnglishCounterW(
-            self._query, path, 0, ctypes.byref(entry.handle)
-        )
+        status = _pdh.PdhAddEnglishCounterW(self._query, path, 0, ctypes.byref(entry.handle))
         entry.registered = _pdh_ok(status)
         if not entry.registered:
-            logger.debug(
-                "Counter '%s' registration failed: 0x%08X", name, status & 0xFFFFFFFF
-            )
+            logger.debug("Counter '%s' registration failed: 0x%08X", name, status & 0xFFFFFFFF)
         self._counters.append(entry)
         return entry.registered
 
@@ -184,9 +181,7 @@ class PdhQuery:
                 s = _pdh.PdhGetFormattedCounterValue(
                     entry.handle, _PDH_FMT_LARGE, ctypes.byref(ct), ctypes.byref(val)
                 )
-                values[entry.name] = (
-                    val.largeValue if _pdh_ok(s) and _pdh_ok(val.CStatus) else None
-                )
+                values[entry.name] = val.largeValue if _pdh_ok(s) and _pdh_ok(val.CStatus) else None
 
         return values
 
@@ -488,10 +483,7 @@ class PdhPoller:
     def memory_samples_mb(self) -> list[float]:
         """All local memory samples in MB (time series copy)."""
         with self._lock:
-            return [
-                b / (1024 * 1024) if b is not None else 0.0
-                for b in self._memory_local_bytes
-            ]
+            return [b / (1024 * 1024) if b is not None else 0.0 for b in self._memory_local_bytes]
 
     @property
     def is_active(self) -> bool:

--- a/tests/unit/analyze/core/test_qdq.py
+++ b/tests/unit/analyze/core/test_qdq.py
@@ -92,8 +92,7 @@ class TestQDQParameterConfig:
         assert config.support_weight is False
         assert config.support_activation is False
         assert config.support_non_qdq is True
-        assert config.weight_type is None
-        assert config.activation_type is None
+        assert config.qdq_types is None
 
     def test_support_flags(self) -> None:
         """Test support_weight and support_activation flags."""
@@ -112,23 +111,28 @@ class TestQDQParameterConfig:
         assert config_both.support_weight is True
         assert config_both.support_activation is True
 
-    def test_type_implies_support_flag(self) -> None:
-        """Test that setting type implies corresponding support flag is True."""
-        # weight_type implies support_weight=True
-        config_w = QDQParameterConfig(weight_type=dtypes.SupportedONNXType.INT8)
-        assert config_w.support_weight is True
-        assert config_w.weight_type == dtypes.SupportedONNXType.INT8
+    def test_qdq_types_field(self) -> None:
+        """Test that qdq_types stores the specified type list."""
+        # standalone qdq_types — no support_weight or support_activation needed
+        config_standalone = QDQParameterConfig(qdq_types=[dtypes.SupportedONNXType.INT32])
+        assert config_standalone.support_weight is False
+        assert config_standalone.support_activation is False
+        assert config_standalone.qdq_types == [dtypes.SupportedONNXType.INT32]
 
-        # activation_type implies support_activation=True
-        config_a = QDQParameterConfig(activation_type=dtypes.SupportedONNXType.UINT8)
-        assert config_a.support_activation is True
-        assert config_a.activation_type == dtypes.SupportedONNXType.UINT8
-
-        # Even when explicit flag is False, type overrides it
-        config_override = QDQParameterConfig(
-            support_weight=False, weight_type=dtypes.SupportedONNXType.INT8
+        # combined with support_weight — yields both True and the specific types
+        config_w = QDQParameterConfig(
+            support_weight=True, qdq_types=[dtypes.SupportedONNXType.INT8]
         )
-        assert config_override.support_weight is True
+        assert config_w.support_weight is True
+        assert config_w.qdq_types == [dtypes.SupportedONNXType.INT8]
+
+        config_multi = QDQParameterConfig(
+            support_weight=True,
+            qdq_types=[dtypes.SupportedONNXType.INT8, dtypes.SupportedONNXType.INT32],
+        )
+        assert config_multi.qdq_types == [
+            dtypes.SupportedONNXType.INT8, dtypes.SupportedONNXType.INT32
+        ]
 
 
 class TestQDQTypeInfo:
@@ -671,53 +675,44 @@ class TestIterQDQCombinationsUnit:
         )
         assert len(first) == len(second) > 0
 
-    def test_weight_type_override_skips_weight_iteration(self, tanh_gen) -> None:
-        """A fixed weight_type yields |activation_types| models, not |weight| x |activation|."""
+    def test_qdq_types_skips_weight_iteration(self, tanh_gen) -> None:
+        """qdq_types yields |activation_types| models, not |weight| x |activation|."""
         gen = tanh_gen
         kwargs, tags = self._float_kwargs_tags(gen)
         input_name = gen.op_input_names[0]
         is_constant_map = {input_name: True}
-        qdq_config = {
-            input_name: QDQParameterConfig(
-                support_weight=True, weight_type=dtypes.SupportedONNXType.INT8
-            )
-        }
+        qdq_config = {input_name: QDQParameterConfig(qdq_types=[dtypes.SupportedONNXType.INT8])}
+        should_qdq = {input_name: dtypes.SupportedONNXType.INT8}
         results = list(
-            gen.iter_qdq_combinations(kwargs, tags, is_constant_map, {}, qdq_config, set())
+            gen.iter_qdq_combinations(kwargs, tags, is_constant_map, should_qdq, qdq_config, set())
         )
         assert len(results) == len(gen.qdq_generator.activation_onnx_types)
 
-    def test_weight_type_override_sets_correct_type_in_tags(self, tanh_gen) -> None:
-        """A fixed weight_type override appears verbatim in qdq_types for every yielded model."""
+    def test_qdq_types_sets_correct_weight_type_in_tags(self, tanh_gen) -> None:
+        """qdq_types for a constant input appears verbatim in qdq_types tags."""
         gen = tanh_gen
         kwargs, tags = self._float_kwargs_tags(gen)
         input_name = gen.op_input_names[0]
         is_constant_map = {input_name: True}
-        qdq_config = {
-            input_name: QDQParameterConfig(
-                support_weight=True, weight_type=dtypes.SupportedONNXType.INT8
-            )
-        }
+        qdq_config = {input_name: QDQParameterConfig(qdq_types=[dtypes.SupportedONNXType.INT8])}
+        should_qdq = {input_name: dtypes.SupportedONNXType.INT8}
         results = list(
-            gen.iter_qdq_combinations(kwargs, tags, is_constant_map, {}, qdq_config, set())
+            gen.iter_qdq_combinations(kwargs, tags, is_constant_map, should_qdq, qdq_config, set())
         )
         assert len(results) > 0
         for _, final_tags in results:
             assert final_tags["qdq_types"][input_name] == dtypes.SupportedONNXType.INT8.annotation
 
-    def test_activation_type_override_sets_correct_type_in_tags(self, tanh_gen) -> None:
-        """A fixed activation_type override appears verbatim in qdq_types for every model."""
+    def test_qdq_types_sets_correct_activation_type_in_tags(self, tanh_gen) -> None:
+        """qdq_types for a non-constant input appears verbatim in qdq_types tags."""
         gen = tanh_gen
         kwargs, tags = self._float_kwargs_tags(gen)
         input_name = gen.op_input_names[0]
         is_constant_map = {input_name: False}
-        qdq_config = {
-            input_name: QDQParameterConfig(
-                support_activation=True, activation_type=dtypes.SupportedONNXType.UINT8
-            )
-        }
+        qdq_config = {input_name: QDQParameterConfig(qdq_types=[dtypes.SupportedONNXType.UINT8])}
+        should_qdq = {input_name: dtypes.SupportedONNXType.UINT8}
         results = list(
-            gen.iter_qdq_combinations(kwargs, tags, is_constant_map, {}, qdq_config, set())
+            gen.iter_qdq_combinations(kwargs, tags, is_constant_map, should_qdq, qdq_config, set())
         )
         assert len(results) > 0
         for _, final_tags in results:


### PR DESCRIPTION
## Summary

- Replaces the separate `weight_type` and `activation_type` fields in `QDQParameterConfig` with a unified `qdq_types: list[SupportedONNXType]` parameter
- Converts `support_weight` and `support_activation` from computed properties back to plain attributes
- Updates the assertion to also allow `qdq_types` as a valid way to configure a parameter
- Updates all call sites in `conv_input_generator.py`, `matmul_input_generator.py`, `normalization_input_generator.py`, and related tests

## Test plan

- [ ] Existing unit tests in `tests/unit/analyze/core/test_qdq.py` updated to reflect new API
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)