### PR TITLE
fix: unit tests failing in network-isolated containers (#339, #340)

### DIFF
--- a/src/winml/modelkit/loader/hf.py
+++ b/src/winml/modelkit/loader/hf.py
@@ -81,8 +81,7 @@ def resolve_hf_model_class(class_name: str) -> type:
             return cls
 
     raise ImportError(
-        f"Model class '{class_name}' not found in any of: "
-        f"{', '.join(_HF_MODEL_MODULES)}"
+        f"Model class '{class_name}' not found in any of: {', '.join(_HF_MODEL_MODULES)}"
     )
 
 
@@ -131,14 +130,10 @@ def _load_class_from_script(script_path: str, class_name: str) -> type:
 
     # Validate it looks like a model class
     if not isinstance(model_class, type):
-        raise TypeError(
-            f"'{class_name}' in script is not a class, got {type(model_class)}"
-        )
+        raise TypeError(f"'{class_name}' in script is not a class, got {type(model_class)}")
 
     if not hasattr(model_class, "from_pretrained"):
-        raise TypeError(
-            f"Class '{class_name}' must have 'from_pretrained' method"
-        )
+        raise TypeError(f"Class '{class_name}' must have 'from_pretrained' method")
 
     logger.debug("Successfully loaded class: %s", model_class)
     return model_class
@@ -199,25 +194,24 @@ def load_hf_model(
     """
     logger.info("Loading HF model: %s", model_name_or_path)
 
-    # Validate user_script requires trust_remote_code
-    if user_script is not None and not trust_remote_code:
-        raise ValueError(
-            "user_script requires trust_remote_code=True for security. "
-            "Loading arbitrary Python code is potentially dangerous."
-        )
+    # Validate user_script requirements before any network calls
+    if user_script is not None:
+        if not trust_remote_code:
+            raise ValueError(
+                "user_script requires trust_remote_code=True for security. "
+                "Loading arbitrary Python code is potentially dangerous."
+            )
+        if model_class is None:
+            raise ValueError("model_class must be specified when using user_script")
 
     # [1] Load HF Config
     hf_config = AutoConfig.from_pretrained(
-        model_name_or_path, trust_remote_code=trust_remote_code,
+        model_name_or_path,
+        trust_remote_code=trust_remote_code,
     )
 
     # [2] Task & Model Class Resolution
-    # Special case: user_script requires model_class
     if user_script is not None:
-        if model_class is None:
-            raise ValueError(
-                "model_class must be specified when using user_script"
-            )
         resolved_class = _load_class_from_script(user_script, model_class)
         logger.info("Using custom model class from script: %s", model_class)
 
@@ -233,8 +227,7 @@ def load_hf_model(
             )
         except ValueError as e:
             raise ValueError(
-                f"Cannot resolve task/model for {model_name_or_path}. "
-                f"Original error: {e}"
+                f"Cannot resolve task/model for {model_name_or_path}. Original error: {e}"
             ) from e
 
     # [4] Model Instantiation

--- a/tests/unit/eval/test_eval.py
+++ b/tests/unit/eval/test_eval.py
@@ -67,8 +67,19 @@ class TestResolveTask:
     def test_infer_from_model_id(self):
         from winml.modelkit.eval.evaluate import _resolve_task
 
+        fake_hf_config = MagicMock()
         config = WinMLEvaluationConfig(model_id="microsoft/resnet-50")
-        assert _resolve_task(config) == "image-classification"
+        with (
+            patch(
+                "transformers.AutoConfig.from_pretrained",
+                return_value=fake_hf_config,
+            ),
+            patch(
+                "winml.modelkit.loader.task._detect_task_from_config",
+                return_value="image-classification",
+            ),
+        ):
+            assert _resolve_task(config) == "image-classification"
 
 
 class TestEvaluate:

--- a/tests/unit/session/test_ep_monitor.py
+++ b/tests/unit/session/test_ep_monitor.py
@@ -242,8 +242,7 @@ class TestPdhModule:
 
         adapters = enumerate_adapters()
         assert isinstance(adapters, dict)
-        # Should find at least one adapter (CPU always has one)
-        assert len(adapters) > 0
+        # May be empty in containers without WDDM drivers.
 
     def test_adapter_info_npu_heuristic(self):
         from winml.modelkit.sysinfo.pdh_adapters import AdapterInfo


### PR DESCRIPTION
## Summary

- **#340**: Remove false `assert len(adapters) > 0` in `test_enumerate_adapters_returns_dict`. `enumerate_adapters()` queries PDH "GPU Engine" which only lists GPU/NPU adapters — empty dict is valid in containers without WDDM drivers.
- **#339**: Fix two unit tests with implicit network dependencies:
  - `loader/hf.py`: Move `user_script` validations (`trust_remote_code` and `model_class`) before `AutoConfig.from_pretrained()` so they fail fast without network access.
  - `test_eval.py`: Mock `AutoConfig.from_pretrained` in `test_infer_from_model_id` so it doesn't call HuggingFace API.

Closes #339
Closes #340