### PR TITLE
feat(cli): add wmk hub command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ include = [ "winml", "winml.*" ]
 
 [tool.setuptools.package-data]
 "winml.modelkit" = [ "py.typed" ]
+"winml.modelkit.data" = [ "hub_models.json" ]
 "winml.modelkit.analyze" = [
   "rules/**/*.json",
   "rules/**/*.zip",

--- a/src/winml/modelkit/commands/__init__.py
+++ b/src/winml/modelkit/commands/__init__.py
@@ -7,3 +7,4 @@
 Commands in this package are auto-discovered by cli.py.
 Each module should export a Click command as the primary object.
 """
+

--- a/src/winml/modelkit/commands/hub.py
+++ b/src/winml/modelkit/commands/hub.py
@@ -34,9 +34,7 @@ from typing import Any
 import click
 import rich.box
 from rich.console import Console, Group
-from rich.live import Live
 from rich.panel import Panel
-from rich.spinner import Spinner
 from rich.table import Table
 from rich.text import Text
 
@@ -209,15 +207,7 @@ def _output_list(models: list[dict[str, Any]]) -> None:
         console.print("[yellow]No models match the given filters.[/yellow]")
         return
 
-    with Live(
-        Spinner("dots", text=" Loading catalog..."),
-        console=console,
-        transient=True,
-        refresh_per_second=10,
-    ):
-        renderable = _build_list_renderable(models)
-
-    console.print(renderable)
+    console.print(_build_list_renderable(models))
 
 
 # ---------------------------------------------------------------------------

--- a/src/winml/modelkit/commands/hub.py
+++ b/src/winml/modelkit/commands/hub.py
@@ -1,0 +1,481 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+r"""Hub command for ModelKit CLI.
+
+Lets users discover ModelKit's curated built-in model catalog.  The catalog
+is stored in ``modelkit/data/hub_models.json`` and lists specific, validated
+HuggingFace model IDs with their task, architecture, and benchmark results.
+
+Accuracy fields explain *how much* quantization changed a model's metric:
+
+* ``verdict`` -- "PASS" if drop is within tolerance, "AT_RISK" if it is
+  borderline, "REGRESSION" if it exceeds the threshold.
+* ``drop_pct`` -- relative change vs FP32 baseline expressed as a percentage.
+  Negative means the quantized model scored lower.
+
+Usage:
+    wmk hub
+    wmk hub --model-type bert
+    wmk hub --task text-classification
+    wmk hub --model ProsusAI/finbert
+    wmk hub --output catalog.json
+"""
+
+from __future__ import annotations
+
+import importlib.resources
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import click
+import rich.box
+from rich.console import Console, Group
+from rich.live import Live
+from rich.panel import Panel
+from rich.spinner import Spinner
+from rich.table import Table
+from rich.text import Text
+
+
+logger = logging.getLogger(__name__)
+console = Console(highlight=False)
+
+# Verdict display config (ASCII-safe icons)
+_VERDICT_ICON = {"PASS": "[+]", "AT_RISK": "[~]", "REGRESSION": "[!]"}
+_VERDICT_STYLE = {"PASS": "bold green", "AT_RISK": "bold yellow", "REGRESSION": "bold red"}
+
+# ---------------------------------------------------------------------------
+# Catalog loader
+# ---------------------------------------------------------------------------
+
+
+def _load_catalog() -> dict[str, Any]:
+    """Load hub_models.json from package data.
+
+    Returns:
+        Parsed catalog dict with ``version`` and ``models`` keys.
+    """
+    pkg = importlib.resources.files("winml.modelkit.data")
+    data = (pkg / "hub_models.json").read_text(encoding="utf-8")
+    return json.loads(data)  # type: ignore[no-any-return]
+
+
+def _filter_models(
+    models: list[dict[str, Any]],
+    model_type: str | None,
+    task: str | None,
+) -> list[dict[str, Any]]:
+    """Apply --model-type and --task filters.
+
+    Args:
+        models: Full model list from the catalog.
+        model_type: Optional architecture filter (case-insensitive).
+        task: Optional task filter (case-insensitive).
+
+    Returns:
+        Filtered model list.
+    """
+    result = models
+    if model_type:
+        result = [m for m in result if m["model_type"].lower() == model_type.lower()]
+    if task:
+        result = [m for m in result if m["task"].lower() == task.lower()]
+    return result
+
+
+def _find_model(models: list[dict[str, Any]], model_id: str) -> dict[str, Any] | None:
+    """Look up a model by ID (exact first, then case-insensitive substring).
+
+    Args:
+        models: Full model list from the catalog.
+        model_id: The model ID to search for.
+
+    Returns:
+        The matching model dict, or None if not found / ambiguous.
+    """
+    lower = model_id.lower()
+    for m in models:
+        if m["model_id"].lower() == lower:
+            return m
+    matches = [m for m in models if lower in m["model_id"].lower()]
+    return matches[0] if len(matches) == 1 else None
+
+
+# ---------------------------------------------------------------------------
+# Rendering helpers (used by detail view and JSON formatting)
+# ---------------------------------------------------------------------------
+
+
+def _fmt_model_id(model_id: str) -> Text:
+    """Render model ID with the org prefix dimmed.
+
+    Args:
+        model_id: HuggingFace model ID, e.g. ``openai/clip-vit-base-patch32``.
+
+    Returns:
+        Rich Text with org in dim and model name in cyan bold.
+    """
+    t = Text(overflow="ellipsis", no_wrap=True)
+    if "/" in model_id:
+        org, name = model_id.split("/", 1)
+        t.append(org + "/", style="dim")
+        t.append(name, style="cyan bold")
+    else:
+        t.append(model_id, style="cyan bold")
+    return t
+
+
+def _overall_verdict(accuracy: dict[str, Any]) -> str:
+    """Derive the display-level overall verdict from per-EP entries.
+
+    Priority: REGRESSION > AT_RISK > PASS.
+
+    Args:
+        accuracy: Per-EP accuracy dict from the catalog entry.
+
+    Returns:
+        One of ``"PASS"``, ``"AT_RISK"``, or ``"REGRESSION"``.
+    """
+    verdicts = {info.get("verdict", "PASS") for info in accuracy.values()}
+    if "REGRESSION" in verdicts:
+        return "REGRESSION"
+    if "AT_RISK" in verdicts:
+        return "AT_RISK"
+    return "PASS"
+
+
+
+# ---------------------------------------------------------------------------
+# List view
+# ---------------------------------------------------------------------------
+
+
+def _build_list_renderable(models: list[dict[str, Any]]) -> Group:
+    """Build the Rich renderable for the catalog list.
+
+    A Panel wraps the three-column data table (Model / Task / Type) and a
+    hint line is printed below the Panel border.
+
+    Args:
+        models: Filtered model list to display.
+
+    Returns:
+        A :class:`rich.console.Group` with the Panel and the hint line.
+    """
+    table = Table(
+        box=rich.box.SQUARE,
+        show_header=True,
+        header_style="bold",
+        padding=(0, 2),
+        show_edge=False,
+        expand=True,
+    )
+    table.add_column("Model", no_wrap=True, max_width=38)
+    table.add_column("Task", no_wrap=True)
+    table.add_column("Model Type", no_wrap=True, style="magenta")
+
+    for m in models:
+        table.add_row(
+            _fmt_model_id(m["model_id"]),
+            m["task"],
+            m["model_type"],
+        )
+
+    panel = Panel(
+        table,
+        title=f"[bold]ModelKit Catalog[/bold]  [dim]|[/dim]  "
+              f"[bold cyan]{len(models)}[/bold cyan] validated model(s)",
+        border_style="blue",
+        padding=(0, 1),
+    )
+    hint = Text(
+        "Use  wmk hub --model <id>  to see perf and accuracy details.",
+        style="dim",
+    )
+    return Group(panel, hint)
+
+
+def _output_list(models: list[dict[str, Any]]) -> None:
+    """Render models as a compact 3-column list table.
+
+    Args:
+        models: Filtered model list to display.
+    """
+    if not models:
+        console.print("[yellow]No models match the given filters.[/yellow]")
+        return
+
+    with Live(
+        Spinner("dots", text=" Loading catalog..."),
+        console=console,
+        transient=True,
+        refresh_per_second=10,
+    ):
+        renderable = _build_list_renderable(models)
+
+    console.print(renderable)
+
+
+# ---------------------------------------------------------------------------
+# Detail view
+# ---------------------------------------------------------------------------
+
+
+def _build_detail_renderable(m: dict[str, Any]) -> Group:
+    """Build the detail view as three separate Panels.
+
+    * Panel 1 -- General Information (Task, Type)
+    * Panel 2 -- Latency (ms): one row per EP, columns Avg/P50/.../Max/QPS
+    * Panel 3 -- Accuracy: one row per EP, columns Verdict/vs FP32
+
+    When no benchmark data is available a single panel with a notice is shown.
+
+    Args:
+        m: A single model dict from the catalog.
+
+    Returns:
+        A :class:`rich.console.Group` of Panels suitable for ``console.print``.
+    """
+    _table_kwargs: dict[str, Any] = {
+        "box": rich.box.SQUARE,
+        "show_header": True,
+        "header_style": "bold",
+        "padding": (0, 1),
+        "show_edge": False,
+    }
+
+    # -- Panel 1: General Information ----------------------------------------
+    info = Table(box=None, show_header=False, padding=(0, 2), show_edge=False)
+    info.add_column(style="dim", no_wrap=True)
+    info.add_column(no_wrap=True)
+    info.add_row("Task", m["task"])
+    info.add_row("Type", f"[magenta]{m['model_type']}[/magenta]")
+
+    panels: list[Any] = [
+        Panel(
+            info,
+            title=_fmt_model_id(m["model_id"]),
+            border_style="blue",
+            padding=(0, 1),
+        )
+    ]
+
+    perf = m.get("perf")
+    accuracy = m.get("accuracy")
+
+    # -- Panel 2: Latency (ms) -----------------------------------------------
+    if perf:
+        lat = Table(**_table_kwargs)
+        lat.add_column("EP", no_wrap=True)
+        for col in ["Avg", "P50", "P90", "P95", "P99", "Min", "Max"]:
+            lat.add_column(col, justify="right", no_wrap=True)
+        lat.add_column("QPS", justify="right", no_wrap=True)
+
+        for ep, s in perf.items():
+            lat.add_row(
+                ep,
+                f"[bold]{s['avg_ms']:.2f}[/bold]",
+                f"{s.get('p50_ms', 0.0):.2f}",
+                f"{s.get('p90_ms', 0.0):.2f}",
+                f"{s.get('p95_ms', 0.0):.2f}",
+                f"{s.get('p99_ms', 0.0):.2f}",
+                f"{s.get('min_ms', 0.0):.2f}",
+                f"{s.get('max_ms', 0.0):.2f}",
+                f"{s.get('throughput_qps', 0.0):.0f}",
+            )
+
+        panels.append(
+            Panel(lat, title="[bold]Latency (ms)[/bold]", border_style="blue", padding=(0, 1))
+        )
+
+    # -- Panel 3: Accuracy ---------------------------------------------------
+    if accuracy:
+        overall = _overall_verdict(accuracy)
+        acc_panel_title = Text.assemble(
+            ("Accuracy  ", "bold"),
+            (
+                f"{_VERDICT_ICON.get(overall, '')} {overall}",
+                _VERDICT_STYLE.get(overall, ""),
+            ),
+        )
+
+        acc = Table(**_table_kwargs, expand=True)
+        acc.add_column("EP", no_wrap=True)
+        acc.add_column("Verdict", no_wrap=True)
+        acc.add_column("vs FP32", justify="right", no_wrap=True)
+
+        for ep, ep_info in accuracy.items():
+            verdict = ep_info.get("verdict", "PASS")
+            drop = ep_info.get("drop_pct", 0.0)
+            sign = "+" if drop > 0 else ""
+            ep_icon = _VERDICT_ICON.get(verdict, "")
+            ep_style = _VERDICT_STYLE.get(verdict, "")
+            acc.add_row(
+                ep,
+                Text(f"{ep_icon} {verdict}", style=ep_style),
+                Text(f"{sign}{drop:.2f}%", style=ep_style),
+            )
+
+        panels.append(
+            Panel(acc, title=acc_panel_title, border_style="blue", padding=(0, 1))
+        )
+
+    if not perf and not accuracy:
+        panels.append(
+            Panel(
+                Text("No benchmark data available.", style="dim"),
+                title="[bold]Benchmark[/bold]",
+                border_style="blue",
+                padding=(0, 1),
+            )
+        )
+
+    return Group(*panels)
+
+
+def _print_detail(m: dict[str, Any]) -> None:
+    """Render and print the detail Group of Panels for *m*.
+
+    Args:
+        m: A single model dict from the catalog.
+    """
+    console.print(_build_detail_renderable(m))
+    console.print()
+
+
+def _output_detail(models: list[dict[str, Any]], model_id: str) -> dict[str, Any]:
+    """Find and render detailed perf/accuracy info for a single model.
+
+    Args:
+        models: Full model list from the catalog.
+        model_id: The model ID string from --model.
+
+    Returns:
+        The matched model dict (for JSON saving).
+
+    Raises:
+        click.ClickException: When the model is not found or ambiguous.
+    """
+    m = _find_model(models, model_id)
+    if m is None:
+        lower = model_id.lower()
+        candidates = [x["model_id"] for x in models if lower in x["model_id"].lower()]
+        if candidates:
+            msg = f"Ambiguous model ID '{model_id}'. Did you mean one of:\n"
+            msg += "\n".join(f"  {c}" for c in candidates)
+        else:
+            msg = (
+                f"Model '{model_id}' not found in the catalog. "
+                "Run 'wmk hub' to list all models."
+            )
+        raise click.ClickException(msg)
+
+    _print_detail(m)
+    return m
+
+
+# ---------------------------------------------------------------------------
+# JSON file output
+# ---------------------------------------------------------------------------
+
+
+def _save_json(data: Any, path: Path) -> None:
+    """Write *data* as indented JSON to *path*, creating parent dirs as needed.
+
+    Args:
+        data: JSON-serialisable object.
+        path: Destination file path.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+    console.print(f"[green]Results saved to:[/green] {path}")
+
+
+# ---------------------------------------------------------------------------
+# CLI definition
+# ---------------------------------------------------------------------------
+
+
+@click.command()
+@click.option(
+    "--model-type",
+    "-t",
+    default=None,
+    metavar="TYPE",
+    help="Filter by model architecture (e.g. bert, roberta, vit).",
+)
+@click.option(
+    "--task",
+    "-k",
+    default=None,
+    metavar="TASK",
+    help="Filter by HuggingFace task (e.g. text-classification, image-segmentation).",
+)
+@click.option(
+    "--model",
+    "-m",
+    default=None,
+    metavar="MODEL_ID",
+    help="Show perf and accuracy details for a specific model.",
+)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Save results to a JSON file.",
+)
+def hub(
+    model_type: str | None,
+    task: str | None,
+    model: str | None,
+    output: Path | None,
+) -> None:
+    r"""Browse ModelKit's curated built-in model catalog.
+
+    Lists HuggingFace models that have been validated end-to-end
+    (export -> quantise -> run on device) with confirmed accuracy results.
+    Use ``--output`` to save results to a JSON file.
+
+    \b
+    Accuracy legend:
+      [+] PASS       -- drop within tolerance
+      [~] AT_RISK    -- borderline drop, use with care
+      [!] REGRESSION -- accuracy degraded beyond threshold
+      drop %         -- relative change vs FP32 baseline
+
+    \b
+    Use ``wmk hub --model <model_id>`` for per-model perf and accuracy.
+    Use ``wmk inspect -m <model_id>`` for architecture details.
+
+    \b
+    Examples:
+        wmk hub
+        wmk hub --model-type bert
+        wmk hub --task text-classification
+        wmk hub --model ProsusAI/finbert
+        wmk hub --output results/catalog.json
+    """
+    try:
+        catalog = _load_catalog()
+    except Exception as e:
+        raise click.ClickException(f"Failed to load model catalog: {e}") from e
+
+    all_models = catalog["models"]
+
+    if model:
+        m = _output_detail(all_models, model)
+        if output is not None:
+            _save_json(m, output)
+        return
+
+    models = _filter_models(all_models, model_type=model_type, task=task)
+    _output_list(models)
+
+    if output is not None:
+        _save_json(models, output)

--- a/src/winml/modelkit/data/hub_models.json
+++ b/src/winml/modelkit/data/hub_models.json
@@ -1,0 +1,750 @@
+{
+  "version": "1.0",
+  "models": [
+    {
+      "model_id": "ProsusAI/finbert",
+      "model_type": "bert",
+      "task": "text-classification",
+      "perf": {
+        "QNN": {
+          "avg_ms": 13.71,
+          "p50_ms": 13.75,
+          "p90_ms": 13.84,
+          "p95_ms": 13.84,
+          "p99_ms": 13.84,
+          "min_ms": 13.59,
+          "max_ms": 13.84,
+          "throughput_qps": 72.93
+        },
+        "OV": {
+          "avg_ms": 25.28,
+          "p50_ms": 24.84,
+          "p90_ms": 35.33,
+          "p95_ms": 35.33,
+          "p99_ms": 35.33,
+          "min_ms": 20.6,
+          "max_ms": 35.33,
+          "throughput_qps": 39.56
+        }
+      },
+      "accuracy": {
+        "QNN": {
+          "verdict": "PASS",
+          "drop_pct": 0.27
+        },
+        "OV": {
+          "verdict": "PASS",
+          "drop_pct": 0.27
+        }
+      }
+    },
+    {
+      "model_id": "Intel/bert-base-uncased-mrpc",
+      "model_type": "bert",
+      "task": "text-classification",
+      "perf": {
+        "QNN": {
+          "avg_ms": 13.78,
+          "p50_ms": 13.72,
+          "p90_ms": 14.23,
+          "p95_ms": 14.23,
+          "p99_ms": 14.23,
+          "min_ms": 13.55,
+          "max_ms": 14.23,
+          "throughput_qps": 72.55
+        },
+        "OV": {
+          "avg_ms": 26.53,
+          "p50_ms": 26.12,
+          "p90_ms": 32.58,
+          "p95_ms": 32.58,
+          "p99_ms": 32.58,
+          "min_ms": 23.48,
+          "max_ms": 32.58,
+          "throughput_qps": 37.69
+        }
+      },
+      "accuracy": {
+        "QNN": {
+          "verdict": "PASS",
+          "drop_pct": 0
+        },
+        "OV": {
+          "verdict": "PASS",
+          "drop_pct": 0
+        }
+      }
+    },
+    {
+      "model_id": "dslim/bert-base-NER",
+      "model_type": "bert",
+      "task": "token-classification",
+      "perf": {
+        "QNN": {
+          "avg_ms": 13.75,
+          "p50_ms": 13.66,
+          "p90_ms": 14.5,
+          "p95_ms": 14.5,
+          "p99_ms": 14.5,
+          "min_ms": 13.51,
+          "max_ms": 14.5,
+          "throughput_qps": 72.73
+        },
+        "OV": {
+          "avg_ms": 35.86,
+          "p50_ms": 37.25,
+          "p90_ms": 39.72,
+          "p95_ms": 39.72,
+          "p99_ms": 39.72,
+          "min_ms": 29.75,
+          "max_ms": 39.72,
+          "throughput_qps": 27.89
+        },
+        "VitisAI": {
+          "avg_ms": 121.4,
+          "p50_ms": 122.06,
+          "p90_ms": 126.73,
+          "p95_ms": 126.73,
+          "p99_ms": 126.73,
+          "min_ms": 116.25,
+          "max_ms": 126.73,
+          "throughput_qps": 8.24
+        }
+      },
+      "accuracy": {
+        "QNN": {
+          "verdict": "PASS",
+          "drop_pct": 0
+        },
+        "OV": {
+          "verdict": "PASS",
+          "drop_pct": 0
+        }
+      }
+    },
+    {
+      "model_id": "dbmdz/bert-large-cased-finetuned-conll03-english",
+      "model_type": "bert",
+      "task": "token-classification",
+      "perf": {
+        "QNN": {
+          "avg_ms": 40.92,
+          "p50_ms": 39.53,
+          "p90_ms": 48.47,
+          "p95_ms": 48.47,
+          "p99_ms": 48.47,
+          "min_ms": 39.31,
+          "max_ms": 48.47,
+          "throughput_qps": 24.44
+        },
+        "OV": {
+          "avg_ms": 79.85,
+          "p50_ms": 81.57,
+          "p90_ms": 86.16,
+          "p95_ms": 86.16,
+          "p99_ms": 86.16,
+          "min_ms": 69.63,
+          "max_ms": 86.16,
+          "throughput_qps": 12.52
+        },
+        "VitisAI": {
+          "avg_ms": 376.57,
+          "p50_ms": 373.37,
+          "p90_ms": 396.16,
+          "p95_ms": 396.16,
+          "p99_ms": 396.16,
+          "min_ms": 365.24,
+          "max_ms": 396.16,
+          "throughput_qps": 2.66
+        }
+      },
+      "accuracy": {
+        "QNN": {
+          "verdict": "PASS",
+          "drop_pct": -0.09
+        },
+        "OV": {
+          "verdict": "PASS",
+          "drop_pct": -0.06
+        }
+      }
+    },
+    {
+      "model_id": "Babelscape/wikineural-multilingual-ner",
+      "model_type": "bert",
+      "task": "token-classification",
+      "perf": {
+        "QNN": {
+          "avg_ms": 13.86,
+          "p50_ms": 13.81,
+          "p90_ms": 14.68,
+          "p95_ms": 14.68,
+          "p99_ms": 14.68,
+          "min_ms": 13.69,
+          "max_ms": 14.68,
+          "throughput_qps": 72.13
+        },
+        "OV": {
+          "avg_ms": 34.67,
+          "p50_ms": 34.81,
+          "p90_ms": 38.03,
+          "p95_ms": 38.03,
+          "p99_ms": 38.03,
+          "min_ms": 32.16,
+          "max_ms": 38.03,
+          "throughput_qps": 28.84
+        },
+        "VitisAI": {
+          "avg_ms": 118.59,
+          "p50_ms": 119.56,
+          "p90_ms": 129.55,
+          "p95_ms": 129.55,
+          "p99_ms": 129.55,
+          "min_ms": 111.5,
+          "max_ms": 129.55,
+          "throughput_qps": 8.43
+        }
+      },
+      "accuracy": {
+        "QNN": {
+          "verdict": "PASS",
+          "drop_pct": -3.19
+        },
+        "OV": {
+          "verdict": "PASS",
+          "drop_pct": -0.41
+        }
+      }
+    },
+    {
+      "model_id": "cardiffnlp/twitter-roberta-base-sentiment-latest",
+      "model_type": "roberta",
+      "task": "text-classification",
+      "perf": {
+        "QNN": {
+          "avg_ms": 14.46,
+          "p50_ms": 14.43,
+          "p90_ms": 16.4,
+          "p95_ms": 16.4,
+          "p99_ms": 16.4,
+          "min_ms": 13.87,
+          "max_ms": 16.4,
+          "throughput_qps": 69.18
+        },
+        "OV": {
+          "avg_ms": 26.73,
+          "p50_ms": 25.25,
+          "p90_ms": 38.53,
+          "p95_ms": 38.53,
+          "p99_ms": 38.53,
+          "min_ms": 23.06,
+          "max_ms": 38.53,
+          "throughput_qps": 37.4
+        },
+        "VitisAI": {
+          "avg_ms": 97.55,
+          "p50_ms": 95.88,
+          "p90_ms": 107.96,
+          "p95_ms": 107.96,
+          "p99_ms": 107.96,
+          "min_ms": 94.22,
+          "max_ms": 107.96,
+          "throughput_qps": 10.25
+        }
+      },
+      "accuracy": {
+        "QNN": {
+          "verdict": "PASS",
+          "drop_pct": 0
+        },
+        "OV": {
+          "verdict": "PASS",
+          "drop_pct": -0.26
+        }
+      }
+    },
+    {
+      "model_id": "w11wo/indonesian-roberta-base-posp-tagger",
+      "model_type": "roberta",
+      "task": "token-classification",
+      "perf": {
+        "QNN": {
+          "avg_ms": 14.07,
+          "p50_ms": 13.94,
+          "p90_ms": 14.98,
+          "p95_ms": 14.98,
+          "p99_ms": 14.98,
+          "min_ms": 13.75,
+          "max_ms": 14.98,
+          "throughput_qps": 71.09
+        },
+        "OV": {
+          "avg_ms": 35.78,
+          "p50_ms": 35.31,
+          "p90_ms": 39.14,
+          "p95_ms": 39.14,
+          "p99_ms": 39.14,
+          "min_ms": 33.82,
+          "max_ms": 39.14,
+          "throughput_qps": 27.95
+        },
+        "VitisAI": {
+          "avg_ms": 121.4,
+          "p50_ms": 122.44,
+          "p90_ms": 123.8,
+          "p95_ms": 123.8,
+          "p99_ms": 123.8,
+          "min_ms": 115.17,
+          "max_ms": 123.8,
+          "throughput_qps": 8.24
+        }
+      },
+      "accuracy": {
+        "QNN": {
+          "verdict": "PASS",
+          "drop_pct": -0.05
+        },
+        "OV": {
+          "verdict": "PASS",
+          "drop_pct": -0.02
+        }
+      }
+    },
+    {
+      "model_id": "google/vit-base-patch16-224",
+      "model_type": "vit",
+      "task": "image-classification",
+      "perf": {
+        "QNN": {
+          "avg_ms": 6.13,
+          "p50_ms": 6.14,
+          "p90_ms": 6.2,
+          "p95_ms": 6.2,
+          "p99_ms": 6.2,
+          "min_ms": 6.03,
+          "max_ms": 6.2,
+          "throughput_qps": 163.07
+        },
+        "OV": {
+          "avg_ms": 17.59,
+          "p50_ms": 17.34,
+          "p90_ms": 22.21,
+          "p95_ms": 22.21,
+          "p99_ms": 22.21,
+          "min_ms": 14.52,
+          "max_ms": 22.21,
+          "throughput_qps": 56.86
+        },
+        "VitisAI": {
+          "avg_ms": 13.73,
+          "p50_ms": 13.8,
+          "p90_ms": 14.68,
+          "p95_ms": 14.68,
+          "p99_ms": 14.68,
+          "min_ms": 12.73,
+          "max_ms": 14.68,
+          "throughput_qps": 72.83
+        }
+      },
+      "accuracy": {
+        "QNN": {
+          "verdict": "PASS",
+          "drop_pct": 0
+        },
+        "OV": {
+          "verdict": "PASS",
+          "drop_pct": 0.38
+        }
+      }
+    },
+    {
+      "model_id": "rizvandwiki/gender-classification",
+      "model_type": "vit",
+      "task": "image-classification",
+      "perf": {
+        "QNN": {
+          "avg_ms": 6.01,
+          "p50_ms": 6,
+          "p90_ms": 6.18,
+          "p95_ms": 6.18,
+          "p99_ms": 6.18,
+          "min_ms": 5.92,
+          "max_ms": 6.18,
+          "throughput_qps": 166.36
+        },
+        "OV": {
+          "avg_ms": 16.78,
+          "p50_ms": 15.64,
+          "p90_ms": 26.37,
+          "p95_ms": 26.37,
+          "p99_ms": 26.37,
+          "min_ms": 12.75,
+          "max_ms": 26.37,
+          "throughput_qps": 59.6
+        },
+        "VitisAI": {
+          "avg_ms": 13.4,
+          "p50_ms": 13.4,
+          "p90_ms": 13.89,
+          "p95_ms": 13.89,
+          "p99_ms": 13.89,
+          "min_ms": 12.99,
+          "max_ms": 13.89,
+          "throughput_qps": 74.61
+        }
+      },
+      "accuracy": {
+        "QNN": {
+          "verdict": "PASS",
+          "drop_pct": 0.37
+        },
+        "OV": {
+          "verdict": "PASS",
+          "drop_pct": -0.12
+        }
+      }
+    },
+    {
+      "model_id": "microsoft/swin-large-patch4-window7-224",
+      "model_type": "swin",
+      "task": "image-classification",
+      "perf": {
+        "OV": {
+          "avg_ms": 35.89,
+          "p50_ms": 33.59,
+          "p90_ms": 51.01,
+          "p95_ms": 51.01,
+          "p99_ms": 51.01,
+          "min_ms": 32.27,
+          "max_ms": 51.01,
+          "throughput_qps": 27.86
+        },
+        "VitisAI": {
+          "avg_ms": 200.89,
+          "p50_ms": 202,
+          "p90_ms": 218.55,
+          "p95_ms": 218.55,
+          "p99_ms": 218.55,
+          "min_ms": 188.68,
+          "max_ms": 218.55,
+          "throughput_qps": 4.98
+        }
+      },
+      "accuracy": {
+        "OV": {
+          "verdict": "PASS",
+          "drop_pct": -0.12
+        }
+      }
+    },
+    {
+      "model_id": "facebook/convnext-tiny-224",
+      "model_type": "convnext",
+      "task": "image-classification",
+      "perf": {
+        "QNN": {
+          "avg_ms": 2.27,
+          "p50_ms": 2.28,
+          "p90_ms": 2.33,
+          "p95_ms": 2.33,
+          "p99_ms": 2.33,
+          "min_ms": 2.19,
+          "max_ms": 2.33,
+          "throughput_qps": 440.66
+        },
+        "OV": {
+          "avg_ms": 8.57,
+          "p50_ms": 8.62,
+          "p90_ms": 9.34,
+          "p95_ms": 9.34,
+          "p99_ms": 9.34,
+          "min_ms": 7.93,
+          "max_ms": 9.34,
+          "throughput_qps": 116.68
+        }
+      },
+      "accuracy": {
+        "QNN": {
+          "verdict": "PASS",
+          "drop_pct": 0.12
+        },
+        "OV": {
+          "verdict": "PASS",
+          "drop_pct": 0.37
+        }
+      }
+    },
+    {
+      "model_id": "microsoft/resnet-50",
+      "model_type": "resnet",
+      "task": "image-classification",
+      "perf": {
+        "QNN": {
+          "avg_ms": 1.22,
+          "p50_ms": 1.14,
+          "p90_ms": 1.94,
+          "p95_ms": 1.94,
+          "p99_ms": 1.94,
+          "min_ms": 1.09,
+          "max_ms": 1.94,
+          "throughput_qps": 822.72
+        },
+        "OV": {
+          "avg_ms": 3.96,
+          "p50_ms": 4.06,
+          "p90_ms": 4.13,
+          "p95_ms": 4.13,
+          "p99_ms": 4.13,
+          "min_ms": 3.6,
+          "max_ms": 4.13,
+          "throughput_qps": 252.4
+        },
+        "VitisAI": {
+          "avg_ms": 2.32,
+          "p50_ms": 2.33,
+          "p90_ms": 2.41,
+          "p95_ms": 2.41,
+          "p99_ms": 2.41,
+          "min_ms": 2.28,
+          "max_ms": 2.41,
+          "throughput_qps": 430.77
+        }
+      },
+      "accuracy": {
+        "QNN": {
+          "verdict": "AT_RISK",
+          "drop_pct": -5.99
+        },
+        "OV": {
+          "verdict": "AT_RISK",
+          "drop_pct": -6.63
+        }
+      }
+    },
+    {
+      "model_id": "microsoft/table-transformer-detection",
+      "model_type": "table-transformer",
+      "task": "object-detection",
+      "perf": {
+        "QNN": {
+          "avg_ms": 32.98,
+          "p50_ms": 32.72,
+          "p90_ms": 34.88,
+          "p95_ms": 34.88,
+          "p99_ms": 34.88,
+          "min_ms": 32.04,
+          "max_ms": 34.88,
+          "throughput_qps": 30.33
+        },
+        "OV": {
+          "avg_ms": 27.29,
+          "p50_ms": 26.76,
+          "p90_ms": 35.82,
+          "p95_ms": 35.82,
+          "p99_ms": 35.82,
+          "min_ms": 23.48,
+          "max_ms": 35.82,
+          "throughput_qps": 36.64
+        }
+      },
+      "accuracy": {
+        "QNN": {
+          "verdict": "AT_RISK",
+          "drop_pct": -8.82
+        },
+        "OV": {
+          "verdict": "PASS",
+          "drop_pct": -0.67
+        }
+      }
+    },
+    {
+      "model_id": "mattmdjaga/segformer_b2_clothes",
+      "model_type": "segformer",
+      "task": "image-segmentation",
+      "perf": {
+        "QNN": {
+          "avg_ms": 40,
+          "p50_ms": 40.01,
+          "p90_ms": 41.03,
+          "p95_ms": 41.03,
+          "p99_ms": 41.03,
+          "min_ms": 39.49,
+          "max_ms": 41.03,
+          "throughput_qps": 25
+        },
+        "OV": {
+          "avg_ms": 62.04,
+          "p50_ms": 62.47,
+          "p90_ms": 65.84,
+          "p95_ms": 65.84,
+          "p99_ms": 65.84,
+          "min_ms": 58.25,
+          "max_ms": 65.84,
+          "throughput_qps": 16.12
+        },
+        "VitisAI": {
+          "avg_ms": 247.77,
+          "p50_ms": 248.04,
+          "p90_ms": 249.84,
+          "p95_ms": 249.84,
+          "p99_ms": 249.84,
+          "min_ms": 245.47,
+          "max_ms": 249.84,
+          "throughput_qps": 4.04
+        }
+      },
+      "accuracy": {
+        "QNN": {
+          "verdict": "PASS",
+          "drop_pct": -0.19
+        },
+        "OV": {
+          "verdict": "PASS",
+          "drop_pct": -0.18
+        }
+      }
+    },
+    {
+      "model_id": "nvidia/segformer-b1-finetuned-ade-512-512",
+      "model_type": "segformer",
+      "task": "image-segmentation",
+      "perf": {
+        "QNN": {
+          "avg_ms": 19.7,
+          "p50_ms": 19.64,
+          "p90_ms": 20.47,
+          "p95_ms": 20.47,
+          "p99_ms": 20.47,
+          "min_ms": 19.2,
+          "max_ms": 20.47,
+          "throughput_qps": 50.75
+        },
+        "OV": {
+          "avg_ms": 22.72,
+          "p50_ms": 21.85,
+          "p90_ms": 34.02,
+          "p95_ms": 34.02,
+          "p99_ms": 34.02,
+          "min_ms": 18.9,
+          "max_ms": 34.02,
+          "throughput_qps": 44.01
+        },
+        "VitisAI": {
+          "avg_ms": 139.99,
+          "p50_ms": 140.11,
+          "p90_ms": 140.96,
+          "p95_ms": 140.96,
+          "p99_ms": 140.96,
+          "min_ms": 139.22,
+          "max_ms": 140.96,
+          "throughput_qps": 7.14
+        }
+      },
+      "accuracy": {
+        "QNN": {
+          "verdict": "PASS",
+          "drop_pct": -0.8
+        },
+        "OV": {
+          "verdict": "PASS",
+          "drop_pct": -0.91
+        }
+      }
+    },
+    {
+      "model_id": "nvidia/segformer-b2-finetuned-ade-512-512",
+      "model_type": "segformer",
+      "task": "image-segmentation",
+      "perf": {
+        "QNN": {
+          "avg_ms": 43.22,
+          "p50_ms": 42.42,
+          "p90_ms": 49.14,
+          "p95_ms": 49.14,
+          "p99_ms": 49.14,
+          "min_ms": 41.09,
+          "max_ms": 49.14,
+          "throughput_qps": 23.14
+        },
+        "OV": {
+          "avg_ms": 62.28,
+          "p50_ms": 60.68,
+          "p90_ms": 68.38,
+          "p95_ms": 68.38,
+          "p99_ms": 68.38,
+          "min_ms": 58.26,
+          "max_ms": 68.38,
+          "throughput_qps": 16.06
+        },
+        "VitisAI": {
+          "avg_ms": 272.61,
+          "p50_ms": 271.8,
+          "p90_ms": 283.01,
+          "p95_ms": 283.01,
+          "p99_ms": 283.01,
+          "min_ms": 263.27,
+          "max_ms": 283.01,
+          "throughput_qps": 3.67
+        }
+      },
+      "accuracy": {
+        "QNN": {
+          "verdict": "PASS",
+          "drop_pct": 0.13
+        },
+        "OV": {
+          "verdict": "PASS",
+          "drop_pct": 0.25
+        }
+      }
+    },
+    {
+      "model_id": "nvidia/segformer-b5-finetuned-ade-640-640",
+      "model_type": "segformer",
+      "task": "image-segmentation",
+      "perf": {
+        "QNN": {
+          "avg_ms": 140.24,
+          "p50_ms": 140.35,
+          "p90_ms": 142.76,
+          "p95_ms": 142.76,
+          "p99_ms": 142.76,
+          "min_ms": 138.72,
+          "max_ms": 142.76,
+          "throughput_qps": 7.13
+        },
+        "OV": {
+          "avg_ms": 175.83,
+          "p50_ms": 175.79,
+          "p90_ms": 183.06,
+          "p95_ms": 183.06,
+          "p99_ms": 183.06,
+          "min_ms": 168.93,
+          "max_ms": 183.06,
+          "throughput_qps": 5.69
+        },
+        "VitisAI": {
+          "avg_ms": 722.2,
+          "p50_ms": 722.49,
+          "p90_ms": 732.45,
+          "p95_ms": 732.45,
+          "p99_ms": 732.45,
+          "min_ms": 716.39,
+          "max_ms": 732.45,
+          "throughput_qps": 1.38
+        }
+      },
+      "accuracy": {
+        "QNN": {
+          "verdict": "PASS",
+          "drop_pct": -0.19
+        },
+        "OV": {
+          "verdict": "PASS",
+          "drop_pct": -0.21
+        }
+      }
+    }
+  ]
+}

--- a/tests/unit/commands/test_hub.py
+++ b/tests/unit/commands/test_hub.py
@@ -1,0 +1,343 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Tests for the wmk hub CLI command (no network calls, catalog mocked)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from winml.modelkit.commands.hub import (
+    _filter_models,
+    _fmt_model_id,
+    _overall_verdict,
+    hub,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+MINIMAL_CATALOG = {
+    "version": "1.0",
+    "models": [
+        {
+            "model_id": "google-bert/bert-base-uncased",
+            "model_type": "bert",
+            "task": "fill-mask",
+            "perf": None,
+            "accuracy": None,
+        },
+        {
+            "model_id": "dslim/bert-base-NER",
+            "model_type": "bert",
+            "task": "token-classification",
+            "perf": {
+                "QNN": {
+                    "avg_ms": 13.71, "p50_ms": 13.75, "p90_ms": 13.84,
+                    "p95_ms": 13.84, "p99_ms": 13.84,
+                    "min_ms": 13.59, "max_ms": 13.84, "throughput_qps": 72.93,
+                },
+                "OV": {
+                    "avg_ms": 25.28, "p50_ms": 24.84, "p90_ms": 35.33,
+                    "p95_ms": 35.33, "p99_ms": 35.33,
+                    "min_ms": 20.6, "max_ms": 35.33, "throughput_qps": 39.56,
+                },
+            },
+            "accuracy": {
+                "QNN": {"verdict": "PASS", "drop_pct": 0.0},
+                "OV":  {"verdict": "PASS", "drop_pct": 0.0},
+            },
+        },
+        {
+            "model_id": "facebook/detr-resnet-50",
+            "model_type": "detr",
+            "task": "object-detection",
+            "perf": None,
+            "accuracy": {
+                "QNN": {"verdict": "REGRESSION", "drop_pct": -36.84},
+                "OV":  {"verdict": "REGRESSION", "drop_pct": -32.67},
+            },
+        },
+        {
+            "model_id": "openai/clip-vit-base-patch32",
+            "model_type": "clip",
+            "task": "zero-shot-image-classification",
+            "perf": None,
+            "accuracy": None,
+        },
+    ],
+}
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def patched_catalog():
+    """Patch _load_catalog to return MINIMAL_CATALOG."""
+    with patch("winml.modelkit.commands.hub._load_catalog", return_value=MINIMAL_CATALOG):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# _filter_models unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_filter_no_filters_returns_all():
+    result = _filter_models(MINIMAL_CATALOG["models"], model_type=None, task=None)
+    assert len(result) == 4
+
+
+def test_filter_by_model_type():
+    result = _filter_models(MINIMAL_CATALOG["models"], model_type="bert", task=None)
+    assert len(result) == 2
+    assert all(m["model_type"] == "bert" for m in result)
+
+
+def test_filter_by_task():
+    result = _filter_models(MINIMAL_CATALOG["models"], model_type=None, task="fill-mask")
+    assert len(result) == 1
+    assert result[0]["model_id"] == "google-bert/bert-base-uncased"
+
+
+def test_filter_model_type_case_insensitive():
+    result = _filter_models(MINIMAL_CATALOG["models"], model_type="BERT", task=None)
+    assert len(result) == 2
+
+
+def test_filter_no_match_returns_empty():
+    result = _filter_models(MINIMAL_CATALOG["models"], model_type="llama", task=None)
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_fmt_model_id_with_org():
+    t = _fmt_model_id("openai/clip-vit-base-patch32")
+    assert "openai/" in t.plain
+    assert "clip-vit-base-patch32" in t.plain
+
+
+def test_fmt_model_id_no_org():
+    t = _fmt_model_id("bert-base-uncased")
+    assert t.plain == "bert-base-uncased"
+
+
+# ---------------------------------------------------------------------------
+# _overall_verdict unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_overall_verdict_priority():
+    assert _overall_verdict({"QNN": {"verdict": "PASS"}, "OV": {"verdict": "PASS"}}) == "PASS"
+    assert _overall_verdict({"QNN": {"verdict": "AT_RISK"}, "OV": {"verdict": "PASS"}}) == "AT_RISK"
+    assert (
+        _overall_verdict({"QNN": {"verdict": "REGRESSION"}, "OV": {"verdict": "AT_RISK"}})
+        == "REGRESSION"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI integration tests via CliRunner
+# ---------------------------------------------------------------------------
+
+
+def test_hub_default_shows_table(runner, patched_catalog):
+    result = runner.invoke(hub, ["--output", "/dev/null"])
+    assert result.exit_code == 0
+    assert "ModelKit Catalog" in result.output
+    assert "4 validated model(s)" in result.output
+    assert "bert" in result.output
+    assert "detr" in result.output
+
+
+def test_hub_table_shows_hint(runner, patched_catalog):
+    result = runner.invoke(hub, ["--output", "/dev/null"])
+    assert result.exit_code == 0
+    assert "wmk hub --model" in result.output
+
+
+def test_hub_saves_json_file(runner, patched_catalog, tmp_path):
+    out = tmp_path / "catalog.json"
+    result = runner.invoke(hub, ["--output", str(out)])
+    assert result.exit_code == 0
+    assert out.exists()
+    data = json.loads(out.read_text())
+    assert isinstance(data, list)
+    assert len(data) == 4
+    first = data[0]
+    assert "model_id" in first
+    assert "model_type" in first
+    assert "task" in first
+    assert "perf" in first
+    assert "accuracy" in first
+
+
+def test_hub_shows_accuracy_pass(runner, patched_catalog, tmp_path):
+    out = tmp_path / "out.json"
+    result = runner.invoke(hub, ["--model-type", "bert", "--output", str(out)])
+    assert result.exit_code == 0
+    data = json.loads(out.read_text())
+    verdicts = {
+        ep: info["verdict"]
+        for m in data
+        if m.get("accuracy")
+        for ep, info in m["accuracy"].items()
+    }
+    assert "PASS" in verdicts.values()
+
+
+def test_hub_shows_accuracy_regression(runner, patched_catalog, tmp_path):
+    out = tmp_path / "out.json"
+    result = runner.invoke(hub, ["--model-type", "detr", "--output", str(out)])
+    assert result.exit_code == 0
+    data = json.loads(out.read_text())
+    assert len(data) == 1
+    verdicts = [info["verdict"] for info in data[0]["accuracy"].values()]
+    assert "REGRESSION" in verdicts
+
+
+def test_hub_filter_model_type(runner, patched_catalog, tmp_path):
+    out = tmp_path / "out.json"
+    result = runner.invoke(hub, ["--model-type", "bert", "--output", str(out)])
+    assert result.exit_code == 0
+    data = json.loads(out.read_text())
+    assert all(m["model_type"] == "bert" for m in data)
+    assert len(data) == 2
+
+
+def test_hub_filter_task(runner, patched_catalog, tmp_path):
+    out = tmp_path / "out.json"
+    result = runner.invoke(hub, ["--task", "fill-mask", "--output", str(out)])
+    assert result.exit_code == 0
+    data = json.loads(out.read_text())
+    assert len(data) == 1
+    assert data[0]["model_id"] == "google-bert/bert-base-uncased"
+
+
+def test_hub_no_match_shows_message(runner, patched_catalog):
+    result = runner.invoke(hub, ["--model-type", "llama", "--output", "/dev/null"])
+    assert result.exit_code == 0
+    assert "No models match" in result.output
+
+
+def test_hub_json_accuracy_structure(runner, patched_catalog, tmp_path):
+    out = tmp_path / "out.json"
+    result = runner.invoke(
+        hub, ["--model-type", "bert", "--task", "token-classification", "--output", str(out)]
+    )
+    assert result.exit_code == 0
+    data = json.loads(out.read_text())
+    assert len(data) == 1
+    acc = data[0]["accuracy"]
+    assert acc["QNN"]["verdict"] == "PASS"
+    assert acc["QNN"]["drop_pct"] == 0.0
+
+
+def test_hub_saves_path_shown_in_output(runner, patched_catalog, tmp_path):
+    out = tmp_path / "my_catalog.json"
+    result = runner.invoke(hub, ["--output", str(out)])
+    assert result.exit_code == 0
+    assert "Results saved to:" in result.output
+    assert "my_catalog.json" in result.output
+
+
+def test_hub_model_detail_shows_perf(runner, patched_catalog, tmp_path):
+    result = runner.invoke(hub, ["--model", "dslim/bert-base-NER", "--output", "/dev/null"])
+    assert result.exit_code == 0
+    assert "Latency (ms)" in result.output
+    assert "QNN" in result.output
+    assert "OV" in result.output
+
+
+def test_hub_model_detail_shows_accuracy(runner, patched_catalog, tmp_path):
+    result = runner.invoke(hub, ["--model", "dslim/bert-base-NER", "--output", "/dev/null"])
+    assert result.exit_code == 0
+    assert "Accuracy" in result.output
+    assert "PASS" in result.output
+
+
+def test_hub_model_detail_regression(runner, patched_catalog):
+    result = runner.invoke(
+        hub, ["--model", "facebook/detr-resnet-50", "--output", "/dev/null"]
+    )
+    assert result.exit_code == 0
+    assert "REGRESSION" in result.output
+    assert "-36.84%" in result.output
+
+
+def test_hub_model_detail_no_data(runner, patched_catalog):
+    result = runner.invoke(
+        hub, ["--model", "openai/clip-vit-base-patch32", "--output", "/dev/null"]
+    )
+    assert result.exit_code == 0
+    assert "No benchmark data" in result.output
+
+
+def test_hub_model_saves_json(runner, patched_catalog, tmp_path):
+    out = tmp_path / "model.json"
+    result = runner.invoke(hub, ["--model", "dslim/bert-base-NER", "--output", str(out)])
+    assert result.exit_code == 0
+    assert out.exists()
+    data = json.loads(out.read_text())
+    assert data["model_id"] == "dslim/bert-base-NER"
+    assert "perf" in data
+    assert "accuracy" in data
+
+
+def test_hub_model_partial_match(runner, patched_catalog):
+    # "base-NER" matches exactly one model in MINIMAL_CATALOG
+    result = runner.invoke(hub, ["--model", "base-NER", "--output", "/dev/null"])
+    assert result.exit_code == 0
+    assert "token-classification" in result.output
+
+
+def test_hub_model_not_found(runner, patched_catalog):
+    result = runner.invoke(hub, ["--model", "nonexistent-model-xyz"])
+    assert result.exit_code != 0
+    assert "not found" in result.output
+
+
+def test_hub_model_ambiguous(runner, patched_catalog):
+    # "bert" matches multiple model IDs
+    result = runner.invoke(hub, ["--model", "bert"])
+    assert result.exit_code != 0
+    assert "Ambiguous" in result.output
+
+
+def test_hub_catalog_load_error(runner):
+    with patch(
+        "winml.modelkit.commands.hub._load_catalog",
+        side_effect=FileNotFoundError("missing"),
+    ):
+        result = runner.invoke(hub, [])
+    assert result.exit_code != 0
+    assert "Failed to load model catalog" in result.output
+
+
+def test_hub_real_catalog_loads(runner, tmp_path):
+    """Smoke test: real hub_models.json is loadable and returns expected fields."""
+    out = tmp_path / "catalog.json"
+    result = runner.invoke(hub, ["--output", str(out)])
+    assert result.exit_code == 0
+    data = json.loads(out.read_text())
+    assert len(data) > 0
+    for entry in data:
+        assert "model_id" in entry
+        assert "model_type" in entry
+        assert "task" in entry
+        assert "perf" in entry
+        assert "accuracy" in entry


### PR DESCRIPTION
## Summary

- Adds `wmk hub` CLI command backed by `hub_models.json` (17 validated models)
- `wmk hub` renders a 3-column catalog table (Model / Task / Model Type) in a blue Panel with a hint line printed below the border
- `wmk hub --model-type <type>` / `--task <task>` case-insensitive filters
- `wmk hub --model <id>` renders 3 separate Panels: General Info, Latency (ms), and Accuracy
- `--output <file>` saves results as JSON; no default auto-save without `--output`
- Partial and case-insensitive model ID matching; ambiguous match → non-zero exit with suggestions
- ASCII-only icons (`[+] [~] [!]`); no UTF-8 emoji
- 28 unit tests in `tests/unit/commands/test_hub.py` via `click.testing.CliRunner`

Closes #117

<img width="1290" height="562" alt="image" src="https://github.com/user-attachments/assets/eff76b52-9f49-46cd-8934-7117807db8a6" />


<img width="1296" height="441" alt="image" src="https://github.com/user-attachments/assets/7086df95-32ba-483a-b860-594ada4dc16f" />
