### PR TITLE
fix: config display shows wrong device when requested device has no compatible EP

### DIFF
--- a/src/winml/modelkit/commands/config.py
+++ b/src/winml/modelkit/commands/config.py
@@ -432,7 +432,7 @@ def config(
             # Fix #4: Device from resolve_device (existing API)
             from ..sysinfo import resolve_device as _rd
 
-            _resolved_dev, _ = _rd()
+            _resolved_dev, _ = _rd(device)
             console.print(f"      Device:     [cyan]{_resolved_dev.upper()}[/cyan]")
 
             # EP — only shown when user explicitly passed --ep


### PR DESCRIPTION
## Problem

When running `winml config -d npu --ep qnn ...` on a machine where QNN/VitisAI EPs are not installed, the output **Resolution** block incorrectly displayed `Device: GPU` instead of `Device: NPU`.

**Example:**
```
winml config --no-compile -d npu --ep qnn -p w8a16 -o config.json -m BAAI/bge-base-en-v1.5 -t sentence-similarity
```

Output before fix:
```
   ⚙️  Resolution:
      Device:     GPU          ← wrong, user requested NPU
      EP:         QNNExecutionProvider
      Quant:      uint8/uint16  (weight/activation)
```

## Root Cause

`config.py:435` called `resolve_device()` with **no arguments**, so it always defaulted to `device="auto"`. In auto mode, `resolve_device` walks the device→EP map and returns the first device whose EP is available on the system — which was `GPU` on the reporter's machine (DML is available, QNN is not).

The `-d npu` flag from the CLI was never passed to `resolve_device`, making the displayed device completely independent of what the user requested.

```python
# Before (always auto-resolves, ignores -d flag):
_resolved_dev, _ = _rd()

# After (respects the CLI -d/--device argument):
_resolved_dev, _ = _rd(device)
```

## Fix

Pass the `device` CLI parameter to `resolve_device(device)` so the display reflects what was actually requested. When the requested device has no compatible EP, the existing warning is still emitted:

```
WARNING: Device 'npu' requested but no compatible EP found. Compatible EPs: [...]
```

...but the **Resolution** block now correctly shows `Device: NPU`.

## Impact

- Single-line change, display-only path
- No effect on the generated config content (device resolution for the actual config was already correct)
- No new tests needed — this is a display bug in the console output path