### PR TITLE
fix: use infer_onnx_shapes for external-data-safe shape inference

### DIFF
--- a/src/winml/modelkit/analyze/core/doc_constraint_checker.py
+++ b/src/winml/modelkit/analyze/core/doc_constraint_checker.py
@@ -18,8 +18,8 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 import onnx
 import pandas as pd
-from onnx import shape_inference
 
+from ...onnx import infer_onnx_shapes
 from ..doc_checker.mapping_checkers import get_qnn_op_for_onnx_node
 from ..doc_checker.shape_checker import ShapeConstraintChecker
 from ..models.runtime_checks import PatternAlternative, PatternRuntime, RuntimeTestResult
@@ -86,7 +86,7 @@ class DocConstraintChecker:
         if skip_shape_inference:
             self.model_proto = model_proto
         else:
-            self.model_proto = shape_inference.infer_shapes(model_proto)
+            self.model_proto = infer_onnx_shapes(model_proto)
         self.ep_name = ep_name
         self.device_type = device_type
         self.valueinfo = collect_valueinfo_dict(self.model_proto)

--- a/src/winml/modelkit/analyze/core/runtime_checker_query.py
+++ b/src/winml/modelkit/analyze/core/runtime_checker_query.py
@@ -16,7 +16,7 @@ import numpy as np
 import onnx
 import onnxruntime as ort
 import pandas as pd
-from onnx import numpy_helper, shape_inference
+from onnx import numpy_helper
 
 from ...onnx import (
     ONNXDomain,
@@ -867,8 +867,9 @@ class RuntimeCheckerQuery:
         self.dynamic_axis_strict_mode = dynamic_axis_strict_mode
         # Try shape inference: standard ONNX first, then symbolic (onnxruntime)
         try:
-            # First apply standard ONNX shape inference
-            self.model_proto = shape_inference.infer_shapes(model_proto)
+            # Standard ONNX shape inference — uses temp file for models
+            # with external data (avoids silent empty-graph result).
+            self.model_proto = infer_onnx_shapes(model_proto)
 
             # Then try to enhance with symbolic shape inference
             # if available which supports Microsoft domain


### PR DESCRIPTION
## Summary
- Replace direct `onnx.shape_inference.infer_shapes` calls with `infer_onnx_shapes` in `runtime_checker_query.py` and `doc_constraint_checker.py`
- `infer_onnx_shapes` uses a temp file for large models with external data, avoiding silent empty-graph results