### PR TITLE
Remove local run check when optimize.

### DIFF
--- a/src/winml/modelkit/analyze/analyzer.py
+++ b/src/winml/modelkit/analyze/analyzer.py
@@ -799,6 +799,7 @@ def analyze_onnx(
     ep: str | None = None,
     device: str | None = None,
     autoconf: bool = True,
+    run_unknown_op: bool = True,
     on_ep_start: Callable | None = None,
     on_node_result: Callable | None = None,
 ) -> AnalyzeResult:
@@ -856,6 +857,7 @@ def analyze_onnx(
         ep=ep,
         device=device,
         enable_information=autoconf,
+        run_unknown_op=run_unknown_op,
         on_ep_start=on_ep_start,
         on_node_result=on_node_result,
     )

--- a/src/winml/modelkit/analyze/core/runtime_checker_query.py
+++ b/src/winml/modelkit/analyze/core/runtime_checker_query.py
@@ -1042,7 +1042,8 @@ class RuntimeCheckerQuery:
 
         for domain, opset_version in self.opset_versions.items():
             file_prefix = domain.name
-            base = f"{self.ep_name}_{self.device_type}_{file_prefix}_opset{opset_version}"
+            # Device type is uppercased to align with the convention used by check ops.
+            base = f"{self.ep_name}_{self.device_type.upper()}_{file_prefix}_opset{opset_version}"
             rule_zip_path = resolve_rule_zip_path(f"{base}.zip")
             rule_file = f"{base}_negative_rules.json"
             qdq_rule_file = f"{base}_negative_rules_qdq.json"

--- a/src/winml/modelkit/build/common.py
+++ b/src/winml/modelkit/build/common.py
@@ -143,6 +143,7 @@ def _run_analyze_loop(
                 iter_model,
                 ep=ep,
                 device=device,
+                run_unknown_op=False,
                 on_ep_start=on_ep_start,
                 on_node_result=on_node_result,
             )
@@ -188,6 +189,7 @@ def _run_analyze_loop(
             iter_model,
             ep=ep,
             device=device,
+            run_unknown_op=False,
             on_node_result=lambda _: None,
         )
 

--- a/src/winml/modelkit/commands/analyze.py
+++ b/src/winml/modelkit/commands/analyze.py
@@ -516,6 +516,10 @@ def analyze(
         run_unknown_op_for_ep = run_unknown_op
         if ep == "VitisAIExecutionProvider":
             run_unknown_op_for_ep = False
+            logger.info(
+                "Disabling --run-unknown-op for VitisAIExecutionProvider: "
+                "AMD op runtime results are not available yet"
+            )
 
         def _finalize_live(mark_complete: bool = True) -> None:
             """Stop the active Live display, optionally marking it complete."""

--- a/src/winml/modelkit/commands/analyze.py
+++ b/src/winml/modelkit/commands/analyze.py
@@ -513,6 +513,10 @@ def analyze(
         live: Live | None = None
         ep_counter = 0
 
+        run_unknown_op_for_ep = run_unknown_op
+        if ep == "VitisAIExecutionProvider":
+            run_unknown_op_for_ep = False
+
         def _finalize_live(mark_complete: bool = True) -> None:
             """Stop the active Live display, optionally marking it complete."""
             nonlocal live
@@ -607,7 +611,7 @@ def analyze(
                     device=device,
                     enable_information=information,
                     htp_metadata_path=str(htp_metadata) if htp_metadata else None,
-                    run_unknown_op=run_unknown_op,
+                    run_unknown_op=run_unknown_op_for_ep,
                     save_node_types=save_node_types,
                     on_node_result=on_node_result,
                     on_ep_start=on_ep_start,
@@ -654,7 +658,7 @@ def analyze(
                 device=device,
                 enable_information=information,
                 htp_metadata_path=str(htp_metadata) if htp_metadata else None,
-                run_unknown_op=run_unknown_op,
+                run_unknown_op=run_unknown_op_for_ep,
                 save_node_types=save_node_types,
             )
 


### PR DESCRIPTION
- Test sam2.1-hiera-large analyze("total_operators": 1081) on qnn device. Time deduction 68%.
91.99s -> 29.37s

- Remove local run on AMD devcie.
- Fix file name case issue.