### PR TITLE
Import cleanup Phase 9: pattern package + CLAUDE.md import rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,26 @@ Investigate root cause and fix the underlying issue. Never use `pytest.mark.skip
 - **Temp files**: Use `temp/` folder in project root.
 - **Node.js**: Available via fnm. Use `eval "$(fnm env)"` before npm/npx commands.
 
+## Import Rules
+
+### Source code (`src/`)
+
+- **Relative imports** through `__init__.py`: `from ..onnx import ONNXDomain` (not `from winml.modelkit.onnx.domains import ONNXDomain`)
+- **Within the same package**, sibling-relative is fine: `from .utils import EXTERNAL_DATA_THRESHOLD`
+- Never use absolute `from winml.modelkit.*` paths in source code
+
+### Test code (`tests/`)
+
+- **Absolute imports** from package level: `from winml.modelkit.onnx import ONNXDomain`
+- Never reach into internal submodules for symbols exported by `__init__.py`
+- **Exception**: private `_`-prefixed functions may use internal imports for testing implementation details
+
+### `__init__.py` public API
+
+- Every symbol that external code needs must be exported in the package's `__init__.py`
+- When adding new public classes/functions, add them to both the import and `__all__`
+- Private (`_`-prefixed) symbols are never added to `__init__.py`
+
 ## Code Quality
 
 - Run `uv run ruff check --fix` after revising Python code

--- a/src/winml/modelkit/pattern/__init__.py
+++ b/src/winml/modelkit/pattern/__init__.py
@@ -9,13 +9,13 @@ This package provides pattern matching, input generation, and graph rewriting
 infrastructure used by both the static analyzer and the optimizer.
 """
 
-from winml.modelkit.pattern.attention_patterns import (
+from .attention_patterns import (
     ExpandedAttentionPattern,
     ExpandedAttentionPatternInputGenerator,
     TransposeAttentionPattern,
     TransposeAttentionPatternInputGenerator,
 )
-from winml.modelkit.pattern.base import (
+from .base import (
     InvalidPatternMatcherModelError,
     Pattern,
     PatternInputGenerator,
@@ -30,7 +30,7 @@ from winml.modelkit.pattern.base import (
     opschema_to_pattern_schema,
     register_pattern_input_generator,
 )
-from winml.modelkit.pattern.gelu_patterns import (
+from .gelu_patterns import (
     Gelu1Pattern,
     Gelu1PatternInputGenerator,
     Gelu2Pattern,
@@ -41,13 +41,13 @@ from winml.modelkit.pattern.gelu_patterns import (
     Gelu4PatternInputGenerator,
     SingleGeluPattern,
 )
-from winml.modelkit.pattern.gemm_patterns import (
+from .gemm_patterns import (
     MatMulAddPattern,
     MatMulAddPatternInputGenerator,
     ReshapeGemmReshapePattern,
     ReshapeGemmReshapePatternInputGenerator,
 )
-from winml.modelkit.pattern.layernorm_patterns import (
+from .layernorm_patterns import (
     LayerNormalizationMulPattern,
     LayerNormalizationMulPatternInputGenerator,
     LayerNormalizationPowPattern,
@@ -55,9 +55,9 @@ from winml.modelkit.pattern.layernorm_patterns import (
     TransposedSingleLayerNormalizationPattern,
     TransposedSingleLayerNormalizationPatternInputGenerator,
 )
-from winml.modelkit.pattern.match import InputInfo, PatternMatchResult, SkeletonMatchResult
-from winml.modelkit.pattern.models import OperatorPattern, PatternType, SubgraphPattern
-from winml.modelkit.pattern.rmsnorm_patterns import (
+from .match import InputInfo, PatternMatchResult, SkeletonMatchResult
+from .models import OperatorPattern, PatternType, SubgraphPattern
+from .rmsnorm_patterns import (
     RMSNormalizationMulPattern,
     RMSNormalizationMulPatternInputGenerator,
     RMSNormalizationPowPattern,
@@ -65,7 +65,7 @@ from winml.modelkit.pattern.rmsnorm_patterns import (
     TransposedSingleRMSNormalizationPattern,
     TransposedSingleRMSNormalizationPatternInputGenerator,
 )
-from winml.modelkit.pattern.transpose_patterns import (
+from .transpose_patterns import (
     ReshapeTransposeReshapeLowDimPattern,
     ReshapeTransposeReshapeLowDimPatternInputGenerator,
     ReshapeTransposeReshapeOverlyHighDimPattern,

--- a/tests/unit/analyze/core/model_validators/test_validators.py
+++ b/tests/unit/analyze/core/model_validators/test_validators.py
@@ -25,8 +25,12 @@ from winml.modelkit.analyze.models.runtime_checks import (  # Testing internal i
     NodeTag,
     PatternRuntime,
 )
-from winml.modelkit.pattern.match import PatternMatchResult, SkeletonMatchResult
-from winml.modelkit.pattern.models import OperatorPattern, PatternType
+from winml.modelkit.pattern import (
+    OperatorPattern,
+    PatternMatchResult,
+    PatternType,
+    SkeletonMatchResult,
+)
 
 
 def create_onnx_model_wrapper(model_proto):

--- a/tests/unit/analyze/core/test_node_checkers.py
+++ b/tests/unit/analyze/core/test_node_checkers.py
@@ -22,8 +22,12 @@ from winml.modelkit.analyze.models.runtime_checks import (
     PatternAlternative,  # Testing internal implementation
 )
 from winml.modelkit.onnx import ONNXDomain
-from winml.modelkit.pattern.match import PatternMatchResult, SkeletonMatchResult
-from winml.modelkit.pattern.models import OperatorPattern, PatternType
+from winml.modelkit.pattern import (
+    OperatorPattern,
+    PatternMatchResult,
+    PatternType,
+    SkeletonMatchResult,
+)
 
 
 class TestEPContextNodeChecker:

--- a/tests/unit/analyze/core/test_output_aggregator.py
+++ b/tests/unit/analyze/core/test_output_aggregator.py
@@ -23,8 +23,12 @@ from winml.modelkit.analyze import (
 from winml.modelkit.analyze.models.runtime_checks import (
     PatternRuntime,  # Testing internal implementation
 )
-from winml.modelkit.pattern.match import PatternMatchResult, SkeletonMatchResult
-from winml.modelkit.pattern.models import OperatorPattern, PatternType
+from winml.modelkit.pattern import (
+    OperatorPattern,
+    PatternMatchResult,
+    PatternType,
+    SkeletonMatchResult,
+)
 
 
 @pytest.fixture

--- a/tests/unit/analyze/core/test_pattern_deduplication.py
+++ b/tests/unit/analyze/core/test_pattern_deduplication.py
@@ -12,8 +12,7 @@ import pytest
 from onnx import TensorProto, helper
 
 from winml.modelkit.analyze import ONNXModel, PatternExtractor
-from winml.modelkit.pattern.match import PatternMatchResult, SkeletonMatchResult
-from winml.modelkit.pattern.models import SubgraphPattern
+from winml.modelkit.pattern import PatternMatchResult, SkeletonMatchResult, SubgraphPattern
 
 
 @pytest.fixture

--- a/tests/unit/analyze/core/test_pattern_extractor.py
+++ b/tests/unit/analyze/core/test_pattern_extractor.py
@@ -13,8 +13,7 @@ import pytest
 from onnx import TensorProto, helper
 
 from winml.modelkit.analyze import ModelStats, ONNXModel, PatternExtractor
-from winml.modelkit.pattern.match import PatternMatchResult, SkeletonMatchResult
-from winml.modelkit.pattern.models import SubgraphPattern
+from winml.modelkit.pattern import PatternMatchResult, SkeletonMatchResult, SubgraphPattern
 
 
 @pytest.fixture

--- a/tests/unit/analyze/core/test_runtime_checker.py
+++ b/tests/unit/analyze/core/test_runtime_checker.py
@@ -22,8 +22,12 @@ from winml.modelkit.analyze.models.runtime_checks import (  # Testing internal i
     PatternAlternative,
     PatternRuntime,
 )
-from winml.modelkit.pattern.match import PatternMatchResult, SkeletonMatchResult
-from winml.modelkit.pattern.models import OperatorPattern, PatternType
+from winml.modelkit.pattern import (
+    OperatorPattern,
+    PatternMatchResult,
+    PatternType,
+    SkeletonMatchResult,
+)
 
 
 @pytest.fixture

--- a/tests/unit/analyze/models/test_output.py
+++ b/tests/unit/analyze/models/test_output.py
@@ -367,7 +367,7 @@ class TestAnalysisOutputValidation:
     def test_comprehensive_output_with_all_fields(self):
         """Test AnalysisOutput with all fields populated."""
         from winml.modelkit.analyze import Information
-        from winml.modelkit.pattern.models import SubgraphPattern
+        from winml.modelkit.pattern import SubgraphPattern
 
         # Create the subgraph pattern
         _subgraph_pattern = SubgraphPattern(

--- a/tests/unit/analyze/models/test_patterns.py
+++ b/tests/unit/analyze/models/test_patterns.py
@@ -17,8 +17,16 @@ Tests verify:
 import pytest
 from pydantic import ValidationError
 
-from winml.modelkit.pattern.match import PatternMatchResult, SkeletonMatchResult
-from winml.modelkit.pattern.models import OperatorPattern, Pattern, PatternType, SubgraphPattern
+from winml.modelkit.pattern import (
+    OperatorPattern,
+    PatternMatchResult,
+    PatternType,
+    SkeletonMatchResult,
+)
+from winml.modelkit.pattern.models import (  # Pattern name collision with pattern.base.Pattern
+    Pattern,
+    SubgraphPattern,
+)
 
 
 def create_pattern_match_for_testing(pattern, node_protos):

--- a/tests/unit/analyze/pattern/conftest.py
+++ b/tests/unit/analyze/pattern/conftest.py
@@ -20,7 +20,7 @@ import onnx
 from onnx import helper
 
 from winml.modelkit.onnx import ONNXDomain
-from winml.modelkit.pattern.base import (
+from winml.modelkit.pattern import (
     InvalidPatternMatcherModelError,
     PatternMatcher,
     get_pattern_input_generator,

--- a/tests/unit/analyze/pattern/test_gemm_patterns.py
+++ b/tests/unit/analyze/pattern/test_gemm_patterns.py
@@ -12,8 +12,8 @@ import numpy as np
 from winml.modelkit.pattern import (
     MatMulAddPattern,
     PatternMatcher,
+    ReshapeGemmReshapePattern,
 )
-from winml.modelkit.pattern.gemm_patterns import ReshapeGemmReshapePattern
 
 from .conftest import TEST_DOMAIN_VERSIONS
 
@@ -30,9 +30,7 @@ def _create_gemm_family_model(pattern, *, with_constants=False):
         "C": with_constants,
     }
     output_dtypes = ["tensor(float)"]
-    return pattern.get_onnx_model(
-        inputs, {}, is_constant_map, output_dtypes, TEST_DOMAIN_VERSIONS
-    )
+    return pattern.get_onnx_model(inputs, {}, is_constant_map, output_dtypes, TEST_DOMAIN_VERSIONS)
 
 
 class TestGemmFamilyCrossMatching:
@@ -53,11 +51,13 @@ class TestGemmFamilyCrossMatching:
         results1 = matcher1.match()
 
         matmuladd_matches = [
-            r for r in results1
+            r
+            for r in results1
             if type(r.skeleton_match_result.pattern).__name__ == "MatMulAddPattern"
         ]
         reshape_matches = [
-            r for r in results1
+            r
+            for r in results1
             if type(r.skeleton_match_result.pattern).__name__ == "ReshapeGemmReshapePattern"
         ]
         assert len(matmuladd_matches) == 1
@@ -70,11 +70,13 @@ class TestGemmFamilyCrossMatching:
         results2 = matcher2.match()
 
         matmuladd_matches2 = [
-            r for r in results2
+            r
+            for r in results2
             if type(r.skeleton_match_result.pattern).__name__ == "MatMulAddPattern"
         ]
         reshape_matches2 = [
-            r for r in results2
+            r
+            for r in results2
             if type(r.skeleton_match_result.pattern).__name__ == "ReshapeGemmReshapePattern"
         ]
         assert len(matmuladd_matches2) == 0

--- a/tests/unit/analyze/pattern/test_pattern_input_generator.py
+++ b/tests/unit/analyze/pattern/test_pattern_input_generator.py
@@ -13,7 +13,7 @@ Tests verify:
 
 import pytest
 
-from winml.modelkit.pattern.base import (
+from winml.modelkit.pattern import (
     get_pattern_input_generator,
     get_registered_pattern_input_generators,
 )
@@ -54,14 +54,10 @@ class TestPatternInputGeneratorValidation:
     def test_pattern_validation(self, pattern_name: str) -> None:
         """Test that each pattern's input generator validates successfully."""
         if pattern_name in SKIP_VALIDATION_PATTERNS:
-            pytest.skip(
-                f"Skipping validation for {pattern_name} (known runtime limitation)"
-            )
+            pytest.skip(f"Skipping validation for {pattern_name} (known runtime limitation)")
 
         generator_class = get_pattern_input_generator(pattern_name)
-        domain_versions = PATTERNS_REQUIRING_NEWER_OPSET.get(
-            pattern_name, TEST_DOMAIN_VERSIONS
-        )
+        domain_versions = PATTERNS_REQUIRING_NEWER_OPSET.get(pattern_name, TEST_DOMAIN_VERSIONS)
         gen = generator_class(domain_versions=domain_versions)
         gen.validate_inputs()
 
@@ -69,8 +65,6 @@ class TestPatternInputGeneratorValidation:
     def test_pattern_instantiation(self, pattern_name: str) -> None:
         """Test that each pattern's input generator can be instantiated."""
         generator_class = get_pattern_input_generator(pattern_name)
-        domain_versions = PATTERNS_REQUIRING_NEWER_OPSET.get(
-            pattern_name, TEST_DOMAIN_VERSIONS
-        )
+        domain_versions = PATTERNS_REQUIRING_NEWER_OPSET.get(pattern_name, TEST_DOMAIN_VERSIONS)
         gen = generator_class(domain_versions=domain_versions)
         assert gen.registration_name == pattern_name

--- a/tests/unit/analyze/pattern/test_pattern_matching.py
+++ b/tests/unit/analyze/pattern/test_pattern_matching.py
@@ -15,8 +15,8 @@ from winml.modelkit.pattern import (
     Gelu2Pattern,
     MatMulAddPattern,
     PatternMatcher,
+    ReshapeGemmReshapePattern,
 )
-from winml.modelkit.pattern.gemm_patterns import ReshapeGemmReshapePattern
 
 
 # Path to test fixtures

--- a/tests/unit/analyze/pattern/test_pattern_rewriting.py
+++ b/tests/unit/analyze/pattern/test_pattern_rewriting.py
@@ -16,10 +16,10 @@ from winml.modelkit.pattern import (
     MatMulAddPattern,
     PatternMatcher,
     PatternRewriter,
+    ReshapeGemmReshapePattern,
     SingleGeluPattern,
     TransposeAttentionPattern,
 )
-from winml.modelkit.pattern.gemm_patterns import ReshapeGemmReshapePattern
 
 
 # Path to test fixtures
@@ -145,7 +145,8 @@ class TestPatternRewriting:
 
         # Check that new nodes have the expected naming pattern
         rewrite_nodes = [
-            node for node in new_model.graph.node
+            node
+            for node in new_model.graph.node
             if node.name.startswith("Rewrite_ReshapeGemmReshapePattern_")
         ]
 
@@ -245,8 +246,7 @@ class TestPatternRewriterWarnings:
 
         # 36 - 1 = 35 patterns should be rewritten
         assert len(reshape_gemm_results) == 35, (
-            f"Expected 35 ReshapeGemmReshape matches (1 skipped), "
-            f"found {len(reshape_gemm_results)}"
+            f"Expected 35 ReshapeGemmReshape matches (1 skipped), found {len(reshape_gemm_results)}"
         )
 
 
@@ -284,14 +284,10 @@ class TestComprehensivePatternRewriting:
 
         # Categorize results
         gelu_results = [
-            r
-            for r in all_results
-            if isinstance(r.skeleton_match_result.pattern, Gelu2Pattern)
+            r for r in all_results if isinstance(r.skeleton_match_result.pattern, Gelu2Pattern)
         ]
         matmuladd_results = [
-            r
-            for r in all_results
-            if isinstance(r.skeleton_match_result.pattern, MatMulAddPattern)
+            r for r in all_results if isinstance(r.skeleton_match_result.pattern, MatMulAddPattern)
         ]
 
         # Verify expected counts before rewriting
@@ -302,10 +298,12 @@ class TestComprehensivePatternRewriting:
 
         # Rewrite all patterns
         rewriter = PatternRewriter(erf_convnext_model)
-        new_model = rewriter.rewrite([
-            (gelu_results, SingleGeluPattern),
-            (matmuladd_results, ReshapeGemmReshapePattern),
-        ])
+        new_model = rewriter.rewrite(
+            [
+                (gelu_results, SingleGeluPattern),
+                (matmuladd_results, ReshapeGemmReshapePattern),
+            ]
+        )
 
         # Verify model validity
         onnx.checker.check_model(new_model)
@@ -355,9 +353,7 @@ class TestComprehensivePatternRewriting:
         new_results = new_matcher2.match()
 
         new_msft_gelu = [
-            r
-            for r in new_results
-            if isinstance(r.skeleton_match_result.pattern, SingleGeluPattern)
+            r for r in new_results if isinstance(r.skeleton_match_result.pattern, SingleGeluPattern)
         ]
         new_reshape_gemm = [
             r
@@ -369,8 +365,7 @@ class TestComprehensivePatternRewriting:
             f"Expected 18 SingleGelu matches after rewriting, found {len(new_msft_gelu)}"
         )
         assert len(new_reshape_gemm) == 36, (
-            f"Expected 36 ReshapeGemmReshape matches after rewriting, "
-            f"found {len(new_reshape_gemm)}"
+            f"Expected 36 ReshapeGemmReshape matches after rewriting, found {len(new_reshape_gemm)}"
         )
 
 
@@ -493,7 +488,8 @@ class TestAttentionPatternRewriting:
 
         # Check that new nodes have the expected naming pattern
         rewrite_nodes = [
-            node for node in new_model.graph.node
+            node
+            for node in new_model.graph.node
             if node.name.startswith("Rewrite_TransposeAttentionPattern_")
         ]
 
@@ -527,12 +523,12 @@ class TestAttentionPatternRewriting:
                     break
 
             if original_scales[i] is not None:
-                assert scale_attr is not None, (
-                    f"Attention node {i} should have scale attribute"
-                )
+                assert scale_attr is not None, f"Attention node {i} should have scale attribute"
                 np.testing.assert_allclose(
-                    scale_attr, original_scales[i], rtol=1e-5,
-                    err_msg=f"Attention node {i} scale should match original"
+                    scale_attr,
+                    original_scales[i],
+                    rtol=1e-5,
+                    err_msg=f"Attention node {i} scale should match original",
                 )
 
     def test_rewrite_original_model_unchanged(self, bert_tiny_model):

--- a/tests/unit/analyze/pattern/test_rewrite_pipe.py
+++ b/tests/unit/analyze/pattern/test_rewrite_pipe.py
@@ -26,7 +26,7 @@ import pytest
 from winml.modelkit.onnx import ONNXDomain
 from winml.modelkit.optim.pipes.rewrite import RewritePipe
 from winml.modelkit.optim.pipes.rewrite_rules import REWRITE_GROUPS
-from winml.modelkit.pattern.base import PatternMatcher
+from winml.modelkit.pattern import PatternMatcher
 
 # Reuse the conftest helpers (available as module-level functions)
 from .conftest import generate_self_matching_model
@@ -41,7 +41,7 @@ TEST_DOMAIN_VERSIONS: dict[ONNXDomain, int] = {ONNXDomain.AI_ONNX: 17}
 
 def _count_pattern_matches(model: onnx.ModelProto, pattern_name: str) -> int:
     """Return number of times a named pattern matches in the model."""
-    from winml.modelkit.pattern.base import get_pattern_input_generator
+    from winml.modelkit.pattern import get_pattern_input_generator
 
     gen_class = get_pattern_input_generator(pattern_name)
     gen = gen_class(domain_versions=TEST_DOMAIN_VERSIONS)

--- a/tests/unit/analyze/pattern/test_sam2_transpose_rewriting.py
+++ b/tests/unit/analyze/pattern/test_sam2_transpose_rewriting.py
@@ -15,8 +15,9 @@ from pathlib import Path
 import onnx
 import pytest
 
-from winml.modelkit.pattern import PatternMatcher, PatternRewriter
-from winml.modelkit.pattern.transpose_patterns import (
+from winml.modelkit.pattern import (
+    PatternMatcher,
+    PatternRewriter,
     ReshapeTransposeReshapeLowDimPattern,
     ReshapeTransposeReshapeOverlyHighDimPattern,
 )

--- a/tests/unit/analyze/pattern/test_transpose_patterns.py
+++ b/tests/unit/analyze/pattern/test_transpose_patterns.py
@@ -17,10 +17,10 @@ import onnxruntime as ort
 from winml.modelkit.pattern import (
     MatMulAddPattern,
     PatternMatcher,
+    ReshapeGemmReshapePattern,
     ReshapeTransposeReshapeLowDimPattern,
     ReshapeTransposeReshapeOverlyHighDimPattern,
 )
-from winml.modelkit.pattern.gemm_patterns import ReshapeGemmReshapePattern
 
 from .conftest import TEST_DOMAIN_VERSIONS
 
@@ -144,7 +144,7 @@ class TestReshapeTransposeReshapeLowDimPattern:
 
     def test_no_merging_with_fully_reversed_perm(self) -> None:
         """Fully reversed perm has no consecutive axes, so no merging."""
-        from winml.modelkit.pattern.transpose_patterns import (
+        from winml.modelkit.pattern.transpose_patterns import (  # Testing internal implementation
             _compute_merged_transpose,
         )
 

--- a/tests/unit/analyze/pattern/test_universal_pattern.py
+++ b/tests/unit/analyze/pattern/test_universal_pattern.py
@@ -12,7 +12,7 @@ for ONNX generation, self-matching, removability, schema, and match structure.
 import onnx
 import pytest
 
-from winml.modelkit.pattern.base import (
+from winml.modelkit.pattern import (
     PatternMatcher,
     get_registered_pattern_input_generators,
 )
@@ -55,9 +55,7 @@ class TestUniversalPatternONNXGeneration:
         _model, _pattern, result = generate_self_matching_model(pattern_name)
         assert result.skeleton_match_result.removable is True
 
-    def test_self_match_not_removable_with_intermediate_output(
-        self, pattern_name: str
-    ) -> None:
+    def test_self_match_not_removable_with_intermediate_output(self, pattern_name: str) -> None:
         """Pattern becomes non-removable when an intermediate output is a graph output."""
         _skip_if_unsupported(pattern_name)
         model, pattern, _result = generate_self_matching_model(pattern_name)
@@ -134,8 +132,6 @@ class TestUniversalPatternMatchStructure:
 
         # Input infos present for each schema input
         for inp in schema.inputs:
-            assert inp.name in result.input_infos, (
-                f"Missing input info for '{inp.name}'"
-            )
+            assert inp.name in result.input_infos, f"Missing input info for '{inp.name}'"
             info = result.input_infos[inp.name]
             assert isinstance(info.is_constant, bool)

--- a/tests/unit/optim/pipes/test_pipe_rewrite.py
+++ b/tests/unit/optim/pipes/test_pipe_rewrite.py
@@ -36,12 +36,13 @@ from winml.modelkit.optim.pipes.rewrite_rules import (
     get_rewrite_rules_for_capability,
     list_rewrite_families,
 )
-from winml.modelkit.pattern.base import (
+from winml.modelkit.pattern import (
     InvalidPatternMatcherModelError,
     PatternMatcher,
+    PatternMatchResult,
+    SkeletonMatchResult,
     get_pattern_input_generator,
 )
-from winml.modelkit.pattern.match import PatternMatchResult, SkeletonMatchResult
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

### pattern
- Convert `pattern/__init__.py` from 9 absolute `from winml.modelkit.pattern.*` imports to relative `from .*`
- Convert ~30 test imports from `pattern.match`, `pattern.models`, `pattern.base`, `pattern.gemm_patterns`, `pattern.transpose_patterns` submodules to package-level `from winml.modelkit.pattern import`
- Handle `Pattern` name collision (`base.Pattern` ABC vs `models.Pattern` Pydantic model) — keep `models.Pattern` as submodule import
- Private `_compute_merged_transpose` kept as internal import
- `op_input_gen` and `config` submodule imports kept — testing internals

### CLAUDE.md
- Add **Import Rules** section documenting the codebase-wide policy:
  - Source code: relative imports through `__init__.py`
  - Tests: absolute imports from package level
  - Private `_`-prefixed functions: internal imports for testing
  - `__init__.py` must export all externally needed symbols

Closes #38