### PR TITLE
Import cleanup Phase 1: datasets + quant packages

### DIFF
--- a/src/winml/modelkit/datasets/__init__.py
+++ b/src/winml/modelkit/datasets/__init__.py
@@ -16,10 +16,11 @@ from typing import TYPE_CHECKING, Any
 from onnxruntime.quantization import CalibrationDataReader
 
 from .base import BaseTaskDataset
+from .config import DatasetConfig
 from .data_utils import format_data
 from .image import ImageDataset
 from .image_segmentation import ImageSegmentationDataset
-from .object_detection import ObjectDetectionDataset
+from .object_detection import DEFAULT_OBJECT_DETECTION_SIZE, ObjectDetectionDataset
 from .processor_utils import get_image_processor_config
 from .random_dataset import RandomDataset
 from .text import TextDataset
@@ -264,6 +265,9 @@ __all__ = [  # noqa: RUF022
     "universal_calib_dataset",
     # Calibration reader
     "DatasetCalibrationReader",
+    # Config
+    "DatasetConfig",
+    "DEFAULT_OBJECT_DETECTION_SIZE",
     # Dataset classes
     "BaseTaskDataset",
     "ImageDataset",

--- a/tests/unit/config/test_build.py
+++ b/tests/unit/config/test_build.py
@@ -37,7 +37,7 @@ from winml.modelkit.export import ONNXConfigNotFoundError, resolve_io_specs
 from winml.modelkit.export.config import InputTensorSpec, OutputTensorSpec, WinMLExportConfig
 from winml.modelkit.loader.config import WinMLLoaderConfig
 from winml.modelkit.optim.config import WinMLOptimizationConfig
-from winml.modelkit.quant.config import WinMLQuantizationConfig
+from winml.modelkit.quant import WinMLQuantizationConfig
 from winml.modelkit.utils.config_utils import merge_config
 
 

--- a/tests/unit/config/test_build_onnx.py
+++ b/tests/unit/config/test_build_onnx.py
@@ -34,7 +34,7 @@ from winml.modelkit.config.build import (
 from winml.modelkit.export.config import InputTensorSpec, OutputTensorSpec, WinMLExportConfig
 from winml.modelkit.loader.config import WinMLLoaderConfig
 from winml.modelkit.optim.config import WinMLOptimizationConfig
-from winml.modelkit.quant.config import WinMLQuantizationConfig
+from winml.modelkit.quant import WinMLQuantizationConfig
 from winml.modelkit.utils.config_utils import merge_config
 
 

--- a/tests/unit/datasets/test_object_detection.py
+++ b/tests/unit/datasets/test_object_detection.py
@@ -21,7 +21,7 @@ class TestGetImageProcessorConfig:
     @pytest.mark.skipif(not _hf_hub_available, reason="HF Hub disabled in offline mode")
     def test_loads_config_from_huggingface(self) -> None:
         """Should load preprocessor config from HuggingFace model."""
-        from winml.modelkit.datasets.processor_utils import get_image_processor_config
+        from winml.modelkit.datasets import get_image_processor_config
 
         # Use a real model to test loading
         config = get_image_processor_config("facebook/detr-resnet-50")
@@ -33,7 +33,7 @@ class TestGetImageProcessorConfig:
     @pytest.mark.skipif(not _hf_hub_available, reason="HF Hub disabled in offline mode")
     def test_merges_kwargs_with_loaded_config(self) -> None:
         """kwargs should override loaded config values."""
-        from winml.modelkit.datasets.processor_utils import get_image_processor_config
+        from winml.modelkit.datasets import get_image_processor_config
 
         config = get_image_processor_config(
             "facebook/detr-resnet-50",
@@ -47,7 +47,7 @@ class TestGetImageProcessorConfig:
     @pytest.mark.skipif(not _hf_hub_available, reason="HF Hub disabled in offline mode")
     def test_kwargs_take_precedence(self) -> None:
         """kwargs should take precedence over loaded config."""
-        from winml.modelkit.datasets.processor_utils import get_image_processor_config
+        from winml.modelkit.datasets import get_image_processor_config
 
         # Override a value that exists in the original config
         config = get_image_processor_config(
@@ -59,7 +59,7 @@ class TestGetImageProcessorConfig:
 
     def test_handles_invalid_model_gracefully(self) -> None:
         """Should return empty dict with kwargs on invalid model."""
-        from winml.modelkit.datasets.processor_utils import get_image_processor_config
+        from winml.modelkit.datasets import get_image_processor_config
 
         config = get_image_processor_config(
             "nonexistent/model-that-does-not-exist-xyz",
@@ -76,7 +76,7 @@ class TestObjectDetectionDatasetDeriveOverrides:
     @pytest.fixture
     def dataset_class(self) -> type:
         """Get ObjectDetectionDataset class without instantiation."""
-        from winml.modelkit.datasets.object_detection import ObjectDetectionDataset
+        from winml.modelkit.datasets import ObjectDetectionDataset
 
         return ObjectDetectionDataset
 
@@ -210,7 +210,7 @@ class TestObjectDetectionDatasetIntegration:
 
     def test_default_size_is_640(self) -> None:
         """Default image size should be 640 for object detection."""
-        from winml.modelkit.datasets.object_detection import DEFAULT_OBJECT_DETECTION_SIZE
+        from winml.modelkit.datasets import DEFAULT_OBJECT_DETECTION_SIZE
 
         assert DEFAULT_OBJECT_DETECTION_SIZE == 640
 
@@ -222,7 +222,7 @@ class TestObjectDetectionDatasetIntegration:
 
     def test_io_config_passed_through_kwargs(self) -> None:
         """io_config should be accessible via self._config."""
-        from winml.modelkit.datasets.object_detection import ObjectDetectionDataset
+        from winml.modelkit.datasets import ObjectDetectionDataset
 
         # Create instance without calling _initialize
         instance = object.__new__(ObjectDetectionDataset)

--- a/tests/unit/datasets/test_random_dataset.py
+++ b/tests/unit/datasets/test_random_dataset.py
@@ -308,7 +308,7 @@ class TestRandomDatasetValueRanges:
 
     def test_value_ranges_from_metadata(self, tmp_path: Path) -> None:
         """RandomDataset auto-reads winml.io.inputs and uses value ranges."""
-        from winml.modelkit.datasets.random_dataset import RandomDataset
+        from winml.modelkit.datasets import RandomDataset
 
         model_path = _create_onnx_with_metadata(
             tmp_path,
@@ -325,7 +325,7 @@ class TestRandomDatasetValueRanges:
 
     def test_fallback_without_metadata(self, tmp_path: Path) -> None:
         """RandomDataset falls back to dtype-based ranges without metadata."""
-        from winml.modelkit.datasets.random_dataset import RandomDataset
+        from winml.modelkit.datasets import RandomDataset
 
         model_path = _create_onnx_with_metadata(
             tmp_path,
@@ -340,7 +340,7 @@ class TestRandomDatasetValueRanges:
 
     def test_partial_metadata(self, tmp_path: Path) -> None:
         """Inputs without value_range in metadata fall back."""
-        from winml.modelkit.datasets.random_dataset import RandomDataset
+        from winml.modelkit.datasets import RandomDataset
 
         model_path = _create_onnx_with_metadata(
             tmp_path,

--- a/tests/unit/eval/test_align_labels.py
+++ b/tests/unit/eval/test_align_labels.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 import pytest
 from datasets import ClassLabel, Dataset, Features, Sequence, Value
 
-from winml.modelkit.datasets.config import DatasetConfig
+from winml.modelkit.datasets import DatasetConfig
 from winml.modelkit.eval.base_evaluator import WinMLEvaluator
 
 

--- a/tests/unit/eval/test_eval.py
+++ b/tests/unit/eval/test_eval.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
-from winml.modelkit.datasets.config import DatasetConfig
+from winml.modelkit.datasets import DatasetConfig
 from winml.modelkit.eval.config import WinMLEvaluationConfig
 from winml.modelkit.eval.evaluate import EvalResult
 

--- a/tests/unit/eval/test_object_detection_evaluator.py
+++ b/tests/unit/eval/test_object_detection_evaluator.py
@@ -8,7 +8,7 @@
 import pytest
 from datasets import ClassLabel, Dataset, Features, Sequence, Value
 
-from winml.modelkit.datasets.config import DatasetConfig
+from winml.modelkit.datasets import DatasetConfig
 from winml.modelkit.eval.object_detection_evaluator import WinMLObjectDetectionEvaluator
 
 

--- a/tests/unit/eval/test_text_classification.py
+++ b/tests/unit/eval/test_text_classification.py
@@ -32,20 +32,20 @@ class TestTextDatasetBasic:
 
     def test_class_exists(self):
         """Test that the class exists and is importable."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         assert TextDataset is not None
 
     def test_default_seq_len_constant(self):
         """Test DEFAULT_SEQ_LEN class constant exists."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         assert hasattr(TextDataset, "DEFAULT_SEQ_LEN")
         assert TextDataset.DEFAULT_SEQ_LEN == 128
 
     def test_default_dataset_glue_mrpc(self):
         """Test default dataset is glue/mrpc when none specified."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         dataset = TextDataset(
             model_name="bert-base-uncased",
@@ -57,7 +57,7 @@ class TestTextDatasetBasic:
 
     def test_explicit_dataset_name(self):
         """Test explicit dataset name is used."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         dataset = TextDataset(
             model_name="bert-base-uncased",
@@ -72,7 +72,7 @@ class TestTextDatasetBasic:
 
     def test_max_samples_limits_dataset_size(self):
         """Test max_samples parameter limits dataset size."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         dataset = TextDataset(
             model_name="bert-base-uncased",
@@ -87,7 +87,7 @@ class TestMaxLengthPriority:
 
     def test_default_max_length(self):
         """Test max_length defaults to DEFAULT_SEQ_LEN (128)."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         dataset = TextDataset(
             model_name="bert-base-uncased",
@@ -98,7 +98,7 @@ class TestMaxLengthPriority:
 
     def test_explicit_max_length_overrides_default(self):
         """Test explicit max_length overrides default."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         dataset = TextDataset(
             model_name="bert-base-uncased",
@@ -110,7 +110,7 @@ class TestMaxLengthPriority:
 
     def test_io_config_overrides_explicit(self):
         """Test io_config max_length overrides explicit param."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         io_config = {
             "input_ids": {"shape": [1, 64], "dtype": "int64"},
@@ -129,7 +129,7 @@ class TestMaxLengthPriority:
 
     def test_io_config_overrides_default(self):
         """Test io_config max_length overrides default."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         io_config = {
             "input_ids": {"shape": [1, 512], "dtype": "int64"},
@@ -145,7 +145,7 @@ class TestMaxLengthPriority:
 
     def test_io_config_with_remapped_input_name(self):
         """Test io_config with remapped input name via io_mapping."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         # Custom ONNX with different input name
         io_config = {
@@ -171,7 +171,7 @@ class TestIoMapping:
 
     def test_no_io_mapping_keeps_standard_names(self):
         """Test standard HF names are preserved without io_mapping."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         dataset = TextDataset(
             model_name="bert-base-uncased",
@@ -185,7 +185,7 @@ class TestIoMapping:
 
     def test_io_mapping_renames_columns(self):
         """Test io_mapping renames columns to ONNX input names."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         io_mapping = {
             "input_ids": "custom_ids",
@@ -208,7 +208,7 @@ class TestIoMapping:
 
     def test_partial_io_mapping(self):
         """Test partial io_mapping only renames specified columns."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         io_mapping = {
             "input_ids": "custom_ids",
@@ -231,7 +231,7 @@ class TestColumnDetection:
 
     def test_detects_text_columns(self):
         """Test detection of text columns by Value dtype=string."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         # GLUE/MRPC has sentence1 and sentence2 text columns
         dataset = TextDataset(
@@ -244,7 +244,7 @@ class TestColumnDetection:
 
     def test_detects_label_column(self):
         """Test detection of label column by ClassLabel type."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         dataset = TextDataset(
             model_name="bert-base-uncased",
@@ -256,7 +256,7 @@ class TestColumnDetection:
 
     def test_sentence_pair_detection_mrpc(self):
         """Test sentence pair detection for MRPC (2 text columns)."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         # GLUE/MRPC is a sentence pair task
         dataset = TextDataset(
@@ -269,7 +269,7 @@ class TestColumnDetection:
 
     def test_single_sentence_detection_sst2(self):
         """Test single sentence detection for SST2 (1 text column)."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         # GLUE/SST2 is a single sentence task
         dataset = TextDataset(
@@ -289,7 +289,7 @@ class TestTokenization:
 
     def test_tokenized_output_has_correct_keys(self):
         """Test tokenized output contains expected keys."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         dataset = TextDataset(
             model_name="bert-base-uncased",
@@ -304,7 +304,7 @@ class TestTokenization:
 
     def test_tokenized_tensors_have_correct_shape(self):
         """Test tokenized tensors have correct shape [batch, seq_len]."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         dataset = TextDataset(
             model_name="bert-base-uncased",
@@ -320,7 +320,7 @@ class TestTokenization:
 
     def test_tokenized_tensors_are_torch_tensors(self):
         """Test tokenized output is torch tensors."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         dataset = TextDataset(
             model_name="bert-base-uncased",
@@ -334,7 +334,7 @@ class TestTokenization:
 
     def test_max_length_applied_to_tokenization(self):
         """Test max_length is applied during tokenization."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         dataset = TextDataset(
             model_name="bert-base-uncased",
@@ -353,7 +353,7 @@ class TestReadonlyProperties:
 
     def test_max_length_property(self):
         """Test max_length property is accessible."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         dataset = TextDataset(
             model_name="bert-base-uncased",
@@ -365,7 +365,7 @@ class TestReadonlyProperties:
 
     def test_label_col_property(self):
         """Test label_col property is accessible."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         dataset = TextDataset(
             model_name="bert-base-uncased",
@@ -376,7 +376,7 @@ class TestReadonlyProperties:
 
     def test_label_names_property(self):
         """Test label_names property returns class names."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         dataset = TextDataset(
             model_name="bert-base-uncased",
@@ -388,7 +388,7 @@ class TestReadonlyProperties:
 
     def test_is_sentence_pair_property(self):
         """Test is_sentence_pair property."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         dataset = TextDataset(
             model_name="bert-base-uncased",
@@ -399,7 +399,7 @@ class TestReadonlyProperties:
 
     def test_text_columns_property(self):
         """Test text_columns property returns column names."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         dataset = TextDataset(
             model_name="bert-base-uncased",
@@ -415,7 +415,7 @@ class TestSamplingBehavior:
 
     def test_sequential_sampling_without_shuffle(self):
         """Test sequential sampling when shuffle=False."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         dataset = TextDataset(
             model_name="bert-base-uncased",
@@ -427,7 +427,7 @@ class TestSamplingBehavior:
 
     def test_random_sampling_with_shuffle(self):
         """Test random sampling when shuffle=True."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         dataset = TextDataset(
             model_name="bert-base-uncased",
@@ -440,7 +440,7 @@ class TestSamplingBehavior:
 
     def test_seed_reproducibility(self):
         """Test same seed produces same samples."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         dataset1 = TextDataset(
             model_name="bert-base-uncased",
@@ -467,7 +467,7 @@ class TestEdgeCases:
 
     def test_getitem_returns_dict(self):
         """Test __getitem__ returns dict."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         dataset = TextDataset(
             model_name="bert-base-uncased",
@@ -479,7 +479,7 @@ class TestEdgeCases:
 
     def test_len_returns_int(self):
         """Test __len__ returns int."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         dataset = TextDataset(
             model_name="bert-base-uncased",
@@ -491,7 +491,7 @@ class TestEdgeCases:
 
     def test_io_config_missing_input_ids_uses_default(self):
         """Test io_config without input_ids falls back to explicit/default."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         # io_config without input_ids
         io_config = {
@@ -510,7 +510,7 @@ class TestEdgeCases:
 
     def test_empty_io_mapping(self):
         """Test empty io_mapping dict."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         dataset = TextDataset(
             model_name="bert-base-uncased",
@@ -528,7 +528,7 @@ class TestIntegration:
 
     def test_full_pipeline_glue_mrpc(self):
         """Test full pipeline with GLUE/MRPC."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         dataset = TextDataset(
             model_name="bert-base-uncased",
@@ -551,7 +551,7 @@ class TestIntegration:
 
     def test_full_pipeline_with_io_config(self):
         """Test full pipeline with io_config override."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         io_config = {
             "input_ids": {"shape": [1, 64], "dtype": "int64"},
@@ -571,7 +571,7 @@ class TestIntegration:
 
     def test_full_pipeline_with_io_mapping(self):
         """Test full pipeline with io_mapping renaming."""
-        from winml.modelkit.datasets.text import TextDataset
+        from winml.modelkit.datasets import TextDataset
 
         io_mapping = {
             "input_ids": "ids",

--- a/tests/unit/models/auto/test_config.py
+++ b/tests/unit/models/auto/test_config.py
@@ -94,7 +94,7 @@ class TestWinMLQuantizationConfig:
 
     def test_default_values(self):
         """AC-1: Test default quantization config."""
-        from winml.modelkit.quant.config import WinMLQuantizationConfig
+        from winml.modelkit.quant import WinMLQuantizationConfig
 
         config = WinMLQuantizationConfig()
 
@@ -105,7 +105,7 @@ class TestWinMLQuantizationConfig:
 
     def test_qdq_mode_config(self):
         """Test QDQ-specific configuration."""
-        from winml.modelkit.quant.config import WinMLQuantizationConfig
+        from winml.modelkit.quant import WinMLQuantizationConfig
 
         config = WinMLQuantizationConfig(
             mode="qdq",

--- a/tests/unit/utils/test_config_utils.py
+++ b/tests/unit/utils/test_config_utils.py
@@ -26,7 +26,7 @@ import pytest
 from winml.modelkit.config import WinMLBuildConfig, merge_config
 from winml.modelkit.export.config import InputTensorSpec, OutputTensorSpec, WinMLExportConfig
 from winml.modelkit.optim.config import WinMLOptimizationConfig
-from winml.modelkit.quant.config import WinMLQuantizationConfig
+from winml.modelkit.quant import WinMLQuantizationConfig
 
 
 class TestMergeConfigBasic:


### PR DESCRIPTION
## Summary

- Add `DatasetConfig` and `DEFAULT_OBJECT_DETECTION_SIZE` to `datasets/__init__.py` exports
- Convert 10 test files from internal submodule imports to package-level absolute imports:
  - `datasets.text.TextDataset` → `datasets.TextDataset` (36 inline imports)
  - `datasets.config.DatasetConfig` → `datasets.DatasetConfig` (3 files)
  - `datasets.random_dataset.RandomDataset` → `datasets.RandomDataset`
  - `datasets.processor_utils.get_image_processor_config` → `datasets.get_image_processor_config`
  - `datasets.object_detection.ObjectDetectionDataset` → `datasets.ObjectDetectionDataset`
  - `quant.config.WinMLQuantizationConfig` → `quant.WinMLQuantizationConfig` (5 files)

Closes #30