### PR TITLE
Exclude LayerNormalization from quantization for vision-encoder-decoder models

### DIFF
--- a/src/winml/modelkit/models/hf/vision_encoder_decoder.py
+++ b/src/winml/modelkit/models/hf/vision_encoder_decoder.py
@@ -5,13 +5,40 @@
 
 from ...config import WinMLBuildConfig
 from ...optim import WinMLOptimizationConfig
+from ...quant import WinMLQuantizationConfig
 
 
 # =============================================================================
 # WinML Build Config
 # =============================================================================
+
+# Quantization op list: all standard ONNX compute ops plus Gelu.
+# LayerNormalization is excluded because quantizing it causes all-zero
+# outputs and DEVICE_LOST on OpenVINO NPU for large encoder-decoder
+# graphs.
+_QUANT_OPS = [
+    "MatMul",
+    "Gemm",
+    "Conv",
+    "ConvTranspose",
+    "Add",
+    "Mul",
+    "Softmax",
+    "Div",
+    "Concat",
+    "Slice",
+    "Pad",
+    "Transpose",
+    "Reshape",
+    "Gather",
+    "Gelu",
+]
+
 VISION_ENCODER_DECODER_CONFIG = WinMLBuildConfig(
     optim=WinMLOptimizationConfig(
         reshape_mergedreshape=True,
+    ),
+    quant=WinMLQuantizationConfig(
+        op_types_to_quantize=_QUANT_OPS,
     ),
 )


### PR DESCRIPTION
## Problem

`winml perf` fails for image-to-text vision-encoder-decoder models (e.g., `facebook/nougat-base`, `naver-clova-ix/donut-base`) on OpenVINO NPU with `OUT_OF_HOST_MEMORY` when quantization is enabled.

**Reproduce on main** (all fail):

    # Default precision (w8a8) — FAIL
    winml perf -m facebook/nougat-base --ep openvino --device npu --iterations 3 --warmup 1

    # w8a16 — FAIL
    winml perf -m facebook/nougat-base --ep openvino --device npu --precision w8a16 --iterations 3 --warmup 1

    # fp32 (no quantization) — PASS, 5.22 sps
    winml perf -m facebook/nougat-base --ep openvino --device npu --precision fp32 --iterations 3 --warmup 1

## Root Cause

Quantizing `LayerNormalization` ops causes the compiled EPContext blob to exceed NPU memory capacity. The build stage's compile session holds NPU resources, preventing the perf stage from creating a second session → `ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY`.

This was isolated by testing all 15 op types in the nougat-base model individually:
- 13 standard ops + Gelu (excluding LayerNormalization) → **PASS**
- 13 standard ops + LayerNormalization (excluding Gelu) → **FAIL** (`OUT_OF_HOST_MEMORY`)

## Fix

Add `op_types_to_quantize` to the `VISION_ENCODER_DECODER_CONFIG` in `vision_encoder_decoder.py`, listing all 15 op types except `LayerNormalization`. This follows the same pattern as `CLIP_CONFIG` in `clip.py` — model-specific build configuration via the `MODEL_BUILD_CONFIGS` registry.

**Only affects `vision-encoder-decoder` model type** (donut-base, nougat-base). No other models are impacted.

## Results after fix

    # Default precision (w8a8) — PASS, 5.08 sps
    winml perf -m facebook/nougat-base --ep openvino --device npu --iterations 3 --warmup 1

    # w8a16 — PASS, 3.34 sps
    winml perf -m facebook/nougat-base --ep openvino --device npu --precision w8a16 --iterations 3 --warmup 1

    # fp32 — PASS, 5.19 sps (unchanged)
    winml perf -m facebook/nougat-base --ep openvino --device npu --precision fp32 --iterations 3 --warmup 1

All 3833 unit tests pass.