### PR TITLE
fix: suppress ep_registry log leaks in wmk sys output

### DIFF
--- a/src/winml/modelkit/commands/sys.py
+++ b/src/winml/modelkit/commands/sys.py
@@ -31,6 +31,7 @@ from typing import Any
 
 import click
 from rich.console import Console
+from rich.logging import RichHandler
 from rich.panel import Panel
 from rich.table import Table
 
@@ -595,6 +596,16 @@ def sysinfo(
     # Inherit debug mode from parent
     if ctx.obj.get("debug"):
         verbose = True
+
+    # Route winml.modelkit logs through Rich so they never interleave with CLI output.
+    # In normal mode suppress everything below WARNING; in debug mode show all levels.
+    _log_level = logging.DEBUG if verbose else logging.WARNING
+    _rich_handler = RichHandler(console=console, show_path=False)
+    _rich_handler.setLevel(_log_level)
+    _pkg_logger = logging.getLogger("winml.modelkit")
+    _pkg_logger.setLevel(_log_level)
+    _pkg_logger.addHandler(_rich_handler)
+    _pkg_logger.propagate = False
 
     use_json = output_format.lower() == "json"
 

--- a/src/winml/modelkit/commands/sys.py
+++ b/src/winml/modelkit/commands/sys.py
@@ -599,13 +599,14 @@ def sysinfo(
 
     # Route winml.modelkit logs through Rich so they never interleave with CLI output.
     # In normal mode suppress everything below WARNING; in debug mode show all levels.
-    _log_level = logging.DEBUG if verbose else logging.WARNING
-    _rich_handler = RichHandler(console=console, show_path=False)
-    _rich_handler.setLevel(_log_level)
-    _pkg_logger = logging.getLogger("winml.modelkit")
-    _pkg_logger.setLevel(_log_level)
-    _pkg_logger.addHandler(_rich_handler)
-    _pkg_logger.propagate = False
+    log_level = logging.DEBUG if verbose else logging.WARNING
+    pkg_logger = logging.getLogger("winml.modelkit")
+    pkg_logger.handlers = [h for h in pkg_logger.handlers if not isinstance(h, RichHandler)]
+    rich_handler = RichHandler(console=console, show_path=False)
+    rich_handler.setLevel(log_level)
+    pkg_logger.setLevel(log_level)
+    pkg_logger.addHandler(rich_handler)
+    pkg_logger.propagate = False
 
     use_json = output_format.lower() == "json"
 

--- a/src/winml/modelkit/commands/sys.py
+++ b/src/winml/modelkit/commands/sys.py
@@ -599,8 +599,12 @@ def sysinfo(
 
     # Route winml.modelkit logs through Rich so they never interleave with CLI output.
     # In normal mode suppress everything below WARNING; in debug mode show all levels.
+    # Restore logger state on exit so tests using caplog are not affected.
     log_level = logging.DEBUG if verbose else logging.WARNING
     pkg_logger = logging.getLogger("winml.modelkit")
+    _saved_handlers = pkg_logger.handlers[:]
+    _saved_level = pkg_logger.level
+    _saved_propagate = pkg_logger.propagate
     pkg_logger.handlers = [h for h in pkg_logger.handlers if not isinstance(h, RichHandler)]
     rich_handler = RichHandler(console=console, show_path=False)
     rich_handler.setLevel(log_level)
@@ -608,73 +612,79 @@ def sysinfo(
     pkg_logger.addHandler(rich_handler)
     pkg_logger.propagate = False
 
-    use_json = output_format.lower() == "json"
-
-    # Handle --list-device and/or --list-ep (combinable)
-    if list_device or list_ep:
-        if list_device:
-            try:
-                devices = _gather_device_info()
-                if use_json:
-                    _output_device_json(devices)
-                else:
-                    _output_device_text(devices)
-            except Exception as e:
-                console.print(f"[bold red]Error detecting devices:[/bold red] {e}")
-                logger.exception("Failed to detect devices")
-                raise click.ClickException(f"Error detecting devices: {e}") from e
-
-        if list_ep:
-            try:
-                eps = _gather_ep_info()
-                if use_json:
-                    _output_ep_json(eps)
-                else:
-                    _output_ep_text(eps)
-            except Exception as e:
-                console.print(
-                    f"[bold red]Error detecting execution providers:[/bold red] {e}"
-                )
-                logger.exception("Failed to detect execution providers")
-                raise click.ClickException(
-                    f"Error detecting execution providers: {e}"
-                ) from e
-        return
-
-    # Default: full sysinfo including devices and EPs
     try:
-        info = _gather_system_info(verbose=verbose)
+        use_json = output_format.lower() == "json"
 
-        if use_json:
-            # Add devices and EPs to JSON output
-            try:
-                info["devices"] = _gather_device_info()
-            except Exception:
-                info["devices"] = []
-            try:
-                info["executionProviders"] = _gather_ep_info()
-            except Exception:
-                info["executionProviders"] = []
-            _output_json(info)
-        elif output_format.lower() == "compact":
-            _output_compact(info)
-        else:
-            _output_text(info, verbose=verbose)
-            # Append devices and EPs to text output
-            console.print()
-            try:
-                devices = _gather_device_info()
-                _output_device_text(devices)
-            except Exception:
-                logger.debug("Device detection failed in default output")
-            console.print()
-            try:
-                eps = _gather_ep_info()
-                _output_ep_text(eps)
-            except Exception:
-                logger.debug("EP detection failed in default output")
+        # Handle --list-device and/or --list-ep (combinable)
+        if list_device or list_ep:
+            if list_device:
+                try:
+                    devices = _gather_device_info()
+                    if use_json:
+                        _output_device_json(devices)
+                    else:
+                        _output_device_text(devices)
+                except Exception as e:
+                    console.print(f"[bold red]Error detecting devices:[/bold red] {e}")
+                    logger.exception("Failed to detect devices")
+                    raise click.ClickException(f"Error detecting devices: {e}") from e
 
-    except Exception as e:
-        console.print(f"[bold red]Error gathering system information:[/bold red] {e}")
-        logger.exception("Failed to gather system information")
-        raise click.ClickException(f"Error gathering system information: {e}") from e
+            if list_ep:
+                try:
+                    eps = _gather_ep_info()
+                    if use_json:
+                        _output_ep_json(eps)
+                    else:
+                        _output_ep_text(eps)
+                except Exception as e:
+                    console.print(
+                        f"[bold red]Error detecting execution providers:[/bold red] {e}"
+                    )
+                    logger.exception("Failed to detect execution providers")
+                    raise click.ClickException(
+                        f"Error detecting execution providers: {e}"
+                    ) from e
+            return
+
+        # Default: full sysinfo including devices and EPs
+        try:
+            info = _gather_system_info(verbose=verbose)
+
+            if use_json:
+                # Add devices and EPs to JSON output
+                try:
+                    info["devices"] = _gather_device_info()
+                except Exception:
+                    info["devices"] = []
+                try:
+                    info["executionProviders"] = _gather_ep_info()
+                except Exception:
+                    info["executionProviders"] = []
+                _output_json(info)
+            elif output_format.lower() == "compact":
+                _output_compact(info)
+            else:
+                _output_text(info, verbose=verbose)
+                # Append devices and EPs to text output
+                console.print()
+                try:
+                    devices = _gather_device_info()
+                    _output_device_text(devices)
+                except Exception:
+                    logger.debug("Device detection failed in default output")
+                console.print()
+                try:
+                    eps = _gather_ep_info()
+                    _output_ep_text(eps)
+                except Exception:
+                    logger.debug("EP detection failed in default output")
+
+        except Exception as e:
+            console.print(f"[bold red]Error gathering system information:[/bold red] {e}")
+            logger.exception("Failed to gather system information")
+            raise click.ClickException(f"Error gathering system information: {e}") from e
+
+    finally:
+        pkg_logger.handlers = _saved_handlers
+        pkg_logger.setLevel(_saved_level)
+        pkg_logger.propagate = _saved_propagate

--- a/src/winml/modelkit/session/ep_registry.py
+++ b/src/winml/modelkit/session/ep_registry.py
@@ -61,7 +61,7 @@ class WinMLEPRegistry:
             self._init_windows_app_sdk()
             self._load_ep_catalog()
             self._winml_available = True
-            logger.info("WinML EP discovery successful: %s", list(self._ep_paths.keys()))
+            logger.debug("WinML EP discovery successful: %s", list(self._ep_paths.keys()))
         except ImportError as e:
             logger.warning("WinML not available (missing packages): %s", e)
             self._winml_available = False
@@ -126,7 +126,7 @@ class WinMLEPRegistry:
                 # Use ORT's native EP registration API
                 ort.register_execution_provider_library(name, dll_path)
                 self._registered_eps.append(name)
-                logger.info("Registered EP: %s -> %s", name, dll_path)
+                logger.debug("Registered EP: %s -> %s", name, dll_path)
             except Exception as e:
                 logger.warning("Failed to register EP %s: %s", name, e)
 


### PR DESCRIPTION
## Summary

- Change `logger.info` → `logger.debug` in `ep_registry.py` for EP discovery and registration messages, so they don't leak into formatted CLI output during normal runs
- Add `RichHandler` in `sys.py` to route all `winml.modelkit` logs through the same Rich `console`, preventing interleaving with CLI sections; `--verbose` enables DEBUG level, otherwise WARNING+ only

Closes #184

<img width="758" height="302" alt="image" src="https://github.com/user-attachments/assets/84480722-3fe9-4740-857e-33dcb73f5821" />
