### PR TITLE
fix: suppress false-alarm WinMLModel pipeline warning in winml eval (#258)

### DIFF
--- a/src/winml/modelkit/_warnings.py
+++ b/src/winml/modelkit/_warnings.py
@@ -44,9 +44,20 @@ def _configure() -> None:
         def filter(self, record: logging.LogRecord) -> bool:
             return "Multiple distributions found" not in record.getMessage()
 
-    logging.getLogger("diffusers.utils.import_utils").addFilter(
-        _DiffusersDistributionFilter()
-    )
+    logging.getLogger("diffusers.utils.import_utils").addFilter(_DiffusersDistributionFilter())
+
+    class _WinMLPipelineFilter(logging.Filter):
+        """Filter false-alarm 'WinMLModel* is not supported' from transformers pipeline.
+
+        HuggingFace's pipeline emits an error-level log when the model class is not
+        in its built-in registry. WinML wrapper classes are intentionally not
+        registered with HF; evaluation works correctly regardless.
+        """
+
+        def filter(self, record: logging.LogRecord) -> bool:
+            return "WinMLModel" not in record.getMessage()
+
+    logging.getLogger("transformers.pipelines.base").addFilter(_WinMLPipelineFilter())
 
     # =========================================================================
     # Warning filters (for warnings.warn() calls)

--- a/src/winml/modelkit/commands/hub.py
+++ b/src/winml/modelkit/commands/hub.py
@@ -117,7 +117,7 @@ def _fmt_model_id(model_id: str) -> Text:
     Returns:
         Rich Text with org in dim and model name in cyan bold.
     """
-    t = Text(overflow="ellipsis", no_wrap=True)
+    t = Text(overflow="crop", no_wrap=True)
     if "/" in model_id:
         org, name = model_id.split("/", 1)
         t.append(org + "/", style="dim")
@@ -171,9 +171,9 @@ def _build_list_renderable(models: list[dict[str, Any]]) -> Group:
         show_edge=False,
         expand=True,
     )
-    table.add_column("Model", no_wrap=True, max_width=38)
-    table.add_column("Task", no_wrap=True)
-    table.add_column("Model Type", no_wrap=True, style="magenta")
+    table.add_column("Model", no_wrap=True, max_width=38, overflow="crop")
+    table.add_column("Task", no_wrap=True, overflow="crop")
+    table.add_column("Model Type", no_wrap=True, style="magenta", overflow="crop")
 
     for m in models:
         table.add_row(

--- a/src/winml/modelkit/commands/sys.py
+++ b/src/winml/modelkit/commands/sys.py
@@ -449,11 +449,6 @@ def _output_device_text(devices: list[dict[str, Any]]) -> None:
             )
 
 
-def _output_device_json(devices: list[dict[str, Any]]) -> None:
-    """Display device list as JSON."""
-    click.echo(json.dumps(devices, indent=2))
-
-
 # --- EP listing ---
 
 
@@ -518,11 +513,6 @@ def _output_ep_text(eps: list[dict[str, Any]]) -> None:
             console.print(f"    Path: {ep['path']}")
         else:
             console.print("    [dim](built-in)[/dim]")
-
-
-def _output_ep_json(eps: list[dict[str, Any]]) -> None:
-    """Display EP list as JSON."""
-    click.echo(json.dumps(eps, indent=2))
 
 
 @click.command()  # type: ignore[misc]
@@ -614,29 +604,60 @@ def sysinfo(
 
         # Handle --list-device and/or --list-ep (combinable)
         if list_device or list_ep:
-            if list_device:
-                try:
-                    devices = _gather_device_info()
-                    if use_json:
-                        _output_device_json(devices)
-                    else:
+            if use_json:
+                # Combine both into a single JSON object so output is always valid JSON
+                result: dict[str, Any] = {}
+                if list_device:
+                    try:
+                        result["devices"] = _gather_device_info()
+                    except Exception as e:
+                        logger.exception("Failed to detect devices")
+                        raise click.ClickException(f"Error detecting devices: {e}") from e
+                if list_ep:
+                    try:
+                        result["executionProviders"] = _gather_ep_info()
+                    except Exception as e:
+                        logger.exception("Failed to detect execution providers")
+                        msg = f"Error detecting execution providers: {e}"
+                        raise click.ClickException(msg) from e
+                click.echo(json.dumps(result, indent=2))
+            elif output_format.lower() == "compact":
+                if list_device:
+                    try:
+                        devices = _gather_device_info()
+                        parts = [f"{d['type']}: {d['name'].strip()}" for d in devices]
+                        click.echo(" | ".join(parts) if parts else "No devices found")
+                    except Exception as e:
+                        logger.exception("Failed to detect devices")
+                        raise click.ClickException(f"Error detecting devices: {e}") from e
+                if list_ep:
+                    try:
+                        eps = _gather_ep_info()
+                        parts = [f"{ep['name']}({ep['device']})" for ep in eps]
+                        click.echo("EPs: " + ", ".join(parts) if parts else "EPs: none")
+                    except Exception as e:
+                        logger.exception("Failed to detect execution providers")
+                        msg = f"Error detecting execution providers: {e}"
+                        raise click.ClickException(msg) from e
+            else:
+                if list_device:
+                    try:
+                        devices = _gather_device_info()
                         _output_device_text(devices)
-                except Exception as e:
-                    console.print(f"[bold red]Error detecting devices:[/bold red] {e}")
-                    logger.exception("Failed to detect devices")
-                    raise click.ClickException(f"Error detecting devices: {e}") from e
-
-            if list_ep:
-                try:
-                    eps = _gather_ep_info()
-                    if use_json:
-                        _output_ep_json(eps)
-                    else:
+                    except Exception as e:
+                        console.print(f"[bold red]Error detecting devices:[/bold red] {e}")
+                        logger.exception("Failed to detect devices")
+                        raise click.ClickException(f"Error detecting devices: {e}") from e
+                if list_ep:
+                    try:
+                        eps = _gather_ep_info()
                         _output_ep_text(eps)
-                except Exception as e:
-                    console.print(f"[bold red]Error detecting execution providers:[/bold red] {e}")
-                    logger.exception("Failed to detect execution providers")
-                    raise click.ClickException(f"Error detecting execution providers: {e}") from e
+                    except Exception as e:
+                        err_msg = f"[bold red]Error detecting execution providers:[/bold red] {e}"
+                        console.print(err_msg)
+                        logger.exception("Failed to detect execution providers")
+                        msg = f"Error detecting execution providers: {e}"
+                        raise click.ClickException(msg) from e
             return
 
         # Default: full sysinfo including devices and EPs

--- a/src/winml/modelkit/core/onnx_node_bucketizer.py
+++ b/src/winml/modelkit/core/onnx_node_bucketizer.py
@@ -111,7 +111,7 @@ def demonstrate_bucketization():
 
         # Verify expectation
         status = "✅" if actual_scope == expected_scope else "❌"
-        print(f"{status} {node_name:50} → {actual_scope}")
+        print(f"{status} {node_name:50} -> {actual_scope}")
 
     print("\n📊 Scope Buckets:")
     print("-" * 30)

--- a/src/winml/modelkit/optim/capabilities/graph.py
+++ b/src/winml/modelkit/optim/capabilities/graph.py
@@ -27,7 +27,7 @@ CONCAT_SLICE_ELIMINATION = BoolCapability(
 DOUBLE_QDQ_PAIRS_REMOVER = BoolCapability(
     name="double-qdq-pairs-remover",
     ort_name="DoubleQDQPairsRemover",
-    description="Remove consecutive QuantizeLinear→DequantizeLinear pairs",
+    description="Remove consecutive QuantizeLinear->DequantizeLinear pairs",
     category=CapabilityCategory.GRAPH,
     default=False,
 )

--- a/src/winml/modelkit/optim/capabilities/layernorm.py
+++ b/src/winml/modelkit/optim/capabilities/layernorm.py
@@ -24,7 +24,7 @@ from ..registry import BoolCapability, CapabilityCategory
 LAYER_NORM_FUSION = BoolCapability(
     name="layer-norm-fusion",
     ort_name="LayerNormFusionL2",
-    description="Fuse LayerNorm computation (ReduceMean→Sub→Pow→Sqrt→Div→Mul→Add)",
+    description="Fuse LayerNorm computation (ReduceMean->Sub->Pow->Sqrt->Div->Mul->Add)",
     category=CapabilityCategory.LAYER_NORM,
     default=False,
 )
@@ -78,7 +78,7 @@ BIAS_SKIP_LAYER_NORM_FUSION = BoolCapability(
 FUSE_RMSNORM = BoolCapability(
     name="fuse-rmsnorm",
     ort_name=None,  # Custom implementation, not ORT optimizer
-    description="Fuse RMSNorm (Pow→ReduceMean→Add→Sqrt→Div→Mul) into LpNormalization(p=2)",
+    description="Fuse RMSNorm (Pow->ReduceMean->Add->Sqrt->Div->Mul) into LpNormalization(p=2)",
     category=CapabilityCategory.LAYER_NORM,
     default=False,
 )

--- a/src/winml/modelkit/optim/capabilities/surgery.py
+++ b/src/winml/modelkit/optim/capabilities/surgery.py
@@ -22,7 +22,7 @@ from ..registry import BoolCapability, CapabilityCategory
 CLAMP_CONSTANT_VALUES = BoolCapability(
     name="clamp-constant-values",
     ort_name=None,  # Custom implementation, not ORT optimizer
-    description="Clamp extreme float constants (e.g., -inf → -1e3) to prevent quantization issues",
+    description="Clamp extreme float constants (e.g., -inf -> -1e3) to prevent quantization issues",
     category=CapabilityCategory.SURGERY,
     default=False,
 )

--- a/src/winml/modelkit/optim/pipes/rewrite_rules.py
+++ b/src/winml/modelkit/optim/pipes/rewrite_rules.py
@@ -279,7 +279,7 @@ def _build_rewrite_capabilities() -> dict[str, Any]:
         caps[name] = BoolCapability(
             name=name,
             ort_name=None,
-            description=f"Rewrite [{sources_str}] → {group.target_class}",
+            description=f"Rewrite [{sources_str}] -> {group.target_class}",
             category=CapabilityCategory.REWRITE,
             default=False,
         )
@@ -291,7 +291,7 @@ def _build_rewrite_capabilities() -> dict[str, Any]:
                     caps[src_flag] = BoolCapability(
                         name=src_flag,
                         ort_name=None,
-                        description=f"Rewrite {src} → {group.target_class}",
+                        description=f"Rewrite {src} -> {group.target_class}",
                         category=CapabilityCategory.REWRITE,
                         default=False,
                     )

--- a/src/winml/modelkit/optim/pipes/surgery.py
+++ b/src/winml/modelkit/optim/pipes/surgery.py
@@ -200,7 +200,7 @@ class SurgeryPipe(BasePipe):
 
                 if verbose:
                     logger.info(
-                        "Clamped tensor '%s': [%.2e, %.2e] → [%.2e, %.2e]",
+                        "Clamped tensor '%s': [%.2e, %.2e] -> [%.2e, %.2e]",
                         initializer.name,
                         original_min,
                         original_max,

--- a/src/winml/modelkit/pattern/op_input_gen/qdq_gen.py
+++ b/src/winml/modelkit/pattern/op_input_gen/qdq_gen.py
@@ -4,11 +4,15 @@
 # --------------------------------------------------------------------------
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, ClassVar
 
 from onnx.defs import SchemaError
 
 from ...onnx import SupportedONNXType
+
+
+logger = logging.getLogger(__name__)
 
 
 if TYPE_CHECKING:
@@ -52,25 +56,25 @@ class QDQGenerator:
 
         try:
             self.dequantize_linear_schema = domain.get_op_schema("DequantizeLinear", opset_version)
-            print(
-                "DequantizeLinear schema since_version:",
+            logger.debug(
+                "DequantizeLinear schema since_version: %s",
                 self.dequantize_linear_schema.since_version,
             )
             self.opset_version = self.dequantize_linear_schema.since_version
         except SchemaError as e:
-            print(f"Failed DequantizeLinear: {e}")
+            logger.debug("Failed DequantizeLinear: %s", e)
             raise
 
         try:
             self.quantize_linear_schema = domain.get_op_schema("QuantizeLinear", opset_version)
-            print(
-                "QuantizeLinear schema since_version:",
+            logger.debug(
+                "QuantizeLinear schema since_version: %s",
                 self.quantize_linear_schema.since_version,
             )
             ql_ver = self.quantize_linear_schema.since_version
             self.opset_version = max(self.opset_version, ql_ver)
         except SchemaError as e:
-            print(f"Failed QuantizeLinear: {e}")
+            logger.debug("Failed QuantizeLinear: %s", e)
             raise
 
         supported_onnx_types = {x.onnx_type: x for x in SupportedONNXType}
@@ -117,9 +121,9 @@ class QDQGenerator:
         self.weight_all_onnx_types: list[str] = [
             t for t in schema_weight_types if t in supported_onnx_types
         ]
-        print("DequantizeLinear weight types:", self.weight_onnx_types)
-        print("DequantizeLinear output types:", self.dq_output_onnx_types)
-        print("DequantizeLinear all weight types:", self.weight_all_onnx_types)
+        logger.debug("DequantizeLinear weight types: %s", self.weight_onnx_types)
+        logger.debug("DequantizeLinear output types: %s", self.dq_output_onnx_types)
+        logger.debug("DequantizeLinear all weight types: %s", self.weight_all_onnx_types)
 
     def _build_q_type_vars(self, supported_onnx_types: dict[str, SupportedONNXType]) -> None:
         """Create the following mappings for QuantizeLinear.
@@ -162,6 +166,6 @@ class QDQGenerator:
         self.activation_all_onnx_types: list[str] = [
             t for t in schema_activation_types if t in supported_onnx_types
         ]
-        print("QuantizeLinear activation types:", self.activation_onnx_types)
-        print("QuantizeLinear input types:", self.q_input_onnx_types)
-        print("QuantizeLinear all activation types:", self.activation_all_onnx_types)
+        logger.debug("QuantizeLinear activation types: %s", self.activation_onnx_types)
+        logger.debug("QuantizeLinear input types: %s", self.q_input_onnx_types)
+        logger.debug("QuantizeLinear all activation types: %s", self.activation_all_onnx_types)

--- a/src/winml/modelkit/sysinfo/helper.py
+++ b/src/winml/modelkit/sysinfo/helper.py
@@ -47,7 +47,8 @@ class CimInstance:
                     "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; "
                     + f"Get-CimInstance -ClassName {class_name} | "
                     + "ConvertTo-Json -Depth 99",
-                ]
+                ],
+                stderr=subprocess.DEVNULL,
             )
         except subprocess.CalledProcessError:
             # This will throw if no matching device is found
@@ -95,7 +96,8 @@ class PnpDevice:
                     "-Command",
                     "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; "
                     + f"Get-PnpDevice -Class {class_name} | ConvertTo-Json -Depth 99",
-                ]
+                ],
+                stderr=subprocess.DEVNULL,
             )
         except subprocess.CalledProcessError:
             return []
@@ -122,7 +124,8 @@ class PnpDevice:
                     "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; "
                     + f"Get-PnpDeviceProperty -InstanceId '{self._pnp_id}' | "
                     + "ConvertTo-Json -Depth 99",
-                ]
+                ],
+                stderr=subprocess.DEVNULL,
             )
         except subprocess.CalledProcessError:
             # This may happen if the device has no extra properties
@@ -183,7 +186,8 @@ class AppxPackage:
                     "-Command",
                     "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; "
                     + f"Get-AppxPackage {hint} | ConvertTo-Json -Depth 99",
-                ]
+                ],
+                stderr=subprocess.DEVNULL,
             )
         except subprocess.CalledProcessError:
             return []

--- a/tests/regression/test_design_gaps.py
+++ b/tests/regression/test_design_gaps.py
@@ -13,6 +13,7 @@ Design Gap IDs reference the CLI verification plan.
 Markers:
     regression: Regression test suite
 """
+
 from __future__ import annotations
 
 from unittest.mock import patch
@@ -33,6 +34,7 @@ pytestmark = [pytest.mark.regression]
 # A-1: All --help text must be ASCII-safe (no non-ASCII chars in descriptions)
 # ===========================================================================
 
+
 class TestA1HelpTextAsciiSafe:
     """Verify that --help output contains no non-ASCII characters (regression: #228).
 
@@ -45,9 +47,8 @@ class TestA1HelpTextAsciiSafe:
         result = runner.invoke(cmd, args, obj={})
         assert result.exit_code == 0, f"--help exited {result.exit_code}: {result.exception}"
         non_ascii = [(i, c) for i, c in enumerate(result.output) if ord(c) > 127]
-        assert not non_ascii, (
-            f"Non-ASCII characters found in help output: "
-            + ", ".join(f"pos {i} U+{ord(c):04X}" for i, c in non_ascii[:5])
+        assert not non_ascii, "Non-ASCII characters found in help output: " + ", ".join(
+            f"pos {i} U+{ord(c):04X}" for i, c in non_ascii[:5]
         )
 
     def test_optimize_help_is_ascii_safe(self):
@@ -67,6 +68,7 @@ class TestA1HelpTextAsciiSafe:
 # M-1: --list-tasks NOT in inspect --help
 # ===========================================================================
 
+
 class TestM1ListTasksAbsent:
     """Document that --list-tasks is not implemented in inspect."""
 
@@ -82,6 +84,7 @@ class TestM1ListTasksAbsent:
 # M-5: --no-analyze NOT in build --help
 # ===========================================================================
 
+
 class TestM5NoAnalyzePresent:
     """Verify that --no-analyze IS now implemented in build (M-5 fixed)."""
 
@@ -96,6 +99,7 @@ class TestM5NoAnalyzePresent:
 # ===========================================================================
 # B-2: precision values accepted by perf CLI
 # ===========================================================================
+
 
 class TestB2PerfPrecisionValues:
     """Document current precision values accepted by perf --precision."""
@@ -130,12 +134,14 @@ class TestB2PerfPrecisionValues:
 # D-6: DEFAULT_VOCAB_SIZE == 30522
 # ===========================================================================
 
+
 class TestD6NoHardcodedVocab:
     """Verify that DEFAULT_VOCAB_SIZE is removed from perf.py (D-6 fixed)."""
 
     def test_no_default_vocab_size_constant(self):
         """perf.py should NOT have DEFAULT_VOCAB_SIZE constant after D-6 fix."""
         import winml.modelkit.commands.perf as perf_mod
+
         assert not hasattr(perf_mod, "DEFAULT_VOCAB_SIZE"), (
             "DEFAULT_VOCAB_SIZE still exists — D-6 not fixed"
         )
@@ -144,6 +150,7 @@ class TestD6NoHardcodedVocab:
 # ===========================================================================
 # B-1: inspect help says "HuggingFace" (no ONNX mention)
 # ===========================================================================
+
 
 class TestB1InspectHelpScope:
     """Document that inspect only targets HuggingFace models."""
@@ -172,6 +179,7 @@ class TestB1InspectHelpScope:
 # B-4: config --model-type bert without --task (e2e-level)
 # ===========================================================================
 
+
 class TestB4ConfigModelTypeNoTask:
     """Document that config --model-type without --task does not crash."""
 
@@ -197,6 +205,5 @@ class TestB4ConfigModelTypeNoTask:
         runner = CliRunner()
         result = runner.invoke(config, ["--model-type", "bert"])
         assert result.exit_code == 0, (
-            f"config --model-type bert crashed (exit {result.exit_code}):\n"
-            f"{result.output}"
+            f"config --model-type bert crashed (exit {result.exit_code}):\n{result.output}"
         )

--- a/tests/regression/test_design_gaps.py
+++ b/tests/regression/test_design_gaps.py
@@ -22,10 +22,45 @@ from click.testing import CliRunner
 
 from winml.modelkit.commands.build import build
 from winml.modelkit.commands.inspect import inspect
+from winml.modelkit.commands.optimize import optimize
 from winml.modelkit.commands.perf import perf
 
 
 pytestmark = [pytest.mark.regression]
+
+
+# ===========================================================================
+# A-1: All --help text must be ASCII-safe (no non-ASCII chars in descriptions)
+# ===========================================================================
+
+class TestA1HelpTextAsciiSafe:
+    """Verify that --help output contains no non-ASCII characters (regression: #228).
+
+    Non-ASCII chars in capability/rewrite descriptions (e.g. U+2192 →) crash
+    winml on Windows terminals using cp1252 encoding.
+    """
+
+    def _assert_ascii_help(self, cmd, args: list) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cmd, args, obj={})
+        assert result.exit_code == 0, f"--help exited {result.exit_code}: {result.exception}"
+        non_ascii = [(i, c) for i, c in enumerate(result.output) if ord(c) > 127]
+        assert not non_ascii, (
+            f"Non-ASCII characters found in help output: "
+            + ", ".join(f"pos {i} U+{ord(c):04X}" for i, c in non_ascii[:5])
+        )
+
+    def test_optimize_help_is_ascii_safe(self):
+        """winml optimize --help must not contain non-ASCII characters."""
+        self._assert_ascii_help(optimize, ["--help"])
+
+    def test_optimize_list_capabilities_is_ascii_safe(self):
+        """winml optimize --list-capabilities must not contain non-ASCII characters."""
+        self._assert_ascii_help(optimize, ["--list-capabilities"])
+
+    def test_optimize_list_rewrites_is_ascii_safe(self):
+        """winml optimize --list-rewrites must not contain non-ASCII characters."""
+        self._assert_ascii_help(optimize, ["--list-rewrites"])
 
 
 # ===========================================================================

--- a/tests/unit/analyze/core/test_qdq.py
+++ b/tests/unit/analyze/core/test_qdq.py
@@ -52,6 +52,15 @@ class TestQDQGenerator:
         assert isinstance(qdq_generator.dq_output_onnx_types, list)
         assert isinstance(qdq_generator.q_input_onnx_types, list)
 
+    def test_initialization_does_not_print_to_stdout(self, capsys) -> None:
+        """QDQGenerator.__init__ must not write to stdout (regression: #231)."""
+        QDQGenerator(opset_version=17, domain=ONNXDomain.AI_ONNX)
+        captured = capsys.readouterr()
+        assert captured.out == "", (
+            "QDQGenerator printed to stdout during init — "
+            "debug print() statements must be converted to logger.debug()"
+        )
+
     def test_type_lists_validity(self, qdq_generator: QDQGenerator) -> None:
         """Test that type lists contain valid quantization types."""
         assert len(qdq_generator.weight_onnx_types) > 0

--- a/tests/unit/commands/test_cli.py
+++ b/tests/unit/commands/test_cli.py
@@ -195,15 +195,11 @@ class TestSysCommand:
         result = runner.invoke(main, ["sys", "--verbose"])
         assert result.exit_code == 0
 
-    def test_sys_list_device_list_ep_json_is_valid_single_object(
-        self, runner: CliRunner
-    ) -> None:
+    def test_sys_list_device_list_ep_json_is_valid_single_object(self, runner: CliRunner) -> None:
         """--list-device --list-ep --format json must emit one valid JSON object, not two arrays."""
         import json
 
-        result = runner.invoke(
-            main, ["sys", "--list-device", "--list-ep", "--format", "json"]
-        )
+        result = runner.invoke(main, ["sys", "--list-device", "--list-ep", "--format", "json"])
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert "devices" in data
@@ -212,7 +208,7 @@ class TestSysCommand:
         assert isinstance(data["executionProviders"], list)
 
     def test_sys_list_device_compact(self, runner: CliRunner) -> None:
-        """--list-device --format compact must produce compact single-line output, not text table."""
+        """--list-device --format compact must produce compact output, not text table."""
         result = runner.invoke(main, ["sys", "--list-device", "--format", "compact"])
         assert result.exit_code == 0
         assert "CPU" in result.output

--- a/tests/unit/commands/test_cli.py
+++ b/tests/unit/commands/test_cli.py
@@ -195,6 +195,38 @@ class TestSysCommand:
         result = runner.invoke(main, ["sys", "--verbose"])
         assert result.exit_code == 0
 
+    def test_sys_list_device_list_ep_json_is_valid_single_object(
+        self, runner: CliRunner
+    ) -> None:
+        """--list-device --list-ep --format json must emit one valid JSON object, not two arrays."""
+        import json
+
+        result = runner.invoke(
+            main, ["sys", "--list-device", "--list-ep", "--format", "json"]
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "devices" in data
+        assert "executionProviders" in data
+        assert isinstance(data["devices"], list)
+        assert isinstance(data["executionProviders"], list)
+
+    def test_sys_list_device_compact(self, runner: CliRunner) -> None:
+        """--list-device --format compact must produce compact single-line output, not text table."""
+        result = runner.invoke(main, ["sys", "--list-device", "--format", "compact"])
+        assert result.exit_code == 0
+        assert "CPU" in result.output
+        # Compact output is a single line; no Rich panel borders
+        assert "Available Devices" not in result.output
+
+    def test_sys_list_ep_compact(self, runner: CliRunner) -> None:
+        """--list-ep --format compact must produce compact output, not text table."""
+        result = runner.invoke(main, ["sys", "--list-ep", "--format", "compact"])
+        assert result.exit_code == 0
+        assert "CPUExecutionProvider" in result.output
+        # Compact output is a single line; no Rich panel headers
+        assert "Available Execution Providers" not in result.output
+
 
 class TestModuleExecution:
     """Test python -m winml.modelkit execution."""

--- a/tests/unit/commands/test_hub.py
+++ b/tests/unit/commands/test_hub.py
@@ -146,6 +146,19 @@ def test_fmt_model_id_no_org():
     assert t.plain == "bert-base-uncased"
 
 
+def test_fmt_model_id_overflow_is_ascii_safe():
+    """Text overflow must use 'crop', not 'ellipsis' (regression: #233).
+
+    'ellipsis' emits U+2026 (…) which is unrepresentable in cp1252 terminals.
+    'crop' simply truncates without appending any non-ASCII character.
+    """
+    t = _fmt_model_id("org/model-name")
+    assert t.overflow == "crop", (
+        f"Expected overflow='crop', got {t.overflow!r}. "
+        "Using 'ellipsis' would emit U+2026 (…) on cp1252 terminals."
+    )
+
+
 # ---------------------------------------------------------------------------
 # _overall_verdict unit tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds a logging filter on `transformers.pipelines.base` to suppress the misleading `WinMLModel* is not supported for image-classification` message emitted during `winml eval`
- The warning is a false alarm: HuggingFace's `pipeline()` logs an error when the model class is not in its built-in registry, but WinML wrapper classes are intentionally not registered with HF and evaluation works correctly regardless

Closes #258

## Change

[`src/winml/modelkit/_warnings.py`](src/winml/modelkit/_warnings.py) — added `_WinMLPipelineFilter` logging filter following the existing `_DiffusersDistributionFilter` pattern.