### PR TITLE
Import cleanup Phase 0: onnx package

### DIFF
--- a/src/winml/modelkit/analyze/core/node_checkers/base.py
+++ b/src/winml/modelkit/analyze/core/node_checkers/base.py
@@ -13,9 +13,9 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     import onnx
 
-    from winml.modelkit.onnx.domains import ONNXDomain
     from winml.modelkit.pattern.match import PatternMatchResult
 
+    from ....onnx import ONNXDomain
     from ...models.runtime_checks import PatternAlternative, PatternRuntime
 
 

--- a/src/winml/modelkit/analyze/core/node_checkers/ep_context_node_checker.py
+++ b/src/winml/modelkit/analyze/core/node_checkers/ep_context_node_checker.py
@@ -4,8 +4,7 @@
 # --------------------------------------------------------------------------
 from typing import TYPE_CHECKING, Any
 
-from winml.modelkit.onnx.domains import ONNXDomain
-
+from ....onnx import ONNXDomain
 from ...models.runtime_checks import PatternAlternative, PatternRuntime, RuntimeTestResult
 from .base import NodeChecker
 from .registry import NodeCheckerRegistry

--- a/src/winml/modelkit/analyze/core/runtime_checker_query.py
+++ b/src/winml/modelkit/analyze/core/runtime_checker_query.py
@@ -18,14 +18,17 @@ import onnxruntime as ort
 import pandas as pd
 from onnx import numpy_helper, shape_inference
 
-from winml.modelkit.onnx.domains import ONNXDomain
-from winml.modelkit.onnx.dtypes import SupportedONNXType, remove_optional_from_type_annotation
-from winml.modelkit.onnx.shape import infer_onnx_shapes
 from winml.modelkit.pattern.base import get_registered_pattern_input_generators
 from winml.modelkit.pattern.op_input_gen import (
     get_runtime_checker_op,
 )
 
+from ...onnx import (
+    ONNXDomain,
+    SupportedONNXType,
+    infer_onnx_shapes,
+    remove_optional_from_type_annotation,
+)
 from ..exceptions import (
     OpLackOfRequiredInformationError,
     OpOptionalInputSupportError,

--- a/src/winml/modelkit/analyze/models/onnx_model.py
+++ b/src/winml/modelkit/analyze/models/onnx_model.py
@@ -11,7 +11,7 @@ from enum import Enum
 import onnx
 from pydantic import BaseModel, Field, field_validator
 
-from winml.modelkit.onnx.domains import ONNXDomain
+from ...onnx import ONNXDomain
 
 
 class ModelTag(str, Enum):

--- a/src/winml/modelkit/analyze/pattern/check_patterns.py
+++ b/src/winml/modelkit/analyze/pattern/check_patterns.py
@@ -23,7 +23,6 @@ import onnx
 import onnxruntime as ort
 from google.protobuf import json_format
 
-from winml.modelkit.onnx.domains import ONNXDomain
 from winml.modelkit.pattern.base import (
     PatternInputGenerator,
     get_pattern_input_generator,
@@ -31,6 +30,7 @@ from winml.modelkit.pattern.base import (
 )
 
 from ... import winml
+from ...onnx import ONNXDomain
 from ...sysinfo import SysInfo
 from ...utils import constants
 from ..runtime_checker.ep_checker import EPChecker

--- a/src/winml/modelkit/analyze/runtime_checker/case_runner.py
+++ b/src/winml/modelkit/analyze/runtime_checker/case_runner.py
@@ -16,7 +16,6 @@ if TYPE_CHECKING:
 import numpy as np
 import onnx
 
-from winml.modelkit.onnx.domains import ONNXDomain
 from winml.modelkit.pattern.op_input_gen import get_runtime_checker_op
 from winml.modelkit.pattern.op_input_gen.op_input_gen import (
     InputShapeConstraint,
@@ -24,6 +23,7 @@ from winml.modelkit.pattern.op_input_gen.op_input_gen import (
     model_from_b64,
 )
 
+from ...onnx import ONNXDomain
 from .check_ops import get_ep_checker
 from .runner import ResilientRunner
 

--- a/src/winml/modelkit/analyze/runtime_checker/check_ops.py
+++ b/src/winml/modelkit/analyze/runtime_checker/check_ops.py
@@ -26,7 +26,6 @@ import onnxruntime as ort
 from google.protobuf import json_format
 from onnx.defs import SchemaError
 
-from winml.modelkit.onnx.domains import ONNXDomain
 from winml.modelkit.pattern.op_input_gen import (
     OpInputGenerator,
     get_registered_operators,
@@ -35,6 +34,7 @@ from winml.modelkit.pattern.op_input_gen import (
 from winml.modelkit.pattern.op_input_gen.qdq_gen import QDQGenerator
 
 from ... import winml
+from ...onnx import ONNXDomain
 from ...sysinfo import SysInfo
 from ...utils import constants
 from ..utils.model_utils import get_op_since_version

--- a/src/winml/modelkit/analyze/runtime_checker/result_processor.py
+++ b/src/winml/modelkit/analyze/runtime_checker/result_processor.py
@@ -12,10 +12,10 @@ import pandas as pd
 from colorama import Fore, Style
 from onnx.defs import SchemaError, onnx_opset_version
 
-from winml.modelkit.onnx.domains import ONNXDomain
 from winml.modelkit.pattern.base import get_pattern_input_generator
 from winml.modelkit.pattern.op_input_gen import OpInputGenerator, get_runtime_checker_op
 
+from ...onnx import ONNXDomain
 from ..utils.model_utils import get_op_since_version, make_hashable
 
 

--- a/src/winml/modelkit/onnx/__init__.py
+++ b/src/winml/modelkit/onnx/__init__.py
@@ -14,25 +14,35 @@ are available via ``modelkit.onnx.inspection`` for diagnostic use.
 from __future__ import annotations
 
 from .detection import is_compiled_onnx, is_quantized_onnx
+from .domains import ONNXDomain
+from .dtypes import SupportedONNXType, remove_optional_from_type_annotation
 from .external_data import copy_onnx_model
 from .io import InputTensorSpec, OutputTensorSpec, generate_inputs_from_onnx, get_io_config
 from .metadata import capture_metadata, restore_metadata
 from .persistence import cleanup_onnx, load_onnx, save_onnx
-from .shape import infer_shapes
+from .shape import infer_onnx_shapes, infer_shapes
+from .utils import EXTERNAL_DATA_THRESHOLD, check_onnx_model, get_model_size
 
 
 __all__ = [
+    "EXTERNAL_DATA_THRESHOLD",
     "InputTensorSpec",
+    "ONNXDomain",
     "OutputTensorSpec",
+    "SupportedONNXType",
     "capture_metadata",
+    "check_onnx_model",
     "cleanup_onnx",
     "copy_onnx_model",
     "generate_inputs_from_onnx",
     "get_io_config",
+    "get_model_size",
+    "infer_onnx_shapes",
     "infer_shapes",
     "is_compiled_onnx",
     "is_quantized_onnx",
     "load_onnx",
+    "remove_optional_from_type_annotation",
     "restore_metadata",
     "save_onnx",
 ]

--- a/src/winml/modelkit/onnx/persistence.py
+++ b/src/winml/modelkit/onnx/persistence.py
@@ -18,7 +18,7 @@ from pathlib import Path
 import onnx
 from onnx.external_data_helper import _get_all_tensors, uses_external_data
 
-from winml.modelkit.onnx.utils import EXTERNAL_DATA_THRESHOLD, get_model_size
+from .utils import EXTERNAL_DATA_THRESHOLD, get_model_size
 
 
 logger = logging.getLogger(__name__)

--- a/src/winml/modelkit/onnx/shape.py
+++ b/src/winml/modelkit/onnx/shape.py
@@ -22,9 +22,8 @@ from pathlib import Path
 
 import onnx
 
-from winml.modelkit.onnx.utils import EXTERNAL_DATA_THRESHOLD, get_model_size
-
 from .metadata import capture_metadata, restore_metadata
+from .utils import EXTERNAL_DATA_THRESHOLD, get_model_size
 
 
 logger = logging.getLogger(__name__)

--- a/src/winml/modelkit/pattern/attention_patterns.py
+++ b/src/winml/modelkit/pattern/attention_patterns.py
@@ -44,7 +44,6 @@ from typing import Any
 import numpy as np
 from onnx.defs import OpSchema
 
-from winml.modelkit.onnx.domains import ONNXDomain
 from winml.modelkit.pattern.base import (
     Pattern,
     PatternInputGenerator,
@@ -55,6 +54,8 @@ from winml.modelkit.pattern.base import (
     register_pattern_input_generator,
 )
 from winml.modelkit.pattern.op_input_gen import InputShapeConstraint
+
+from ..onnx import ONNXDomain
 
 
 # Type constraints for Attention operator (from opset 24 spec)

--- a/src/winml/modelkit/pattern/base.py
+++ b/src/winml/modelkit/pattern/base.py
@@ -175,14 +175,12 @@ import onnx
 from onnx import ModelProto, numpy_helper
 from onnx.defs import OpSchema
 
-from winml.modelkit.onnx.domains import ONNXDomain
-from winml.modelkit.onnx.dtypes import SupportedONNXType
-from winml.modelkit.onnx.shape import infer_onnx_shapes
-from winml.modelkit.onnx.utils import check_onnx_model
 from winml.modelkit.pattern.match import InputInfo, PatternMatchResult, SkeletonMatchResult
 from winml.modelkit.pattern.op_input_gen import InputShapeConstraint
 from winml.modelkit.pattern.op_input_gen.op_input_gen import OpInputGenerator
 from winml.modelkit.pattern.utils import get_attribute_proto_value, make_hashable
+
+from ..onnx import ONNXDomain, SupportedONNXType, check_onnx_model, infer_onnx_shapes
 
 
 logger = logging.getLogger(__name__)

--- a/src/winml/modelkit/pattern/gelu_patterns.py
+++ b/src/winml/modelkit/pattern/gelu_patterns.py
@@ -6,7 +6,6 @@ from typing import Any
 
 import numpy as np
 
-from winml.modelkit.onnx.domains import ONNXDomain
 from winml.modelkit.pattern.base import (
     Pattern,
     PatternInputGenerator,
@@ -16,6 +15,8 @@ from winml.modelkit.pattern.base import (
     register_pattern_input_generator,
 )
 from winml.modelkit.pattern.op_input_gen import get_runtime_checker_op
+
+from ..onnx import ONNXDomain
 
 
 # TODO: Add and Mul are commutative, support matching either

--- a/src/winml/modelkit/pattern/gemm_patterns.py
+++ b/src/winml/modelkit/pattern/gemm_patterns.py
@@ -7,7 +7,6 @@ from typing import Any
 import numpy as np
 from onnx.defs import OpSchema
 
-from winml.modelkit.onnx.domains import ONNXDomain
 from winml.modelkit.pattern.base import (
     Pattern,
     PatternInputGenerator,
@@ -17,6 +16,8 @@ from winml.modelkit.pattern.base import (
 )
 from winml.modelkit.pattern.match import PatternMatchResult, SkeletonMatchResult
 from winml.modelkit.pattern.op_input_gen import InputShapeConstraint, InputValueConstraint
+
+from ..onnx import ONNXDomain
 
 
 # Shared schema for MatMulAdd and ReshapeGemmReshape patterns

--- a/src/winml/modelkit/pattern/layernorm_patterns.py
+++ b/src/winml/modelkit/pattern/layernorm_patterns.py
@@ -19,7 +19,6 @@ from typing import Any
 import numpy as np
 from onnx.defs import OpSchema
 
-from winml.modelkit.onnx.domains import ONNXDomain
 from winml.modelkit.pattern.base import (
     Pattern,
     PatternInputGenerator,
@@ -36,6 +35,8 @@ from winml.modelkit.pattern.utils import (
     get_tensor_shape,
     validate_scale_bias_shape_for_axis,
 )
+
+from ..onnx import ONNXDomain
 
 
 def _validate_layernorm_scale_bias(

--- a/src/winml/modelkit/pattern/op_input_gen/constant_of_shape_input_generator.py
+++ b/src/winml/modelkit/pattern/op_input_gen/constant_of_shape_input_generator.py
@@ -8,9 +8,7 @@ import numpy as np
 import onnx
 from onnx import TensorProto
 
-import winml.modelkit.onnx.dtypes as dtypes
-from winml.modelkit.onnx.dtypes import SupportedONNXType
-
+from ...onnx import SupportedONNXType
 from .op_input_gen import (
     InputConstraint,
     InputValueConstraint,
@@ -42,7 +40,7 @@ class ConstantOfShapeInputGenerator(OpInputGenerator):
             "value": [
                 onnx.helper.make_tensor(
                     name="value",
-                    data_type=dtypes.SupportedONNXType.from_onnx_type(x).tensor_proto_type,
+                    data_type=SupportedONNXType.from_onnx_type(x).tensor_proto_type,
                     dims=[1],
                     vals=[2],
                 )

--- a/src/winml/modelkit/pattern/op_input_gen/conv_input_generator.py
+++ b/src/winml/modelkit/pattern/op_input_gen/conv_input_generator.py
@@ -16,8 +16,7 @@ import itertools
 
 import numpy as np
 
-import winml.modelkit.onnx.dtypes as dtypes
-
+from ...onnx import SupportedONNXType
 from .op_input_gen import (
     InputConstraint,
     InputShapeConstraint,
@@ -132,7 +131,7 @@ class ConvInputGenerator(OpInputGenerator):
         return {
             "X": QDQParameterConfig(support_activation=True),
             "W": QDQParameterConfig(support_weight=True),
-            "B": QDQParameterConfig(qdq_types=[dtypes.SupportedONNXType.INT32]),
+            "B": QDQParameterConfig(qdq_types=[SupportedONNXType.INT32]),
         }
 
 

--- a/src/winml/modelkit/pattern/op_input_gen/matmul_input_generator.py
+++ b/src/winml/modelkit/pattern/op_input_gen/matmul_input_generator.py
@@ -13,8 +13,7 @@ Matrix multiplication operators perform matrix product operations on tensors,
 following Numpy's matmul semantics with broadcasting support for higher dimensions.
 """
 
-import winml.modelkit.onnx.dtypes as dtypes
-
+from ...onnx import SupportedONNXType
 from .op_input_gen import (
     InputConstraint,
     InputShapeConstraint,
@@ -305,5 +304,5 @@ class GemmInputGenerator(OpInputGenerator):
         return {
             "A": QDQParameterConfig(support_activation=True),
             "B": QDQParameterConfig(support_weight=True),
-            "C": QDQParameterConfig(qdq_types=[dtypes.SupportedONNXType.INT32]),
+            "C": QDQParameterConfig(qdq_types=[SupportedONNXType.INT32]),
         }

--- a/src/winml/modelkit/pattern/op_input_gen/normalization_input_generator.py
+++ b/src/winml/modelkit/pattern/op_input_gen/normalization_input_generator.py
@@ -15,8 +15,7 @@ subclasses for each normalization operator's specific requirements.
 
 import numpy as np
 
-import winml.modelkit.onnx.dtypes as dtypes
-
+from ...onnx import SupportedONNXType
 from .op_input_gen import (
     InputConstraint,
     InputShapeConstraint,
@@ -335,7 +334,7 @@ class InstanceNormalizationInputGenerator(NormalizationInputGenerator):
         return {
             self.op_input_names[0]: QDQParameterConfig(support_activation=True),
             self.op_input_names[1]: QDQParameterConfig(support_weight=True),
-            self.op_input_names[2]: QDQParameterConfig(qdq_types=[dtypes.SupportedONNXType.INT32]),
+            self.op_input_names[2]: QDQParameterConfig(qdq_types=[SupportedONNXType.INT32]),
         }
 
 
@@ -415,7 +414,7 @@ class LayerNormalizationInputGenerator(NormalizationInputGenerator):
         return {
             "X": QDQParameterConfig(support_activation=True),
             "Scale": QDQParameterConfig(support_activation=True, support_weight=True),
-            "B": QDQParameterConfig(qdq_types=[dtypes.SupportedONNXType.INT32]),
+            "B": QDQParameterConfig(qdq_types=[SupportedONNXType.INT32]),
         }
 
 

--- a/src/winml/modelkit/pattern/op_input_gen/op_input_gen.py
+++ b/src/winml/modelkit/pattern/op_input_gen/op_input_gen.py
@@ -19,10 +19,9 @@ import onnx
 from colorama import Fore, Style
 from onnx.defs import OpSchema
 
-import winml.modelkit.onnx.dtypes as dtypes
-from winml.modelkit.onnx.domains import ONNXDomain
 from winml.modelkit.pattern.utils import get_op_input_properties
 
+from ...onnx import ONNXDomain, SupportedONNXType
 from .qdq_gen import QDQGenerator
 
 
@@ -150,7 +149,7 @@ class InputValueConstraint(InputConstraint):
         # based on type_annotation; maybe use covariant typing for InputValueConstraint
         # to handle this cleanly
         if isinstance(self.value, np.ndarray):
-            np_dtype = dtypes.SupportedONNXType.from_annotation(type_annotation).np_type
+            np_dtype = SupportedONNXType.from_annotation(type_annotation).np_type
             return self.value.astype(np_dtype)
         return self.value
 
@@ -195,7 +194,7 @@ class InputShapeConstraint(InputConstraint):
     def get_value(self, type_annotation: str) -> Any:
         """Generate a tensor with the specified shape and type."""
         # random values may cause runtime errors when running an op
-        np_dtype = dtypes.SupportedONNXType.from_annotation(type_annotation).np_type
+        np_dtype = SupportedONNXType.from_annotation(type_annotation).np_type
         seed_material = json.dumps(
             {
                 "shape": list(self.shape),
@@ -260,7 +259,7 @@ class QDQParameterConfig:
         support_weight: bool = False,
         support_activation: bool = False,
         support_non_qdq: bool = False,
-        qdq_types: list[dtypes.SupportedONNXType] | None = None,
+        qdq_types: list[SupportedONNXType] | None = None,
     ):
         """Initialize QDQParameterConfig.
 
@@ -348,9 +347,9 @@ class OpInputGenerator(ABC):
             )
 
         self.onnx_types_to_check = (
-            {dtypes.SupportedONNXType.from_annotation(t).onnx_type for t in onnx_types_to_check}
+            {SupportedONNXType.from_annotation(t).onnx_type for t in onnx_types_to_check}
             if onnx_types_to_check is not None
-            else {x.onnx_type for x in dtypes.SupportedONNXType}
+            else {x.onnx_type for x in SupportedONNXType}
         )
 
         output_only_type_vars = {x.type_str for x in self.schema.outputs} - {
@@ -361,7 +360,7 @@ class OpInputGenerator(ABC):
             # legacy compatibility: adding _op_name suffix
             f"{constraint.type_param_str}_{self.op_name}": list(
                 map(
-                    dtypes.SupportedONNXType.from_onnx_type,
+                    SupportedONNXType.from_onnx_type,
                     filter(lambda x: x in self.onnx_types_to_check, constraint.allowed_type_strs),
                 )
             )
@@ -370,7 +369,7 @@ class OpInputGenerator(ABC):
         }
 
         self.type_vars_with_unique_dtypes = {
-            f"{constraint.type_param_str}_{self.op_name}": dtypes.SupportedONNXType.from_onnx_type(
+            f"{constraint.type_param_str}_{self.op_name}": SupportedONNXType.from_onnx_type(
                 constraint.allowed_type_strs[0]
             )
             for constraint in self.schema.type_constraints
@@ -647,11 +646,11 @@ class OpInputGenerator(ABC):
 
         # For each input in the config, collect the possible should_qdq values.
         input_names: list[str] = []
-        input_option_lists: list[list[bool | dtypes.SupportedONNXType]] = []
+        input_option_lists: list[list[bool | SupportedONNXType]] = []
         for input_name, config in expanded_config.items():
             if input_name not in schema_input_names:
                 continue  # output name present in qdq_config; handled below
-            options: list[bool | dtypes.SupportedONNXType] = []
+            options: list[bool | SupportedONNXType] = []
             if config.support_activation or config.support_weight:
                 options.append(True)
             if config.qdq_types is not None:
@@ -690,7 +689,7 @@ class OpInputGenerator(ABC):
         kwargs: dict[str, Any],
         is_constant_map: dict[str, bool],
         output_dtypes: list[str],
-        qdq_types: dict[str, dtypes.SupportedONNXType | None] | None = None,
+        qdq_types: dict[str, SupportedONNXType | None] | None = None,
         dynamic_axes: dict[str, tuple[int, ...]] | None = None,
     ) -> onnx.ModelProto:
         """Create ONNX model with specified constant/non-constant configuration.
@@ -800,7 +799,7 @@ class OpInputGenerator(ABC):
                 else:
                     tensor = onnx.helper.make_tensor(
                         name=input_name,
-                        data_type=dtypes.SupportedONNXType.from_np_type(
+                        data_type=SupportedONNXType.from_np_type(
                             input_value.dtype
                         ).tensor_proto_type,
                         dims=input_shape,
@@ -862,7 +861,7 @@ class OpInputGenerator(ABC):
                 else:
                     input_info = onnx.helper.make_tensor_value_info(
                         input_name,
-                        dtypes.SupportedONNXType.from_np_type(input_value.dtype).tensor_proto_type,
+                        SupportedONNXType.from_np_type(input_value.dtype).tensor_proto_type,
                         input_shape,
                     )
                     graph_inputs.append(input_info)
@@ -878,7 +877,7 @@ class OpInputGenerator(ABC):
         op_output_names = []  # Actual outputs from the operator node
 
         for idx, dtype in enumerate(output_dtypes):
-            output_dtype = dtypes.SupportedONNXType.from_annotation(dtype).tensor_proto_type
+            output_dtype = SupportedONNXType.from_annotation(dtype).tensor_proto_type
             # Get schema output name for this index
             schema_output_name = (
                 self.schema.outputs[idx].name if idx < len(self.schema.outputs) else None
@@ -1151,7 +1150,7 @@ class OpInputGenerator(ABC):
             config = qdq_config[input_name]
             should_val = should_qdq_map.get(input_name)
 
-            if isinstance(should_val, dtypes.SupportedONNXType):
+            if isinstance(should_val, SupportedONNXType):
                 # Specific type from qdq_types — always quantize with this type, skip
                 # weight/activation mode checks since the type is fully determined.
                 pass
@@ -1194,13 +1193,13 @@ class OpInputGenerator(ABC):
             if (
                 not config.support_activation
                 and not config.support_weight
-                and not isinstance(should_val, dtypes.SupportedONNXType)
+                and not isinstance(should_val, SupportedONNXType)
             ):
                 continue  # This input is not quantized, skip type check
             type_template = self.type_annotations[ta_key]
             annotation = self._apply_type_var_combination(type_template, tags[self.type_vars_key])
             try:
-                onnx_type = dtypes.SupportedONNXType.from_annotation(annotation).onnx_type
+                onnx_type = SupportedONNXType.from_annotation(annotation).onnx_type
             except ValueError:
                 return
             if onnx_type not in self.qdq_generator.SUPPORT_DQ_OUTPUT_TYPES:
@@ -1223,7 +1222,7 @@ class OpInputGenerator(ABC):
                     # (support_non_qdq only), skip validation
                     continue
             try:
-                onnx_type = dtypes.SupportedONNXType.from_annotation(output_annotation).onnx_type
+                onnx_type = SupportedONNXType.from_annotation(output_annotation).onnx_type
             except ValueError:
                 return
             if onnx_type not in self.qdq_generator.SUPPORTED_Q_INPUT_TYPES:
@@ -1241,7 +1240,7 @@ class OpInputGenerator(ABC):
         for weight_onnx_type in weight_types_to_iterate:
             for activation_onnx_type in self.qdq_generator.activation_onnx_types:
                 # Build qdq_types mapping for each input
-                qdq_types: dict[str, dtypes.SupportedONNXType | None] = {}
+                qdq_types: dict[str, SupportedONNXType | None] = {}
                 new_constant_map: dict[str, bool] = {}
 
                 for input_name, is_constant in is_constant_map.items():
@@ -1261,7 +1260,7 @@ class OpInputGenerator(ABC):
                     if (
                         not config.support_activation
                         and not config.support_weight
-                        and not isinstance(should_val, dtypes.SupportedONNXType)
+                        and not isinstance(should_val, SupportedONNXType)
                     ):
                         qdq_types[input_name] = None  # Pass-through input (support_non_qdq only)
                         new_constant_map[input_name] = (
@@ -1269,14 +1268,12 @@ class OpInputGenerator(ABC):
                         )
                         continue
 
-                    if isinstance(should_val, dtypes.SupportedONNXType):
+                    if isinstance(should_val, SupportedONNXType):
                         qdq_types[input_name] = should_val
                     elif is_constant:
-                        qdq_types[input_name] = dtypes.SupportedONNXType.from_onnx_type(
-                            weight_onnx_type
-                        )
+                        qdq_types[input_name] = SupportedONNXType.from_onnx_type(weight_onnx_type)
                     else:
-                        qdq_types[input_name] = dtypes.SupportedONNXType.from_onnx_type(
+                        qdq_types[input_name] = SupportedONNXType.from_onnx_type(
                             activation_onnx_type
                         )
 
@@ -1286,7 +1283,7 @@ class OpInputGenerator(ABC):
                 # Store output quantization type only for outputs that will be created
                 # Outputs use activation type
                 output_type = (
-                    dtypes.SupportedONNXType.from_onnx_type(activation_onnx_type)
+                    SupportedONNXType.from_onnx_type(activation_onnx_type)
                     if activation_onnx_type is not None
                     else None
                 )
@@ -1777,7 +1774,7 @@ class OpInputGenerator(ABC):
                 # Get the quantization type for this input
                 quant_type_annotation = qdq_types[qdq_key]
                 if isinstance(quant_type_annotation, str):
-                    quant_type = dtypes.SupportedONNXType.from_annotation(quant_type_annotation)
+                    quant_type = SupportedONNXType.from_annotation(quant_type_annotation)
                 else:
                     # Already a SupportedONNXType
                     quant_type = quant_type_annotation
@@ -1865,7 +1862,7 @@ class OpInputGenerator(ABC):
             elif type_var_key_with_op_name in self.type_vars_with_unique_dtypes:
                 annotation = self.type_vars_with_unique_dtypes[type_var_key_with_op_name].annotation
             else:
-                annotation = dtypes.SupportedONNXType.from_onnx_type(type_var_key).annotation
+                annotation = SupportedONNXType.from_onnx_type(type_var_key).annotation
             # TODO: decide what to do with optional outputs
             # in a general way - currently we add them to outputs
             # NOTE: variadic output not handled in this general

--- a/src/winml/modelkit/pattern/op_input_gen/qdq_gen.py
+++ b/src/winml/modelkit/pattern/op_input_gen/qdq_gen.py
@@ -8,11 +8,11 @@ from typing import TYPE_CHECKING, ClassVar
 
 from onnx.defs import SchemaError
 
-import winml.modelkit.onnx.dtypes as dtypes
+from ...onnx import SupportedONNXType
 
 
 if TYPE_CHECKING:
-    from winml.modelkit.onnx.domains import ONNXDomain
+    from ...onnx import ONNXDomain
 
 
 class QDQGenerator:
@@ -25,26 +25,26 @@ class QDQGenerator:
 
     # Supported quantized types for weights (DQ input)
     SUPPORTED_WEIGHT_TYPES: ClassVar[set[str]] = {
-        dtypes.SupportedONNXType.INT8.onnx_type,
-        dtypes.SupportedONNXType.UINT8.onnx_type,
-        dtypes.SupportedONNXType.INT16.onnx_type,
-        dtypes.SupportedONNXType.UINT16.onnx_type,
+        SupportedONNXType.INT8.onnx_type,
+        SupportedONNXType.UINT8.onnx_type,
+        SupportedONNXType.INT16.onnx_type,
+        SupportedONNXType.UINT16.onnx_type,
     }
 
     SUPPORT_DQ_OUTPUT_TYPES: ClassVar[set[str]] = {
-        dtypes.SupportedONNXType.FLOAT.onnx_type,
+        SupportedONNXType.FLOAT.onnx_type,
     }
 
     # Supported quantized types for activations (Q output)
     SUPPORTED_ACTIVATION_TYPES: ClassVar[set[str]] = {
-        dtypes.SupportedONNXType.INT8.onnx_type,
-        dtypes.SupportedONNXType.UINT8.onnx_type,
-        dtypes.SupportedONNXType.INT16.onnx_type,
-        dtypes.SupportedONNXType.UINT16.onnx_type,
+        SupportedONNXType.INT8.onnx_type,
+        SupportedONNXType.UINT8.onnx_type,
+        SupportedONNXType.INT16.onnx_type,
+        SupportedONNXType.UINT16.onnx_type,
     }
 
     SUPPORTED_Q_INPUT_TYPES: ClassVar[set[str]] = {
-        dtypes.SupportedONNXType.FLOAT.onnx_type,
+        SupportedONNXType.FLOAT.onnx_type,
     }
 
     def __init__(self, opset_version: int, domain: ONNXDomain) -> None:
@@ -73,13 +73,11 @@ class QDQGenerator:
             print(f"Failed QuantizeLinear: {e}")
             raise
 
-        supported_onnx_types = {x.onnx_type: x for x in dtypes.SupportedONNXType}
+        supported_onnx_types = {x.onnx_type: x for x in SupportedONNXType}
         self._build_dq_type_vars(supported_onnx_types)
         self._build_q_type_vars(supported_onnx_types)
 
-    def _build_dq_type_vars(
-        self, supported_onnx_types: dict[str, dtypes.SupportedONNXType]
-    ) -> None:
+    def _build_dq_type_vars(self, supported_onnx_types: dict[str, SupportedONNXType]) -> None:
         """Create the following mappings for DequantizeLinear.
 
         self.weight_onnx_types:
@@ -123,7 +121,7 @@ class QDQGenerator:
         print("DequantizeLinear output types:", self.dq_output_onnx_types)
         print("DequantizeLinear all weight types:", self.weight_all_onnx_types)
 
-    def _build_q_type_vars(self, supported_onnx_types: dict[str, dtypes.SupportedONNXType]) -> None:
+    def _build_q_type_vars(self, supported_onnx_types: dict[str, SupportedONNXType]) -> None:
         """Create the following mappings for QuantizeLinear.
 
         self.activation_onnx_types:

--- a/src/winml/modelkit/pattern/op_input_gen/unary_like_input_generator.py
+++ b/src/winml/modelkit/pattern/op_input_gen/unary_like_input_generator.py
@@ -14,8 +14,7 @@ from typing import Any
 
 import numpy as np
 
-from winml.modelkit.onnx.dtypes import SupportedONNXType
-
+from ...onnx import SupportedONNXType
 from .op_input_gen import (
     InputConstraint,
     InputShapeConstraint,

--- a/src/winml/modelkit/pattern/rmsnorm_patterns.py
+++ b/src/winml/modelkit/pattern/rmsnorm_patterns.py
@@ -23,7 +23,6 @@ from typing import Any
 import numpy as np
 from onnx.defs import OpSchema
 
-from winml.modelkit.onnx.domains import ONNXDomain
 from winml.modelkit.pattern.base import (
     Pattern,
     PatternInputGenerator,
@@ -40,6 +39,8 @@ from winml.modelkit.pattern.utils import (
     get_tensor_shape,
     validate_scale_bias_shape_for_axis,
 )
+
+from ..onnx import ONNXDomain
 
 
 def _validate_rmsnorm_scale(

--- a/src/winml/modelkit/pattern/transpose_patterns.py
+++ b/src/winml/modelkit/pattern/transpose_patterns.py
@@ -14,7 +14,6 @@ from typing import Any
 import numpy as np
 from onnx.defs import OpSchema
 
-from winml.modelkit.onnx.domains import ONNXDomain
 from winml.modelkit.pattern.base import (
     Pattern,
     PatternInputGenerator,
@@ -26,6 +25,8 @@ from winml.modelkit.pattern.base import (
     register_pattern_input_generator,
 )
 from winml.modelkit.pattern.op_input_gen import InputShapeConstraint
+
+from ..onnx import ONNXDomain
 
 
 # Schema for ReshapeTransposeReshape pattern

--- a/src/winml/modelkit/pattern/utils.py
+++ b/src/winml/modelkit/pattern/utils.py
@@ -19,8 +19,7 @@ from google.protobuf import json_format
 from onnx import AttributeProto, ModelProto, TensorProto, ValueInfoProto
 from onnx.defs import OpSchema
 
-from winml.modelkit.onnx.domains import ONNXDomain
-from winml.modelkit.onnx.dtypes import SupportedONNXType
+from ..onnx import ONNXDomain, SupportedONNXType
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/analyze/runtime_checker/test_helper.py
+++ b/tests/integration/analyze/runtime_checker/test_helper.py
@@ -12,7 +12,7 @@ import pytest
 from winml.modelkit.analyze.runtime_checker.ep_checker import (
     EPChecker,
 )
-from winml.modelkit.onnx.domains import ONNXDomain
+from winml.modelkit.onnx import ONNXDomain
 from winml.modelkit.pattern.op_input_gen import (
     ExampleReshapeInputGenerator,
     get_runtime_checker_op,

--- a/tests/unit/analyze/core/test_node_checkers.py
+++ b/tests/unit/analyze/core/test_node_checkers.py
@@ -22,7 +22,7 @@ from winml.modelkit.analyze.models.runtime_checks import (
     PatternAlternative,
     RuntimeTestResult,
 )
-from winml.modelkit.onnx.domains import ONNXDomain
+from winml.modelkit.onnx import ONNXDomain
 from winml.modelkit.pattern.match import PatternMatchResult, SkeletonMatchResult
 from winml.modelkit.pattern.models import OperatorPattern, PatternType
 

--- a/tests/unit/analyze/core/test_qdq.py
+++ b/tests/unit/analyze/core/test_qdq.py
@@ -21,8 +21,7 @@ from winml.modelkit.analyze.core.runtime_checker_query import (
     RuntimeCheckerQuery,
     _get_qdq_query_conditions_for_node,
 )
-from winml.modelkit.onnx import dtypes
-from winml.modelkit.onnx.domains import ONNXDomain
+from winml.modelkit.onnx import ONNXDomain, dtypes
 from winml.modelkit.pattern.op_input_gen.op_input_gen import (
     QDQParameterConfig,
 )
@@ -131,7 +130,8 @@ class TestQDQParameterConfig:
             qdq_types=[dtypes.SupportedONNXType.INT8, dtypes.SupportedONNXType.INT32],
         )
         assert config_multi.qdq_types == [
-            dtypes.SupportedONNXType.INT8, dtypes.SupportedONNXType.INT32
+            dtypes.SupportedONNXType.INT8,
+            dtypes.SupportedONNXType.INT32,
         ]
 
 

--- a/tests/unit/analyze/pattern/conftest.py
+++ b/tests/unit/analyze/pattern/conftest.py
@@ -19,7 +19,7 @@ from typing import Any
 import onnx
 from onnx import helper
 
-from winml.modelkit.onnx.domains import ONNXDomain
+from winml.modelkit.onnx import ONNXDomain
 from winml.modelkit.pattern.base import (
     InvalidPatternMatcherModelError,
     PatternMatcher,

--- a/tests/unit/analyze/pattern/test_attention_patterns.py
+++ b/tests/unit/analyze/pattern/test_attention_patterns.py
@@ -12,7 +12,7 @@ import numpy as np
 import onnx
 import pytest
 
-from winml.modelkit.onnx.domains import ONNXDomain
+from winml.modelkit.onnx import ONNXDomain
 from winml.modelkit.pattern import (
     ExpandedAttentionPattern,
     PatternMatcher,
@@ -83,10 +83,7 @@ class TestAttentionPatternCrossMatching:
         results = matcher.match()
 
         assert len(results) == 1
-        assert (
-            type(results[0].skeleton_match_result.pattern).__name__
-            == "ExpandedAttentionPattern"
-        )
+        assert type(results[0].skeleton_match_result.pattern).__name__ == "ExpandedAttentionPattern"
 
 
 class TestBertTinyAttentionPatternRewriting:
@@ -105,9 +102,7 @@ class TestBertTinyAttentionPatternRewriting:
 
         # Keep only opset imports for domains actually used by nodes
         used_domains = {n.domain for n in model.graph.node}
-        opset_imports = [
-            opset for opset in model.opset_import if opset.domain in used_domains
-        ]
+        opset_imports = [opset for opset in model.opset_import if opset.domain in used_domains]
         del model.opset_import[:]
         model.opset_import.extend(opset_imports)
 
@@ -142,14 +137,10 @@ class TestBertTinyAttentionPatternRewriting:
         rewriter = PatternRewriter(bert_tiny_model)
         rewritten_model = rewriter.rewrite([(results, TransposeAttentionPattern)])
 
-        attention_count = sum(
-            1 for n in rewritten_model.graph.node if n.op_type == "Attention"
-        )
+        attention_count = sum(1 for n in rewritten_model.graph.node if n.op_type == "Attention")
         assert attention_count == 2
 
-    def test_bert_tiny_rewritten_model_has_transpose_attention(
-        self, bert_tiny_model
-    ) -> None:
+    def test_bert_tiny_rewritten_model_has_transpose_attention(self, bert_tiny_model) -> None:
         from winml.modelkit.pattern import PatternRewriter
 
         expanded_pattern = ExpandedAttentionPattern()
@@ -166,9 +157,7 @@ class TestBertTinyAttentionPatternRewriting:
 
         assert len(new_results) == 2
 
-    def test_bert_tiny_rewritten_model_no_expanded_patterns(
-        self, bert_tiny_model
-    ) -> None:
+    def test_bert_tiny_rewritten_model_no_expanded_patterns(self, bert_tiny_model) -> None:
         from winml.modelkit.pattern import PatternRewriter
 
         expanded_pattern = ExpandedAttentionPattern()

--- a/tests/unit/analyze/pattern/test_rewrite_pipe.py
+++ b/tests/unit/analyze/pattern/test_rewrite_pipe.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import onnx
 import pytest
 
-from winml.modelkit.onnx.domains import ONNXDomain
+from winml.modelkit.onnx import ONNXDomain
 from winml.modelkit.optim.pipes.rewrite import RewritePipe
 from winml.modelkit.optim.pipes.rewrite_rules import REWRITE_GROUPS
 from winml.modelkit.pattern.base import PatternMatcher

--- a/tests/unit/analyze/pattern/test_rmsnorm_patterns.py
+++ b/tests/unit/analyze/pattern/test_rmsnorm_patterns.py
@@ -21,7 +21,7 @@ import onnx
 import onnxruntime as ort
 import pytest
 
-from winml.modelkit.onnx.domains import ONNXDomain
+from winml.modelkit.onnx import ONNXDomain
 from winml.modelkit.pattern import (
     LayerNormalizationMulPattern,
     LayerNormalizationPowPattern,
@@ -51,9 +51,7 @@ def _make_rmsnorm_model(
         if axis == -1 or normalized_axis == rank - 1:
             scale_shape = (normalized_dim,)
         else:
-            scale_shape = tuple(
-                normalized_dim if i == normalized_axis else 1 for i in range(rank)
-            )
+            scale_shape = tuple(normalized_dim if i == normalized_axis else 1 for i in range(rank))
 
     inputs = {
         "X": np.random.randn(*x_shape).astype(dtype),
@@ -76,9 +74,7 @@ def _make_rmsnorm_model(
     )
 
 
-def _numpy_rmsnorm(
-    x: np.ndarray, scale: np.ndarray, axis: int, epsilon: float
-) -> np.ndarray:
+def _numpy_rmsnorm(x: np.ndarray, scale: np.ndarray, axis: int, epsilon: float) -> np.ndarray:
     """Compute RMSNorm using numpy for reference."""
     rms = np.sqrt(np.mean(x**2, axis=axis, keepdims=True) + epsilon)
     return x / rms * scale
@@ -101,15 +97,11 @@ class TestRMSNormPatternSpecifics:
 
     def test_rmsnorm_pow_has_correct_constants(self) -> None:
         """Pow pattern has exponent=2.0 and epsilon constant."""
-        model = _make_rmsnorm_model(
-            RMSNormalizationPowPattern(), (2, 4, 6), epsilon=1e-5
-        )
+        model = _make_rmsnorm_model(RMSNormalizationPowPattern(), (2, 4, 6), epsilon=1e-5)
 
         pow_node = model.graph.node[0]
         exponent_name = pow_node.input[1]
-        exponent_init = next(
-            i for i in model.graph.initializer if i.name == exponent_name
-        )
+        exponent_init = next(i for i in model.graph.initializer if i.name == exponent_name)
         np.testing.assert_allclose(onnx.numpy_helper.to_array(exponent_init), 2.0)
 
         add_node = model.graph.node[2]
@@ -214,9 +206,7 @@ class TestRMSNormNumericalEquivalence:
             "Mul-axis-1",
         ],
     )
-    def test_numerical_equivalence(
-        self, pattern_class, axis, x_shape, scale_shape
-    ) -> None:
+    def test_numerical_equivalence(self, pattern_class, axis, x_shape, scale_shape) -> None:
         pattern = pattern_class()
         x_data = np.random.randn(*x_shape).astype(np.float32)
         scale_data = np.ones(scale_shape, dtype=np.float32) * 1.5
@@ -337,8 +327,6 @@ class TestRMSNormOpsetCompatibility:
         onnx.checker.check_model(model)
 
         reducemean_node = model.graph.node[1]
-        axes_attr = next(
-            (a for a in reducemean_node.attribute if a.name == "axes"), None
-        )
+        axes_attr = next((a for a in reducemean_node.attribute if a.name == "axes"), None)
         assert axes_attr is not None
         assert list(axes_attr.ints) == [-1]

--- a/tests/unit/analyze/pattern/test_transposed_layernorm.py
+++ b/tests/unit/analyze/pattern/test_transposed_layernorm.py
@@ -18,7 +18,7 @@ import numpy as np
 import onnx
 import pytest
 
-from winml.modelkit.onnx.domains import ONNXDomain
+from winml.modelkit.onnx import ONNXDomain
 from winml.modelkit.pattern import (
     LayerNormalizationMulPattern,
     LayerNormalizationPowPattern,

--- a/tests/unit/analyze/pattern/test_transposed_rmsnorm.py
+++ b/tests/unit/analyze/pattern/test_transposed_rmsnorm.py
@@ -19,7 +19,7 @@ import onnx
 import onnxruntime as ort
 import pytest
 
-from winml.modelkit.onnx.domains import ONNXDomain
+from winml.modelkit.onnx import ONNXDomain
 from winml.modelkit.pattern import (
     PatternMatcher,
     PatternRewriter,
@@ -34,9 +34,7 @@ _pattern_instance = TransposedSingleRMSNormalizationPattern()
 _compute_transpose_permutation = _pattern_instance._compute_transpose_permutation
 
 
-def _numpy_rmsnorm(
-    x: np.ndarray, scale: np.ndarray, axis: int, epsilon: float
-) -> np.ndarray:
+def _numpy_rmsnorm(x: np.ndarray, scale: np.ndarray, axis: int, epsilon: float) -> np.ndarray:
     """Compute RMSNorm using numpy for reference."""
     rms = np.sqrt(np.mean(x**2, axis=axis, keepdims=True) + epsilon)
     return x / rms * scale
@@ -144,9 +142,7 @@ class TestTransposedRMSNormPattern:
 
         # Verify RMSNormalization has axis=-1
         rmsnorm_node = model.graph.node[2]
-        axis_attr = next(
-            (attr for attr in rmsnorm_node.attribute if attr.name == "axis"), None
-        )
+        axis_attr = next((attr for attr in rmsnorm_node.attribute if attr.name == "axis"), None)
         assert axis_attr is not None
         assert axis_attr.i == -1
 
@@ -239,12 +235,8 @@ class TestTransposedRMSNormPattern:
         # Verify Transpose nodes have identity permutation for axis=-1
         transpose1 = model.graph.node[0]
         transpose2 = model.graph.node[3]
-        perm1 = next(
-            (attr.ints for attr in transpose1.attribute if attr.name == "perm"), None
-        )
-        perm2 = next(
-            (attr.ints for attr in transpose2.attribute if attr.name == "perm"), None
-        )
+        perm1 = next((attr.ints for attr in transpose1.attribute if attr.name == "perm"), None)
+        perm2 = next((attr.ints for attr in transpose2.attribute if attr.name == "perm"), None)
         assert list(perm1) == [0, 1, 2]
         assert list(perm2) == [0, 1, 2]
 
@@ -283,9 +275,7 @@ class TestTransposedRMSNormPattern:
 
         # Verify Transpose permutation moves axis 0 to the end
         transpose1 = model.graph.node[0]
-        perm1 = list(
-            next(attr.ints for attr in transpose1.attribute if attr.name == "perm")
-        )
+        perm1 = list(next(attr.ints for attr in transpose1.attribute if attr.name == "perm"))
         assert perm1 == [1, 2, 0]
 
         # Self-match should recover axis=0
@@ -366,9 +356,7 @@ class TestRMSNormalizationPatternRewriting:
         assert len(pow_results) == 1
 
         rewriter = PatternRewriter(model)
-        new_model = rewriter.rewrite(
-            [(pow_results, TransposedSingleRMSNormalizationPattern)]
-        )
+        new_model = rewriter.rewrite([(pow_results, TransposedSingleRMSNormalizationPattern)])
 
         onnx.checker.check_model(new_model)
 
@@ -382,9 +370,7 @@ class TestRMSNormalizationPatternRewriting:
         assert len(new_matcher.match()) == 0
 
         # Verify RMSNormalization node exists
-        rmsnorm_nodes = [
-            n for n in new_model.graph.node if n.op_type == "RMSNormalization"
-        ]
+        rmsnorm_nodes = [n for n in new_model.graph.node if n.op_type == "RMSNormalization"]
         assert len(rmsnorm_nodes) == 1
 
     def test_rewrite_rmsnorm_mul_to_transposed(self):
@@ -418,9 +404,7 @@ class TestRMSNormalizationPatternRewriting:
         assert len(mul_results) == 1
 
         rewriter = PatternRewriter(model)
-        new_model = rewriter.rewrite(
-            [(mul_results, TransposedSingleRMSNormalizationPattern)]
-        )
+        new_model = rewriter.rewrite([(mul_results, TransposedSingleRMSNormalizationPattern)])
 
         onnx.checker.check_model(new_model)
 
@@ -431,9 +415,7 @@ class TestRMSNormalizationPatternRewriting:
         new_matcher.register_pattern(mul_pattern)
         assert len(new_matcher.match()) == 0
 
-        rmsnorm_nodes = [
-            n for n in new_model.graph.node if n.op_type == "RMSNormalization"
-        ]
+        rmsnorm_nodes = [n for n in new_model.graph.node if n.op_type == "RMSNormalization"]
         assert len(rmsnorm_nodes) == 1
 
     def test_rewrite_preserves_rmsnorm_semantics(self):
@@ -465,9 +447,7 @@ class TestRMSNormalizationPatternRewriting:
         pow_results = matcher.match()
 
         rewriter = PatternRewriter(model)
-        new_model = rewriter.rewrite(
-            [(pow_results, TransposedSingleRMSNormalizationPattern)]
-        )
+        new_model = rewriter.rewrite([(pow_results, TransposedSingleRMSNormalizationPattern)])
 
         # Run rewritten model
         new_sess = ort.InferenceSession(new_model.SerializeToString())
@@ -515,15 +495,11 @@ class TestRMSNormalizationPatternRewriting:
         assert pow_results[0].attributes["axis"] == 1
 
         rewriter = PatternRewriter(model)
-        new_model = rewriter.rewrite(
-            [(pow_results, TransposedSingleRMSNormalizationPattern)]
-        )
+        new_model = rewriter.rewrite([(pow_results, TransposedSingleRMSNormalizationPattern)])
 
         onnx.checker.check_model(new_model)
 
-        rmsnorm_nodes = [
-            n for n in new_model.graph.node if n.op_type == "RMSNormalization"
-        ]
+        rmsnorm_nodes = [n for n in new_model.graph.node if n.op_type == "RMSNormalization"]
         assert len(rmsnorm_nodes) == 1
 
         new_sess = ort.InferenceSession(new_model.SerializeToString())
@@ -570,15 +546,11 @@ class TestRMSNormalizationPatternRewriting:
         assert mul_results[0].attributes["axis"] == 0
 
         rewriter = PatternRewriter(model)
-        new_model = rewriter.rewrite(
-            [(mul_results, TransposedSingleRMSNormalizationPattern)]
-        )
+        new_model = rewriter.rewrite([(mul_results, TransposedSingleRMSNormalizationPattern)])
 
         onnx.checker.check_model(new_model)
 
-        rmsnorm_nodes = [
-            n for n in new_model.graph.node if n.op_type == "RMSNormalization"
-        ]
+        rmsnorm_nodes = [n for n in new_model.graph.node if n.op_type == "RMSNormalization"]
         assert len(rmsnorm_nodes) == 1
 
         new_sess = ort.InferenceSession(new_model.SerializeToString())

--- a/tests/unit/analyze/test_input_generators.py
+++ b/tests/unit/analyze/test_input_generators.py
@@ -15,7 +15,7 @@ Tests verify:
 import pytest
 from onnx.defs import SchemaError
 
-from winml.modelkit.onnx.domains import ONNXDomain
+from winml.modelkit.onnx import ONNXDomain
 from winml.modelkit.pattern.op_input_gen.op_input_gen import (
     get_registered_operators,
     get_runtime_checker_op,

--- a/tests/unit/onnx/test_persistence.py
+++ b/tests/unit/onnx/test_persistence.py
@@ -19,12 +19,12 @@ import pytest
 from onnx import TensorProto, helper, numpy_helper
 from onnx.external_data_helper import _get_all_tensors, uses_external_data
 
+from winml.modelkit.onnx import EXTERNAL_DATA_THRESHOLD
 from winml.modelkit.onnx.persistence import (
     cleanup_onnx,
     load_onnx,
     save_onnx,
 )
-from winml.modelkit.onnx.utils import EXTERNAL_DATA_THRESHOLD
 
 
 if TYPE_CHECKING:

--- a/tests/unit/optim/pipes/test_pipe_rewrite.py
+++ b/tests/unit/optim/pipes/test_pipe_rewrite.py
@@ -26,7 +26,7 @@ import onnx
 import onnx.helper as oh
 import pytest
 
-from winml.modelkit.onnx.domains import ONNXDomain
+from winml.modelkit.onnx import ONNXDomain
 from winml.modelkit.optim.pipes.rewrite import RewritePipe, RewritePipeConfig, _detect_conflicts
 from winml.modelkit.optim.pipes.rewrite_rules import (
     REWRITE_CAPABILITIES,

--- a/tests/unit/optim/test_error_paths.py
+++ b/tests/unit/optim/test_error_paths.py
@@ -320,7 +320,7 @@ class TestShapeInferenceFallback:
 
     def test_symbolic_failure_falls_back_to_onnx(self, simple_model: onnx.ModelProto) -> None:
         """Test that symbolic failure falls back to ONNX shape inference."""
-        from winml.modelkit.onnx.shape import infer_shapes
+        from winml.modelkit.onnx import infer_shapes
 
         with (
             patch(
@@ -337,7 +337,7 @@ class TestShapeInferenceFallback:
 
     def test_both_inference_failures_returns_original(self, simple_model: onnx.ModelProto) -> None:
         """Test that both failures return original model."""
-        from winml.modelkit.onnx.shape import infer_shapes
+        from winml.modelkit.onnx import infer_shapes
 
         with (
             patch(
@@ -354,7 +354,7 @@ class TestShapeInferenceFallback:
 
     def test_symbolic_success_skips_onnx(self, simple_model: onnx.ModelProto) -> None:
         """Test that symbolic success skips ONNX inference."""
-        from winml.modelkit.onnx.shape import infer_shapes
+        from winml.modelkit.onnx import infer_shapes
 
         mock_onnx = MagicMock()
 


### PR DESCRIPTION
## Summary

- Expand `onnx/__init__.py` to export 7 new symbols (`ONNXDomain`, `SupportedONNXType`, `remove_optional_from_type_annotation`, `infer_onnx_shapes`, `check_onnx_model`, `EXTERNAL_DATA_THRESHOLD`, `get_model_size`)
- Convert 26 source files from absolute `from winml.modelkit.onnx.<submodule>` to relative `from ..onnx` / `from ...onnx` imports through `__init__.py`
- Convert 13 test files from internal submodule to package-level absolute imports
- Replace 44 `dtypes.SupportedONNXType` usages with direct `SupportedONNXType` imports
- Fix 2 intra-package imports (`persistence.py`, `shape.py`) to use sibling-relative `from .utils`

Closes #29