### PR TITLE
feat: implement image-to-text evaluator with teacher-forcing perplexity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
   "rich>=14",
   "scikit-learn>=1.7",
   "scipy>=1.15,<1.16",
+  "sentencepiece>=0.2",
   "seqeval>=1.2.2",
   "snakemd>=2",
   "timm>=1.0.22",

--- a/scripts/e2e_eval/run_pytorch_baseline.py
+++ b/scripts/e2e_eval/run_pytorch_baseline.py
@@ -65,6 +65,7 @@ _TASK_HF_METRIC_KEY: dict[str, str] = {
     "sentence-similarity": "cosine_spearman",
     "image-feature-extraction": "knn_top1_accuracy",
     "fill-mask": "pseudo_perplexity",
+    "image-to-text": "perplexity",
 }
 
 
@@ -76,8 +77,8 @@ _TASK_HF_METRIC_KEY: dict[str, str] = {
 def _load_pytorch_model(model_id: str, task: str, device_str: str):
     """Load a native PyTorch model with the task-appropriate AutoModel class."""
     import torch
-
     from transformers import AutoConfig
+
     from winml.modelkit.loader.task import resolve_task_and_model_class
 
     config = AutoConfig.from_pretrained(model_id)

--- a/src/winml/modelkit/eval/__init__.py
+++ b/src/winml/modelkit/eval/__init__.py
@@ -15,6 +15,7 @@ from .feature_extraction_evaluator import WinMLFeatureExtractionEvaluator
 from .fill_mask_evaluator import WinMLFillMaskEvaluator
 from .image_feature_extraction_evaluator import WinMLImageFeatureExtractionEvaluator
 from .image_segmentation_evaluator import WinMLImageSegmentationEvaluator
+from .image_to_text_evaluator import WinMLImageToTextEvaluator
 from .metrics.knn_accuracy import KNNAccuracyMetric
 from .metrics.mean_average_precision import MAPMetric
 from .metrics.mean_iou import IGNORE_INDEX, MeanIoUMetric
@@ -40,6 +41,7 @@ __all__ = [
     "WinMLFillMaskEvaluator",
     "WinMLImageFeatureExtractionEvaluator",
     "WinMLImageSegmentationEvaluator",
+    "WinMLImageToTextEvaluator",
     "WinMLObjectDetectionEvaluator",
     "WinMLQuestionAnsweringEvaluator",
     "WinMLTextClassificationEvaluator",

--- a/src/winml/modelkit/eval/evaluate.py
+++ b/src/winml/modelkit/eval/evaluate.py
@@ -20,6 +20,7 @@ from .feature_extraction_evaluator import WinMLFeatureExtractionEvaluator
 from .fill_mask_evaluator import WinMLFillMaskEvaluator
 from .image_feature_extraction_evaluator import WinMLImageFeatureExtractionEvaluator
 from .image_segmentation_evaluator import WinMLImageSegmentationEvaluator
+from .image_to_text_evaluator import WinMLImageToTextEvaluator
 from .object_detection_evaluator import WinMLObjectDetectionEvaluator
 from .question_answering_evaluator import WinMLQuestionAnsweringEvaluator
 from .text_classification_evaluator import WinMLTextClassificationEvaluator
@@ -43,6 +44,7 @@ _EVALUATOR_REGISTRY: dict[str, type[WinMLEvaluator]] = {
     "sentence-similarity": WinMLFeatureExtractionEvaluator,
     "image-feature-extraction": WinMLImageFeatureExtractionEvaluator,
     "fill-mask": WinMLFillMaskEvaluator,
+    "image-to-text": WinMLImageToTextEvaluator,
 }
 
 _FE_DEFAULT = DatasetConfig(
@@ -125,6 +127,17 @@ _DEFAULT_DATASETS: dict[str, DatasetConfig] = {
         shuffle=True,
         streaming=True,
         columns_mapping={"input_column": "text"},
+    ),
+    "image-to-text": DatasetConfig(
+        path="nlphuji/flickr30k",
+        split="test",
+        samples=100,
+        shuffle=True,
+        streaming=True,
+        columns_mapping={
+            "input_column": "image",
+            "caption_column": "caption",
+        },
     ),
 }
 

--- a/src/winml/modelkit/eval/evaluate.py
+++ b/src/winml/modelkit/eval/evaluate.py
@@ -129,14 +129,14 @@ _DEFAULT_DATASETS: dict[str, DatasetConfig] = {
         columns_mapping={"input_column": "text"},
     ),
     "image-to-text": DatasetConfig(
-        path="nlphuji/flickr30k",
+        path="clip-benchmark/wds_mscoco_captions",
         split="test",
         samples=100,
         shuffle=True,
         streaming=True,
         columns_mapping={
-            "input_column": "image",
-            "caption_column": "caption",
+            "input_column": "jpg",
+            "caption_column": "txt",
         },
     ),
 }

--- a/src/winml/modelkit/eval/image_to_text_evaluator.py
+++ b/src/winml/modelkit/eval/image_to_text_evaluator.py
@@ -1,0 +1,215 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+"""Image-to-text evaluator using image-conditional perplexity.
+
+Evaluates seq2seq vision-encoder-decoder models (e.g. donut, trocr, vit-gpt2)
+by computing the negative log-likelihood (NLL) of reference captions given input
+images under teacher forcing:
+
+    For each (image, caption) pair:
+        decoder_input  = tokenized_caption[:-1]
+        target         = tokenized_caption[1:]
+        token_log_prob = log P(target_i | image, decoder_input[:i])
+
+    Aggregate:
+        nll        = -mean(token_log_probs)        # lower is better
+        perplexity = exp(nll)                      # lower is better
+
+Comparing WinML (ONNX) perplexity to the PyTorch baseline perplexity detects
+accuracy regressions from export or quantization.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import TYPE_CHECKING, Any
+
+import torch
+import torch.nn.functional as F
+from tqdm import tqdm
+
+from .base_evaluator import WinMLEvaluator
+
+
+if TYPE_CHECKING:
+    from datasets import Dataset
+    from transformers.pipelines.base import Pipeline
+
+    from ..datasets.config import DatasetConfig
+    from ..models.winml.base import WinMLPreTrainedModel
+    from .config import WinMLEvaluationConfig
+
+logger = logging.getLogger(__name__)
+
+
+class WinMLImageToTextEvaluator(WinMLEvaluator):
+    """Evaluator for image-to-text models via image-conditional perplexity."""
+
+    @classmethod
+    def schema_info(cls) -> list:
+        """Return expected dataset schema for image-to-text evaluation."""
+        from .config import SchemaColumn
+
+        return [
+            SchemaColumn("image", "Image", "input_column", description="PIL Image"),
+            SchemaColumn(
+                "caption",
+                "Value(string)",
+                "caption_column",
+                description="Reference caption text (string or list of strings)",
+            ),
+        ]
+
+    def __init__(
+        self,
+        config: WinMLEvaluationConfig,
+        model: WinMLPreTrainedModel,
+    ) -> None:
+        self._input_col = config.dataset.columns_mapping.get("input_column", "image")
+        self._caption_col = config.dataset.columns_mapping.get("caption_column", "caption")
+        self._processor: Any = None
+        super().__init__(config, model)
+
+    def prepare_pipeline(self) -> Pipeline:
+        """Bypass the HF pipeline; compute() calls the model directly.
+
+        Teacher-forcing perplexity requires access to raw logits at every
+        decoder position, which the HF image-to-text pipeline does not expose.
+        """
+        return None  # type: ignore[return-value]
+
+    def align_labels(self, dataset: Dataset, ds_config: DatasetConfig) -> Dataset:
+        """No-op: image-to-text uses no discrete class labels."""
+        return dataset
+
+    def _get_processor(self) -> Any:
+        """Lazily load the model's processor (image processor + tokenizer)."""
+        if self._processor is None:
+            from transformers import AutoProcessor
+
+            self._processor = AutoProcessor.from_pretrained(self.config.model_id)
+        return self._processor
+
+    def _logits(self, outputs: Any) -> torch.Tensor:
+        """Extract logits tensor from model output (dict or object)."""
+        if isinstance(outputs, dict):
+            if "logits" not in outputs:
+                raise KeyError(f"Model output dict has no 'logits' key; got keys {list(outputs)}.")
+            return outputs["logits"]
+        return outputs.logits
+
+    def _score_sample(
+        self,
+        image: Any,
+        caption: str,
+        processor: Any,
+    ) -> torch.Tensor | None:
+        """Compute per-token log P(caption | image) for one sample.
+
+        Args:
+            image: PIL Image or any format accepted by the model's image processor.
+            caption: Reference caption string.
+            processor: AutoProcessor instance with image_processor and tokenizer.
+
+        Returns:
+            1-D tensor of per-token log-probabilities, or None if the sample
+            should be skipped (e.g. too short, processor error).
+        """
+        # Process image → pixel_values
+        try:
+            processed = processor(images=image, return_tensors="pt")
+        except Exception as exc:
+            logger.debug("Image processing failed, skipping sample: %s", exc)
+            return None
+
+        pixel_values = processed.get("pixel_values")
+        if pixel_values is None:
+            logger.debug("Processor did not return 'pixel_values', skipping sample.")
+            return None
+
+        # Tokenize caption
+        tokenizer = getattr(processor, "tokenizer", processor)
+        tok_out = tokenizer(caption, return_tensors="pt", truncation=True, max_length=128)
+        input_ids = tok_out["input_ids"]  # [1, seq_len]
+
+        if input_ids.shape[1] < 2:
+            logger.debug("Caption too short after tokenization, skipping sample.")
+            return None
+
+        # Teacher forcing: shift right so decoder_input[i] predicts target[i]
+        decoder_input_ids = input_ids[:, :-1]  # [1, seq_len-1]
+        target_ids = input_ids[:, 1:]  # [1, seq_len-1]
+
+        with torch.no_grad():
+            try:
+                outputs = self.model(
+                    pixel_values=pixel_values,
+                    decoder_input_ids=decoder_input_ids,
+                )
+            except Exception as exc:
+                logger.debug("Model forward pass failed, skipping sample: %s", exc)
+                return None
+
+        logits = self._logits(outputs)  # [1, seq_len-1, vocab_size]
+
+        # Per-token log P(target | context, image)
+        log_probs = F.log_softmax(logits[0], dim=-1)  # [seq_len-1, vocab_size]
+        target_flat = target_ids[0].long()  # [seq_len-1]
+        return log_probs[torch.arange(target_flat.shape[0]), target_flat]  # [seq_len-1]
+
+    def compute(self) -> dict[str, Any]:
+        """Run image-conditional perplexity evaluation over the dataset.
+
+        Returns:
+            Dict with keys:
+                nll:        mean negative log-likelihood per token (lower = better)
+                perplexity: exp(nll) (lower = better)
+
+        Raises:
+            ValueError: If no valid token log-probabilities were accumulated.
+        """
+        processor = self._get_processor()
+
+        total_neg_log_p = 0.0
+        total_tokens = 0
+
+        for sample in tqdm(self.data, desc="Evaluating image-to-text (perplexity)"):
+            image = sample.get(self._input_col)
+            caption = sample.get(self._caption_col)
+
+            if image is None or caption is None:
+                continue
+
+            # Handle list of captions — take the first
+            if isinstance(caption, list):
+                if not caption:
+                    continue
+                caption = caption[0]
+
+            if not isinstance(caption, str) or not caption.strip():
+                continue
+
+            token_log_probs = self._score_sample(image, caption, processor)
+            if token_log_probs is None or token_log_probs.numel() == 0:
+                continue
+
+            total_neg_log_p += float(-token_log_probs.sum().item())
+            total_tokens += int(token_log_probs.numel())
+
+        if total_tokens == 0:
+            raise ValueError(
+                "No valid token log-probabilities accumulated during image-to-text "
+                "evaluation. Check that the dataset has non-empty 'image' and "
+                f"'{self._caption_col}' columns and that the model accepts "
+                "pixel_values + decoder_input_ids."
+            )
+
+        mean_nll = total_neg_log_p / total_tokens
+        return {
+            "nll": round(mean_nll, 4),
+            "perplexity": round(math.exp(mean_nll), 4),
+        }

--- a/src/winml/modelkit/eval/image_to_text_evaluator.py
+++ b/src/winml/modelkit/eval/image_to_text_evaluator.py
@@ -94,6 +94,20 @@ class WinMLImageToTextEvaluator(WinMLEvaluator):
             self._processor = AutoProcessor.from_pretrained(self.config.model_id)
         return self._processor
 
+    def _decoder_seq_len(self) -> int | None:
+        """Return fixed decoder_input_ids sequence length from model's io_config, if any.
+
+        ONNX models compiled with static shapes have a fixed decoder length.
+        Dynamic PyTorch models return None (any length accepted).
+        """
+        io_config = getattr(self.model, "io_config", None) or {}
+        shapes = io_config.get("input_shapes") or []
+        # decoder_input_ids is typically the second input, shape [batch, seq_len]
+        for shape in shapes:
+            if len(shape) == 2 and isinstance(shape[1], int):
+                return shape[1]
+        return None
+
     def _logits(self, outputs: Any) -> torch.Tensor:
         """Extract logits tensor from model output (dict or object)."""
         if isinstance(outputs, dict):
@@ -107,6 +121,7 @@ class WinMLImageToTextEvaluator(WinMLEvaluator):
         image: Any,
         caption: str,
         processor: Any,
+        fixed_seq_len: int | None,
     ) -> torch.Tensor | None:
         """Compute per-token log P(caption | image) for one sample.
 
@@ -114,6 +129,8 @@ class WinMLImageToTextEvaluator(WinMLEvaluator):
             image: PIL Image or any format accepted by the model's image processor.
             caption: Reference caption string.
             processor: AutoProcessor instance with image_processor and tokenizer.
+            fixed_seq_len: If not None, pad/truncate decoder_input_ids to this
+                exact length (required by ONNX models compiled with static shapes).
 
         Returns:
             1-D tensor of per-token log-probabilities, or None if the sample
@@ -131,18 +148,31 @@ class WinMLImageToTextEvaluator(WinMLEvaluator):
             logger.debug("Processor did not return 'pixel_values', skipping sample.")
             return None
 
-        # Tokenize caption
+        # Tokenize caption — cap at fixed_seq_len+1 if model has static shapes
+        max_tok_len = (fixed_seq_len + 1) if fixed_seq_len is not None else 128
         tokenizer = getattr(processor, "tokenizer", processor)
-        tok_out = tokenizer(caption, return_tensors="pt", truncation=True, max_length=128)
+        tok_out = tokenizer(caption, return_tensors="pt", truncation=True, max_length=max_tok_len)
         input_ids = tok_out["input_ids"]  # [1, seq_len]
 
         if input_ids.shape[1] < 2:
             logger.debug("Caption too short after tokenization, skipping sample.")
             return None
 
-        # Teacher forcing: shift right so decoder_input[i] predicts target[i]
-        decoder_input_ids = input_ids[:, :-1]  # [1, seq_len-1]
-        target_ids = input_ids[:, 1:]  # [1, seq_len-1]
+        # Teacher forcing: decoder_input[i] predicts target[i]
+        raw_pad = getattr(tokenizer, "pad_token_id", None)
+        pad_id: int = raw_pad if isinstance(raw_pad, int) else 0
+
+        if fixed_seq_len is not None:
+            # Pad to fixed_seq_len+1 if shorter, then slice to [fixed_seq_len+1]
+            cur_len = input_ids.shape[1]
+            need_len = fixed_seq_len + 1
+            if cur_len < need_len:
+                pad = torch.full((1, need_len - cur_len), pad_id, dtype=input_ids.dtype)
+                input_ids = torch.cat([input_ids, pad], dim=1)
+            input_ids = input_ids[:, :need_len]
+
+        decoder_input_ids = input_ids[:, :-1]  # [1, fixed_seq_len] or [1, seq_len-1]
+        target_ids = input_ids[:, 1:]  # same length
 
         with torch.no_grad():
             try:
@@ -154,12 +184,21 @@ class WinMLImageToTextEvaluator(WinMLEvaluator):
                 logger.debug("Model forward pass failed, skipping sample: %s", exc)
                 return None
 
-        logits = self._logits(outputs)  # [1, seq_len-1, vocab_size]
+        logits = self._logits(outputs)  # [1, L, vocab_size]
 
         # Per-token log P(target | context, image)
-        log_probs = F.log_softmax(logits[0], dim=-1)  # [seq_len-1, vocab_size]
-        target_flat = target_ids[0].long()  # [seq_len-1]
-        return log_probs[torch.arange(target_flat.shape[0]), target_flat]  # [seq_len-1]
+        log_probs = F.log_softmax(logits[0], dim=-1)  # [L, vocab_size]
+        target_flat = target_ids[0].long()  # [L]
+
+        # Exclude pad-token positions from the metric (only meaningful with fixed shapes)
+        if fixed_seq_len is not None:
+            valid_mask = target_flat != pad_id
+            if not valid_mask.any():
+                return None
+            log_probs = log_probs[valid_mask]
+            target_flat = target_flat[valid_mask]
+
+        return log_probs[torch.arange(target_flat.shape[0]), target_flat]  # [num_valid]
 
     def compute(self) -> dict[str, Any]:
         """Run image-conditional perplexity evaluation over the dataset.
@@ -173,6 +212,7 @@ class WinMLImageToTextEvaluator(WinMLEvaluator):
             ValueError: If no valid token log-probabilities were accumulated.
         """
         processor = self._get_processor()
+        fixed_seq_len = self._decoder_seq_len()
 
         total_neg_log_p = 0.0
         total_tokens = 0
@@ -193,7 +233,7 @@ class WinMLImageToTextEvaluator(WinMLEvaluator):
             if not isinstance(caption, str) or not caption.strip():
                 continue
 
-            token_log_probs = self._score_sample(image, caption, processor)
+            token_log_probs = self._score_sample(image, caption, processor, fixed_seq_len)
             if token_log_probs is None or token_log_probs.numel() == 0:
                 continue
 

--- a/tests/unit/eval/test_image_to_text_evaluator.py
+++ b/tests/unit/eval/test_image_to_text_evaluator.py
@@ -157,6 +157,34 @@ class TestLogits:
 
 
 # ---------------------------------------------------------------------------
+# _decoder_seq_len
+# ---------------------------------------------------------------------------
+
+
+class TestDecoderSeqLen:
+    def test_reads_second_input_shape(self) -> None:
+        model = MagicMock()
+        model.config.label2id = None
+        model.io_config = {"input_shapes": [[1, 3, 64, 64], [1, 16]]}
+        ev = _make_evaluator(model=model)
+        assert ev._decoder_seq_len() == 16
+
+    def test_returns_none_when_no_io_config(self) -> None:
+        model = MagicMock()
+        model.config.label2id = None
+        model.io_config = {}
+        ev = _make_evaluator(model=model)
+        assert ev._decoder_seq_len() is None
+
+    def test_returns_none_when_dynamic_dims(self) -> None:
+        model = MagicMock()
+        model.config.label2id = None
+        model.io_config = {"input_shapes": [[1, 3, 64, 64], ["batch", "seq"]]}
+        ev = _make_evaluator(model=model)
+        assert ev._decoder_seq_len() is None
+
+
+# ---------------------------------------------------------------------------
 # _score_sample
 # ---------------------------------------------------------------------------
 
@@ -171,7 +199,7 @@ class TestScoreSample:
         # Model returns uniform logits → each token gets log(1/vocab)
         ev.model = MagicMock(return_value={"logits": torch.zeros(1, 3, vocab)})
 
-        log_probs = ev._score_sample("fake_image", "hello world", proc)
+        log_probs = ev._score_sample("fake_image", "hello world", proc, fixed_seq_len=None)
 
         assert log_probs is not None
         assert log_probs.shape == (3,)
@@ -190,7 +218,7 @@ class TestScoreSample:
         )
         proc.tokenizer.__call__ = proc.tokenizer.side_effect
 
-        result = ev._score_sample("img", "x", proc)
+        result = ev._score_sample("img", "x", proc, fixed_seq_len=None)
         assert result is None
 
     def test_image_processor_failure_returns_none(self) -> None:
@@ -199,7 +227,7 @@ class TestScoreSample:
         proc.side_effect = RuntimeError("bad image")
         proc.__call__ = proc.side_effect
 
-        result = ev._score_sample("bad_img", "hello", proc)
+        result = ev._score_sample("bad_img", "hello", proc, fixed_seq_len=None)
         assert result is None
 
     def test_model_forward_failure_returns_none(self) -> None:
@@ -207,7 +235,7 @@ class TestScoreSample:
         proc = _make_processor()
         ev.model = MagicMock(side_effect=RuntimeError("ORT error"))
 
-        result = ev._score_sample("img", "hello", proc)
+        result = ev._score_sample("img", "hello", proc, fixed_seq_len=None)
         assert result is None
 
     def test_missing_pixel_values_returns_none(self) -> None:
@@ -216,8 +244,51 @@ class TestScoreSample:
         proc.side_effect = lambda images, **kw: {}  # No "pixel_values" key
         proc.__call__ = proc.side_effect
 
-        result = ev._score_sample("img", "hello", proc)
+        result = ev._score_sample("img", "hello", proc, fixed_seq_len=None)
         assert result is None
+
+    def test_fixed_seq_len_pads_short_caption(self) -> None:
+        """decoder_input_ids is padded to fixed_seq_len when caption is shorter."""
+        vocab, fixed = 50, 8
+        seen_shapes: list[tuple] = []
+
+        def _forward(**kwargs):
+            seen_shapes.append(tuple(kwargs["decoder_input_ids"].shape))
+            return {"logits": torch.zeros(1, fixed, vocab)}
+
+        ev = _make_evaluator()
+        ev.model = MagicMock(side_effect=_forward)
+        proc = _make_processor(vocab_size=vocab)
+        # Tokenizer returns only 3 tokens ([bos, t1, t2]) — shorter than fixed+1
+        proc.tokenizer.side_effect = lambda text, **kw: {"input_ids": torch.tensor([[0, 1, 2]])}
+
+        result = ev._score_sample("img", "short", proc, fixed_seq_len=fixed)
+
+        assert result is not None
+        # decoder_input_ids must be [1, fixed]
+        assert seen_shapes == [(1, fixed)]
+
+    def test_fixed_seq_len_truncates_long_caption(self) -> None:
+        """decoder_input_ids is truncated to fixed_seq_len when caption is longer."""
+        vocab, fixed = 50, 4
+        seen_shapes: list[tuple] = []
+
+        def _forward(**kwargs):
+            seen_shapes.append(tuple(kwargs["decoder_input_ids"].shape))
+            return {"logits": torch.zeros(1, fixed, vocab)}
+
+        ev = _make_evaluator()
+        ev.model = MagicMock(side_effect=_forward)
+        proc = _make_processor(vocab_size=vocab)
+        # Tokenizer returns 10 tokens — longer than fixed+1
+        proc.tokenizer.side_effect = lambda text, **kw: {
+            "input_ids": torch.tensor([[0, 1, 2, 3, 4, 1, 2, 3, 4, 1]])
+        }
+
+        result = ev._score_sample("img", "long caption text here", proc, fixed_seq_len=fixed)
+
+        assert result is not None
+        assert seen_shapes == [(1, fixed)]
 
 
 # ---------------------------------------------------------------------------
@@ -345,7 +416,7 @@ class TestRegistry:
 
         assert "image-to-text" in _DEFAULT_DATASETS
         ds = _DEFAULT_DATASETS["image-to-text"]
-        assert ds.path == "nlphuji/flickr30k"
+        assert ds.path == "clip-benchmark/wds_mscoco_captions"
         assert ds.samples == 100
-        assert ds.columns_mapping.get("input_column") == "image"
-        assert ds.columns_mapping.get("caption_column") == "caption"
+        assert ds.columns_mapping.get("input_column") == "jpg"
+        assert ds.columns_mapping.get("caption_column") == "txt"

--- a/tests/unit/eval/test_image_to_text_evaluator.py
+++ b/tests/unit/eval/test_image_to_text_evaluator.py
@@ -1,0 +1,351 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+"""Unit tests for WinMLImageToTextEvaluator."""
+
+from __future__ import annotations
+
+import math
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from winml.modelkit.eval import WinMLImageToTextEvaluator
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_processor(vocab_size: int = 100, bos_id: int = 0) -> MagicMock:
+    """Build a mock processor with image_processor + tokenizer.
+
+    Token IDs are clamped to [0, vocab_size-1] so index-into-logits never
+    goes out of bounds regardless of the vocab_size argument.
+    """
+    proc = MagicMock()
+
+    def _process_images(images, return_tensors=None, **kwargs):
+        return {"pixel_values": torch.zeros(1, 3, 64, 64)}
+
+    proc.side_effect = _process_images
+    proc.__call__ = _process_images
+
+    tokenizer = MagicMock()
+
+    def _tokenize(text, return_tensors=None, truncation=None, max_length=None, **kwargs):
+        # Return 4-token sequence with IDs in [0, vocab_size-1]
+        t1 = min(1, vocab_size - 1)
+        t2 = min(2, vocab_size - 1)
+        t3 = min(3, vocab_size - 1)
+        return {"input_ids": torch.tensor([[bos_id, t1, t2, t3]])}
+
+    tokenizer.side_effect = _tokenize
+    tokenizer.__call__ = _tokenize
+    proc.tokenizer = tokenizer
+
+    return proc
+
+
+def _make_evaluator(
+    model: MagicMock | None = None,
+    columns_mapping: dict | None = None,
+    num_ds_items: int = 5,
+) -> WinMLImageToTextEvaluator:
+    """Instantiate evaluator by patching external dependencies."""
+    from winml.modelkit.datasets import DatasetConfig
+    from winml.modelkit.eval import WinMLEvaluationConfig
+
+    mapping = columns_mapping or {}
+
+    mock_ds = MagicMock()
+    mock_ds.__len__ = lambda self: num_ds_items
+    mock_ds.shuffle.return_value = mock_ds
+    mock_ds.select.return_value = mock_ds
+    mock_ds.column_names = ["image", "caption"]
+
+    if model is None:
+        model = MagicMock()
+        model.config.label2id = None
+        model.io_config = {}
+
+    config = WinMLEvaluationConfig(
+        model_id="test/mock-donut",
+        task="image-to-text",
+        dataset=DatasetConfig(
+            path="nlphuji/flickr30k",
+            columns_mapping=mapping,
+        ),
+    )
+
+    with patch("datasets.load_dataset", return_value=mock_ds):
+        return WinMLImageToTextEvaluator(config, model)
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+class TestSchema:
+    def test_schema_has_image_and_caption(self) -> None:
+        schema = WinMLImageToTextEvaluator.schema_info()
+        names = [col.name for col in schema]
+        assert "image" in names
+        assert "caption" in names
+
+    def test_schema_types(self) -> None:
+        schema = WinMLImageToTextEvaluator.schema_info()
+        by_name = {col.name: col for col in schema}
+        assert by_name["image"].type == "Image"
+        assert by_name["caption"].type == "Value(string)"
+
+
+# ---------------------------------------------------------------------------
+# Init / lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestInit:
+    def test_default_column_names(self) -> None:
+        ev = _make_evaluator()
+        assert ev._input_col == "image"
+        assert ev._caption_col == "caption"
+
+    def test_custom_column_names(self) -> None:
+        ev = _make_evaluator(columns_mapping={"input_column": "img", "caption_column": "text"})
+        assert ev._input_col == "img"
+        assert ev._caption_col == "text"
+
+    def test_prepare_pipeline_returns_none(self) -> None:
+        ev = _make_evaluator()
+        assert ev.pipe is None
+
+    def test_align_labels_is_noop(self) -> None:
+        ev = _make_evaluator()
+        ds = MagicMock()
+        assert ev.align_labels(ds, MagicMock()) is ds
+
+
+# ---------------------------------------------------------------------------
+# _logits
+# ---------------------------------------------------------------------------
+
+
+class TestLogits:
+    def test_dict_with_logits_key(self) -> None:
+        logits = torch.randn(1, 3, 50)
+        ev = _make_evaluator()
+        result = ev._logits({"logits": logits, "other": None})
+        assert torch.equal(result, logits)
+
+    def test_dict_without_logits_raises(self) -> None:
+        ev = _make_evaluator()
+        with pytest.raises(KeyError, match="no 'logits' key"):
+            ev._logits({"output": torch.randn(1, 3, 50)})
+
+    def test_object_attribute(self) -> None:
+        logits = torch.randn(1, 3, 50)
+        out = MagicMock()
+        out.logits = logits
+        ev = _make_evaluator()
+        assert torch.equal(ev._logits(out), logits)
+
+
+# ---------------------------------------------------------------------------
+# _score_sample
+# ---------------------------------------------------------------------------
+
+
+class TestScoreSample:
+    def test_returns_token_log_probs(self) -> None:
+        vocab = 50
+
+        ev = _make_evaluator()
+        proc = _make_processor(vocab_size=vocab)
+
+        # Model returns uniform logits → each token gets log(1/vocab)
+        ev.model = MagicMock(return_value={"logits": torch.zeros(1, 3, vocab)})
+
+        log_probs = ev._score_sample("fake_image", "hello world", proc)
+
+        assert log_probs is not None
+        assert log_probs.shape == (3,)
+        expected = -math.log(vocab)
+        assert all(abs(float(lp) - expected) < 1e-4 for lp in log_probs)
+
+    def test_skips_short_caption(self) -> None:
+        ev = _make_evaluator()
+        proc = MagicMock()
+
+        # Only one token → can't teacher-force
+        proc.side_effect = lambda images, **kw: {"pixel_values": torch.zeros(1, 3, 64, 64)}
+        proc.__call__ = proc.side_effect
+        proc.tokenizer = MagicMock(
+            side_effect=lambda text, **kw: {"input_ids": torch.tensor([[0]])}
+        )
+        proc.tokenizer.__call__ = proc.tokenizer.side_effect
+
+        result = ev._score_sample("img", "x", proc)
+        assert result is None
+
+    def test_image_processor_failure_returns_none(self) -> None:
+        ev = _make_evaluator()
+        proc = MagicMock()
+        proc.side_effect = RuntimeError("bad image")
+        proc.__call__ = proc.side_effect
+
+        result = ev._score_sample("bad_img", "hello", proc)
+        assert result is None
+
+    def test_model_forward_failure_returns_none(self) -> None:
+        ev = _make_evaluator()
+        proc = _make_processor()
+        ev.model = MagicMock(side_effect=RuntimeError("ORT error"))
+
+        result = ev._score_sample("img", "hello", proc)
+        assert result is None
+
+    def test_missing_pixel_values_returns_none(self) -> None:
+        ev = _make_evaluator()
+        proc = MagicMock()
+        proc.side_effect = lambda images, **kw: {}  # No "pixel_values" key
+        proc.__call__ = proc.side_effect
+
+        result = ev._score_sample("img", "hello", proc)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# compute
+# ---------------------------------------------------------------------------
+
+
+class TestCompute:
+    def test_uniform_logits_give_correct_perplexity(self) -> None:
+        """With uniform logits, perplexity should equal vocab size."""
+        vocab = 50
+
+        model = MagicMock()
+        model.config.label2id = None
+        model.io_config = {}
+        model.return_value = {"logits": torch.zeros(1, 3, vocab)}
+
+        ev = _make_evaluator(model=model)
+        ev._processor = _make_processor(vocab_size=vocab)
+
+        ev.data = [
+            {"image": "img1", "caption": "hello world"},
+            {"image": "img2", "caption": "foo bar"},
+        ]
+
+        result = ev.compute()
+
+        assert "nll" in result
+        assert "perplexity" in result
+        assert result["perplexity"] == pytest.approx(vocab, rel=1e-2)
+
+    def test_skips_none_image_or_caption(self) -> None:
+        vocab = 10
+        model = MagicMock()
+        model.config.label2id = None
+        model.io_config = {}
+        model.return_value = {"logits": torch.zeros(1, 3, vocab)}
+
+        ev = _make_evaluator(model=model)
+        ev._processor = _make_processor(vocab_size=vocab)
+
+        ev.data = [
+            {"image": "img1", "caption": "valid"},
+            {"image": None, "caption": "valid"},  # skipped
+            {"image": "img2", "caption": None},  # skipped
+        ]
+
+        result = ev.compute()
+        # Only one valid sample, but should still succeed
+        assert "perplexity" in result
+
+    def test_list_caption_uses_first_element(self) -> None:
+        vocab = 10
+        model = MagicMock()
+        model.config.label2id = None
+        model.io_config = {}
+        model.return_value = {"logits": torch.zeros(1, 3, vocab)}
+
+        ev = _make_evaluator(model=model)
+        ev._processor = _make_processor(vocab_size=vocab)
+
+        ev.data = [{"image": "img", "caption": ["first caption", "second caption"]}]
+
+        result = ev.compute()
+        assert "perplexity" in result
+
+    def test_empty_list_caption_skipped(self) -> None:
+        vocab = 10
+        model = MagicMock()
+        model.config.label2id = None
+        model.io_config = {}
+        model.return_value = {"logits": torch.zeros(1, 3, vocab)}
+
+        ev = _make_evaluator(model=model)
+        ev._processor = _make_processor(vocab_size=vocab)
+
+        ev.data = [
+            {"image": "img1", "caption": []},  # skipped: empty list
+            {"image": "img2", "caption": "valid one"},
+        ]
+
+        result = ev.compute()
+        assert "perplexity" in result
+
+    def test_no_valid_samples_raises(self) -> None:
+        ev = _make_evaluator()
+        ev._processor = _make_processor()
+        ev.data = [
+            {"image": None, "caption": None},
+            {"image": None, "caption": None},
+        ]
+
+        with pytest.raises(ValueError, match="No valid token log-probabilities"):
+            ev.compute()
+
+    def test_perplexity_is_exp_nll(self) -> None:
+        vocab = 20
+        model = MagicMock()
+        model.config.label2id = None
+        model.io_config = {}
+        model.return_value = {"logits": torch.zeros(1, 3, vocab)}
+
+        ev = _make_evaluator(model=model)
+        ev._processor = _make_processor(vocab_size=vocab)
+        ev.data = [{"image": "img", "caption": "some text"}]
+
+        result = ev.compute()
+        assert result["perplexity"] == pytest.approx(math.exp(result["nll"]), rel=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_registered_in_evaluator_registry(self) -> None:
+        from winml.modelkit.eval.evaluate import _EVALUATOR_REGISTRY
+
+        assert "image-to-text" in _EVALUATOR_REGISTRY
+        assert _EVALUATOR_REGISTRY["image-to-text"] is WinMLImageToTextEvaluator
+
+    def test_default_dataset_registered(self) -> None:
+        from winml.modelkit.eval.evaluate import _DEFAULT_DATASETS
+
+        assert "image-to-text" in _DEFAULT_DATASETS
+        ds = _DEFAULT_DATASETS["image-to-text"]
+        assert ds.path == "nlphuji/flickr30k"
+        assert ds.samples == 100
+        assert ds.columns_mapping.get("input_column") == "image"
+        assert ds.columns_mapping.get("caption_column") == "caption"


### PR DESCRIPTION
## Summary

Implements `WinMLImageToTextEvaluator` for the `image-to-text` task, enabling `winml eval` to measure accuracy regression across all `vision-encoder-decoder` models (donut, trocr, vit-gpt2, etc.).

### Metric: image-conditional perplexity under teacher forcing

For each (image, caption) pair, run a single forward pass with `decoder_input_ids = caption[:-1]` and compute cross-entropy loss vs `caption[1:]`. Aggregate as mean NLL + exp(NLL) = perplexity. Comparing PyTorch vs. WinML (ONNX) perplexity surfaces accuracy regressions from quantization or export.

**Why not the HF pipeline?** The `image-to-text` pipeline runs autoregressive generation — slow, non-deterministic (beam search), and doesn't expose per-token logits. Teacher forcing computes the full likelihood in a single pass, making it fast and directly comparable between PyTorch and ONNX.

### End-to-end result (naver-clova-ix/donut-base-finetuned-cord-v2, 100 samples, CPU)

```
nll: 7.8136  |  perplexity: 2474.1393
```

High perplexity is expected — donut is a document-understanding model evaluated out-of-domain on MSCOCO captions. The value is stable and comparable between PyTorch and WinML for regression detection.

## Changed files

| File | Change |
|---|---|
| `src/winml/modelkit/eval/image_to_text_evaluator.py` | New evaluator class |
| `src/winml/modelkit/eval/evaluate.py` | Register evaluator + default dataset (`clip-benchmark/wds_mscoco_captions`) |
| `src/winml/modelkit/eval/__init__.py` | Export `WinMLImageToTextEvaluator` |
| `scripts/e2e_eval/run_pytorch_baseline.py` | Add `"image-to-text": "perplexity"` to `_TASK_HF_METRIC_KEY` |
| `pyproject.toml` | Add `sentencepiece>=0.2` (required by `XLMRobertaTokenizerFast` used by DonutProcessor) |
| `tests/unit/eval/test_image_to_text_evaluator.py` | 27 unit tests |

## Design notes

**ONNX static decoder shape handling:** ONNX models compiled with fixed shapes require `decoder_input_ids` to be exactly the right length. The evaluator reads `model.io_config["input_shapes"]` to detect this and pads/truncates accordingly, excluding pad positions from NLL accumulation.

**Default dataset:** `clip-benchmark/wds_mscoco_captions` — parquet/WebDataset, no `.py` loading script, supports streaming. The originally-considered `nlphuji/flickr30k` raises `RuntimeError: Dataset scripts are no longer supported` on current HuggingFace.

**`pad_token_id` type guard:** `pad_id: int = raw_pad if isinstance(raw_pad, int) else 0` — prevents `TypeError` from `torch.full()` when `pad_token_id` is `None` or absent.

## Tests

27 tests covering: schema, init, column mapping, `_decoder_seq_len` (static vs. dynamic), `_logits` (dict/object), `_score_sample` (happy path, short skip, image/forward failures, pad/truncate for static shapes), `compute` (uniform logits → perplexity == vocab_size, None skipping, list captions, no-valid-samples error), registry entries.