### PR TITLE
Add property ort_device

### DIFF
--- a/src/winml/modelkit/models/winml/base.py
+++ b/src/winml/modelkit/models/winml/base.py
@@ -199,8 +199,18 @@ class WinMLPreTrainedModel(PreTrainedModel, ABC):
         return self._session.perf(warmup=warmup)
 
     @property
-    def device(self) -> str:
-        """Current device."""
+    def device(self) -> torch.device:
+        """Torch device for HF pipeline compatibility.
+
+        Always returns ``torch.device("cpu")`` because WinML models run
+        through ORT, not PyTorch — tensors passed to/from the model live
+        on CPU.  Use :pyattr:`ort_device` for the actual ORT EP target.
+        """
+        return torch.device("cpu")
+
+    @property
+    def ort_device(self) -> str:
+        """ORT execution provider target (e.g. "npu", "gpu", "cpu", "auto")."""
         return self._device
 
     @property

--- a/tests/unit/models/auto/test_automodel.py
+++ b/tests/unit/models/auto/test_automodel.py
@@ -133,17 +133,15 @@ class TestDevicePolicySelection:
     """Test device policy selection."""
 
     def test_device_property(self):
-        """AC-6: device property returns current device."""
+        """AC-6: device property returns torch.device for HF compatibility."""
         model = _make_mock_model()
 
-        assert model.device == "cpu"
+        assert model.device == torch.device("cpu")
 
-    def test_device_policy_not_ep_names(self):
-        """AC-6: Uses policy names not EP names."""
-        # Valid device names: auto, npu, gpu, cpu
-        # Not execution provider names
+    def test_ort_device_property(self):
+        """AC-6: ort_device returns the ORT EP target string."""
         model = _make_mock_model()
-        assert model.device in ("auto", "npu", "gpu", "cpu")
+        assert model.ort_device in ("auto", "npu", "gpu", "cpu")
 
 
 class TestONNXPipeline:

--- a/tests/unit/models/auto/test_image_classification.py
+++ b/tests/unit/models/auto/test_image_classification.py
@@ -178,10 +178,10 @@ class TestProperties:
         assert model.num_labels == 1000
 
     def test_device_property(self):
-        """device property returns current device."""
+        """device property returns torch.device for HF compatibility."""
         model = create_mock_model()
 
-        assert model.device == "cpu"
+        assert model.device == torch.device("cpu")
 
     def test_dtype_property(self):
         """dtype property returns float32."""

--- a/tests/unit/models/auto/test_image_segmentation.py
+++ b/tests/unit/models/auto/test_image_segmentation.py
@@ -249,10 +249,10 @@ class TestProperties:
         assert model.num_labels == 150
 
     def test_device_property(self):
-        """device property returns current device."""
+        """device property returns torch.device for HF compatibility."""
         model = create_mock_model()
 
-        assert model.device == "cpu"
+        assert model.device == torch.device("cpu")
 
     def test_dtype_property(self):
         """dtype property returns float32."""

--- a/tests/unit/models/auto/test_sequence_classification.py
+++ b/tests/unit/models/auto/test_sequence_classification.py
@@ -153,10 +153,10 @@ class TestProperties:
         assert model.num_labels == 2
 
     def test_device_property(self):
-        """device property returns current device."""
+        """device property returns torch.device for HF compatibility."""
         model = create_mock_model()
 
-        assert model.device == "cpu"
+        assert model.device == torch.device("cpu")
 
     def test_dtype_property(self):
         """dtype property returns float32."""


### PR DESCRIPTION
This PR adds an `ort_device` property to differentiate the HF-facing device from the ORT execution-provider target.

### Problem

`WinMLPreTrainedModel` aims to fit into the HuggingFace ecosystem (e.g. `pipeline`). HF expects `model.device` to return a `torch.device` indicating where tensors live, and pairs it with `model.to()` for device placement. Our implementation returns an ORT device string (`"npu"`, `"cpu"`, …) instead, which breaks compatibility in two ways:

1. **Type mismatch** — HF expects `torch.device`, not `str`. Torch has no `"npu"` device, so the value is also semantically invalid.
2. **Semantic mismatch** — HF uses `device` and `to()` as a pair for tensor placement. Our `to()` is intentionally a no-op since ORT handles device placement via EP policy, so `device` should reflect where tensors actually live (CPU), not the ORT backend target.

### Solution

- `device` now returns `torch.device("cpu")` — tensors passed to/from the model always live on CPU.
- New `ort_device` property exposes the ORT EP target string (`"auto"`, `"npu"`, `"gpu"`, `"cpu"`).