### PR TITLE
Mock WinML EP init for non-e2e session tests

### DIFF
--- a/tests/session/conftest.py
+++ b/tests/session/conftest.py
@@ -63,10 +63,16 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
     Note: EP discovery is only performed when tests with @pytest.mark.ep() markers
     are found. This avoids slow WinML initialization for pure unit tests.
     """
-    # First, check if any items have EP markers - skip discovery if none
-    items_with_ep_markers = [item for item in items if any(item.iter_markers(name="ep"))]
+    # Only consider non-e2e items with EP markers. E2e tests handle their own
+    # EP discovery. This hook runs before -m filtering, so e2e items are still
+    # in the list — skip them to avoid triggering WinML SDK initialization.
+    items_with_ep_markers = [
+        item
+        for item in items
+        if any(item.iter_markers(name="ep")) and not any(item.iter_markers(name="e2e"))
+    ]
     if not items_with_ep_markers:
-        return  # No EP markers, skip expensive WinML discovery
+        return  # No non-e2e EP markers, skip expensive WinML discovery
 
     import onnxruntime as ort
 

--- a/tests/session/conftest.py
+++ b/tests/session/conftest.py
@@ -100,6 +100,23 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
                 item.add_marker(pytest.mark.skip(reason=f"EP not available: {provider_name}"))
 
 
+@pytest.fixture(autouse=True)
+def _skip_winml_ep_init(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mock WinML EP initialization for non-e2e tests.
+
+    WinMLSession.__init__ calls _init_winml_eps_once() which triggers
+    WinML SDK runtime initialization. This can hang on CI environments
+    without the SDK installed. Mock it for non-e2e tests since they
+    only need basic session functionality (CPU).
+    """
+    if "e2e" in {m.name for m in request.node.iter_markers()}:
+        return  # Let e2e tests use real SDK initialization
+    monkeypatch.setattr(
+        "winml.modelkit.session.session.WinMLSession._init_winml_eps_once",
+        classmethod(lambda cls: None),
+    )
+
+
 def create_matmul_onnx(output_path: Path) -> Path:
     """
     Create a simple MatMul ONNX model for testing.


### PR DESCRIPTION
## Summary

- Add autouse fixture in `tests/session/conftest.py` to mock `WinMLSession._init_winml_eps_once()` for non-e2e tests
- `WinMLSession.__init__` unconditionally calls `_init_winml_eps_once()` which triggers WinML SDK runtime initialization — this can hang on CI environments without the SDK installed
- E2e tests (marked `@pytest.mark.e2e`) are excluded from the mock and use real SDK initialization