### PR TITLE
disable `winml run` and `winml serve` CLI commands

### DIFF
--- a/src/winml/modelkit/cli.py
+++ b/src/winml/modelkit/cli.py
@@ -34,6 +34,11 @@ logger = logging.getLogger(__name__)
 
 _COMMANDS_DIR = Path(__file__).parent / "commands"
 
+# Commands that are temporarily disabled from the CLI surface.
+# The modules remain on disk so tests and internal imports still work;
+# they simply do not appear in ``winml --help`` or accept user invocations.
+_DISABLED_COMMANDS: frozenset[str] = frozenset({"run", "serve"})
+
 
 def _parse_click_help(path: Path) -> str:
     """Extract short help from a command module without importing it.
@@ -68,10 +73,20 @@ class LazyGroup(click.Group):
         """Return command names from filesystem — no module imports."""
         if not _COMMANDS_DIR.exists():
             return []
-        return sorted(p.stem for p in _COMMANDS_DIR.glob("*.py") if not p.name.startswith("_"))
+        return sorted(
+            p.stem
+            for p in _COMMANDS_DIR.glob("*.py")
+            if not p.name.startswith("_") and p.stem not in _DISABLED_COMMANDS
+        )
 
     def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command | None:
         """Import command module only when the command is actually invoked."""
+        if cmd_name in _DISABLED_COMMANDS:
+            ctx.fail(
+                f"'winml {cmd_name}' is currently disabled. "
+                f"Use 'winml eval' for model evaluation instead."
+            )
+
         try:
             module = import_module(
                 f".commands.{cmd_name}",

--- a/tests/unit/commands/test_cli.py
+++ b/tests/unit/commands/test_cli.py
@@ -224,6 +224,37 @@ class TestSysCommand:
         assert "Available Execution Providers" not in result.output
 
 
+class TestDisabledCommands:
+    """Test that disabled commands (run, serve) are hidden and reject invocations."""
+
+    def test_run_not_in_help(self, runner: CliRunner) -> None:
+        """Disabled 'run' command must not appear in --help output."""
+        result = runner.invoke(main, ["--help"])
+        assert result.exit_code == 0
+        # 'run' should not be listed as a command
+        command_lines = result.output.split("Commands:")[1] if "Commands:" in result.output else ""
+        assert "run" not in command_lines.split()
+
+    def test_serve_not_in_help(self, runner: CliRunner) -> None:
+        """Disabled 'serve' command must not appear in --help output."""
+        result = runner.invoke(main, ["--help"])
+        assert result.exit_code == 0
+        command_lines = result.output.split("Commands:")[1] if "Commands:" in result.output else ""
+        assert "serve" not in command_lines.split()
+
+    def test_run_invocation_rejected(self, runner: CliRunner) -> None:
+        """Invoking 'winml run' must fail with a clear disabled message."""
+        result = runner.invoke(main, ["run", "--help"])
+        assert result.exit_code != 0
+        assert "disabled" in result.output.lower()
+
+    def test_serve_invocation_rejected(self, runner: CliRunner) -> None:
+        """Invoking 'winml serve' must fail with a clear disabled message."""
+        result = runner.invoke(main, ["serve", "--help"])
+        assert result.exit_code != 0
+        assert "disabled" in result.output.lower()
+
+
 class TestModuleExecution:
     """Test python -m winml.modelkit execution."""
 


### PR DESCRIPTION
## Summary
- Hide `run` and `serve` from CLI command discovery (`winml --help`)
- Reject direct invocations (`winml run ...`, `winml serve ...`) with a clear "disabled" error message
- Modules remain on disk — existing tests and internal imports (e.g. `eval` using `serve/`) are unaffected
- Re-enabling is a one-line change: remove entries from `_DISABLED_COMMANDS` frozenset

🤖 Generated with [Claude Code](https://claude.com/claude-code)