### PR TITLE
fix: clean .onnx.data file in temp

### DIFF
--- a/src/winml/modelkit/optim/pipes/fusion.py
+++ b/src/winml/modelkit/optim/pipes/fusion.py
@@ -301,6 +301,8 @@ class ORTFusionPipe(BasePipe):
             ) from e
 
         finally:
-            # Clean up temporary file
+            # Clean up temporary file and its external data sidecar
             if input_path:
-                Path(input_path).unlink(missing_ok=True)
+                p = Path(input_path)
+                p.unlink(missing_ok=True)
+                (p.parent / f"{p.name}.data").unlink(missing_ok=True)

--- a/src/winml/modelkit/optim/pipes/graph.py
+++ b/src/winml/modelkit/optim/pipes/graph.py
@@ -593,8 +593,9 @@ class ORTGraphPipe(BasePipe):
                 ) from e
 
         finally:
-            # Clean up temporary files (always execute)
-            if input_file and input_file.exists():
-                input_file.unlink(missing_ok=True)
-            if output_file and output_file.exists():
-                output_file.unlink(missing_ok=True)
+            # Clean up temporary files and their external data sidecars
+            for tmp in (input_file, output_file):
+                if tmp is not None:
+                    tmp.unlink(missing_ok=True)
+                    data_sidecar = tmp.parent / f"{tmp.name}.data"
+                    data_sidecar.unlink(missing_ok=True)


### PR DESCRIPTION
## Clean up leaked `.onnx.data` sidecar files in optimization pipes

When `save_onnx` writes a large model to a temp file, it creates an external data sidecar (`{filename}.data`) alongside the `.onnx` file. The cleanup in `ORTGraphPipe` and `ORTFusionPipe` only deleted the `.onnx` temp file, leaving the `.data` sidecar behind in the system temp directory.

### Changes

- **`optim/pipes/graph.py`** — Also delete the `.data` sidecar for both input and output temp files. Simplified cleanup into a loop.
- **`optim/pipes/fusion.py`** — Also delete the `.data` sidecar for the input temp file.

### Root cause

`save_onnx` automatically writes weights to `{path}.data` when the model exceeds the external data threshold (100 MiB). The `finally` blocks only called `unlink` on the `.onnx` file itself.