### PR TITLE
fix: delete stale external data sidecar before save_onnx overwrites it

### DIFF
--- a/src/winml/modelkit/onnx/persistence.py
+++ b/src/winml/modelkit/onnx/persistence.py
@@ -106,6 +106,12 @@ def save_onnx(
 
     if save_external:
         ext_location = location or f"{path.name}.data"
+        # Delete any pre-existing sidecar so onnx.save_model doesn't raise
+        # FileExistsError (e.g. when ORT quantize() already wrote the file).
+        ext_path = path.parent / ext_location
+        if ext_path.exists():
+            ext_path.unlink()
+            logger.debug("Removed existing external data sidecar: %s", ext_path)
         logger.debug(
             "Saving ONNX model with external data to %s (location=%s)",
             path,


### PR DESCRIPTION
## Summary

- `quantize_onnx` calls ORT's `quantize()` (Step 3) which writes `<output>.onnx.data`, then calls `save_onnx` (Step 8) which tries to write the same sidecar again
- `onnx.save_model` has no overwrite option and raises `FileExistsError: External data file exists in <location>`
- Fix: `save_onnx` now deletes the existing `.data` sidecar before writing, so re-saving over an ORT-generated file works cleanly