### PR TITLE
Move WinML EP init mock to root conftest for global coverage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,26 @@ from onnx import TensorProto
 
 
 # =============================================================================
+# WINML SDK INITIALIZATION GUARD
+# =============================================================================
+# winml.modelkit.models.winml.base imports WinMLSession at module level,
+# which triggers WinMLEPRegistry._discover_eps() → WinML SDK runtime init.
+# This can hang on CI environments without the SDK installed.
+# Mock it globally for non-e2e tests; e2e tests use real initialization.
+
+
+@pytest.fixture(autouse=True)
+def _skip_winml_ep_init(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mock WinML EP initialization for non-e2e tests."""
+    if "e2e" in {m.name for m in request.node.iter_markers()}:
+        return
+    monkeypatch.setattr(
+        "winml.modelkit.session.session.WinMLSession._init_winml_eps_once",
+        classmethod(lambda cls: None),
+    )
+
+
+# =============================================================================
 # ORT GRAPH OPTIMIZATION TEST FIXTURES (Module-scoped)
 # =============================================================================
 

--- a/tests/session/conftest.py
+++ b/tests/session/conftest.py
@@ -106,23 +106,6 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
                 item.add_marker(pytest.mark.skip(reason=f"EP not available: {provider_name}"))
 
 
-@pytest.fixture(autouse=True)
-def _skip_winml_ep_init(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Mock WinML EP initialization for non-e2e tests.
-
-    WinMLSession.__init__ calls _init_winml_eps_once() which triggers
-    WinML SDK runtime initialization. This can hang on CI environments
-    without the SDK installed. Mock it for non-e2e tests since they
-    only need basic session functionality (CPU).
-    """
-    if "e2e" in {m.name for m in request.node.iter_markers()}:
-        return  # Let e2e tests use real SDK initialization
-    monkeypatch.setattr(
-        "winml.modelkit.session.session.WinMLSession._init_winml_eps_once",
-        classmethod(lambda cls: None),
-    )
-
-
 def create_matmul_onnx(output_path: Path) -> Path:
     """
     Create a simple MatMul ONNX model for testing.


### PR DESCRIPTION
## Summary

- Move autouse fixture `_skip_winml_ep_init` from `tests/session/conftest.py` to root `tests/conftest.py`
- `winml.modelkit.models.winml.base` imports `WinMLSession` at module level, which triggers `WinMLEPRegistry._discover_eps()` → WinML SDK runtime initialization on **any** `winml.modelkit` import
- This causes ALL test groups (unit, models, commands, etc.) to potentially hang on CI environments without the SDK installed — not just `tests/session`
- The fixture mocks `WinMLSession._init_winml_eps_once` for non-e2e tests; e2e tests (marked `@pytest.mark.e2e`) bypass the mock and use real SDK initialization

### Import chain
```
winml.modelkit.__init__
  → winml.modelkit.models
    → winml.modelkit.models.winml
      → winml.modelkit.models.winml.base
        → winml.modelkit.session.session (WinMLSession)
          → winml.modelkit.session.ep_registry (WinMLEPRegistry)
```