### PR TITLE
Import cleanup Phase 8: analyze package

### DIFF
--- a/src/winml/modelkit/analyze/__init__.py
+++ b/src/winml/modelkit/analyze/__init__.py
@@ -24,21 +24,55 @@ from .core.onnx_loader import ONNXLoader
 from .core.output_aggregator import OutputAggregator
 from .core.pattern_extractor import PatternExtractor
 from .core.runtime_checker import RuntimeChecker
-from .models.output import AnalysisOutput
+from .models import (
+    Action,
+    ActionItem,
+    ActionLevel,
+    AlternativeType,
+    AnalysisOutput,
+    EPSupport,
+    IHVType,
+    Information,
+    ModelStats,
+    ModelTag,
+    ONNXModel,
+    ONNXOp,
+    RuntimeCheckRule,
+    RuntimeTestResult,
+    SupportLevel,
+)
+from .utils import infer_ihv_from_ep_name
+from .utils.rule_loader import RuleLoader
 
 
 __all__ = [
+    "Action",
+    "ActionItem",
+    "ActionLevel",
+    "AlternativeType",
     "AnalysisOutput",
     "AnalysisResult",
     "AnalyzeResult",
     "AnalyzerConfig",
+    "EPSupport",
+    "IHVType",
+    "Information",
     "InformationEngine",
     "LintResult",
+    "ModelStats",
+    "ModelTag",
     "ONNXLoader",
+    "ONNXModel",
+    "ONNXOp",
     "ONNXStaticAnalyzer",
     "OutputAggregator",
     "PatternExtractor",
+    "RuleLoader",
+    "RuntimeCheckRule",
     "RuntimeChecker",
+    "RuntimeTestResult",
+    "SupportLevel",
     "__version__",
     "analyze_onnx",
+    "infer_ihv_from_ep_name",
 ]

--- a/src/winml/modelkit/analyze/models/__init__.py
+++ b/src/winml/modelkit/analyze/models/__init__.py
@@ -4,11 +4,10 @@
 # --------------------------------------------------------------------------
 """Pydantic data models for ONNX Static Analyzer."""
 
-from winml.modelkit.pattern.match import InputInfo, PatternMatchResult
-from winml.modelkit.pattern.models import OperatorPattern, Pattern, PatternType, SubgraphPattern
-
+from ...pattern.match import InputInfo, PatternMatchResult
+from ...pattern.models import OperatorPattern, Pattern, PatternType, SubgraphPattern
 from .ihv_type import IHVType
-from .information import Action, ActionLevel, Information
+from .information import Action, ActionItem, ActionLevel, Information
 from .onnx_model import ModelTag, ONNXModel
 from .onnx_op import ONNXOp
 from .output import AnalysisOutput, EPSupport, ModelStats, extract_model_stats
@@ -18,6 +17,7 @@ from .support_level import SupportLevel
 
 __all__ = [
     "Action",
+    "ActionItem",
     "ActionLevel",
     "AlternativeType",
     "AnalysisOutput",

--- a/src/winml/modelkit/pattern/match.py
+++ b/src/winml/modelkit/pattern/match.py
@@ -146,7 +146,7 @@ class PatternMatchResult:
             Falls back to dicts when ONNXOp is not available.
         """
         try:
-            from winml.modelkit.analyze.models.onnx_op import ONNXOp
+            from ..analyze import ONNXOp
 
             return [
                 ONNXOp(

--- a/src/winml/modelkit/pattern/op_input_gen/op_input_gen.py
+++ b/src/winml/modelkit/pattern/op_input_gen/op_input_gen.py
@@ -26,8 +26,8 @@ from .qdq_gen import QDQGenerator
 
 
 if TYPE_CHECKING:
-    from winml.modelkit.analyze.runtime_checker.ep_checker import EPChecker
-    from winml.modelkit.analyze.runtime_checker.runner import ResilientRunner
+    from ...analyze.runtime_checker.ep_checker import EPChecker
+    from ...analyze.runtime_checker.runner import ResilientRunner
 
 
 def model_bytes_to_b64(model_bytes: bytes) -> str:
@@ -1443,7 +1443,7 @@ class OpInputGenerator(ABC):
 
         # TODO: parallel and/or distributed execution of `check_compile`/`check_run`
         cases_skipped = 0
-        from winml.modelkit.analyze.runtime_checker.runner import ResilientRunner
+        from ...analyze.runtime_checker.runner import ResilientRunner
 
         with ResilientRunner(capture_output=capture_output, timeout_sec=60) as runner:
             for case_idx, (kwargs, tags) in enumerate(self.iter()):

--- a/tests/unit/analyze/core/model_validators/test_validators.py
+++ b/tests/unit/analyze/core/model_validators/test_validators.py
@@ -16,15 +16,14 @@ from __future__ import annotations
 import pytest
 from onnx import TensorProto, helper
 
+from winml.modelkit.analyze import ONNXModel, RuntimeTestResult
 from winml.modelkit.analyze.core.model_validators import (
     ConstantFoldingValidator,
     ModelValidatorManager,
 )
-from winml.modelkit.analyze.models.onnx_model import ONNXModel
-from winml.modelkit.analyze.models.runtime_checks import (
+from winml.modelkit.analyze.models.runtime_checks import (  # Testing internal implementation
     NodeTag,
     PatternRuntime,
-    RuntimeTestResult,
 )
 from winml.modelkit.pattern.match import PatternMatchResult, SkeletonMatchResult
 from winml.modelkit.pattern.models import OperatorPattern, PatternType

--- a/tests/unit/analyze/core/test_information_engine.py
+++ b/tests/unit/analyze/core/test_information_engine.py
@@ -7,16 +7,19 @@
 import onnx
 import pytest
 
-from winml.modelkit.analyze.core.information_engine import InformationEngine
-from winml.modelkit.analyze.models.information import ActionLevel, Information
-from winml.modelkit.analyze.models.onnx_model import ONNXModel
-from winml.modelkit.analyze.models.runtime_checks import (
+from winml.modelkit.analyze import (
+    ActionLevel,
     AlternativeType,
+    Information,
+    InformationEngine,
+    ONNXModel,
+    RuntimeTestResult,
+    SupportLevel,
+)
+from winml.modelkit.analyze.models.runtime_checks import (  # Testing internal implementation
     PatternAlternative,
     PatternRuntime,
-    RuntimeTestResult,
 )
-from winml.modelkit.analyze.models.support_level import SupportLevel
 
 
 @pytest.fixture

--- a/tests/unit/analyze/core/test_node_checkers.py
+++ b/tests/unit/analyze/core/test_node_checkers.py
@@ -14,13 +14,12 @@ Tests verify:
 import pytest
 from onnx import helper
 
+from winml.modelkit.analyze import AlternativeType, RuntimeTestResult
 from winml.modelkit.analyze.core.node_checkers.ep_context_node_checker import (
-    EPContextNodeChecker,
+    EPContextNodeChecker,  # Testing internal implementation
 )
 from winml.modelkit.analyze.models.runtime_checks import (
-    AlternativeType,
-    PatternAlternative,
-    RuntimeTestResult,
+    PatternAlternative,  # Testing internal implementation
 )
 from winml.modelkit.onnx import ONNXDomain
 from winml.modelkit.pattern.match import PatternMatchResult, SkeletonMatchResult

--- a/tests/unit/analyze/core/test_onnx_loader.py
+++ b/tests/unit/analyze/core/test_onnx_loader.py
@@ -16,12 +16,12 @@ if TYPE_CHECKING:
 import pytest
 from onnx import TensorProto, checker, helper
 
+from winml.modelkit.analyze import ONNXModel
 from winml.modelkit.analyze.core.onnx_loader import (
     ONNXLoader,
     ONNXLoadError,
     load_onnx_model,
 )
-from winml.modelkit.analyze.models.onnx_model import ONNXModel
 
 
 @pytest.fixture

--- a/tests/unit/analyze/core/test_output_aggregator.py
+++ b/tests/unit/analyze/core/test_output_aggregator.py
@@ -8,19 +8,21 @@ from datetime import datetime
 
 import pytest
 
-from winml.modelkit.analyze.core.output_aggregator import OutputAggregator
-from winml.modelkit.analyze.models.ihv_type import IHVType
-from winml.modelkit.analyze.models.information import Action, ActionLevel, Information
-from winml.modelkit.analyze.models.output import (
+from winml.modelkit.analyze import (
+    Action,
+    ActionLevel,
     AnalysisOutput,
     EPSupport,
+    IHVType,
+    Information,
     ModelStats,
+    OutputAggregator,
+    RuntimeTestResult,
+    SupportLevel,
 )
 from winml.modelkit.analyze.models.runtime_checks import (
-    PatternRuntime,
-    RuntimeTestResult,
+    PatternRuntime,  # Testing internal implementation
 )
-from winml.modelkit.analyze.models.support_level import SupportLevel
 from winml.modelkit.pattern.match import PatternMatchResult, SkeletonMatchResult
 from winml.modelkit.pattern.models import OperatorPattern, PatternType
 

--- a/tests/unit/analyze/core/test_pattern_deduplication.py
+++ b/tests/unit/analyze/core/test_pattern_deduplication.py
@@ -11,8 +11,7 @@ Priority: HTP metadata > hierarchy_tag > PatternMatcher
 import pytest
 from onnx import TensorProto, helper
 
-from winml.modelkit.analyze.core.pattern_extractor import PatternExtractor
-from winml.modelkit.analyze.models.onnx_model import ONNXModel
+from winml.modelkit.analyze import ONNXModel, PatternExtractor
 from winml.modelkit.pattern.match import PatternMatchResult, SkeletonMatchResult
 from winml.modelkit.pattern.models import SubgraphPattern
 
@@ -221,7 +220,7 @@ class TestPatternMatchNodeAccess:
 
     def test_matched_node_names_returns_onnx_ops(self):
         """Test that matched_node_names returns ONNXOp objects."""
-        from winml.modelkit.analyze.models.onnx_op import ONNXOp
+        from winml.modelkit.analyze import ONNXOp
 
         pattern = SubgraphPattern(
             pattern_id="SUBGRAPH/Test",

--- a/tests/unit/analyze/core/test_pattern_extractor.py
+++ b/tests/unit/analyze/core/test_pattern_extractor.py
@@ -12,9 +12,7 @@ import onnx
 import pytest
 from onnx import TensorProto, helper
 
-from winml.modelkit.analyze.core.pattern_extractor import PatternExtractor
-from winml.modelkit.analyze.models.onnx_model import ONNXModel
-from winml.modelkit.analyze.models.output import ModelStats
+from winml.modelkit.analyze import ModelStats, ONNXModel, PatternExtractor
 from winml.modelkit.pattern.match import PatternMatchResult, SkeletonMatchResult
 from winml.modelkit.pattern.models import SubgraphPattern
 

--- a/tests/unit/analyze/core/test_rule_loader_suffix.py
+++ b/tests/unit/analyze/core/test_rule_loader_suffix.py
@@ -14,8 +14,7 @@ from pathlib import Path
 
 import pytest
 
-from winml.modelkit.analyze.models.information import Information
-from winml.modelkit.analyze.utils.rule_loader import RuleLoader
+from winml.modelkit.analyze import Information, RuleLoader
 
 
 @pytest.fixture

--- a/tests/unit/analyze/core/test_runtime_checker.py
+++ b/tests/unit/analyze/core/test_runtime_checker.py
@@ -17,12 +17,10 @@ import time
 import pytest
 from onnx import TensorProto, helper
 
-from winml.modelkit.analyze.core.runtime_checker import RuntimeChecker
-from winml.modelkit.analyze.models.onnx_model import ONNXModel
-from winml.modelkit.analyze.models.runtime_checks import (
+from winml.modelkit.analyze import ONNXModel, RuntimeChecker, RuntimeTestResult
+from winml.modelkit.analyze.models.runtime_checks import (  # Testing internal implementation
     PatternAlternative,
     PatternRuntime,
-    RuntimeTestResult,
 )
 from winml.modelkit.pattern.match import PatternMatchResult, SkeletonMatchResult
 from winml.modelkit.pattern.models import OperatorPattern, PatternType

--- a/tests/unit/analyze/models/test_information.py
+++ b/tests/unit/analyze/models/test_information.py
@@ -18,8 +18,7 @@ from uuid import UUID
 import pytest
 from pydantic import ValidationError
 
-from winml.modelkit.analyze.models.information import Action, ActionItem, ActionLevel, Information
-from winml.modelkit.analyze.models.support_level import SupportLevel
+from winml.modelkit.analyze import Action, ActionItem, ActionLevel, Information, SupportLevel
 
 
 class TestActionValidation:

--- a/tests/unit/analyze/models/test_onnx_model.py
+++ b/tests/unit/analyze/models/test_onnx_model.py
@@ -17,7 +17,7 @@ import pytest
 from onnx import TensorProto, helper
 from pydantic import ValidationError
 
-from winml.modelkit.analyze.models.onnx_model import ONNXModel
+from winml.modelkit.analyze import ONNXModel
 
 
 class TestONNXModelValidation:

--- a/tests/unit/analyze/models/test_output.py
+++ b/tests/unit/analyze/models/test_output.py
@@ -17,13 +17,13 @@ import json
 import pytest
 from pydantic import ValidationError
 
-from winml.modelkit.analyze.models.ihv_type import IHVType
-from winml.modelkit.analyze.models.output import (
+from winml.modelkit.analyze import (
     AnalysisOutput,
     EPSupport,
+    IHVType,
     ModelStats,
+    SupportLevel,
 )
-from winml.modelkit.analyze.models.support_level import SupportLevel
 
 
 class TestModelStatsValidation:
@@ -366,7 +366,7 @@ class TestAnalysisOutputValidation:
 
     def test_comprehensive_output_with_all_fields(self):
         """Test AnalysisOutput with all fields populated."""
-        from winml.modelkit.analyze.models.information import Information
+        from winml.modelkit.analyze import Information
         from winml.modelkit.pattern.models import SubgraphPattern
 
         # Create the subgraph pattern

--- a/tests/unit/analyze/models/test_rule_loader.py
+++ b/tests/unit/analyze/models/test_rule_loader.py
@@ -20,8 +20,7 @@ from pathlib import Path
 
 import pytest
 
-from winml.modelkit.analyze.models.ihv_type import IHVType
-from winml.modelkit.analyze.utils.rule_loader import RuleLoader
+from winml.modelkit.analyze import IHVType, RuleLoader
 
 
 class TestRuleLoaderBasicLoading:

--- a/tests/unit/analyze/models/test_rules.py
+++ b/tests/unit/analyze/models/test_rules.py
@@ -17,12 +17,7 @@ from uuid import UUID
 import pytest
 from pydantic import ValidationError
 
-from winml.modelkit.analyze.models.ihv_type import IHVType
-from winml.modelkit.analyze.models.runtime_checks import (
-    RuntimeCheckRule,
-    RuntimeTestResult,
-)
-from winml.modelkit.analyze.models.support_level import SupportLevel
+from winml.modelkit.analyze import IHVType, RuntimeCheckRule, RuntimeTestResult, SupportLevel
 
 
 class TestRuntimeTestResultValidation:
@@ -317,7 +312,7 @@ class TestRuntimeCheckRuleValidation:
         assert rule.alternatives is None
 
         # With alternatives
-        from winml.modelkit.analyze.models.runtime_checks import AlternativeType
+        from winml.modelkit.analyze import AlternativeType
 
         rule_with_alts = RuntimeCheckRule(
             pattern_id="SUBGRAPH/GELU_Erf",

--- a/tests/unit/analyze/test_analyze_onnx.py
+++ b/tests/unit/analyze/test_analyze_onnx.py
@@ -10,16 +10,20 @@ from unittest.mock import patch
 
 import pytest
 
-from winml.modelkit.analyze.analyzer import (
+from winml.modelkit.analyze import (
+    Action,
+    ActionItem,
+    AnalysisOutput,
     AnalysisResult,
     AnalyzeResult,
+    EPSupport,
+    IHVType,
+    Information,
     LintResult,
+    ModelStats,
+    SupportLevel,
     analyze_onnx,
 )
-from winml.modelkit.analyze.models.ihv_type import IHVType
-from winml.modelkit.analyze.models.information import Action, ActionItem, Information
-from winml.modelkit.analyze.models.output import AnalysisOutput, EPSupport, ModelStats
-from winml.modelkit.analyze.models.support_level import SupportLevel
 from winml.modelkit.optim import WinMLOptimizationConfig
 
 

--- a/tests/unit/analyze/test_analyzer.py
+++ b/tests/unit/analyze/test_analyzer.py
@@ -11,16 +11,20 @@ from unittest.mock import MagicMock, Mock, patch
 import onnx
 import pytest
 
-from winml.modelkit.analyze.analyzer import (
+from winml.modelkit.analyze import (
+    Action,
+    ActionItem,
+    AnalysisOutput,
     AnalysisResult,
     AnalyzerConfig,
+    EPSupport,
+    IHVType,
+    Information,
+    ModelStats,
     ONNXStaticAnalyzer,
+    SupportLevel,
+    infer_ihv_from_ep_name,
 )
-from winml.modelkit.analyze.models.ihv_type import IHVType
-from winml.modelkit.analyze.models.information import Action, ActionItem, Information
-from winml.modelkit.analyze.models.output import AnalysisOutput, EPSupport, ModelStats
-from winml.modelkit.analyze.models.support_level import SupportLevel
-from winml.modelkit.analyze.utils import infer_ihv_from_ep_name
 from winml.modelkit.optim import WinMLOptimizationConfig
 
 

--- a/tests/unit/build/test_hf.py
+++ b/tests/unit/build/test_hf.py
@@ -87,7 +87,7 @@ def _create_file_side_effect(output_kwarg_name: str, return_value: object = None
 
 def _default_analyze_result():
     """Build a default AnalyzeResult with no opportunities (analyzer converges)."""
-    from winml.modelkit.analyze.analyzer import AnalyzeResult, LintResult
+    from winml.modelkit.analyze import AnalyzeResult, LintResult
     from winml.modelkit.optim import WinMLOptimizationConfig
 
     config = WinMLOptimizationConfig()
@@ -602,7 +602,7 @@ class TestBuildAnalyzerLoop:
         optimization_config: dict | None = None,
     ):
         """Build a mock AnalyzeResult."""
-        from winml.modelkit.analyze.analyzer import AnalyzeResult, LintResult
+        from winml.modelkit.analyze import AnalyzeResult, LintResult
         from winml.modelkit.optim import WinMLOptimizationConfig
 
         config = WinMLOptimizationConfig(**(optimization_config or {}))

--- a/tests/unit/build/test_onnx.py
+++ b/tests/unit/build/test_onnx.py
@@ -90,7 +90,7 @@ def _create_file_side_effect(output_kwarg_name: str, return_value: object = None
 
 def _default_analyze_result():
     """Build a default AnalyzeResult with no opportunities (analyzer converges)."""
-    from winml.modelkit.analyze.analyzer import AnalyzeResult, LintResult
+    from winml.modelkit.analyze import AnalyzeResult, LintResult
     from winml.modelkit.optim import WinMLOptimizationConfig
 
     config = WinMLOptimizationConfig()


### PR DESCRIPTION
## Summary

- Add ~15 symbols to `analyze/__init__.py` re-exported from `analyze.models`: `IHVType`, `SupportLevel`, `Action`, `ActionItem`, `ActionLevel`, `Information`, `EPSupport`, `ModelStats`, `ONNXModel`, `ONNXOp`, `ModelTag`, `RuntimeCheckRule`, `RuntimeTestResult`, `AlternativeType`
- Add `RuleLoader` and `infer_ihv_from_ep_name` from `analyze.utils`
- Convert 3 source files to relative imports:
  - `analyze/models/__init__.py`: absolute → relative for pattern imports
  - `pattern/match.py`: `analyze.models.onnx_op` → `..analyze`
  - `pattern/op_input_gen/op_input_gen.py`: `analyze.runtime_checker` → `...analyze.runtime_checker`
- Convert ~20 test files from internal submodule to package-level imports
- Internal models kept as internal imports: `PatternRuntime`, `PatternAlternative`, `NodeTag`, `EPChecker`, `EPContextNodeChecker`, `pattern_matching` utils, `runtime_checker_query`, `onnx_loader`, `model_validators`

Closes #37