### PR TITLE
fix: Enable RTR rewrite autoconf for QNN 6D Reshape models (Swin, Nougat)

### DIFF
--- a/src/winml/modelkit/analyze/analyzer.py
+++ b/src/winml/modelkit/analyze/analyzer.py
@@ -393,7 +393,10 @@ class AnalysisResult:
                     continue
 
                 if action_item.optimization_options:
-                    optim_options.update(action_item.optimization_options)
+                    # Normalize kebab-case keys to snake_case (python_name)
+                    # so they match the capability system's python_name format.
+                    for key, value in action_item.optimization_options.items():
+                        optim_options[key.replace("-", "_")] = value
 
         # Create and return config from collected options
         return WinMLOptimizationConfig(**optim_options)

--- a/src/winml/modelkit/analyze/rules/information_rules/default_information.json
+++ b/src/winml/modelkit/analyze/rules/information_rules/default_information.json
@@ -56,7 +56,7 @@
                     {
                         "type": "GraphOptimization",
                         "optimization_options": {
-                            "highdimRTR-lowdimRTR": true
+                            "highdimRTR_lowdimRTR": true
                         }
                     }
                 ],

--- a/src/winml/modelkit/analyze/rules/information_rules/qc_information.json
+++ b/src/winml/modelkit/analyze/rules/information_rules/qc_information.json
@@ -10,7 +10,7 @@
                     {
                         "type": "GraphOptimization",
                         "optimization_options": {
-                            "attention-expandedattention": true
+                            "attention_expandedattention": true
                         }
                     }
                 ],

--- a/src/winml/modelkit/pattern/transpose_patterns.py
+++ b/src/winml/modelkit/pattern/transpose_patterns.py
@@ -315,7 +315,7 @@ class ReshapeTransposeReshapeOverlyHighDimPattern(Pattern):
     @property
     def pattern_id(self) -> str:
         """Return pattern ID matching the information rule configuration."""
-        return "SUBGRAPH/ReshapeTransposeReshapeOverlyHighDimPattern"
+        return f"SUBGRAPH/{type(self).__name__}"
 
     def get_schema(self) -> PatternSchema:
         """Return the schema definition for ReshapeTransposeReshape pattern.
@@ -617,7 +617,7 @@ class ReshapeTransposeReshapeLowDimPattern(ReshapeTransposeReshapeOverlyHighDimP
     @property
     def pattern_id(self) -> str:
         """Return pattern ID matching the information rule configuration."""
-        return "SUBGRAPH/ReshapeTransposeReshapeLowDimPattern"
+        return f"SUBGRAPH/{type(self).__name__}"
 
     def get_schema(self) -> PatternSchema:
         """Return the schema definition for ReshapeTransposeReshapeLowDim pattern."""

--- a/src/winml/modelkit/pattern/transpose_patterns.py
+++ b/src/winml/modelkit/pattern/transpose_patterns.py
@@ -312,6 +312,11 @@ class ReshapeTransposeReshapeOverlyHighDimPattern(Pattern):
             return None
         return result
 
+    @property
+    def pattern_id(self) -> str:
+        """Return pattern ID matching the information rule configuration."""
+        return "SUBGRAPH/ReshapeTransposeReshapeOverlyHighDimPattern"
+
     def get_schema(self) -> PatternSchema:
         """Return the schema definition for ReshapeTransposeReshape pattern.
 
@@ -608,6 +613,11 @@ class ReshapeTransposeReshapeLowDimPattern(ReshapeTransposeReshapeOverlyHighDimP
         }
 
         return internal_constants, internal_attributes
+
+    @property
+    def pattern_id(self) -> str:
+        """Return pattern ID matching the information rule configuration."""
+        return "SUBGRAPH/ReshapeTransposeReshapeLowDimPattern"
 
     def get_schema(self) -> PatternSchema:
         """Return the schema definition for ReshapeTransposeReshapeLowDim pattern."""

--- a/tests/unit/analyze/core/test_unified_pattern_config.py
+++ b/tests/unit/analyze/core/test_unified_pattern_config.py
@@ -31,7 +31,7 @@ class TestUnifiedPatternConfig:
             "SUBGRAPH/GeluPattern",  # Shared by Gelu1-4
             "SUBGRAPH/GemmPattern",  # MatMulAdd
             "SUBGRAPH/LayerNormalizationPattern",  # Shared by Pow and Mul variants
-            "SUBGRAPH/ReshapeTransposeReshapePattern",
+            "SUBGRAPH/ReshapeTransposeReshapeOverlyHighDimPattern",
         }
         assert skeleton_pattern_ids == expected_ids, f"Pattern IDs mismatch: {skeleton_pattern_ids}"
 

--- a/tests/unit/analyze/models/test_information.py
+++ b/tests/unit/analyze/models/test_information.py
@@ -381,7 +381,7 @@ class TestActionItemModelRewrite:
         action_items = entry["actions"][0]["action_items"]
         assert len(action_items) == 1
         assert action_items[0]["type"] == "GraphOptimization"
-        assert action_items[0]["optimization_options"] == {"highdimRTR-lowdimRTR": True}
+        assert action_items[0]["optimization_options"] == {"highdimRTR_lowdimRTR": True}
 
     def test_qc_information_json_has_transpose_attention_entry(self):
         """Test that qc_information.json has the QC-specific TransposeAttentionPattern entry."""
@@ -408,7 +408,7 @@ class TestActionItemModelRewrite:
         action_items = entry["actions"][0]["action_items"]
         assert len(action_items) == 1
         assert action_items[0]["type"] == "GraphOptimization"
-        assert action_items[0]["optimization_options"] == {"attention-expandedattention": True}
+        assert action_items[0]["optimization_options"] == {"attention_expandedattention": True}
 
     def test_default_information_json_does_not_have_transpose_attention_entry(self):
         """Test that TransposeAttentionPattern is NOT in default_information.json (QC-specific)."""

--- a/tests/unit/analyze/pattern/test_transpose_patterns.py
+++ b/tests/unit/analyze/pattern/test_transpose_patterns.py
@@ -218,3 +218,32 @@ class TestReshapeTransposeReshapeLowDimPattern:
         assert len(results) == 1, (
             "Unmerged 6-D RTR must match ReshapeTransposeReshapeOverlyHighDimPattern"
         )
+
+
+class TestRTRPatternIdAlignment:
+    """Verify pattern_id values match the rule configuration expectations."""
+
+    def test_overly_high_dim_pattern_id(self) -> None:
+        """ReshapeTransposeReshapeOverlyHighDimPattern must have distinct pattern_id."""
+        pattern = ReshapeTransposeReshapeOverlyHighDimPattern()
+        assert pattern.pattern_id == "SUBGRAPH/ReshapeTransposeReshapeOverlyHighDimPattern"
+
+    def test_low_dim_pattern_id(self) -> None:
+        """ReshapeTransposeReshapeLowDimPattern must have distinct pattern_id."""
+        pattern = ReshapeTransposeReshapeLowDimPattern()
+        assert pattern.pattern_id == "SUBGRAPH/ReshapeTransposeReshapeLowDimPattern"
+
+    def test_pattern_ids_are_distinct(self) -> None:
+        """Both RTR subclasses must return different pattern_ids."""
+        high_dim = ReshapeTransposeReshapeOverlyHighDimPattern()
+        low_dim = ReshapeTransposeReshapeLowDimPattern()
+        assert high_dim.pattern_id != low_dim.pattern_id
+
+    def test_pattern_id_differs_from_schema_name(self) -> None:
+        """pattern_id must NOT fall back to the shared schema name."""
+        high_dim = ReshapeTransposeReshapeOverlyHighDimPattern()
+        low_dim = ReshapeTransposeReshapeLowDimPattern()
+        schema_based = f"SUBGRAPH/{high_dim.get_schema().name}"
+        # Both classes share the same schema, so schema-based ID would be identical.
+        # The override ensures they are distinct.
+        assert high_dim.pattern_id != schema_based or low_dim.pattern_id != schema_based

--- a/tests/unit/analyze/pattern/test_transpose_patterns.py
+++ b/tests/unit/analyze/pattern/test_transpose_patterns.py
@@ -233,17 +233,14 @@ class TestRTRPatternIdAlignment:
         pattern = ReshapeTransposeReshapeLowDimPattern()
         assert pattern.pattern_id == "SUBGRAPH/ReshapeTransposeReshapeLowDimPattern"
 
-    def test_pattern_ids_are_distinct(self) -> None:
-        """Both RTR subclasses must return different pattern_ids."""
-        high_dim = ReshapeTransposeReshapeOverlyHighDimPattern()
-        low_dim = ReshapeTransposeReshapeLowDimPattern()
-        assert high_dim.pattern_id != low_dim.pattern_id
+    def test_high_dim_pattern_id_differs_from_schema_name(self) -> None:
+        """HighDim pattern_id must NOT fall back to the shared schema name."""
+        pattern = ReshapeTransposeReshapeOverlyHighDimPattern()
+        schema_based = f"SUBGRAPH/{pattern.get_schema().name}"
+        assert pattern.pattern_id != schema_based
 
-    def test_pattern_id_differs_from_schema_name(self) -> None:
-        """pattern_id must NOT fall back to the shared schema name."""
-        high_dim = ReshapeTransposeReshapeOverlyHighDimPattern()
-        low_dim = ReshapeTransposeReshapeLowDimPattern()
-        schema_based = f"SUBGRAPH/{high_dim.get_schema().name}"
-        # Both classes share the same schema, so schema-based ID would be identical.
-        # The override ensures they are distinct.
-        assert high_dim.pattern_id != schema_based or low_dim.pattern_id != schema_based
+    def test_low_dim_pattern_id_differs_from_schema_name(self) -> None:
+        """LowDim pattern_id must NOT fall back to the shared schema name."""
+        pattern = ReshapeTransposeReshapeLowDimPattern()
+        schema_based = f"SUBGRAPH/{pattern.get_schema().name}"
+        assert pattern.pattern_id != schema_based

--- a/tests/unit/analyze/test_analyzer.py
+++ b/tests/unit/analyze/test_analyzer.py
@@ -658,6 +658,69 @@ class TestAnalysisResult:
         # Should accept any custom option
         assert config.get("custom_fusion", False) is True
 
+    def test_get_optimization_config_normalizes_kebab_case(
+        self, mock_output: AnalysisOutput
+    ) -> None:
+        """Test get_optimization_config normalizes kebab-case keys to snake_case."""
+        rtr_action = Action(
+            pattern_from_id="SUBGRAPH/ReshapeTransposeReshapeOverlyHighDimPattern",
+            pattern_to_id="SUBGRAPH/ReshapeTransposeReshapeLowDimPattern",
+            details="RTR optimization",
+            action_items=[
+                ActionItem(
+                    type="GraphOptimization",
+                    optimization_options={"highdimRTR-lowdimRTR": True},
+                )
+            ],
+        )
+        mock_output.results[0].information = [
+            Information(
+                pattern_id="SUBGRAPH/ReshapeTransposeReshapeOverlyHighDimPattern",
+                explanation="RTR pattern detected",
+                actions=[rtr_action],
+            )
+        ]
+
+        result = AnalysisResult(output=mock_output)
+        config = result.get_optimization_config()
+
+        # Kebab-case key should be normalized to underscore
+        assert config.get("highdimRTR_lowdimRTR", False) is True
+        # Original kebab-case key should NOT be present
+        assert "highdimRTR-lowdimRTR" not in config
+
+    def test_get_optimization_config_mixed_kebab_and_snake(
+        self, mock_output: AnalysisOutput
+    ) -> None:
+        """Test get_optimization_config handles mix of kebab-case and snake_case keys."""
+        action = Action(
+            pattern_from_id="SUBGRAPH/TestPattern",
+            pattern_to_id="OP/Test",
+            details="Mixed key test",
+            action_items=[
+                ActionItem(
+                    type="GraphOptimization",
+                    optimization_options={
+                        "already_snake": True,
+                        "kebab-style-key": True,
+                    },
+                )
+            ],
+        )
+        mock_output.results[0].information = [
+            Information(
+                pattern_id="SUBGRAPH/TestPattern",
+                explanation="Test",
+                actions=[action],
+            )
+        ]
+
+        result = AnalysisResult(output=mock_output)
+        config = result.get_optimization_config()
+
+        assert config.get("already_snake", False) is True
+        assert config.get("kebab_style_key", False) is True
+
 
 class TestONNXStaticAnalyzer:
     """Tests for ONNXStaticAnalyzer."""


### PR DESCRIPTION
## Problem

Several models fail on QNN EP (NPU) because Swin's window partition creates **6D Reshape operations** (e.g. `[1, 8, 7, 8, 7, 192]`), exceeding QNN's **max tensor rank of 5D**.

The codebase already has a `ReshapeTransposeReshapeOverlyHighDimPattern` rewrite that merges consecutive dimensions to reduce 6D→≤5D, but it was **never auto-triggered** due to two bugs in the autoconf pipeline.

### Affected Models
- `microsoft/swin-large-patch4-window7-224` (image-classification)
- `facebook/nougat-base` (image-to-text, vision-encoder-decoder)
- `naver-clova-ix/donut-base` (image-to-text, vision-encoder-decoder)
- `PekingU/rtdetr_r50vd_coco_o365` (object-detection) — already worked, no 6D Reshapes

## Root Cause

### Bug 1: `pattern_id` mismatch

`ReshapeTransposeReshapeOverlyHighDimPattern` and `LowDimPattern` both inherit `pattern_id` from a shared `PatternSchema` (`name="ReshapeTransposeReshapePattern"`), producing `SUBGRAPH/ReshapeTransposeReshapePattern` instead of the class-specific IDs expected by information rules (e.g. `SUBGRAPH/ReshapeTransposeReshapeOverlyHighDimPattern`).

### Bug 2: kebab/snake case key mismatch

The information rule emits `"highdimRTR-lowdimRTR": true` (kebab-case), but `RewritePipe.build_config()` looks up `kwargs.get("highdimRTR_lowdimRTR")` (snake_case via `cap.python_name`).

## Fix

1. **Override `pattern_id`** in both `OverlyHighDimPattern` and `LowDimPattern` to return their class-specific IDs (uses the base class's designed extension point).

2. **Normalize keys** in `AnalysisResult.get_optimization_config()` with `key.replace("-", "_")` — no-op for existing snake_case keys.

## Testing

### Unit Tests
- **3821 passed**, 73 skipped (hardware-gated), 0 failures

### Perf Verification (`winml perf` on Snapdragon X Elite NPU)

| Model | Task | Before | After | Latency |
|---|---|---|---|---|
| `PekingU/rtdetr_r50vd_coco_o365` | object-detection | ✅ NPU | ✅ NPU | **303ms** |
| `microsoft/swin-large-patch4-window7-224` | image-classification | ❌ `ComposeGraph failed` | ✅ **NPU** | **141ms** |
| `facebook/nougat-base` | image-to-text | ❌ `ComposeGraph failed` | ✅ **NPU** | **459ms** |
| `naver-clova-ix/donut-base` | image-to-text | ❌ `ComposeGraph failed` | ⚠️ `FinalizeGraphs 6020` | Input 2560×1920 exceeds QNN DDR spill limits |