### PR TITLE
Fix issue where OV sentence similarity report NaN metric

### DIFF
--- a/src/winml/modelkit/eval/metrics/spearman_correlation.py
+++ b/src/winml/modelkit/eval/metrics/spearman_correlation.py
@@ -11,7 +11,12 @@ ground-truth human similarity scores (e.g. STS-B scores in [0, 5]).
 
 from __future__ import annotations
 
+import logging
+import math
 from typing import Any
+
+
+logger = logging.getLogger(__name__)
 
 
 class SpearmanCorrelationMetric:
@@ -54,4 +59,12 @@ class SpearmanCorrelationMetric:
             )
 
         corr, _ = spearmanr(predictions, references)
+
+        if math.isnan(corr):
+            logger.warning(
+                "Spearman correlation is NaN. This typically means the model "
+                "produced constant outputs (zero variance). Returning 0.0.",
+            )
+            corr = 0.0
+
         return {"cosine_spearman": round(float(corr) * 100, 4)}

--- a/tests/unit/eval/test_feature_extraction_evaluator.py
+++ b/tests/unit/eval/test_feature_extraction_evaluator.py
@@ -92,6 +92,12 @@ class TestSpearmanCorrelationMetric:
         result = metric.compute([0.1, 0.5, 0.9, 0.3], [1.0, 3.0, 5.0, 2.0])
         assert -100.0 <= result["cosine_spearman"] <= 100.0
 
+    def test_constant_predictions_returns_zero(self):
+        """Zero variance in predictions → correlation = 0.0, not NaN."""
+        metric = SpearmanCorrelationMetric()
+        result = metric.compute([1.0] * 10, [0.5, 1.2, 3.1, 4.0, 2.0, 0.1, 3.5, 4.8, 1.7, 2.9])
+        assert result["cosine_spearman"] == 0.0
+
 
 # ---------------------------------------------------------------------------
 # WinMLFeatureExtractionEvaluator._embed


### PR DESCRIPTION
We use spearman correlation to measure the sentence similar models. The metric calculation library returns a NaN value when the prediction array contains constant values, meaning no sentence similarity rank order.

When the predictions output constant value, this means severe regression as the model completely lose the capability to detect sentence similarity.

Therefore, we treat the metric as zero when the lib returns NaN. 0 means the model has no ranking capability.