### PR TITLE
Fix PR build issue caused by new pyarrow 24.0.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,18 @@ dev = [
   "pytest-timeout>=2.4.0",
 ]
 
+# =============================================================================
+# UV - Resolver Configuration
+# =============================================================================
+# Ensure uv resolves to versions that have installable distributions on the
+# platforms we actually support. Without this, uv may pick the newest release
+# of a transitive dep that lacks Windows wheels, and CI on Windows will fail
+# at install time.
+[tool.uv]
+required-environments = [
+  "sys_platform == 'win32' and platform_machine == 'AMD64'",
+]
+
 [tool.setuptools.packages.find]
 where = [ "src" ]
 include = [ "winml", "winml.*" ]


### PR DESCRIPTION
### Summary

Add `[tool.uv] required-environments` in pyproject.toml to pin uv's resolver to Windows AMD64, the only platform we support and test on.

### Background

CI lint started failing today (2026-04-21) with `No solution found` when installing pyarrow 24.0.0. This release was published on PyPI ~hours before our CI ran and only includes macOS wheels (`macosx_12_0_x86_64`, `macosx_12_0_arm64`) — no Windows, no Linux, no sdist. The previous version, pyarrow 23.0.1 (Feb 16, 2026), ships the full 49-wheel matrix including Windows x64. Related upstream issue: [apache/arrow#49623](https://github.com/apache/arrow/issues/49623) (Windows verification for the 24.0.0 release).

Because our uv.lock is gitignored, every CI run re-resolves from scratch and can pick up newly published upstream versions. uv's universal resolver only checks that a candidate is installable on *some* platform, not on ours — so a partial upstream release silently breaks our Windows CI with zero changes to our code.

### What this does

`required-environments` tells uv the lockfile must be installable on the listed environments. During resolution, uv rejects any version lacking a compatible distribution for those environments and backtracks to an installable one. In the pyarrow case, uv will skip 24.0.0 (no Windows wheel) and fall back to 23.0.1.

```toml
[tool.uv]
required-environments = [
  "sys_platform == 'win32' and platform_machine == 'AMD64'",
]
```

This converts silent upstream-release breakage into deterministic resolution on Windows. The fix is general-purpose — it protects against future incomplete releases of any transitive dep, not just pyarrow.

### Scope

- Only AMD64 is listed; adding Windows ARM64 isn't viable today because `torch` doesn't publish Windows ARM64 wheels.
- Behavior-only change for the resolver; no runtime code or dependency versions modified.
- Reference: [uv docs — required-environments](https://docs.astral.sh/uv/reference/settings/#required-environments).