### PR TITLE
fix: enable EP context for OpenVINO compile output (#255)

### DIFF
--- a/src/winml/modelkit/commands/compile.py
+++ b/src/winml/modelkit/commands/compile.py
@@ -199,6 +199,15 @@ def compile(
         result = compile_onnx(model, output_path=output_dir, config=config)
 
         if result.success:
+            if config.ep_config.enable_ep_context and not result.output_path:
+                console.print(
+                    "\n[bold yellow]Warning:[/bold yellow] Compilation finished "
+                    "but no output file was written to the output directory."
+                )
+                raise click.ClickException(
+                    "No output file produced. Check EP context support for "
+                    f"provider '{config.ep_config.provider}'."
+                )
             console.print("\n[bold green]Success![/bold green] Model compiled")
             if result.output_path:
                 console.print(f"[dim]Output: {result.output_path}[/dim]")

--- a/src/winml/modelkit/compiler/configs.py
+++ b/src/winml/modelkit/compiler/configs.py
@@ -202,7 +202,7 @@ class WinMLCompileConfig:
                 stacklevel=2,
             )
         return cls(
-            ep_config=EPConfig(provider="openvino", enable_ep_context=False),
+            ep_config=EPConfig(provider="openvino", enable_ep_context=True),
         )
 
     @classmethod
@@ -246,9 +246,7 @@ class WinMLCompileConfig:
             "embed_context": self.ep_config.embed_context,
             "compiler": self.ep_config.compiler,
             "qnn_sdk_root": (
-                str(self.ep_config.qnn_sdk_root)
-                if self.ep_config.qnn_sdk_root
-                else None
+                str(self.ep_config.qnn_sdk_root) if self.ep_config.qnn_sdk_root else None
             ),
             "validate": self.validate,
         }
@@ -273,9 +271,7 @@ class WinMLCompileConfig:
             enable_ep_context=data.get("enable_ep_context", True),
             embed_context=data.get("embed_context", False),
             compiler=data.get("compiler", "ort"),
-            qnn_sdk_root=(
-                Path(data["qnn_sdk_root"]) if data.get("qnn_sdk_root") else None
-            ),
+            qnn_sdk_root=(Path(data["qnn_sdk_root"]) if data.get("qnn_sdk_root") else None),
         )
 
         return cls(

--- a/tests/unit/compiler/test_compiler_configs.py
+++ b/tests/unit/compiler/test_compiler_configs.py
@@ -100,7 +100,7 @@ class TestCompileConfig:
         """Test OpenVINO factory method."""
         config = WinMLCompileConfig.for_openvino()
         assert config.ep_config.provider == "openvino"
-        assert config.ep_config.enable_ep_context is False
+        assert config.ep_config.enable_ep_context is True
 
     def test_for_vitisai(self):
         """Test Vitis AI factory method."""


### PR DESCRIPTION
## Summary
- **Root cause**: `for_openvino()` hardcoded `enable_ep_context=False`, which skipped `_finalize_output` — the only code path that writes compiled artifacts to `--output-dir`
- Changed `enable_ep_context` to `True` for OpenVINO (matching `for_qnn()`)
- Added a CLI guard: when `enable_ep_context=True` but no output file is produced, the command now fails explicitly instead of printing a misleading "Success!" message

Closes #255