### PR TITLE
Import cleanup Phase 6: optim package

### DIFF
--- a/src/winml/modelkit/__init__.py
+++ b/src/winml/modelkit/__init__.py
@@ -21,7 +21,7 @@ Usage:
     model = WinMLAutoModel.from_pretrained("microsoft/resnet-50")
 
     # With custom config
-    from winml.modelkit.optim.config import WinMLOptimizationConfig
+    from .optim import WinMLOptimizationConfig
     config = WinMLBuildConfig(
         optim=WinMLOptimizationConfig(gelu_fusion=True),
     )

--- a/src/winml/modelkit/config/build.py
+++ b/src/winml/modelkit/config/build.py
@@ -101,7 +101,7 @@ class WinMLBuildConfig:
 
     Example:
         from winml.modelkit.config import WinMLBuildConfig
-        from winml.modelkit.optim.config import WinMLOptimizationConfig
+        from ..optim import WinMLOptimizationConfig
 
         # Default config
         config = WinMLBuildConfig()

--- a/src/winml/modelkit/optim/__init__.py
+++ b/src/winml/modelkit/optim/__init__.py
@@ -27,12 +27,14 @@ from __future__ import annotations
 from .api import optimize_onnx
 from .config import WinMLOptimizationConfig
 from .errors import ConfigurationError, ModelValidationError, OptimizationError
+from .optimizer import Optimizer
 
 
 __all__ = [
     "ConfigurationError",
     "ModelValidationError",
     "OptimizationError",
+    "Optimizer",
     "WinMLOptimizationConfig",
     "optimize_onnx",
 ]

--- a/src/winml/modelkit/optim/pipes/rewrite_rules.py
+++ b/src/winml/modelkit/optim/pipes/rewrite_rules.py
@@ -270,7 +270,7 @@ def _build_rewrite_capabilities() -> dict[str, Any]:
     - Per-source flags (e.g. ``gelu1-singlegelu``) → applies only that one variant.
     Single-source groups register only the group flag (the two would be identical).
     """
-    from winml.modelkit.optim.registry import BoolCapability, CapabilityCategory
+    from ..registry import BoolCapability, CapabilityCategory
 
     caps: dict[str, BoolCapability] = {}
     for group in REWRITE_GROUPS:

--- a/tests/unit/analyze/test_analyze_onnx.py
+++ b/tests/unit/analyze/test_analyze_onnx.py
@@ -20,7 +20,7 @@ from winml.modelkit.analyze.models.ihv_type import IHVType
 from winml.modelkit.analyze.models.information import Action, ActionItem, Information
 from winml.modelkit.analyze.models.output import AnalysisOutput, EPSupport, ModelStats
 from winml.modelkit.analyze.models.support_level import SupportLevel
-from winml.modelkit.optim.config import WinMLOptimizationConfig
+from winml.modelkit.optim import WinMLOptimizationConfig
 
 
 # =============================================================================

--- a/tests/unit/analyze/test_analyzer.py
+++ b/tests/unit/analyze/test_analyzer.py
@@ -21,7 +21,7 @@ from winml.modelkit.analyze.models.information import Action, ActionItem, Inform
 from winml.modelkit.analyze.models.output import AnalysisOutput, EPSupport, ModelStats
 from winml.modelkit.analyze.models.support_level import SupportLevel
 from winml.modelkit.analyze.utils import infer_ihv_from_ep_name
-from winml.modelkit.optim.config import WinMLOptimizationConfig
+from winml.modelkit.optim import WinMLOptimizationConfig
 
 
 class TestAnalyzerConfig:

--- a/tests/unit/build/test_hf.py
+++ b/tests/unit/build/test_hf.py
@@ -88,7 +88,7 @@ def _create_file_side_effect(output_kwarg_name: str, return_value: object = None
 def _default_analyze_result():
     """Build a default AnalyzeResult with no opportunities (analyzer converges)."""
     from winml.modelkit.analyze.analyzer import AnalyzeResult, LintResult
-    from winml.modelkit.optim.config import WinMLOptimizationConfig
+    from winml.modelkit.optim import WinMLOptimizationConfig
 
     config = WinMLOptimizationConfig()
     lint = LintResult(
@@ -603,7 +603,7 @@ class TestBuildAnalyzerLoop:
     ):
         """Build a mock AnalyzeResult."""
         from winml.modelkit.analyze.analyzer import AnalyzeResult, LintResult
-        from winml.modelkit.optim.config import WinMLOptimizationConfig
+        from winml.modelkit.optim import WinMLOptimizationConfig
 
         config = WinMLOptimizationConfig(**(optimization_config or {}))
         lint = LintResult(

--- a/tests/unit/build/test_onnx.py
+++ b/tests/unit/build/test_onnx.py
@@ -91,7 +91,7 @@ def _create_file_side_effect(output_kwarg_name: str, return_value: object = None
 def _default_analyze_result():
     """Build a default AnalyzeResult with no opportunities (analyzer converges)."""
     from winml.modelkit.analyze.analyzer import AnalyzeResult, LintResult
-    from winml.modelkit.optim.config import WinMLOptimizationConfig
+    from winml.modelkit.optim import WinMLOptimizationConfig
 
     config = WinMLOptimizationConfig()
     lint = LintResult(

--- a/tests/unit/commands/test_build_module.py
+++ b/tests/unit/commands/test_build_module.py
@@ -138,7 +138,7 @@ class TestBuildModuleOrchestration:
         from winml.modelkit.config import WinMLBuildConfig
         from winml.modelkit.export import WinMLExportConfig
         from winml.modelkit.loader.config import WinMLLoaderConfig
-        from winml.modelkit.optim.config import WinMLOptimizationConfig
+        from winml.modelkit.optim import WinMLOptimizationConfig
 
         configs = [
             WinMLBuildConfig(
@@ -204,7 +204,7 @@ class TestBuildModuleOrchestration:
         from winml.modelkit.config import WinMLBuildConfig
         from winml.modelkit.export import WinMLExportConfig
         from winml.modelkit.loader.config import WinMLLoaderConfig
-        from winml.modelkit.optim.config import WinMLOptimizationConfig
+        from winml.modelkit.optim import WinMLOptimizationConfig
 
         configs = [
             WinMLBuildConfig(
@@ -230,7 +230,7 @@ class TestBuildModuleOrchestration:
         from winml.modelkit.config import WinMLBuildConfig
         from winml.modelkit.export import WinMLExportConfig
         from winml.modelkit.loader.config import WinMLLoaderConfig
-        from winml.modelkit.optim.config import WinMLOptimizationConfig
+        from winml.modelkit.optim import WinMLOptimizationConfig
 
         configs = [
             WinMLBuildConfig(

--- a/tests/unit/config/test_build.py
+++ b/tests/unit/config/test_build.py
@@ -41,7 +41,7 @@ from winml.modelkit.export import (
     resolve_io_specs,
 )
 from winml.modelkit.loader.config import WinMLLoaderConfig
-from winml.modelkit.optim.config import WinMLOptimizationConfig
+from winml.modelkit.optim import WinMLOptimizationConfig
 from winml.modelkit.quant import WinMLQuantizationConfig
 from winml.modelkit.utils.config_utils import merge_config
 
@@ -709,7 +709,7 @@ class TestBuildSubmoduleConfig:
     def parent_config(self) -> WinMLBuildConfig:
         """Create a parent config with non-default optim/compile for inheritance tests."""
         from winml.modelkit.compiler import WinMLCompileConfig
-        from winml.modelkit.optim.config import WinMLOptimizationConfig
+        from winml.modelkit.optim import WinMLOptimizationConfig
 
         return WinMLBuildConfig(
             optim=WinMLOptimizationConfig(gelu_fusion=True, matmul_add_fusion=True),

--- a/tests/unit/config/test_build_onnx.py
+++ b/tests/unit/config/test_build_onnx.py
@@ -33,7 +33,7 @@ from winml.modelkit.config.build import (
 )
 from winml.modelkit.export import InputTensorSpec, OutputTensorSpec, WinMLExportConfig
 from winml.modelkit.loader.config import WinMLLoaderConfig
-from winml.modelkit.optim.config import WinMLOptimizationConfig
+from winml.modelkit.optim import WinMLOptimizationConfig
 from winml.modelkit.quant import WinMLQuantizationConfig
 from winml.modelkit.utils.config_utils import merge_config
 

--- a/tests/unit/optim/integration/test_optimizer.py
+++ b/tests/unit/optim/integration/test_optimizer.py
@@ -27,7 +27,7 @@ from typing import Any, ClassVar
 import onnx
 import pytest
 
-from winml.modelkit.optim.optimizer import Optimizer
+from winml.modelkit.optim import Optimizer
 from winml.modelkit.optim.pipes import PIPES, get_all_capabilities
 from winml.modelkit.optim.pipes.base import BasePipe, PipeConfig
 from winml.modelkit.optim.pipes.fusion import ORTFusionPipe, ORTFusionPipeConfig

--- a/tests/unit/optim/test_error_paths.py
+++ b/tests/unit/optim/test_error_paths.py
@@ -22,12 +22,12 @@ import onnx
 import pytest
 from onnx import TensorProto, helper
 
-from winml.modelkit.optim.errors import (
+from winml.modelkit.optim import (
     ConfigurationError,
     ModelValidationError,
     OptimizationError,
+    Optimizer,
 )
-from winml.modelkit.optim.optimizer import Optimizer
 
 
 # =============================================================================

--- a/tests/unit/utils/test_config_utils.py
+++ b/tests/unit/utils/test_config_utils.py
@@ -25,7 +25,7 @@ import pytest
 
 from winml.modelkit.config import WinMLBuildConfig, merge_config
 from winml.modelkit.export import InputTensorSpec, OutputTensorSpec, WinMLExportConfig
-from winml.modelkit.optim.config import WinMLOptimizationConfig
+from winml.modelkit.optim import WinMLOptimizationConfig
 from winml.modelkit.quant import WinMLQuantizationConfig
 
 


### PR DESCRIPTION
## Summary

- Add `Optimizer` to `optim/__init__.py` exports
- Convert 3 source files from absolute to relative imports:
  - `modelkit/__init__.py`: `from .optim import WinMLOptimizationConfig`
  - `config/build.py`: `from ..optim import WinMLOptimizationConfig`
  - `optim/pipes/rewrite_rules.py`: `from ..registry import BoolCapability, CapabilityCategory`
- Convert ~15 test files from `optim.config`/`optim.errors`/`optim.optimizer` submodules to package-level imports
- Pipe internals (`pipes.base`, `pipes.graph`, `pipes.fusion`, `pipes.surgery`, `pipes.rewrite`, `registry`) kept as internal imports — testing pipe implementation details

Closes #35