### PR TITLE
fix: suppress false-alarm WinMLModel pipeline warning in winml eval (#258)

### DIFF
--- a/src/winml/modelkit/_warnings.py
+++ b/src/winml/modelkit/_warnings.py
@@ -44,9 +44,20 @@ def _configure() -> None:
         def filter(self, record: logging.LogRecord) -> bool:
             return "Multiple distributions found" not in record.getMessage()
 
-    logging.getLogger("diffusers.utils.import_utils").addFilter(
-        _DiffusersDistributionFilter()
-    )
+    logging.getLogger("diffusers.utils.import_utils").addFilter(_DiffusersDistributionFilter())
+
+    class _WinMLPipelineFilter(logging.Filter):
+        """Filter false-alarm 'WinMLModel* is not supported' from transformers pipeline.
+
+        HuggingFace's pipeline emits an error-level log when the model class is not
+        in its built-in registry. WinML wrapper classes are intentionally not
+        registered with HF; evaluation works correctly regardless.
+        """
+
+        def filter(self, record: logging.LogRecord) -> bool:
+            return "WinMLModel" not in record.getMessage()
+
+    logging.getLogger("transformers.pipelines.base").addFilter(_WinMLPipelineFilter())
 
     # =========================================================================
     # Warning filters (for warnings.warn() calls)

--- a/src/winml/modelkit/core/onnx_node_bucketizer.py
+++ b/src/winml/modelkit/core/onnx_node_bucketizer.py
@@ -111,7 +111,7 @@ def demonstrate_bucketization():
 
         # Verify expectation
         status = "✅" if actual_scope == expected_scope else "❌"
-        print(f"{status} {node_name:50} → {actual_scope}")
+        print(f"{status} {node_name:50} -> {actual_scope}")
 
     print("\n📊 Scope Buckets:")
     print("-" * 30)

--- a/src/winml/modelkit/optim/pipes/surgery.py
+++ b/src/winml/modelkit/optim/pipes/surgery.py
@@ -200,7 +200,7 @@ class SurgeryPipe(BasePipe):
 
                 if verbose:
                     logger.info(
-                        "Clamped tensor '%s': [%.2e, %.2e] → [%.2e, %.2e]",
+                        "Clamped tensor '%s': [%.2e, %.2e] -> [%.2e, %.2e]",
                         initializer.name,
                         original_min,
                         original_max,


### PR DESCRIPTION
## Summary

- Suppresses the misleading \`WinMLModel* is not supported for image-classification\` log emitted by HuggingFace's \`pipeline()\` during \`winml eval\`
- Replaces \`→\` (U+2192) with \`->\` in two runtime log/print statements to prevent cp1252 encoding crashes on Windows terminals

## Before / After

**Before** — \`winml eval -m microsoft/resnet-50 --device npu\` emits a false-alarm error log before producing correct results:

```
ERROR The model 'WinMLModelForImageClassification' is not supported for image-classification.
      Supported models are ['BeitForImageClassification', 'BitForImageClassification',
      'CLIPForImageClassification', ..., 'ViTMSNForImageClassification'].
{'accuracy': 0.74, 'samples_per_second': 58.04, ...}
```

**After** — the misleading log is suppressed; only the result is printed:

```
{'accuracy': 0.74, 'samples_per_second': 58.04, ...}
```

## Root cause

HuggingFace's `pipeline()` logs `logger.error` when the model class is not in its built-in registry. `WinMLModelForImageClassification` is intentionally not registered with HF — it is a WinML wrapper. Evaluation works correctly regardless of the warning.

## Changes

- [`src/winml/modelkit/_warnings.py`](src/winml/modelkit/_warnings.py) — added `_WinMLPipelineFilter` on `transformers.pipelines.base` logger, following the existing `_DiffusersDistributionFilter` pattern
- [`src/winml/modelkit/optim/pipes/surgery.py`](src/winml/modelkit/optim/pipes/surgery.py) — `logger.info` format string: `→` → `->`
- [`src/winml/modelkit/core/onnx_node_bucketizer.py`](src/winml/modelkit/core/onnx_node_bucketizer.py) — `print()` call: `→` → `->`

Closes #258