### PR TITLE
fix: stale module paths, import violations, and silently skipped Gelu tests

### DIFF
--- a/scripts/e2e_eval/run_pytorch_baseline.py
+++ b/scripts/e2e_eval/run_pytorch_baseline.py
@@ -1,3 +1,8 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
 """PyTorch baseline inference for accuracy evaluation (Signal 2).
 
 Performs native PyTorch inference on a HuggingFace model using the same
@@ -89,7 +94,9 @@ def _load_pytorch_model(model_id: str, task: str, device_str: str):
     transformers = importlib.import_module("transformers")
     cls = getattr(transformers, cls_name)
     _out(f"Loading {cls_name} for {model_id} on {device_str}")
-    device = torch.device(device_str if device_str != "cuda" or torch.cuda.is_available() else "cpu")
+    device = torch.device(
+        device_str if device_str != "cuda" or torch.cuda.is_available() else "cpu"
+    )
     return cls.from_pretrained(model_id).to(device).eval()
 
 
@@ -99,7 +106,7 @@ def _build_dataset_config(ds_dict: dict, num_samples: int):
     The registry uses a "dataset" key (normalised from "path" by
     dataset_config.py).  DatasetConfig uses "path".
     """
-    from modelkit.datasets.config import DatasetConfig
+    from winml.modelkit.datasets.config import DatasetConfig
 
     columns_mapping = ds_dict.get("columns_mapping", {})
     if isinstance(columns_mapping, str):
@@ -133,15 +140,13 @@ def _extract_metric(metrics: dict, task: str, metric_label: str) -> tuple[str, f
     hf_key = _TASK_HF_METRIC_KEY.get(task, "accuracy")
     if hf_key in metrics:
         return metric_label, float(metrics[hf_key])
-    # Fallback: first score-range value (0–1), skipping timing/throughput fields
+    # Fallback: first score-range value (0-1), skipping timing/throughput fields
     # that HF evaluator injects (total_time_in_seconds, samples_per_second, etc.).
-    _SKIP_KEYS = {"total_time_in_seconds", "samples_per_second", "latency_in_seconds"}
+    skip_keys = {"total_time_in_seconds", "samples_per_second", "latency_in_seconds"}
     for k, v in metrics.items():
-        if k not in _SKIP_KEYS and isinstance(v, (int, float)) and 0.0 <= v <= 1.0:
+        if k not in skip_keys and isinstance(v, (int, float)) and 0.0 <= v <= 1.0:
             return metric_label, float(v)
-    raise ValueError(
-        f"No score metric found in evaluator output for task '{task}': {metrics}"
-    )
+    raise ValueError(f"No score metric found in evaluator output for task '{task}': {metrics}")
 
 
 # ---------------------------------------------------------------------------
@@ -150,6 +155,7 @@ def _extract_metric(metrics: dict, task: str, metric_label: str) -> tuple[str, f
 
 
 def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
     parser = argparse.ArgumentParser(
         description="PyTorch baseline inference for accuracy evaluation (Signal 2)"
     )
@@ -187,6 +193,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> None:
+    """Run PyTorch baseline inference for accuracy evaluation."""
     args = parse_args()
     model_id = args.model
 
@@ -212,7 +219,10 @@ def main() -> None:
             try:
                 columns_mapping = json.loads(args.columns_mapping)
             except json.JSONDecodeError:
-                _out(f"WARNING: --columns-mapping is not valid JSON, ignoring: {args.columns_mapping}")
+                _out(
+                    "WARNING: --columns-mapping is not valid JSON, "
+                    f"ignoring: {args.columns_mapping}"
+                )
         ds_config_dict: dict | None = {
             "dataset": args.dataset,
             "split": args.split or "validation",
@@ -234,11 +244,14 @@ def main() -> None:
     metric_label = ds_config_dict.get("metric", _TASK_HF_METRIC_KEY.get(task, "accuracy"))
 
     _out(f"Task: {task} | Model: {model_id} | Device: {args.device} | Samples: {num_samples}")
-    _out(f"Dataset: {ds_config_dict.get('dataset')} / {ds_config_dict.get('dataset_config', '')} [{ds_config_dict.get('split', 'validation')}]")
+    ds_name = ds_config_dict.get("dataset")
+    ds_cfg = ds_config_dict.get("dataset_config", "")
+    ds_split = ds_config_dict.get("split", "validation")
+    _out(f"Dataset: {ds_name} / {ds_cfg} [{ds_split}]")
 
     try:
-        from modelkit.eval.base_evaluator import WinMLEvaluator
-        from modelkit.eval.config import WinMLEvaluationConfig
+        from winml.modelkit.eval.base_evaluator import WinMLEvaluator
+        from winml.modelkit.eval.config import WinMLEvaluationConfig
 
         pytorch_model = _load_pytorch_model(model_id, task, args.device)
         dataset_config = _build_dataset_config(ds_config_dict, num_samples)
@@ -250,7 +263,8 @@ def main() -> None:
             dataset=dataset_config,
         )
 
-        from modelkit.eval.evaluate import _EVALUATOR_REGISTRY
+        from winml.modelkit.eval.evaluate import _EVALUATOR_REGISTRY
+
         evaluator_cls = _EVALUATOR_REGISTRY.get(task, WinMLEvaluator)
         task_evaluator = evaluator_cls(eval_config, pytorch_model)
 

--- a/src/winml/modelkit/__init__.py
+++ b/src/winml/modelkit/__init__.py
@@ -15,7 +15,7 @@ Key Features:
 - Automatic task detection and model selection
 
 Usage:
-    from modelkit import WinMLAutoModel, WinMLBuildConfig
+    from winml.modelkit import WinMLAutoModel, WinMLBuildConfig
 
     # Auto-detect task and load model
     model = WinMLAutoModel.from_pretrained("microsoft/resnet-50")

--- a/src/winml/modelkit/analyze/core/pattern_extractor.py
+++ b/src/winml/modelkit/analyze/core/pattern_extractor.py
@@ -12,9 +12,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, TypedDict
 
-from winml.modelkit.pattern.base import InvalidPatternMatcherModelError, PatternMatcher
-from winml.modelkit.pattern.config import UnifiedPatternConfig
-
+from ...pattern.base import InvalidPatternMatcherModelError, PatternMatcher
+from ...pattern.config import UnifiedPatternConfig
 from ..models.onnx_model import ONNXModel
 from ..models.output import extract_model_stats
 
@@ -334,7 +333,7 @@ class PatternExtractor:
         Returns:
             List of PatternMatch instances
         """
-        from winml.modelkit.pattern.match import PatternMatchResult, SkeletonMatchResult
+        from ...pattern.match import PatternMatchResult, SkeletonMatchResult
 
         # Note: For hierarchy_tag and HTP metadata matches, we create a simplified
         # PatternMatchResult without full skeleton information since these matches

--- a/src/winml/modelkit/analyze/core/runtime_checker.py
+++ b/src/winml/modelkit/analyze/core/runtime_checker.py
@@ -15,8 +15,7 @@ from typing import TYPE_CHECKING
 
 import tqdm
 
-from winml.modelkit.pattern.config import UnifiedPatternConfig
-
+from ...pattern.config import UnifiedPatternConfig
 from ..models.runtime_checks import (
     AlternativeType,
     PatternAlternative,
@@ -343,12 +342,14 @@ class RuntimeChecker:
             if node_name in node_to_pattern_runtime:
                 # Replace with pattern-level result, keeping original pattern_match for traceability
                 pr = node_to_pattern_runtime[node_name]
-                merged.append(PatternRuntime(
-                    pattern_id=op_r.pattern_id,  # keep original op pattern_id
-                    result=pr.result,            # use subgraph-level result
-                    alternatives=pr.alternatives,
-                    pattern_match=op_r.pattern_match,
-                ))
+                merged.append(
+                    PatternRuntime(
+                        pattern_id=op_r.pattern_id,  # keep original op pattern_id
+                        result=pr.result,  # use subgraph-level result
+                        alternatives=pr.alternatives,
+                        pattern_match=op_r.pattern_match,
+                    )
+                )
             else:
                 merged.append(op_r)
 

--- a/src/winml/modelkit/analyze/core/runtime_checker_query.py
+++ b/src/winml/modelkit/analyze/core/runtime_checker_query.py
@@ -18,20 +18,19 @@ import onnxruntime as ort
 import pandas as pd
 from onnx import numpy_helper, shape_inference
 
-from winml.modelkit.pattern.base import (
-    get_pattern_input_generator,
-    get_registered_pattern_input_generators,
-)
-from winml.modelkit.pattern.match import PatternMatchResult
-from winml.modelkit.pattern.op_input_gen import (
-    get_runtime_checker_op,
-)
-
 from ...onnx import (
     ONNXDomain,
     SupportedONNXType,
     infer_onnx_shapes,
     remove_optional_from_type_annotation,
+)
+from ...pattern.base import (
+    get_pattern_input_generator,
+    get_registered_pattern_input_generators,
+)
+from ...pattern.match import PatternMatchResult
+from ...pattern.op_input_gen import (
+    get_runtime_checker_op,
 )
 from ..exceptions import (
     OpLackOfRequiredInformationError,

--- a/src/winml/modelkit/analyze/pattern/check_patterns.py
+++ b/src/winml/modelkit/analyze/pattern/check_patterns.py
@@ -9,10 +9,10 @@ on execution providers, generating test results for each specified pattern.
 
 Usage:
     Test specific patterns:
-        python -m modelkit.analyze.pattern.check_patterns --patterns Gelu MatMulAdd
+        python -m winml.modelkit.analyze.pattern.check_patterns --patterns Gelu MatMulAdd
 
     Test all registered patterns:
-        python -m modelkit.analyze.pattern.check_patterns --all_patterns
+        python -m winml.modelkit.analyze.pattern.check_patterns --all_patterns
 """
 
 import json
@@ -23,14 +23,13 @@ import onnx
 import onnxruntime as ort
 from google.protobuf import json_format
 
-from winml.modelkit.pattern.base import (
+from ... import winml
+from ...onnx import ONNXDomain
+from ...pattern.base import (
     PatternInputGenerator,
     get_pattern_input_generator,
     get_registered_pattern_input_generators,
 )
-
-from ... import winml
-from ...onnx import ONNXDomain
 from ...sysinfo import SysInfo
 from ...utils import constants
 from ..runtime_checker.ep_checker import EPChecker

--- a/src/winml/modelkit/analyze/runtime_checker/README.md
+++ b/src/winml/modelkit/analyze/runtime_checker/README.md
@@ -4,7 +4,7 @@
 The runtime checker tests ONNX operators on various execution providers (EPs) to validate their support across different input combinations, data types, and attributes.
 
 ## check_ops CLI Mode Rules
-When using `modelkit.static_analyzer.runtime_checker.check_ops`, the following mode flags are mutually exclusive (only one can be set at a time):
+When using `winml.modelkit.analyze.runtime_checker.check_ops`, the following mode flags are mutually exclusive (only one can be set at a time):
 
 - `--rerun_failed`
 - `--delta_only`
@@ -14,13 +14,13 @@ Examples:
 
 ```powershell
 # rerun only failed cases
-python -m modelkit.static_analyzer.runtime_checker.check_ops --ops Resize --rerun_failed
+python -m winml.modelkit.analyze.runtime_checker.check_ops --ops Resize --rerun_failed
 
 # run only new (delta) cases
-python -m modelkit.static_analyzer.runtime_checker.check_ops --ops Resize --delta_only
+python -m winml.modelkit.analyze.runtime_checker.check_ops --ops Resize --delta_only
 
 # run only one case by hashed case index
-python -m modelkit.static_analyzer.runtime_checker.check_ops --ops Resize --case_index <hash>
+python -m winml.modelkit.analyze.runtime_checker.check_ops --ops Resize --case_index <hash>
 ```
 
 ## Example Usage
@@ -29,7 +29,7 @@ runnable under different conditions. Compile test will check if it runs on NPU, 
 check if it runs without throwing exception (either on NPU or by falling back to CPU).
 
 ```powershell
-python -m winml.modelkit.static_analyzer.runtime_checker.run_reshape_qnn_example reshape_qnn_results.json --opset 22 --quick --validate_inputs
+python -m winml.modelkit.analyze.runtime_checker.run_reshape_qnn_example reshape_qnn_results.json --opset 22 --quick --validate_inputs
 
 # Arguments:
 #   output_path:        Required (unless --validate_inputs) - Path where test results JSON will be saved

--- a/src/winml/modelkit/analyze/runtime_checker/case_runner.py
+++ b/src/winml/modelkit/analyze/runtime_checker/case_runner.py
@@ -16,14 +16,13 @@ if TYPE_CHECKING:
 import numpy as np
 import onnx
 
-from winml.modelkit.pattern.op_input_gen import get_runtime_checker_op
-from winml.modelkit.pattern.op_input_gen.op_input_gen import (
+from ...onnx import ONNXDomain
+from ...pattern.op_input_gen import get_runtime_checker_op
+from ...pattern.op_input_gen.op_input_gen import (
     InputShapeConstraint,
     OpInputGenerator,
     model_from_b64,
 )
-
-from ...onnx import ONNXDomain
 from .check_ops import get_ep_checker
 from .runner import ResilientRunner
 

--- a/src/winml/modelkit/analyze/runtime_checker/check_ops.py
+++ b/src/winml/modelkit/analyze/runtime_checker/check_ops.py
@@ -9,10 +9,10 @@ generating test results for each specified operator.
 
 Usage:
     Test specific operators:
-        python -m modelkit.analyze.runtime_checker.check_qnn_ops --ops Abs Relu Sigmoid
+        python -m winml.modelkit.analyze.runtime_checker.check_ops --ops Abs Relu Sigmoid
 
     Test all registered operators:
-        python -m modelkit.analyze.runtime_checker.check_qnn_ops --all_ops
+        python -m winml.modelkit.analyze.runtime_checker.check_ops --all_ops
 """
 
 import hashlib
@@ -26,15 +26,14 @@ import onnxruntime as ort
 from google.protobuf import json_format
 from onnx.defs import SchemaError
 
-from winml.modelkit.pattern.op_input_gen import (
+from ... import winml
+from ...onnx import ONNXDomain
+from ...pattern.op_input_gen import (
     OpInputGenerator,
     get_registered_operators,
     get_runtime_checker_op,
 )
-from winml.modelkit.pattern.op_input_gen.qdq_gen import QDQGenerator
-
-from ... import winml
-from ...onnx import ONNXDomain
+from ...pattern.op_input_gen.qdq_gen import QDQGenerator
 from ...sysinfo import SysInfo
 from ...utils import constants
 from ..utils.model_utils import get_op_since_version

--- a/src/winml/modelkit/analyze/runtime_checker/result_processor.py
+++ b/src/winml/modelkit/analyze/runtime_checker/result_processor.py
@@ -12,10 +12,9 @@ import pandas as pd
 from colorama import Fore, Style
 from onnx.defs import SchemaError, onnx_opset_version
 
-from winml.modelkit.pattern.base import get_pattern_input_generator
-from winml.modelkit.pattern.op_input_gen import OpInputGenerator, get_runtime_checker_op
-
 from ...onnx import ONNXDomain
+from ...pattern.base import get_pattern_input_generator
+from ...pattern.op_input_gen import OpInputGenerator, get_runtime_checker_op
 from ..utils.model_utils import get_op_since_version, make_hashable
 
 
@@ -645,7 +644,7 @@ if __name__ == "__main__":
 
     qdq_generator = None
     if any(is_qdq for _, _, _, is_qdq in op_info_set):
-        from winml.modelkit.pattern.op_input_gen.qdq_gen import QDQGenerator
+        from ...pattern.op_input_gen.qdq_gen import QDQGenerator
 
         qdq_generator = QDQGenerator(1, ONNXDomain.COM_MICROSOFT)
 

--- a/src/winml/modelkit/analyze/utils/model_utils.py
+++ b/src/winml/modelkit/analyze/utils/model_utils.py
@@ -12,10 +12,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from winml.modelkit.pattern.models import OperatorPattern, PatternType
+from ...pattern.models import OperatorPattern, PatternType
 
-# Re-export shared utilities from winml.modelkit.pattern.utils
-from winml.modelkit.pattern.utils import (  # noqa: F401
+# Re-export shared utilities from pattern.utils
+from ...pattern.utils import (  # noqa: F401
     DUMMY_FLOAT,
     collect_initializers,
     collect_valueinfo_dict,
@@ -57,7 +57,7 @@ def node_to_pattern_match(
         This is useful for converting individual operators to patterns
         for runtime support checking.
     """
-    from winml.modelkit.pattern.match import PatternMatchResult, SkeletonMatchResult
+    from ...pattern.match import PatternMatchResult, SkeletonMatchResult
 
     # Detect namespace
     namespace = "ai.onnx"

--- a/src/winml/modelkit/cli.py
+++ b/src/winml/modelkit/cli.py
@@ -14,7 +14,7 @@ Usage:
 
 Entry Points:
     - Standalone CLI: wmk
-    - Module execution: python -m modelkit.cli
+    - Module execution: python -m winml.modelkit
 """
 
 from __future__ import annotations

--- a/src/winml/modelkit/compiler/cli.py
+++ b/src/winml/modelkit/compiler/cli.py
@@ -139,18 +139,18 @@ def compile(
 
     Examples:
         # Basic QNN compile with defaults
-        python -m modelkit.compiler compile -m model.onnx --ep qnn
+        python -m winml.modelkit.compiler compile -m model.onnx --ep qnn
 
         # Skip quantization (pre-quantized model)
-        python -m modelkit.compiler compile -m model_qdq.onnx --no-quantize
+        python -m winml.modelkit.compiler compile -m model_qdq.onnx --no-quantize
 
         # Custom calibration
-        python -m modelkit.compiler compile -m model.onnx \
+        python -m winml.modelkit.compiler compile -m model.onnx \
             --calibration-samples 500 \
             --calibration-save calibration.json
 
         # Load pre-computed calibration
-        python -m modelkit.compiler compile -m model.onnx \
+        python -m winml.modelkit.compiler compile -m model.onnx \
             --calibration-load calibration.json
     """
     from .compiler import compile_onnx
@@ -274,10 +274,10 @@ def calibrate(
 
     Examples:
         # Generate calibration data
-        python -m modelkit.compiler calibrate -m model.onnx -o calibration.json
+        python -m winml.modelkit.compiler calibrate -m model.onnx -o calibration.json
 
         # Use more samples
-        python -m modelkit.compiler calibrate -m model.onnx -o calibration.json --samples 500
+        python -m winml.modelkit.compiler calibrate -m model.onnx -o calibration.json --samples 500
     """
     import tempfile
 

--- a/src/winml/modelkit/models/auto.py
+++ b/src/winml/modelkit/models/auto.py
@@ -67,7 +67,7 @@ class WinMLAutoModel:
         → Return inference-ready WinMLPreTrainedModel subclass
 
     Example:
-        >>> from modelkit import WinMLAutoModel
+        >>> from winml.modelkit import WinMLAutoModel
         >>> # From HuggingFace model
         >>> model = WinMLAutoModel.from_pretrained("microsoft/resnet-50")
         >>> # Returns WinMLModelForImageClassification (inference-ready)
@@ -132,8 +132,7 @@ class WinMLAutoModel:
         onnx_path = Path(onnx_path)
         if not onnx_path.is_file():
             raise FileNotFoundError(
-                f"ONNX model not found: {onnx_path}. "
-                f"Provide a valid path to an existing ONNX file."
+                f"ONNX model not found: {onnx_path}. Provide a valid path to an existing ONNX file."
             )
         logger.info("Loading WinML model from ONNX: %s", onnx_path)
 
@@ -174,6 +173,7 @@ class WinMLAutoModel:
             output_dir = get_model_dir(onnx_path.stem, cache_dir=cache_dir_path)
         else:
             import tempfile
+
             cache_dir_path = Path(tempfile.mkdtemp(prefix="wmk_"))
             output_dir = cache_dir_path
             force_rebuild = True
@@ -286,8 +286,13 @@ class WinMLAutoModel:
         # Device/precision resolution is handled inside generate_hf_build_config().
         # When config is provided, it merges as Tier-1 override on top of defaults.
         build_config = generate_hf_build_config(
-            model_id, task=task, override=config, shape_config=shape_config,
-            device=device, precision=precision, ep=kwargs.get("ep"),
+            model_id,
+            task=task,
+            override=config,
+            shape_config=shape_config,
+            device=device,
+            precision=precision,
+            ep=kwargs.get("ep"),
         )
 
         resolved_task = build_config.loader.task
@@ -318,6 +323,7 @@ class WinMLAutoModel:
         else:
             # No cache -- use temp directory, always rebuild
             import tempfile
+
             cache_dir_path = Path(tempfile.mkdtemp(prefix="wmk_"))
             force_rebuild = True
             logger.info("Cache disabled -- using temp directory: %s", cache_dir_path)
@@ -352,36 +358,6 @@ class WinMLAutoModel:
             config=hf_config,  # HF PretrainedConfig for pipeline compatibility
             device=device,  # pass user's original device string; WinMLSession handles "auto"
         )
-
-    @classmethod
-    def _get_model_config(cls, model_type: str) -> WinMLBuildConfig:
-        """Get model-specific config or default.
-
-        .. deprecated:: 1.0
-            Use :func:`modelkit.config.generate_build_config` instead for
-            complete configs with I/O specs, shapes, and dtypes. This method
-            returns bare defaults without I/O specifications.
-        """
-        import warnings
-
-        warnings.warn(
-            "_get_model_config() is deprecated. Use generate_build_config() "
-            "from winml.modelkit.config for complete configs with I/O specs.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-        from ..config import WinMLBuildConfig
-        from . import MODEL_BUILD_CONFIGS
-
-        model_type_normalized = model_type.lower().replace("_", "-")
-
-        if model_type_normalized in MODEL_BUILD_CONFIGS:
-            logger.debug("Using registered config for: %s", model_type_normalized)
-            return MODEL_BUILD_CONFIGS[model_type_normalized]
-
-        logger.debug("Using default config (no registration for %s)", model_type_normalized)
-        return WinMLBuildConfig()
 
     @classmethod
     def supported_tasks(cls) -> list[str]:

--- a/src/winml/modelkit/models/winml/__init__.py
+++ b/src/winml/modelkit/models/winml/__init__.py
@@ -32,18 +32,20 @@ logger = logging.getLogger(__name__)
 
 # Level 1: Task -> Universal WinML class name (lazy import)
 TASK_TO_WINML_CLASS: dict[str, str] = {
+    # Implemented
     "image-classification": "WinMLModelForImageClassification",
     "text-classification": "WinMLModelForSequenceClassification",
     "sequence-classification": "WinMLModelForSequenceClassification",
     "next-sentence-prediction": "WinMLModelForSequenceClassification",
+    "image-segmentation": "WinMLModelForImageSegmentation",
+    "semantic-segmentation": "WinMLModelForSemanticSegmentation",
+    "object-detection": "WinMLModelForObjectDetection",
+    # Not yet implemented — falls back to WinMLModelForGenericTask at runtime
     "token-classification": "WinMLModelForTokenClassification",
     "question-answering": "WinMLModelForQuestionAnswering",
     "text-generation": "WinMLModelForCausalLM",
     "text2text-generation": "WinMLModelForSeq2SeqLM",
     "fill-mask": "WinMLModelForMaskedLM",
-    "image-segmentation": "WinMLModelForImageSegmentation",
-    "semantic-segmentation": "WinMLModelForSemanticSegmentation",
-    "object-detection": "WinMLModelForObjectDetection",
     "feature-extraction": "WinMLModelForFeatureExtraction",
 }
 

--- a/src/winml/modelkit/optim/api.py
+++ b/src/winml/modelkit/optim/api.py
@@ -30,8 +30,7 @@ from typing import Any
 
 import onnx
 
-from winml.modelkit.onnx import load_onnx, save_onnx
-
+from ..onnx import load_onnx, save_onnx
 from .errors import ConfigurationError, ModelValidationError
 from .optimizer import Optimizer
 from .pipes import get_all_capabilities

--- a/src/winml/modelkit/optim/pipes/fusion.py
+++ b/src/winml/modelkit/optim/pipes/fusion.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 if TYPE_CHECKING:
     import onnx
 
-from winml.modelkit.onnx import save_onnx
+from ...onnx import save_onnx
 
 # Import capability modules for FusionPipe
 # Note: gelu import removed - GELU capabilities disabled due to ORT bundling issue

--- a/src/winml/modelkit/optim/pipes/graph.py
+++ b/src/winml/modelkit/optim/pipes/graph.py
@@ -19,8 +19,7 @@ import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from winml.modelkit.onnx import load_onnx, save_onnx
-
+from ...onnx import load_onnx, save_onnx
 from .base import BasePipe, OptimizationError, PipeConfig, caps_dict
 
 

--- a/src/winml/modelkit/optim/pipes/rewrite.py
+++ b/src/winml/modelkit/optim/pipes/rewrite.py
@@ -149,7 +149,7 @@ class RewritePipe(BasePipe):
             return model
 
         try:
-            from winml.modelkit.pattern.base import PatternMatcher, PatternRewriter
+            from ...pattern.base import PatternMatcher, PatternRewriter
 
             # Register source patterns; map source class name → target class
             matcher = PatternMatcher(model)

--- a/src/winml/modelkit/optim/pipes/rewrite_rules.py
+++ b/src/winml/modelkit/optim/pipes/rewrite_rules.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from winml.modelkit.pattern.base import Pattern
+from ...pattern.base import Pattern
 
 
 logger = logging.getLogger(__name__)

--- a/src/winml/modelkit/pattern/attention_patterns.py
+++ b/src/winml/modelkit/pattern/attention_patterns.py
@@ -44,7 +44,8 @@ from typing import Any
 import numpy as np
 from onnx.defs import OpSchema
 
-from winml.modelkit.pattern.base import (
+from ..onnx import ONNXDomain
+from .base import (
     Pattern,
     PatternInputGenerator,
     PatternMatchResult,
@@ -53,9 +54,7 @@ from winml.modelkit.pattern.base import (
     SkeletonMatchResult,
     register_pattern_input_generator,
 )
-from winml.modelkit.pattern.op_input_gen import InputShapeConstraint
-
-from ..onnx import ONNXDomain
+from .op_input_gen import InputShapeConstraint
 
 
 # Type constraints for Attention operator (from opset 24 spec)

--- a/src/winml/modelkit/pattern/base.py
+++ b/src/winml/modelkit/pattern/base.py
@@ -175,17 +175,16 @@ import onnx
 from onnx import ModelProto, numpy_helper
 from onnx.defs import OpSchema
 
-from winml.modelkit.pattern.match import InputInfo, PatternMatchResult, SkeletonMatchResult
-from winml.modelkit.pattern.op_input_gen import InputShapeConstraint
-from winml.modelkit.pattern.op_input_gen.op_input_gen import OpInputGenerator
-from winml.modelkit.pattern.utils import get_attribute_proto_value, make_hashable
-
 from ..onnx import ONNXDomain, SupportedONNXType, check_onnx_model, infer_onnx_shapes
+from .match import InputInfo, PatternMatchResult, SkeletonMatchResult
+from .op_input_gen import InputShapeConstraint
+from .op_input_gen.op_input_gen import OpInputGenerator
+from .utils import get_attribute_proto_value, make_hashable
 
 
 logger = logging.getLogger(__name__)
 
-# ModelTag string constants (inlined to avoid static_analyzer dependency)
+# ModelTag string constants (inlined to avoid analyze module dependency)
 _MODEL_TAG_INVALID_PATTERN_MATCHER_MODEL = "invalid_pattern_matcher_model"
 _MODEL_TAG_MISSING_NODE_NAMES = "missing_node_names"
 

--- a/src/winml/modelkit/pattern/config.py
+++ b/src/winml/modelkit/pattern/config.py
@@ -142,11 +142,7 @@ class UnifiedPatternConfig:
         alternatives = qnn_config.get_alternatives(gelu_pattern)
     """
 
-    def __init__(
-        self,
-        ihv_type: str | None = None,
-        config_path: Path | str | None = None
-    ) -> None:
+    def __init__(self, ihv_type: str | None = None, config_path: Path | str | None = None) -> None:
         """Initialize the unified pattern configuration.
 
         Args:
@@ -171,8 +167,7 @@ class UnifiedPatternConfig:
 
         self.config_path = config_path
         logger.debug(
-            f"UnifiedPatternConfig initialized for IHV={self.ihv_type}, "
-            f"config={self.config_path}"
+            f"UnifiedPatternConfig initialized for IHV={self.ihv_type}, config={self.config_path}"
         )
 
     def get_skeleton_patterns(self) -> list[Pattern]:
@@ -251,7 +246,7 @@ class UnifiedPatternConfig:
             )
 
         logger.info(f"Loading default configuration from {default_config_path}")
-        with default_config_path.open(encoding='utf-8') as f:
+        with default_config_path.open(encoding="utf-8") as f:
             merged_config = json.load(f)
 
         # If IHV-specific config requested, load and merge it
@@ -263,23 +258,23 @@ class UnifiedPatternConfig:
                 )
             else:
                 logger.info(f"Loading IHV configuration from {self.config_path}")
-                with self.config_path.open(encoding='utf-8') as f:
+                with self.config_path.open(encoding="utf-8") as f:
                     ihv_config = json.load(f)
 
                 # Merge HTPPatternRules: IHV overrides default by pattern_id
-                merged_config['HTPPatternRules'] = self._merge_pattern_rules(
-                    merged_config.get('HTPPatternRules', []),
-                    ihv_config.get('HTPPatternRules', []),
-                    key='pattern_id'
+                merged_config["HTPPatternRules"] = self._merge_pattern_rules(
+                    merged_config.get("HTPPatternRules", []),
+                    ihv_config.get("HTPPatternRules", []),
+                    key="pattern_id",
                 )
 
                 # Merge SkeletonPatternRules: IHV overrides default by pattern_class
                 # Using pattern_class as key because multiple Pattern classes
                 # can share the same pattern_id
-                merged_config['SkeletonPatternRules'] = self._merge_pattern_rules(
-                    merged_config.get('SkeletonPatternRules', []),
-                    ihv_config.get('SkeletonPatternRules', []),
-                    key='pattern_class'
+                merged_config["SkeletonPatternRules"] = self._merge_pattern_rules(
+                    merged_config.get("SkeletonPatternRules", []),
+                    ihv_config.get("SkeletonPatternRules", []),
+                    key="pattern_class",
                 )
 
                 logger.info(f"Merged default + {self.ihv_type} configurations")
@@ -287,19 +282,19 @@ class UnifiedPatternConfig:
         config_data = merged_config
 
         # Validate required sections
-        if 'HTPPatternRules' not in config_data:
+        if "HTPPatternRules" not in config_data:
             logger.warning("Missing 'HTPPatternRules' section in configuration")
-            config_data['HTPPatternRules'] = []
+            config_data["HTPPatternRules"] = []
 
-        if 'SkeletonPatternRules' not in config_data:
+        if "SkeletonPatternRules" not in config_data:
             logger.warning("Missing 'SkeletonPatternRules' section in configuration")
-            config_data['SkeletonPatternRules'] = []
+            config_data["SkeletonPatternRules"] = []
 
         # Load HTP pattern metadata
-        for htp_data in config_data['HTPPatternRules']:
+        for htp_data in config_data["HTPPatternRules"]:
             try:
                 # Import SubgraphPattern model
-                from winml.modelkit.pattern.models import SubgraphPattern
+                from .models import SubgraphPattern
 
                 # Convert edge_topology if present
                 if "edge_topology" in htp_data and isinstance(htp_data["edge_topology"], list):
@@ -315,33 +310,31 @@ class UnifiedPatternConfig:
                 self._htp_patterns.append(htp_pattern)
                 logger.debug(f"Loaded HTP pattern: {htp_pattern.pattern_id}")
             except Exception as e:  # noqa: PERF203
-                pattern_id = htp_data.get('pattern_id', 'unknown')
-                logger.warning(
-                    f"Failed to load HTP pattern {pattern_id}: {e}. Skipping."
-                )
+                pattern_id = htp_data.get("pattern_id", "unknown")
+                logger.warning(f"Failed to load HTP pattern {pattern_id}: {e}. Skipping.")
 
         # Load Skeleton pattern configurations
         skeleton_count = 0
-        for pattern_data in config_data['SkeletonPatternRules']:
+        for pattern_data in config_data["SkeletonPatternRules"]:
             # Parse alternatives (metadata only, not loaded as Pattern instances)
             alternatives = [
                 PatternAlternative(
-                    pattern_to_id=alt_data['pattern_to_id'],
-                    priority=alt_data['priority'],
-                    reason=alt_data.get('reason'),
-                    pattern_class=alt_data.get('pattern_class'),
-                    module=alt_data.get('module'),
+                    pattern_to_id=alt_data["pattern_to_id"],
+                    priority=alt_data["priority"],
+                    reason=alt_data.get("reason"),
+                    pattern_class=alt_data.get("pattern_class"),
+                    module=alt_data.get("module"),
                 )
-                for alt_data in pattern_data.get('alternatives', [])
+                for alt_data in pattern_data.get("alternatives", [])
             ]
 
             # Create pattern config
             config = PatternConfig(
-                pattern_id=pattern_data['pattern_id'],
-                pattern_class=pattern_data['pattern_class'],
-                module=pattern_data['module'],
-                enabled=pattern_data['enabled'],
-                description=pattern_data.get('description'),
+                pattern_id=pattern_data["pattern_id"],
+                pattern_class=pattern_data["pattern_class"],
+                module=pattern_data["module"],
+                enabled=pattern_data["enabled"],
+                description=pattern_data.get("description"),
                 alternatives=alternatives,
             )
 
@@ -368,10 +361,7 @@ class UnifiedPatternConfig:
         )
 
     def _merge_pattern_rules(
-        self,
-        base_rules: list[dict],
-        override_rules: list[dict],
-        key: str = 'pattern_id'
+        self, base_rules: list[dict], override_rules: list[dict], key: str = "pattern_id"
     ) -> list[dict]:
         """Merge two pattern rule lists with override behavior.
 

--- a/src/winml/modelkit/pattern/gelu_patterns.py
+++ b/src/winml/modelkit/pattern/gelu_patterns.py
@@ -6,7 +6,8 @@ from typing import Any
 
 import numpy as np
 
-from winml.modelkit.pattern.base import (
+from ..onnx import ONNXDomain
+from .base import (
     Pattern,
     PatternInputGenerator,
     PatternSchema,
@@ -14,9 +15,7 @@ from winml.modelkit.pattern.base import (
     make_single_op_pattern,
     register_pattern_input_generator,
 )
-from winml.modelkit.pattern.op_input_gen import get_runtime_checker_op
-
-from ..onnx import ONNXDomain
+from .op_input_gen import get_runtime_checker_op
 
 
 # TODO: Add and Mul are commutative, support matching either

--- a/src/winml/modelkit/pattern/gemm_patterns.py
+++ b/src/winml/modelkit/pattern/gemm_patterns.py
@@ -7,17 +7,16 @@ from typing import Any
 import numpy as np
 from onnx.defs import OpSchema
 
-from winml.modelkit.pattern.base import (
+from ..onnx import ONNXDomain
+from .base import (
     Pattern,
     PatternInputGenerator,
     PatternSchema,
     Skeleton,
     register_pattern_input_generator,
 )
-from winml.modelkit.pattern.match import PatternMatchResult, SkeletonMatchResult
-from winml.modelkit.pattern.op_input_gen import InputShapeConstraint, InputValueConstraint
-
-from ..onnx import ONNXDomain
+from .match import PatternMatchResult, SkeletonMatchResult
+from .op_input_gen import InputShapeConstraint, InputValueConstraint
 
 
 # Shared schema for MatMulAdd and ReshapeGemmReshape patterns

--- a/src/winml/modelkit/pattern/layernorm_patterns.py
+++ b/src/winml/modelkit/pattern/layernorm_patterns.py
@@ -19,7 +19,8 @@ from typing import Any
 import numpy as np
 from onnx.defs import OpSchema
 
-from winml.modelkit.pattern.base import (
+from ..onnx import ONNXDomain
+from .base import (
     Pattern,
     PatternInputGenerator,
     PatternMatchResult,
@@ -29,14 +30,12 @@ from winml.modelkit.pattern.base import (
     SkeletonMatchResult,
     register_pattern_input_generator,
 )
-from winml.modelkit.pattern.op_input_gen import get_runtime_checker_op
-from winml.modelkit.pattern.utils import (
+from .op_input_gen import get_runtime_checker_op
+from .utils import (
     get_attribute_proto_value,
     get_tensor_shape,
     validate_scale_bias_shape_for_axis,
 )
-
-from ..onnx import ONNXDomain
 
 
 def _validate_layernorm_scale_bias(
@@ -548,7 +547,7 @@ class LayerNormalizationPatternInputGenerator(
 
     def get_input_and_infinite_attribute_combinations(self) -> list[dict[str, Any]]:
         """Return input combinations with broadcast-compatible Scale/B shapes."""
-        from winml.modelkit.pattern.op_input_gen import InputValueConstraint
+        from .op_input_gen import InputValueConstraint
 
         combinations = super().get_input_and_infinite_attribute_combinations()
 

--- a/src/winml/modelkit/pattern/op_input_gen/op_input_gen.py
+++ b/src/winml/modelkit/pattern/op_input_gen/op_input_gen.py
@@ -19,9 +19,8 @@ import onnx
 from colorama import Fore, Style
 from onnx.defs import OpSchema
 
-from winml.modelkit.pattern.utils import get_op_input_properties
-
 from ...onnx import ONNXDomain, SupportedONNXType
+from ..utils import get_op_input_properties
 from .qdq_gen import QDQGenerator
 
 
@@ -321,8 +320,10 @@ class OpInputGenerator(ABC):
                 - "all_axes_combinations": Iterate over all axis
                   subsets for each non-constant and non-scalar
                   input. Not yet implemented.
-            runner: Optional ResilientRunner for EP runtime checking. Injected by static_analyzer.
-            ep_checker: Optional EPChecker for EP validation. Injected by static_analyzer.
+            runner: Optional ResilientRunner for EP runtime checking.
+                Injected by the analyze module.
+            ep_checker: Optional EPChecker for EP validation.
+                Injected by the analyze module.
         """
         assert dynamic_axis_mode in (
             "none",

--- a/src/winml/modelkit/pattern/rmsnorm_patterns.py
+++ b/src/winml/modelkit/pattern/rmsnorm_patterns.py
@@ -23,7 +23,8 @@ from typing import Any
 import numpy as np
 from onnx.defs import OpSchema
 
-from winml.modelkit.pattern.base import (
+from ..onnx import ONNXDomain
+from .base import (
     Pattern,
     PatternInputGenerator,
     PatternMatchResult,
@@ -33,14 +34,12 @@ from winml.modelkit.pattern.base import (
     SkeletonMatchResult,
     register_pattern_input_generator,
 )
-from winml.modelkit.pattern.op_input_gen import InputShapeConstraint, InputValueConstraint
-from winml.modelkit.pattern.utils import (
+from .op_input_gen import InputShapeConstraint, InputValueConstraint
+from .utils import (
     get_attribute_proto_value,
     get_tensor_shape,
     validate_scale_bias_shape_for_axis,
 )
-
-from ..onnx import ONNXDomain
 
 
 def _validate_rmsnorm_scale(

--- a/src/winml/modelkit/pattern/transpose_patterns.py
+++ b/src/winml/modelkit/pattern/transpose_patterns.py
@@ -14,7 +14,8 @@ from typing import Any
 import numpy as np
 from onnx.defs import OpSchema
 
-from winml.modelkit.pattern.base import (
+from ..onnx import ONNXDomain
+from .base import (
     Pattern,
     PatternInputGenerator,
     PatternMatchResult,
@@ -24,9 +25,7 @@ from winml.modelkit.pattern.base import (
     SkeletonMatchResult,
     register_pattern_input_generator,
 )
-from winml.modelkit.pattern.op_input_gen import InputShapeConstraint
-
-from ..onnx import ONNXDomain
+from .op_input_gen import InputShapeConstraint
 
 
 # Schema for ReshapeTransposeReshape pattern

--- a/tests/integration/optim/test_pipe_fusion.py
+++ b/tests/integration/optim/test_pipe_fusion.py
@@ -11,7 +11,7 @@ import onnx
 import pytest
 from onnx import TensorProto, helper
 
-from winml.modelkit.optim.pipes.fusion import ORTFusionPipe, ORTFusionPipeConfig
+from winml.modelkit.optim.pipes import ORTFusionPipe, ORTFusionPipeConfig
 
 
 def _make_simple_model() -> onnx.ModelProto:

--- a/tests/unit/analyze/pattern/test_rewrite_pipe.py
+++ b/tests/unit/analyze/pattern/test_rewrite_pipe.py
@@ -24,7 +24,7 @@ import onnx
 import pytest
 
 from winml.modelkit.onnx import ONNXDomain
-from winml.modelkit.optim.pipes.rewrite import RewritePipe
+from winml.modelkit.optim.pipes import RewritePipe
 from winml.modelkit.optim.pipes.rewrite_rules import REWRITE_GROUPS
 from winml.modelkit.pattern import PatternMatcher
 
@@ -58,8 +58,7 @@ def _gelu_cap_name() -> str | None:
 
 def _gelu_cap_name_for_variant(gelu_variant: str) -> str | None:
     """Return the capability name for the group containing gelu_variant, or None."""
-    source_name = f"{gelu_variant}Pattern"
-    group = next((g for g in REWRITE_GROUPS if source_name in g.sources), None)
+    group = next((g for g in REWRITE_GROUPS if gelu_variant in g.sources), None)
     return group.flag_name if group is not None else None
 
 

--- a/tests/unit/optim/pipes/test_pipe_base.py
+++ b/tests/unit/optim/pipes/test_pipe_base.py
@@ -24,7 +24,7 @@ import onnx
 import pytest
 
 # Import pipe base classes from modelkit (production)
-from winml.modelkit.optim.pipes.base import BasePipe, OptimizationError, PipeConfig
+from winml.modelkit.optim.pipes import BasePipe, OptimizationError, PipeConfig
 
 
 class TestPipeConfig:

--- a/tests/unit/optim/pipes/test_pipe_config.py
+++ b/tests/unit/optim/pipes/test_pipe_config.py
@@ -23,8 +23,12 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from winml.modelkit.optim.pipes.base import PipeConfig
-from winml.modelkit.optim.pipes.graph import GRAPH_CAPABILITIES, ORTGraphPipe, ORTGraphPipeConfig
+from winml.modelkit.optim.pipes import (
+    GRAPH_CAPABILITIES,
+    ORTGraphPipe,
+    ORTGraphPipeConfig,
+    PipeConfig,
+)
 
 
 if TYPE_CHECKING:

--- a/tests/unit/optim/pipes/test_pipe_fusion.py
+++ b/tests/unit/optim/pipes/test_pipe_fusion.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 
 # Import pipe classes from modelkit (production)
-from winml.modelkit.optim.pipes.fusion import ORTFusionPipe, ORTFusionPipeConfig
+from winml.modelkit.optim.pipes import ORTFusionPipe, ORTFusionPipeConfig
 from winml.modelkit.optim.registry import (
     BoolCapability,
     CapabilityCategory,
@@ -114,7 +114,7 @@ class TestORTFusionPipeConfig:
 
     def test_fusion_pipe_config_is_pipe_config(self) -> None:
         """Verify ORTFusionPipeConfig inherits from PipeConfig."""
-        from winml.modelkit.optim.pipes.base import PipeConfig
+        from winml.modelkit.optim.pipes import PipeConfig
 
         config = ORTFusionPipeConfig()
         assert isinstance(config, PipeConfig)

--- a/tests/unit/optim/pipes/test_pipe_graph.py
+++ b/tests/unit/optim/pipes/test_pipe_graph.py
@@ -30,7 +30,7 @@ from dataclasses import dataclass
 import onnx
 import pytest
 
-from winml.modelkit.optim.pipes.graph import GRAPH_CAPABILITIES, ORTGraphPipe, ORTGraphPipeConfig
+from winml.modelkit.optim.pipes import GRAPH_CAPABILITIES, ORTGraphPipe, ORTGraphPipeConfig
 
 from ..conftest import verify_capability_effect
 

--- a/tests/unit/optim/pipes/test_pipe_graph_isolated.py
+++ b/tests/unit/optim/pipes/test_pipe_graph_isolated.py
@@ -80,7 +80,7 @@ import onnx
 import pytest
 from onnx import TensorProto, helper
 
-from winml.modelkit.optim.pipes.graph import GRAPH_CAPABILITIES, ORTGraphPipe, ORTGraphPipeConfig
+from winml.modelkit.optim.pipes import GRAPH_CAPABILITIES, ORTGraphPipe, ORTGraphPipeConfig
 
 # Import all builders
 from ..assets.graphpipe.builders import (

--- a/tests/unit/optim/pipes/test_pipe_surgery.py
+++ b/tests/unit/optim/pipes/test_pipe_surgery.py
@@ -23,7 +23,7 @@ import onnx
 import pytest
 from onnx import numpy_helper
 
-from winml.modelkit.optim.pipes.surgery import (
+from winml.modelkit.optim.pipes import (
     SURGERY_CAPABILITIES,
     SurgeryPipe,
     SurgeryPipeConfig,

--- a/tests/unit/optim/test_optimizer.py
+++ b/tests/unit/optim/test_optimizer.py
@@ -28,11 +28,18 @@ import onnx
 import pytest
 
 from winml.modelkit.optim import Optimizer
-from winml.modelkit.optim.pipes import PIPES, get_all_capabilities
-from winml.modelkit.optim.pipes.base import BasePipe, PipeConfig
-from winml.modelkit.optim.pipes.fusion import ORTFusionPipe, ORTFusionPipeConfig
-from winml.modelkit.optim.pipes.graph import ORTGraphPipe, ORTGraphPipeConfig
-from winml.modelkit.optim.pipes.surgery import SurgeryPipe, SurgeryPipeConfig
+from winml.modelkit.optim.pipes import (
+    PIPES,
+    BasePipe,
+    ORTFusionPipe,
+    ORTFusionPipeConfig,
+    ORTGraphPipe,
+    ORTGraphPipeConfig,
+    PipeConfig,
+    SurgeryPipe,
+    SurgeryPipeConfig,
+    get_all_capabilities,
+)
 from winml.modelkit.optim.registry import (
     BoolCapability,
     CapabilityCategory,

--- a/tests/unit/optim/test_registry_cli.py
+++ b/tests/unit/optim/test_registry_cli.py
@@ -219,7 +219,7 @@ class TestCapabilityCliFlagsIntegration:
 
     def test_graph_capability_flags(self) -> None:
         """Test CLI flags for actual graph capabilities."""
-        from winml.modelkit.optim.pipes.graph import GRAPH_CAPABILITIES
+        from winml.modelkit.optim.pipes import GRAPH_CAPABILITIES
 
         # Check a few actual capabilities
         for _cap_name, cap in list(GRAPH_CAPABILITIES.items())[:5]:
@@ -232,7 +232,7 @@ class TestCapabilityCliFlagsIntegration:
 
     def test_fusion_capability_flags(self) -> None:
         """Test CLI flags for actual fusion capabilities."""
-        from winml.modelkit.optim.pipes.fusion import ORTFusionPipe
+        from winml.modelkit.optim.pipes import ORTFusionPipe
 
         for _cap_name, cap in list(ORTFusionPipe.capabilities.items())[:5]:
             if isinstance(cap, BoolCapability):


### PR DESCRIPTION
## Summary
Fixes #198

- Fix outdated `python -m modelkit.*` paths → `python -m winml.modelkit.*` (11 places)
- Replace stale `static_analyzer` references with `analyze` (8 places)
- Fix wrong `from modelkit import` in docstrings and scripts (6 places, including runtime-breaking imports in `run_pytorch_baseline.py`)
- Convert ~35 absolute imports to relative in `src/` (pattern/, analyze/, optim/)
- Fix test imports bypassing `__init__.py` public API (12 places in optim/pipes tests)
- Fix Gelu rewrite test bug: `f"{gelu_variant}Pattern"` double-suffixed `"Gelu1Pattern"` → `"Gelu1PatternPattern"`, causing 6 tests to be silently skipped
- Remove deprecated private method `_get_model_config()`
- Add comments for unimplemented task class mappings in `TASK_TO_WINML_CLASS`

Verified: 3726 passed, 81 skipped (hardware), 0 failed.