### PR TITLE
fix: make --device flag case-insensitive consistent with other commands (#215)

### DIFF
--- a/src/winml/modelkit/utils/cli.py
+++ b/src/winml/modelkit/utils/cli.py
@@ -78,7 +78,7 @@ def device_option(required=True, optional_message=None, default="NPU"):
         "--device",
         required=required,
         default=default if not required else None,
-        type=click.Choice(SUPPORTED_DEVICES, case_sensitive=True),
+        type=click.Choice(SUPPORTED_DEVICES, case_sensitive=False),
         help=help_text,
     )
 


### PR DESCRIPTION
## Summary

`winml analyze --device` only accepted uppercase (`NPU`, `GPU`, `CPU`). All other commands (`compile`, `eval`, `perf`, `config`) accept lowercase. This single-character fix makes the `device_option()` helper consistent.

## Change

[`src/winml/modelkit/utils/cli.py:81`](src/winml/modelkit/utils/cli.py#L81) — `case_sensitive=True` → `case_sensitive=False`

`click.Choice` with `case_sensitive=False` normalizes the user input to match the canonical form in the choices list (`"npu"` → `"NPU"`), so no downstream code changes are needed.

## Before / After

**Before** — lowercase input fails:

```
$ winml analyze --model model.onnx --ep qnn --device npu
Error: Invalid value for '--device': 'npu' is not one of 'CPU', 'GPU', 'NPU'.

$ winml analyze --model model.onnx --ep qnn --device gpu
Error: Invalid value for '--device': 'gpu' is not one of 'CPU', 'GPU', 'NPU'.
```

**After** — any casing accepted, value normalized to uppercase:

```
$ winml analyze --model model.onnx --ep qnn --device npu   # ✓ device=NPU
$ winml analyze --model model.onnx --ep qnn --device NPU   # ✓ device=NPU
$ winml analyze --model model.onnx --ep qnn --device gpu   # ✓ device=GPU
$ winml analyze --model model.onnx --ep qnn --device Gpu   # ✓ device=GPU
```

Closes #215