### PR TITLE
Import cleanup Phase 3: eval + optracing packages

### DIFF
--- a/src/winml/modelkit/eval/__init__.py
+++ b/src/winml/modelkit/eval/__init__.py
@@ -8,12 +8,27 @@
 Provides accuracy evaluation using HuggingFace pipeline + evaluate library.
 """
 
+from .base_evaluator import WinMLEvaluator
 from .config import WinMLEvaluationConfig
 from .evaluate import EvalResult, evaluate
+from .image_segmentation_evaluator import WinMLImageSegmentationEvaluator
+from .metrics.mean_average_precision import MAPMetric
+from .metrics.mean_iou import IGNORE_INDEX, MeanIoUMetric
+from .object_detection_evaluator import WinMLObjectDetectionEvaluator
+from .text_classification_evaluator import WinMLTextClassificationEvaluator
+from .token_classification_evaluator import WinMLTokenClassificationEvaluator
 
 
 __all__ = [
+    "IGNORE_INDEX",
     "EvalResult",
+    "MAPMetric",
+    "MeanIoUMetric",
     "WinMLEvaluationConfig",
+    "WinMLEvaluator",
+    "WinMLImageSegmentationEvaluator",
+    "WinMLObjectDetectionEvaluator",
+    "WinMLTextClassificationEvaluator",
+    "WinMLTokenClassificationEvaluator",
     "evaluate",
 ]

--- a/src/winml/modelkit/optracing/__init__.py
+++ b/src/winml/modelkit/optracing/__init__.py
@@ -3,7 +3,13 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 """Operator-level profiling for ModelKit."""
+
 from __future__ import annotations
+
+from .base import OpTracer
+from .registry import get_tracer, register_tracer
+from .report import display_op_trace_report, write_op_trace_json
+from .result import OperatorMetrics, OpTraceResult
 
 
 def is_qnn_profiling_available() -> bool:
@@ -14,3 +20,15 @@ def is_qnn_profiling_available() -> bool:
         return "QNNExecutionProvider" in ort.get_available_providers()
     except (ImportError, AttributeError):
         return False
+
+
+__all__ = [
+    "OpTraceResult",
+    "OpTracer",
+    "OperatorMetrics",
+    "display_op_trace_report",
+    "get_tracer",
+    "is_qnn_profiling_available",
+    "register_tracer",
+    "write_op_trace_json",
+]

--- a/tests/unit/eval/test_align_labels.py
+++ b/tests/unit/eval/test_align_labels.py
@@ -11,7 +11,7 @@ import pytest
 from datasets import ClassLabel, Dataset, Features, Sequence, Value
 
 from winml.modelkit.datasets.config import DatasetConfig
-from winml.modelkit.eval.base_evaluator import WinMLEvaluator
+from winml.modelkit.eval import WinMLEvaluator
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/eval/test_eval.py
+++ b/tests/unit/eval/test_eval.py
@@ -13,8 +13,7 @@ import pytest
 from click.testing import CliRunner
 
 from winml.modelkit.datasets.config import DatasetConfig
-from winml.modelkit.eval.config import WinMLEvaluationConfig
-from winml.modelkit.eval.evaluate import EvalResult
+from winml.modelkit.eval import EvalResult, WinMLEvaluationConfig
 
 
 class TestEvaluationConfig:
@@ -148,7 +147,7 @@ class TestWinMLEvaluator:
         mock_hf_eval,
     ):
         """When requested samples exceed dataset size, select uses actual size."""
-        from winml.modelkit.eval.base_evaluator import WinMLEvaluator
+        from winml.modelkit.eval import WinMLEvaluator
 
         mock_ds = MagicMock()
         mock_ds.__len__ = lambda self: 50
@@ -184,7 +183,7 @@ class TestWinMLEvaluator:
         mock_pipeline,
         mock_hf_eval,
     ):
-        from winml.modelkit.eval.base_evaluator import WinMLEvaluator
+        from winml.modelkit.eval import WinMLEvaluator
 
         mock_ds = MagicMock()
         mock_ds.__len__ = lambda self: 1000
@@ -240,7 +239,7 @@ class TestWinMLEvaluator:
         mock_pipeline,
         mock_hf_eval,
     ):
-        from winml.modelkit.eval.base_evaluator import WinMLEvaluator
+        from winml.modelkit.eval import WinMLEvaluator
 
         mock_ds = MagicMock()
         mock_ds.__len__ = lambda self: 1000
@@ -295,7 +294,7 @@ class TestSequenceClassificationEvaluator:
         mock_pipeline,
         mock_hf_eval,
     ):
-        from winml.modelkit.eval.text_classification_evaluator import (
+        from winml.modelkit.eval import (
             WinMLTextClassificationEvaluator,
         )
 
@@ -339,7 +338,7 @@ class TestSequenceClassificationEvaluator:
         mock_pipeline,
         mock_hf_eval,
     ):
-        from winml.modelkit.eval.text_classification_evaluator import (
+        from winml.modelkit.eval import (
             WinMLTextClassificationEvaluator,
         )
 
@@ -386,7 +385,7 @@ class TestTokenClassificationEvaluator:
         mock_hf_eval,
     ):
         """Padding is set via tokenizer_params dict, not top-level."""
-        from winml.modelkit.eval.token_classification_evaluator import (
+        from winml.modelkit.eval import (
             WinMLTokenClassificationEvaluator,
         )
 
@@ -433,7 +432,7 @@ class TestTokenClassificationEvaluator:
         mock_hf_eval,
     ):
         """No tokenizer → no padding config."""
-        from winml.modelkit.eval.token_classification_evaluator import (
+        from winml.modelkit.eval import (
             WinMLTokenClassificationEvaluator,
         )
 
@@ -476,7 +475,7 @@ class TestTokenClassificationEvaluator:
         mock_hf_eval,
     ):
         """Missing input_shapes in io_config → no padding config."""
-        from winml.modelkit.eval.token_classification_evaluator import (
+        from winml.modelkit.eval import (
             WinMLTokenClassificationEvaluator,
         )
 

--- a/tests/unit/eval/test_image_segmentation_evaluator.py
+++ b/tests/unit/eval/test_image_segmentation_evaluator.py
@@ -11,8 +11,7 @@ import pytest
 from datasets import Dataset, Features, Image, Value
 from PIL import Image as PILImage
 
-from winml.modelkit.eval.image_segmentation_evaluator import WinMLImageSegmentationEvaluator
-from winml.modelkit.eval.metrics.mean_iou import IGNORE_INDEX, MeanIoUMetric
+from winml.modelkit.eval import IGNORE_INDEX, MeanIoUMetric, WinMLImageSegmentationEvaluator
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/eval/test_map_metric.py
+++ b/tests/unit/eval/test_map_metric.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import pytest
 
-from winml.modelkit.eval.metrics.mean_average_precision import MAPMetric
+from winml.modelkit.eval import MAPMetric
 
 
 class TestMAPMetricPerfectMatch:

--- a/tests/unit/eval/test_object_detection_evaluator.py
+++ b/tests/unit/eval/test_object_detection_evaluator.py
@@ -9,7 +9,7 @@ import pytest
 from datasets import ClassLabel, Dataset, Features, Sequence, Value
 
 from winml.modelkit.datasets.config import DatasetConfig
-from winml.modelkit.eval.object_detection_evaluator import WinMLObjectDetectionEvaluator
+from winml.modelkit.eval import WinMLObjectDetectionEvaluator
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/optracing/test_integration.py
+++ b/tests/unit/optracing/test_integration.py
@@ -7,10 +7,11 @@
 import json
 from pathlib import Path
 
-from winml.modelkit.optracing.qnn.csv_parser import parse_qnn_profiling_csv
-from winml.modelkit.optracing.qnn.qhas_parser import parse_qhas
-from winml.modelkit.optracing.report import write_op_trace_json
-from winml.modelkit.optracing.result import OperatorMetrics, OpTraceResult
+from winml.modelkit.optracing import OperatorMetrics, OpTraceResult, write_op_trace_json
+from winml.modelkit.optracing.qnn.csv_parser import (
+    parse_qnn_profiling_csv,  # Testing internal implementation
+)
+from winml.modelkit.optracing.qnn.qhas_parser import parse_qhas  # Testing internal implementation
 
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures"

--- a/tests/unit/optracing/test_registry.py
+++ b/tests/unit/optracing/test_registry.py
@@ -10,13 +10,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from winml.modelkit.optracing.base import OpTracer
-from winml.modelkit.optracing.registry import (
-    _TRACERS,
-    get_tracer,
-    register_tracer,
-)
-from winml.modelkit.optracing.result import OpTraceResult
+from winml.modelkit.optracing import OpTracer, OpTraceResult, get_tracer, register_tracer
+from winml.modelkit.optracing.registry import _TRACERS  # Testing internal implementation
 
 
 if TYPE_CHECKING:

--- a/tests/unit/optracing/test_report.py
+++ b/tests/unit/optracing/test_report.py
@@ -10,12 +10,13 @@ from io import StringIO
 import pytest
 from rich.console import Console
 
-from winml.modelkit.optracing.report import (
-    _format_bytes,
+from winml.modelkit.optracing import (
+    OperatorMetrics,
+    OpTraceResult,
     display_op_trace_report,
     write_op_trace_json,
 )
-from winml.modelkit.optracing.result import OperatorMetrics, OpTraceResult
+from winml.modelkit.optracing.report import _format_bytes  # Testing internal implementation
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/optracing/test_result.py
+++ b/tests/unit/optracing/test_result.py
@@ -6,7 +6,7 @@
 
 import json
 
-from winml.modelkit.optracing.result import OperatorMetrics, OpTraceResult
+from winml.modelkit.optracing import OperatorMetrics, OpTraceResult
 
 
 def test_operator_metrics_to_dict():


### PR DESCRIPTION
## Summary

### eval
- Add 8 exports to `eval/__init__.py`: `WinMLEvaluator`, `WinMLObjectDetectionEvaluator`, `WinMLImageSegmentationEvaluator`, `WinMLTextClassificationEvaluator`, `WinMLTokenClassificationEvaluator`, `MAPMetric`, `MeanIoUMetric`, `IGNORE_INDEX`
- Convert 7 test files to package-level imports
- Private `_resolve_task`, `_load_model` kept as internal imports

### optracing
- Build full public API in `optracing/__init__.py`: `OpTracer`, `OpTraceResult`, `OperatorMetrics`, `display_op_trace_report`, `write_op_trace_json`, `get_tracer`, `register_tracer`
- Convert 4 test files to package-level imports
- QNN internals (`csv_parser`, `qhas_parser`, `profiler`, `viewer`) kept as internal imports

Closes #32