### PR TITLE
fix: guard optimize/quantize/compile against EPContext models (#256 #257)

### DIFF
--- a/src/winml/modelkit/commands/compile.py
+++ b/src/winml/modelkit/commands/compile.py
@@ -26,6 +26,7 @@ import click
 from rich.console import Console
 
 from ..config.precision import _DEVICE_TO_PROVIDER, VALID_EPS
+from ..onnx import is_compiled_onnx
 from ..utils.logging import configure_logging
 
 
@@ -158,6 +159,12 @@ def compile(
     # Validate model is provided when not listing
     if model is None:
         raise click.UsageError("Missing option '--model' / '-m'.")
+
+    if is_compiled_onnx(model):
+        raise click.ClickException(
+            f"{model} is already a compiled EPContext model and cannot be re-compiled. "
+            "Run 'winml compile' on the original ONNX model."
+        )
 
     # Import compiler (late import to speed up CLI)
     from ..compiler import WinMLCompileConfig, compile_onnx

--- a/src/winml/modelkit/commands/optimize.py
+++ b/src/winml/modelkit/commands/optimize.py
@@ -30,7 +30,7 @@ from typing import TYPE_CHECKING, Any
 import click
 from rich.console import Console
 
-from ..onnx import load_onnx, save_onnx
+from ..onnx import is_compiled_onnx, load_onnx, save_onnx
 
 
 if TYPE_CHECKING:
@@ -453,6 +453,12 @@ def optimize(
     # Pass verbose to pipes
     if verbose:
         optimizer_kwargs["verbose"] = True
+
+    if is_compiled_onnx(model):
+        raise click.ClickException(
+            f"{model} is a compiled EPContext model and cannot be optimized. "
+            "Run 'winml optimize' on the original ONNX model before compilation."
+        )
 
     try:
         console.print("\n[bold]Loading model...[/bold]")

--- a/src/winml/modelkit/commands/optimize.py
+++ b/src/winml/modelkit/commands/optimize.py
@@ -382,6 +382,12 @@ def optimize(
     if model is None:
         raise click.UsageError("Missing option '--model' / '-m'.")
 
+    if is_compiled_onnx(model):
+        raise click.ClickException(
+            f"{model} is a compiled EPContext model and cannot be optimized. "
+            "Run 'winml optimize' on the original ONNX model before compilation."
+        )
+
     # Inherit debug mode from parent
     if ctx.obj and ctx.obj.get("debug"):
         verbose = True
@@ -453,12 +459,6 @@ def optimize(
     # Pass verbose to pipes
     if verbose:
         optimizer_kwargs["verbose"] = True
-
-    if is_compiled_onnx(model):
-        raise click.ClickException(
-            f"{model} is a compiled EPContext model and cannot be optimized. "
-            "Run 'winml optimize' on the original ONNX model before compilation."
-        )
 
     try:
         console.print("\n[bold]Loading model...[/bold]")

--- a/src/winml/modelkit/commands/quantize.py
+++ b/src/winml/modelkit/commands/quantize.py
@@ -25,6 +25,7 @@ from pathlib import Path
 import click
 from rich.console import Console
 
+from ..onnx import is_compiled_onnx
 from ..utils.logging import configure_logging
 
 
@@ -172,6 +173,12 @@ def quantize(
         per_channel=per_channel,
         symmetric=symmetric,
     )
+
+    if is_compiled_onnx(model):
+        raise click.ClickException(
+            f"{model} is a compiled EPContext model and cannot be quantized. "
+            "Run 'winml quantize' on the original ONNX model before compilation."
+        )
 
     try:
         console.print("\n[bold]Running quantization...[/bold]")

--- a/src/winml/modelkit/commands/quantize.py
+++ b/src/winml/modelkit/commands/quantize.py
@@ -142,6 +142,12 @@ def quantize(
 
     configure_logging(verbose=verbose)
 
+    if is_compiled_onnx(model):
+        raise click.ClickException(
+            f"{model} is a compiled EPContext model and cannot be quantized. "
+            "Run 'winml quantize' on the original ONNX model before compilation."
+        )
+
     # Import quantizer (late import to speed up CLI)
     from ..quant import WinMLQuantizationConfig, quantize_onnx
 
@@ -173,12 +179,6 @@ def quantize(
         per_channel=per_channel,
         symmetric=symmetric,
     )
-
-    if is_compiled_onnx(model):
-        raise click.ClickException(
-            f"{model} is a compiled EPContext model and cannot be quantized. "
-            "Run 'winml quantize' on the original ONNX model before compilation."
-        )
 
     try:
         console.print("\n[bold]Running quantization...[/bold]")


### PR DESCRIPTION
## Summary

`winml optimize` and `winml quantize` crash with an ORT `NOT_IMPLEMENTED` error when given a compiled QNN EPContext model. The crash happens deep inside ORT's session initialization, which gives no indication that the real problem is that the input model is already compiled.

Add an `is_compiled_onnx()` guard at the start of all three commands that operate on uncompiled ONNX models. Also adds the guard to `winml compile` to catch re-compilation attempts.

## Changes

- [`src/winml/modelkit/commands/optimize.py`](src/winml/modelkit/commands/optimize.py) — EPContext guard before the optimizer runs
- [`src/winml/modelkit/commands/quantize.py`](src/winml/modelkit/commands/quantize.py) — EPContext guard before quantization runs
- [`src/winml/modelkit/commands/compile.py`](src/winml/modelkit/commands/compile.py) — EPContext guard to prevent re-compilation (bonus, found during review)

All guards use the existing `is_compiled_onnx()` helper from `winml.modelkit.onnx`.

## Before / After

**`winml optimize` — Before:**
```
Loading model...
Running optimizer...
ERROR ✗ ort_graph failed: ONNX Runtime optimization failed: [ONNXRuntimeError] : 9 : NOT_IMPLEMENTED :
  Could not find an implementation for EPContext(1) node with name
  'QNNExecutionProvider_QNN_16222565441986465013_1_0'
Error: Optimization failed: ONNX Runtime optimization failed: ...
```

**`winml optimize` — After:**
```
Error: model.onnx is a compiled EPContext model and cannot be optimized.
Run 'winml optimize' on the original ONNX model before compilation.
```

---

**`winml quantize` — Before:**
```
Running quantization...
ERROR: Quantization failed
onnxruntime.capi.onnxruntime_pybind11_state.NotImplemented: [ONNXRuntimeError] : 9 : NOT_IMPLEMENTED :
  Could not find an implementation for EPContext(1) node with name
  'QNNExecutionProvider_QNN_16222565441986465013_1_0'
Error: Quantization failed
```

**`winml quantize` — After:**
```
Error: model.onnx is a compiled EPContext model and cannot be quantized.
Run 'winml quantize' on the original ONNX model before compilation.
```

---

**`winml compile` (bonus) — After:**
```
Error: model_ctx.onnx is already a compiled EPContext model and cannot be re-compiled.
Run 'winml compile' on the original ONNX model.
```

Closes #256
Closes #257