### PR TITLE
Import cleanup Phase 2: export + compiler packages

### DIFF
--- a/src/winml/modelkit/compiler/__init__.py
+++ b/src/winml/modelkit/compiler/__init__.py
@@ -31,18 +31,29 @@ from .configs import (
 )
 from .context import CompileContext
 from .result import CompileResult
-from .utils import QDQ_OP_TYPES
+from .stages.compile import CompileStage
+from .stages.optimize import OptimizeStage
+from .stages.qformat import QFormatConvertStage
+from .transforms import clear_transforms, get_transforms_for_ep, register_transform
+from .utils import QDQ_OP_TYPES, needs_format_conversion
 
 
 __all__ = [
     "QDQ_OP_TYPES",
     "CompileContext",
     "CompileResult",
+    "CompileStage",
     "Compiler",
     "EPConfig",
+    "OptimizeStage",
+    "QFormatConvertStage",
     "WinMLCompileConfig",
+    "clear_transforms",
     "compile_onnx",
+    "get_transforms_for_ep",
     "list_compilers",
+    "needs_format_conversion",
+    "register_transform",
 ]
 
 __version__ = "0.1.0"

--- a/src/winml/modelkit/export/__init__.py
+++ b/src/winml/modelkit/export/__init__.py
@@ -20,6 +20,7 @@ from .config import (
 from .io import (
     MaxLengthTextInputGenerator,
     ONNXConfigNotFoundError,
+    generate_dummy_inputs,
     register_onnx_overwrite,
     resolve_io_specs,
 )
@@ -37,6 +38,7 @@ __all__ = [
     "WinMLExportConfig",
     "export_onnx",
     "export_pytorch",
+    "generate_dummy_inputs",
     "register_onnx_overwrite",
     "resolve_export_config",
     "resolve_io_specs",

--- a/tests/unit/commands/test_build_module.py
+++ b/tests/unit/commands/test_build_module.py
@@ -136,7 +136,7 @@ class TestBuildModuleOrchestration:
         """_build_modules calls build_hf_model for each config."""
         from winml.modelkit.commands.build import _build_modules
         from winml.modelkit.config import WinMLBuildConfig
-        from winml.modelkit.export.config import WinMLExportConfig
+        from winml.modelkit.export import WinMLExportConfig
         from winml.modelkit.loader.config import WinMLLoaderConfig
         from winml.modelkit.optim.config import WinMLOptimizationConfig
 
@@ -202,7 +202,7 @@ class TestBuildModuleOrchestration:
         """_build_modules raises if model_type is missing."""
         from winml.modelkit.commands.build import _build_modules
         from winml.modelkit.config import WinMLBuildConfig
-        from winml.modelkit.export.config import WinMLExportConfig
+        from winml.modelkit.export import WinMLExportConfig
         from winml.modelkit.loader.config import WinMLLoaderConfig
         from winml.modelkit.optim.config import WinMLOptimizationConfig
 
@@ -228,7 +228,7 @@ class TestBuildModuleOrchestration:
         """_build_modules raises if module_path is missing."""
         from winml.modelkit.commands.build import _build_modules
         from winml.modelkit.config import WinMLBuildConfig
-        from winml.modelkit.export.config import WinMLExportConfig
+        from winml.modelkit.export import WinMLExportConfig
         from winml.modelkit.loader.config import WinMLLoaderConfig
         from winml.modelkit.optim.config import WinMLOptimizationConfig
 

--- a/tests/unit/commands/test_export.py
+++ b/tests/unit/commands/test_export.py
@@ -199,7 +199,7 @@ class TestExportExportConfig:
     ) -> None:
         """Test export creates ExportConfig dataclass."""
         from winml.modelkit.commands.export import export
-        from winml.modelkit.export.config import WinMLExportConfig
+        from winml.modelkit.export import WinMLExportConfig
 
         output_path = tmp_path / "model.onnx"
         runner.invoke(
@@ -473,7 +473,7 @@ class TestExportAutoResolveInputTensors:
     ) -> None:
         """Test export uses resolve_export_config for input_tensors when no --input-specs."""
         from winml.modelkit.commands.export import export
-        from winml.modelkit.export.config import InputTensorSpec, WinMLExportConfig
+        from winml.modelkit.export import InputTensorSpec, WinMLExportConfig
         from winml.modelkit.loader.config import WinMLLoaderConfig
 
         # Create mock return values for resolve_export_config

--- a/tests/unit/compiler/test_compiler_configs.py
+++ b/tests/unit/compiler/test_compiler_configs.py
@@ -8,7 +8,7 @@ import warnings
 
 import pytest
 
-from winml.modelkit.compiler.configs import (
+from winml.modelkit.compiler import (
     EPConfig,
     WinMLCompileConfig,
 )

--- a/tests/unit/compiler/test_compiler_stages.py
+++ b/tests/unit/compiler/test_compiler_stages.py
@@ -41,9 +41,7 @@ class TestOptimizeStage:
 
     def test_should_not_run_when_no_transforms(self, tmp_path):
         """Stage should skip when no transforms are registered for the EP."""
-        from winml.modelkit.compiler.context import CompileContext
-        from winml.modelkit.compiler.stages.optimize import OptimizeStage
-        from winml.modelkit.compiler.transforms import clear_transforms
+        from winml.modelkit.compiler import CompileContext, OptimizeStage, clear_transforms
 
         clear_transforms()
 
@@ -59,9 +57,12 @@ class TestOptimizeStage:
 
     def test_should_run_when_transforms_registered(self, tmp_path):
         """Stage should run when transforms are registered for the EP."""
-        from winml.modelkit.compiler.context import CompileContext
-        from winml.modelkit.compiler.stages.optimize import OptimizeStage
-        from winml.modelkit.compiler.transforms import clear_transforms, register_transform
+        from winml.modelkit.compiler import (
+            CompileContext,
+            OptimizeStage,
+            clear_transforms,
+            register_transform,
+        )
 
         clear_transforms()
 
@@ -87,9 +88,12 @@ class TestOptimizeStage:
 
     def test_process_applies_transforms(self, tmp_path):
         """Stage should apply transforms and save output model."""
-        from winml.modelkit.compiler.context import CompileContext
-        from winml.modelkit.compiler.stages.optimize import OptimizeStage
-        from winml.modelkit.compiler.transforms import clear_transforms, register_transform
+        from winml.modelkit.compiler import (
+            CompileContext,
+            OptimizeStage,
+            clear_transforms,
+            register_transform,
+        )
 
         clear_transforms()
 
@@ -127,8 +131,7 @@ class TestQFormatConvertStage:
 
     def test_should_not_run_for_plain_model(self, tmp_path):
         """Stage should skip for models without QLinear ops."""
-        from winml.modelkit.compiler.context import CompileContext
-        from winml.modelkit.compiler.stages.qformat import QFormatConvertStage
+        from winml.modelkit.compiler import CompileContext, QFormatConvertStage
 
         model_path = tmp_path / "model.onnx"
         create_simple_model(model_path)
@@ -142,8 +145,7 @@ class TestQFormatConvertStage:
 
     def test_should_run_for_qlinear_model_on_qnn(self, tmp_path):
         """Stage should run when model has QLinear ops targeting QNN."""
-        from winml.modelkit.compiler.context import CompileContext
-        from winml.modelkit.compiler.stages.qformat import QFormatConvertStage
+        from winml.modelkit.compiler import CompileContext, QFormatConvertStage
 
         model_path = tmp_path / "model.onnx"
         create_qlinear_model(model_path)
@@ -157,8 +159,7 @@ class TestQFormatConvertStage:
 
     def test_process_adds_warning(self, tmp_path):
         """Stage should add warning since conversion is not yet implemented."""
-        from winml.modelkit.compiler.context import CompileContext
-        from winml.modelkit.compiler.stages.qformat import QFormatConvertStage
+        from winml.modelkit.compiler import CompileContext, QFormatConvertStage
 
         model_path = tmp_path / "model.onnx"
         create_qlinear_model(model_path)
@@ -180,7 +181,7 @@ class TestCompileContext:
 
     def test_context_properties(self, tmp_path):
         """Test context property accessors."""
-        from winml.modelkit.compiler.context import CompileContext
+        from winml.modelkit.compiler import CompileContext
 
         model_path = tmp_path / "model.onnx"
         create_simple_model(model_path)
@@ -200,7 +201,7 @@ class TestCompileContext:
 
     def test_error_handling(self, tmp_path):
         """Test error and warning handling."""
-        from winml.modelkit.compiler.context import CompileContext
+        from winml.modelkit.compiler import CompileContext
 
         context = CompileContext(
             model_path=tmp_path / "model.onnx",
@@ -219,7 +220,7 @@ class TestCompileContext:
 
     def test_logging(self, tmp_path):
         """Test logging."""
-        from winml.modelkit.compiler.context import CompileContext
+        from winml.modelkit.compiler import CompileContext
 
         context = CompileContext(
             model_path=tmp_path / "model.onnx",
@@ -233,7 +234,7 @@ class TestCompileContext:
 
     def test_no_quant_fields(self, tmp_path):
         """Verify quant-related fields have been removed from context."""
-        from winml.modelkit.compiler.context import CompileContext
+        from winml.modelkit.compiler import CompileContext
 
         context = CompileContext(
             model_path=tmp_path / "model.onnx",
@@ -252,7 +253,7 @@ class TestCompileResult:
 
     def test_no_quant_fields(self):
         """Verify quant-related fields have been removed from result."""
-        from winml.modelkit.compiler.result import CompileResult
+        from winml.modelkit.compiler import CompileResult
 
         result = CompileResult(success=True)
         assert not hasattr(result, "calibration_time")
@@ -261,7 +262,7 @@ class TestCompileResult:
 
     def test_to_dict(self):
         """Test serialization."""
-        from winml.modelkit.compiler.result import CompileResult
+        from winml.modelkit.compiler import CompileResult
 
         result = CompileResult(
             success=True,
@@ -279,7 +280,7 @@ class TestCompileResult:
 
     def test_str(self):
         """Test string representation."""
-        from winml.modelkit.compiler.result import CompileResult
+        from winml.modelkit.compiler import CompileResult
 
         result = CompileResult(
             success=True,
@@ -344,8 +345,7 @@ class TestCompileStageFinalizeOutput:
 
         Key branch: embed_mode == 0 (external), update ep_cache_context to new filename
         """
-        from winml.modelkit.compiler.context import CompileContext
-        from winml.modelkit.compiler.stages.compile import CompileStage
+        from winml.modelkit.compiler import CompileContext, CompileStage
 
         # Setup: work_dir with EPContext pointing to old bin name
         work_dir = tmp_path / "work"
@@ -399,8 +399,7 @@ class TestCompileStageFinalizeOutput:
 
         Key branch: attrs["embed_mode"].i != 0 -> skip update
         """
-        from winml.modelkit.compiler.context import CompileContext
-        from winml.modelkit.compiler.stages.compile import CompileStage
+        from winml.modelkit.compiler import CompileContext, CompileStage
 
         # Setup: work_dir with embedded EPContext
         work_dir = tmp_path / "work"
@@ -445,8 +444,7 @@ class TestCompileStageFinalizeOutput:
 
         Key branch: if src_ctx_path is None: add_warning
         """
-        from winml.modelkit.compiler.context import CompileContext
-        from winml.modelkit.compiler.stages.compile import CompileStage
+        from winml.modelkit.compiler import CompileContext, CompileStage
 
         work_dir = tmp_path / "work"
         output_dir = tmp_path / "output"
@@ -481,10 +479,12 @@ class TestCompilerPipeline:
 
     def test_new_pipeline_stages(self):
         """Verify the pipeline uses the new stages."""
-        from winml.modelkit.compiler.compiler import Compiler
-        from winml.modelkit.compiler.stages.compile import CompileStage
-        from winml.modelkit.compiler.stages.optimize import OptimizeStage
-        from winml.modelkit.compiler.stages.qformat import QFormatConvertStage
+        from winml.modelkit.compiler import (
+            Compiler,
+            CompileStage,
+            OptimizeStage,
+            QFormatConvertStage,
+        )
 
         # Reset cached stages
         Compiler._stages = None
@@ -500,7 +500,7 @@ class TestCompilerPipeline:
 
     def test_passthrough_when_no_config(self, tmp_path):
         """Compile with no config returns passthrough result."""
-        from winml.modelkit.compiler.compiler import Compiler
+        from winml.modelkit.compiler import Compiler
 
         model_path = tmp_path / "model.onnx"
         create_simple_model(model_path)

--- a/tests/unit/compiler/test_utils.py
+++ b/tests/unit/compiler/test_utils.py
@@ -11,12 +11,12 @@ from typing import TYPE_CHECKING
 import onnx
 from onnx import TensorProto, helper
 
-from winml.modelkit.compiler.transforms import (
+from winml.modelkit.compiler import (
     clear_transforms,
     get_transforms_for_ep,
+    needs_format_conversion,
     register_transform,
 )
-from winml.modelkit.compiler.utils import needs_format_conversion
 from winml.modelkit.onnx import is_compiled_onnx, is_quantized_onnx
 
 

--- a/tests/unit/config/test_build.py
+++ b/tests/unit/config/test_build.py
@@ -22,7 +22,7 @@ from click.testing import CliRunner
 # Import models package to trigger ONNX config registration with TasksManager
 import winml.modelkit.models  # noqa: F401
 from winml.modelkit.commands.config import config as config_command
-from winml.modelkit.compiler.configs import EPConfig, WinMLCompileConfig
+from winml.modelkit.compiler import EPConfig, WinMLCompileConfig
 from winml.modelkit.config import (
     WinMLBuildConfig,
     generate_build_config,
@@ -33,8 +33,13 @@ from winml.modelkit.config.build import (
     _build_submodule_config,
     resolve_quant_compile_config,
 )
-from winml.modelkit.export import ONNXConfigNotFoundError, resolve_io_specs
-from winml.modelkit.export.config import InputTensorSpec, OutputTensorSpec, WinMLExportConfig
+from winml.modelkit.export import (
+    InputTensorSpec,
+    ONNXConfigNotFoundError,
+    OutputTensorSpec,
+    WinMLExportConfig,
+    resolve_io_specs,
+)
 from winml.modelkit.loader.config import WinMLLoaderConfig
 from winml.modelkit.optim.config import WinMLOptimizationConfig
 from winml.modelkit.quant.config import WinMLQuantizationConfig
@@ -703,7 +708,7 @@ class TestBuildSubmoduleConfig:
     @pytest.fixture
     def parent_config(self) -> WinMLBuildConfig:
         """Create a parent config with non-default optim/compile for inheritance tests."""
-        from winml.modelkit.compiler.configs import WinMLCompileConfig
+        from winml.modelkit.compiler import WinMLCompileConfig
         from winml.modelkit.optim.config import WinMLOptimizationConfig
 
         return WinMLBuildConfig(

--- a/tests/unit/config/test_build_onnx.py
+++ b/tests/unit/config/test_build_onnx.py
@@ -23,7 +23,7 @@ from click.testing import CliRunner
 # Import models package to trigger ONNX config registration with TasksManager
 import winml.modelkit.models  # noqa: F401
 from winml.modelkit.commands.config import config as config_command
-from winml.modelkit.compiler.configs import WinMLCompileConfig
+from winml.modelkit.compiler import WinMLCompileConfig
 from winml.modelkit.config import (
     WinMLBuildConfig,
     generate_onnx_build_config,
@@ -31,7 +31,7 @@ from winml.modelkit.config import (
 from winml.modelkit.config.build import (
     resolve_quant_compile_config,
 )
-from winml.modelkit.export.config import InputTensorSpec, OutputTensorSpec, WinMLExportConfig
+from winml.modelkit.export import InputTensorSpec, OutputTensorSpec, WinMLExportConfig
 from winml.modelkit.loader.config import WinMLLoaderConfig
 from winml.modelkit.optim.config import WinMLOptimizationConfig
 from winml.modelkit.quant.config import WinMLQuantizationConfig

--- a/tests/unit/export/test_blip_onnx_config.py
+++ b/tests/unit/export/test_blip_onnx_config.py
@@ -22,7 +22,7 @@ from optimum.exporters.tasks import TasksManager
 
 # Trigger OnnxConfig registration with TasksManager
 import winml.modelkit.models  # noqa: F401
-from winml.modelkit.export.io import generate_dummy_inputs, resolve_io_specs
+from winml.modelkit.export import generate_dummy_inputs, resolve_io_specs
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit/export/test_config_validation.py
+++ b/tests/unit/export/test_config_validation.py
@@ -14,7 +14,7 @@ import logging
 
 import pytest
 
-from winml.modelkit.export.config import (
+from winml.modelkit.export import (
     InputTensorSpec,
     OutputTensorSpec,
     WinMLExportConfig,

--- a/tests/unit/export/test_io.py
+++ b/tests/unit/export/test_io.py
@@ -31,11 +31,10 @@ from transformers import (
 # Import models package to trigger ONNX config registration with TasksManager
 # This is required for BERT/CLIP to use max_position_embeddings as sequence_length
 import winml.modelkit.models  # noqa: F401
-from winml.modelkit.export.io import (
+from winml.modelkit.export import generate_dummy_inputs, resolve_io_specs
+from winml.modelkit.export.io import (  # Testing internal implementation
     _get_onnx_config,
     _populate_image_size_from_preprocessor,
-    generate_dummy_inputs,
-    resolve_io_specs,
 )
 
 

--- a/tests/unit/export/test_io_specs.py
+++ b/tests/unit/export/test_io_specs.py
@@ -22,10 +22,10 @@ import pytest
 
 # Trigger OnnxConfig registration with TasksManager
 import winml.modelkit.models  # noqa: F401
-from winml.modelkit.export.io import (
+from winml.modelkit.export import resolve_io_specs
+from winml.modelkit.export.io import (  # Testing internal implementation
     _get_onnx_config,
     _map_task_synonym,
-    resolve_io_specs,
 )
 
 

--- a/tests/unit/export/test_onnx_config_overrides.py
+++ b/tests/unit/export/test_onnx_config_overrides.py
@@ -28,10 +28,9 @@ from optimum.exporters.tasks import TasksManager
 
 # Trigger OnnxConfig registration with TasksManager
 import winml.modelkit.models  # noqa: F401
-from winml.modelkit.export.io import (
+from winml.modelkit.export import generate_dummy_inputs, resolve_io_specs
+from winml.modelkit.export.io import (  # Testing internal implementation
     _populate_image_size_from_preprocessor,
-    generate_dummy_inputs,
-    resolve_io_specs,
 )
 from winml.modelkit.models.hf.roberta import _adjust_position_embeddings
 

--- a/tests/unit/export/test_pytorch_export.py
+++ b/tests/unit/export/test_pytorch_export.py
@@ -15,12 +15,12 @@ import pytest
 import torch
 import torch.nn as nn
 
-from winml.modelkit.export.config import (
+from winml.modelkit.export import (
     InputTensorSpec,
     OutputTensorSpec,
     WinMLExportConfig,
+    export_pytorch,
 )
-from winml.modelkit.export.pytorch import export_pytorch
 
 
 # =============================================================================

--- a/tests/unit/export/test_zoedepth_onnx_config.py
+++ b/tests/unit/export/test_zoedepth_onnx_config.py
@@ -25,7 +25,7 @@ from optimum.exporters.tasks import TasksManager
 
 # Trigger OnnxConfig registration with TasksManager
 import winml.modelkit.models  # noqa: F401
-from winml.modelkit.export.io import resolve_io_specs
+from winml.modelkit.export import resolve_io_specs
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/models/auto/test_config.py
+++ b/tests/unit/models/auto/test_config.py
@@ -30,7 +30,7 @@ class TestWinMLExportConfig:
 
     def test_default_values(self):
         """AC-1: Test default configuration values."""
-        from winml.modelkit.export.config import WinMLExportConfig
+        from winml.modelkit.export import WinMLExportConfig
 
         config = WinMLExportConfig()
 
@@ -40,7 +40,7 @@ class TestWinMLExportConfig:
 
     def test_custom_values(self):
         """AC-1: Test custom configuration values."""
-        from winml.modelkit.export.config import WinMLExportConfig
+        from winml.modelkit.export import WinMLExportConfig
 
         config = WinMLExportConfig(
             opset_version=14,
@@ -54,7 +54,7 @@ class TestWinMLExportConfig:
 
     def test_to_dict(self):
         """AC-2: Test serialization to dict."""
-        from winml.modelkit.export.config import WinMLExportConfig
+        from winml.modelkit.export import WinMLExportConfig
 
         config = WinMLExportConfig(opset_version=15, batch_size=2)
         config_dict = config.to_dict()
@@ -65,7 +65,7 @@ class TestWinMLExportConfig:
 
     def test_from_dict(self):
         """AC-2: Test deserialization from dict."""
-        from winml.modelkit.export.config import WinMLExportConfig
+        from winml.modelkit.export import WinMLExportConfig
 
         config_dict = {"opset_version": 16, "batch_size": 8}
         config = WinMLExportConfig.from_dict(config_dict)
@@ -75,7 +75,7 @@ class TestWinMLExportConfig:
 
     def test_from_dict_ignores_unknown_fields(self):
         """AC-6: Forward compatibility - ignore unknown fields."""
-        from winml.modelkit.export.config import WinMLExportConfig
+        from winml.modelkit.export import WinMLExportConfig
 
         config_dict = {
             "opset_version": 17,
@@ -146,7 +146,7 @@ class TestWinMLCompileConfig:
 
     def test_default_values(self):
         """AC-1: Test default compile config."""
-        from winml.modelkit.compiler.configs import WinMLCompileConfig
+        from winml.modelkit.compiler import WinMLCompileConfig
 
         config = WinMLCompileConfig()
 
@@ -156,7 +156,7 @@ class TestWinMLCompileConfig:
 
     def test_device_via_ep_config(self):
         """Test device via ep_config.provider."""
-        from winml.modelkit.compiler.configs import EPConfig, WinMLCompileConfig
+        from winml.modelkit.compiler import EPConfig, WinMLCompileConfig
 
         for provider in ["qnn", "cpu", "cuda", "dml"]:
             config = WinMLCompileConfig(ep_config=EPConfig(provider=provider))
@@ -164,7 +164,7 @@ class TestWinMLCompileConfig:
 
     def test_factory_methods(self):
         """Test factory methods for common providers."""
-        from winml.modelkit.compiler.configs import WinMLCompileConfig
+        from winml.modelkit.compiler import WinMLCompileConfig
 
         qnn_config = WinMLCompileConfig.for_qnn()
         assert qnn_config.device == "qnn"
@@ -264,7 +264,7 @@ class TestConfigValidation:
 
     def test_opset_version_range(self):
         """Test opset version validation."""
-        from winml.modelkit.export.config import WinMLExportConfig
+        from winml.modelkit.export import WinMLExportConfig
 
         # Valid opset versions
         for version in [11, 14, 17, 20]:
@@ -273,7 +273,7 @@ class TestConfigValidation:
 
     def test_batch_size_positive(self):
         """Test batch size must be positive."""
-        from winml.modelkit.export.config import WinMLExportConfig
+        from winml.modelkit.export import WinMLExportConfig
 
         config = WinMLExportConfig(batch_size=1)
         assert config.batch_size == 1

--- a/tests/unit/models/segformer/test_onnx_config.py
+++ b/tests/unit/models/segformer/test_onnx_config.py
@@ -20,7 +20,8 @@ from transformers import SegformerConfig, SegformerForSemanticSegmentation
 
 # Import triggers ONNX config registration
 import winml.modelkit.models  # noqa: F401
-from winml.modelkit.export.io import _get_onnx_config, generate_dummy_inputs
+from winml.modelkit.export import generate_dummy_inputs
+from winml.modelkit.export.io import _get_onnx_config  # Testing internal implementation
 from winml.modelkit.models.hf.segformer import (
     MODEL_CLASS_MAPPING,
     SegformerIOConfig,

--- a/tests/unit/session/test_qairt_session.py
+++ b/tests/unit/session/test_qairt_session.py
@@ -266,7 +266,7 @@ class TestQairtSessionPaths:
 
         Key logic: ep_config.qnn_sdk_root is used if provided.
         """
-        from winml.modelkit.compiler.configs import EPConfig
+        from winml.modelkit.compiler import EPConfig
         from winml.modelkit.session import WinMLQairtSession
 
         # Set env var to a different path

--- a/tests/unit/session/test_winml_session.py
+++ b/tests/unit/session/test_winml_session.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 import pytest
 
-from winml.modelkit.compiler.configs import EPConfig
+from winml.modelkit.compiler import EPConfig
 from winml.modelkit.session import WinMLSession
 from winml.modelkit.session.ep_registry import WinMLEPRegistry
 from winml.modelkit.session.session import SessionState

--- a/tests/unit/utils/test_config_utils.py
+++ b/tests/unit/utils/test_config_utils.py
@@ -24,7 +24,7 @@ from typing import Any
 import pytest
 
 from winml.modelkit.config import WinMLBuildConfig, merge_config
-from winml.modelkit.export.config import InputTensorSpec, OutputTensorSpec, WinMLExportConfig
+from winml.modelkit.export import InputTensorSpec, OutputTensorSpec, WinMLExportConfig
 from winml.modelkit.optim.config import WinMLOptimizationConfig
 from winml.modelkit.quant.config import WinMLQuantizationConfig
 


### PR DESCRIPTION
## Summary

### export
- Add `generate_dummy_inputs` to `export/__init__.py`
- Convert 12 test files from `export.config`/`export.io`/`export.pytorch` to package-level imports
- Private functions (`_get_onnx_config`, `_populate_image_size_from_preprocessor`, `_map_task_synonym`) stay as internal imports with `# Testing internal implementation` comment

### compiler
- Add 7 symbols to `compiler/__init__.py`: `OptimizeStage`, `QFormatConvertStage`, `CompileStage`, `clear_transforms`, `register_transform`, `get_transforms_for_ep`, `needs_format_conversion`
- Convert 9 test files from `compiler.configs`/`compiler.context`/`compiler.result`/`compiler.stages.*`/`compiler.transforms`/`compiler.utils` to package-level imports

Closes #31