### PR TITLE
feat: add document-question-answering support for vision-encoder-decoder (Donut)

### DIFF
--- a/scripts/e2e_eval/run_pytorch_baseline.py
+++ b/scripts/e2e_eval/run_pytorch_baseline.py
@@ -59,6 +59,7 @@ _TASK_HF_METRIC_KEY: dict[str, str] = {
     "automatic-speech-recognition": "wer",
     "token-classification": "overall_f1",
     "question-answering": "f1",
+    "document-question-answering": "anls",
     "object-detection": "map",
     "image-segmentation": "mean_iou",
     "feature-extraction": "cosine_spearman",
@@ -76,8 +77,8 @@ _TASK_HF_METRIC_KEY: dict[str, str] = {
 def _load_pytorch_model(model_id: str, task: str, device_str: str):
     """Load a native PyTorch model with the task-appropriate AutoModel class."""
     import torch
-
     from transformers import AutoConfig
+
     from winml.modelkit.loader.task import resolve_task_and_model_class
 
     config = AutoConfig.from_pretrained(model_id)

--- a/scripts/e2e_eval/testsets/models_all.json
+++ b/scripts/e2e_eval/testsets/models_all.json
@@ -1721,7 +1721,7 @@
   },
   {
     "hf_id": "naver-clova-ix/donut-base-finetuned-cord-v2",
-    "task": "image-to-text",
+    "task": "document-question-answering",
     "model_type": "vision-encoder-decoder",
     "group": "Top200",
     "priority": "P1",

--- a/src/winml/modelkit/eval/__init__.py
+++ b/src/winml/modelkit/eval/__init__.py
@@ -10,6 +10,7 @@ Provides accuracy evaluation using HuggingFace pipeline + evaluate library.
 
 from .base_evaluator import WinMLEvaluator
 from .config import WinMLEvaluationConfig
+from .document_question_answering_evaluator import WinMLDocumentQuestionAnsweringEvaluator
 from .evaluate import EvalResult, evaluate
 from .feature_extraction_evaluator import WinMLFeatureExtractionEvaluator
 from .fill_mask_evaluator import WinMLFillMaskEvaluator
@@ -34,6 +35,7 @@ __all__ = [
     "MeanIoUMetric",
     "PseudoPerplexityMetric",
     "SpearmanCorrelationMetric",
+    "WinMLDocumentQuestionAnsweringEvaluator",
     "WinMLEvaluationConfig",
     "WinMLEvaluator",
     "WinMLFeatureExtractionEvaluator",

--- a/src/winml/modelkit/eval/document_question_answering_evaluator.py
+++ b/src/winml/modelkit/eval/document_question_answering_evaluator.py
@@ -1,0 +1,154 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+"""Document question answering evaluator (ANLS metric)."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from .base_evaluator import WinMLEvaluator
+
+
+if TYPE_CHECKING:
+    from datasets import Dataset
+
+logger = logging.getLogger(__name__)
+
+
+class WinMLDocumentQuestionAnsweringEvaluator(WinMLEvaluator):
+    """Evaluator for document question answering tasks.
+
+    Runs inference through the HF ``document-question-answering`` pipeline and
+    computes Average Normalized Levenshtein Similarity (ANLS), the standard
+    metric for DocVQA-style benchmarks.
+
+    Dataset schema requires: image, question (or nested dict with ``en`` key),
+    and answers (list of accepted answer strings).
+
+    When ``question_column`` points to a nested-dict column (e.g. the
+    ``query`` field in ``nielsr/docvqa_1200_examples_donut`` which has per-
+    language keys), the evaluator automatically extracts the ``en`` value
+    before running inference.
+    """
+
+    @classmethod
+    def schema_info(cls) -> list:
+        """Return expected dataset schema for document question answering."""
+        from .config import SchemaColumn
+
+        return [
+            SchemaColumn(
+                "image", "Image", "image_column", description="PIL Image of document page"
+            ),
+            SchemaColumn(
+                "question",
+                "Value(string)",
+                "question_column",
+                description="question text (or dict with language-code keys)",
+            ),
+            SchemaColumn(
+                "answers",
+                "List(Value(string))",
+                "label_column",
+                description="list of accepted answer strings",
+            ),
+        ]
+
+    def prepare_data(self) -> Dataset:
+        """Load dataset and normalise nested question column to a flat string."""
+        dataset = super().prepare_data()
+
+        question_col = self.config.dataset.columns_mapping.get("question_column", "question")
+        if question_col not in dataset.column_names:
+            return dataset
+
+        # Flatten per-language dict (e.g. {"en": "...", "de": "..."}) to string.
+        # Use "en" when present; fall back to the first available value.
+        sample_val = dataset[question_col][0] if len(dataset) > 0 else None
+        if isinstance(sample_val, dict):
+            logger.debug("Flattening nested question column '%s' to English string.", question_col)
+            dataset = dataset.map(
+                lambda row: {
+                    question_col: (
+                        row[question_col].get("en") or next(iter(row[question_col].values()), "")
+                    )
+                }
+            )
+
+        return dataset
+
+    def compute(self) -> dict[str, Any]:
+        """Run DQA pipeline and return ANLS metric."""
+        image_col = self.config.dataset.columns_mapping.get("image_column", "image")
+        question_col = self.config.dataset.columns_mapping.get("question_column", "question")
+        label_col = self.config.dataset.columns_mapping.get("label_column", "answers")
+
+        logger.info("Running document question answering evaluation...")
+        anls_scores: list[float] = []
+
+        for row in self.data:
+            result = self.pipe(row[image_col], question=row[question_col])
+            # Pipeline returns a list of dicts or a single dict depending on model.
+            if isinstance(result, list):
+                pred = result[0].get("answer", "")
+            else:
+                pred = result.get("answer", "")
+
+            refs = row[label_col]
+            if isinstance(refs, str):
+                refs = [refs]
+
+            anls_scores.append(self._max_anls(str(pred), refs))
+
+        anls = sum(anls_scores) / len(anls_scores) if anls_scores else 0.0
+        logger.info("ANLS: %.4f (over %d samples)", anls, len(anls_scores))
+        return {"anls": anls}
+
+    # ------------------------------------------------------------------
+    # ANLS helpers (no external dependency required)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _levenshtein(s1: str, s2: str) -> int:
+        """Compute case-insensitive Levenshtein edit distance."""
+        s1, s2 = s1.lower(), s2.lower()
+        if not s1:
+            return len(s2)
+        if not s2:
+            return len(s1)
+        prev = list(range(len(s2) + 1))
+        for i, c1 in enumerate(s1, 1):
+            curr = [i] + [0] * len(s2)
+            for j, c2 in enumerate(s2, 1):
+                curr[j] = min(
+                    prev[j] + 1,
+                    curr[j - 1] + 1,
+                    prev[j - 1] + (c1 != c2),
+                )
+            prev = curr
+        return prev[-1]
+
+    @classmethod
+    def _max_anls(cls, prediction: str, references: list[str], threshold: float = 0.5) -> float:
+        """Return the highest ANLS score between *prediction* and any reference.
+
+        ANLS (Average Normalized Levenshtein Similarity):
+            NLS  = levenshtein(pred, ref) / max(len(pred), len(ref))
+            score = (1 - NLS) if NLS < threshold else 0
+        """
+        best = 0.0
+        pred_s = prediction.strip()
+        for ref in references:
+            ref_s = ref.strip()
+            max_len = max(len(pred_s), len(ref_s))
+            if max_len == 0:
+                best = max(best, 1.0)
+                continue
+            nls = cls._levenshtein(pred_s, ref_s) / max_len
+            score = 1.0 - nls if nls < threshold else 0.0
+            best = max(best, score)
+        return best

--- a/src/winml/modelkit/eval/evaluate.py
+++ b/src/winml/modelkit/eval/evaluate.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any
 from ..datasets.config import DatasetConfig
 from .base_evaluator import WinMLEvaluator
 from .config import WinMLEvaluationConfig
+from .document_question_answering_evaluator import WinMLDocumentQuestionAnsweringEvaluator
 from .feature_extraction_evaluator import WinMLFeatureExtractionEvaluator
 from .fill_mask_evaluator import WinMLFillMaskEvaluator
 from .image_feature_extraction_evaluator import WinMLImageFeatureExtractionEvaluator
@@ -39,6 +40,7 @@ _EVALUATOR_REGISTRY: dict[str, type[WinMLEvaluator]] = {
     "object-detection": WinMLObjectDetectionEvaluator,
     "image-segmentation": WinMLImageSegmentationEvaluator,
     "question-answering": WinMLQuestionAnsweringEvaluator,
+    "document-question-answering": WinMLDocumentQuestionAnsweringEvaluator,
     "feature-extraction": WinMLFeatureExtractionEvaluator,
     "sentence-similarity": WinMLFeatureExtractionEvaluator,
     "image-feature-extraction": WinMLImageFeatureExtractionEvaluator,
@@ -125,6 +127,18 @@ _DEFAULT_DATASETS: dict[str, DatasetConfig] = {
         shuffle=True,
         streaming=True,
         columns_mapping={"input_column": "text"},
+    ),
+    "document-question-answering": DatasetConfig(
+        path="nielsr/docvqa_1200_examples_donut",
+        split="test",
+        samples=100,
+        shuffle=True,
+        streaming=True,
+        columns_mapping={
+            "image_column": "image",
+            "question_column": "query",
+            "label_column": "answers",
+        },
     ),
 }
 

--- a/src/winml/modelkit/models/hf/vision_encoder_decoder.py
+++ b/src/winml/modelkit/models/hf/vision_encoder_decoder.py
@@ -3,7 +3,10 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
+from optimum.exporters.onnx.model_configs import VisionEncoderDecoderOnnxConfig
+
 from ...config import WinMLBuildConfig
+from ...export import register_onnx_overwrite
 from ...optim import WinMLOptimizationConfig
 
 
@@ -15,3 +18,22 @@ VISION_ENCODER_DECODER_CONFIG = WinMLBuildConfig(
         reshape_mergedreshape=True,
     ),
 )
+
+
+# =============================================================================
+# ONNX task registration
+# =============================================================================
+
+
+@register_onnx_overwrite(
+    "vision-encoder-decoder", "document-question-answering", library_name="transformers"
+)
+class VisionEncoderDecoderDocQAOnnxConfig(VisionEncoderDecoderOnnxConfig):
+    """ONNX config for vision-encoder-decoder document-question-answering.
+
+    Donut and similar seq2seq document models share the same graph for both
+    image-to-text and document-question-answering: pixel_values as encoder input
+    and decoder_input_ids as the prompt. The question text is embedded into
+    decoder_input_ids by the processor at runtime, so the ONNX inputs are
+    identical to the image-to-text configuration.
+    """

--- a/tests/unit/eval/test_document_question_answering_evaluator.py
+++ b/tests/unit/eval/test_document_question_answering_evaluator.py
@@ -1,0 +1,356 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+"""Unit tests for WinMLDocumentQuestionAnsweringEvaluator."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from winml.modelkit.eval import WinMLDocumentQuestionAnsweringEvaluator
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_evaluator(columns_mapping=None, dataset_rows=None):
+    """Create evaluator without hitting real network or GPU."""
+    from winml.modelkit.datasets import DatasetConfig
+    from winml.modelkit.eval import WinMLEvaluationConfig
+
+    mapping = columns_mapping or {
+        "image_column": "image",
+        "question_column": "question",
+        "label_column": "answers",
+    }
+
+    rows = dataset_rows or [
+        {"image": MagicMock(), "question": "What is shown?", "answers": ["a cat"]},
+        {"image": MagicMock(), "question": "What color?", "answers": ["red", "crimson"]},
+    ]
+
+    mock_ds = MagicMock()
+    mock_ds.__len__ = lambda self: len(rows)
+    mock_ds.__iter__ = lambda self: iter(rows)
+    mock_ds.shuffle.return_value = mock_ds
+    mock_ds.select.return_value = mock_ds
+    # make column access work for prepare_data flattening check
+    mock_ds.column_names = list(rows[0].keys())
+    mock_ds.__getitem__ = lambda self, key: [r[key] for r in rows]
+    mock_ds.map = lambda fn, **kw: mock_ds  # no-op for flat string questions
+
+    model = MagicMock()
+    model.config.label2id = None
+
+    config = WinMLEvaluationConfig(
+        model_id="test/model",
+        task="document-question-answering",
+        dataset=DatasetConfig(path="fake/dataset", columns_mapping=mapping),
+    )
+
+    with (
+        patch("datasets.load_dataset", return_value=mock_ds),
+        patch("transformers.pipeline", return_value=MagicMock()),
+    ):
+        return WinMLDocumentQuestionAnsweringEvaluator(config, model)
+
+
+# ---------------------------------------------------------------------------
+# schema_info
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaInfo:
+    def test_returns_three_columns(self):
+        schema = WinMLDocumentQuestionAnsweringEvaluator.schema_info()
+        assert len(schema) == 3
+
+    def test_column_names(self):
+        schema = WinMLDocumentQuestionAnsweringEvaluator.schema_info()
+        names = [col.name for col in schema]
+        assert names == ["image", "question", "answers"]
+
+    def test_column_overrides(self):
+        schema = WinMLDocumentQuestionAnsweringEvaluator.schema_info()
+        overrides = [col.override for col in schema]
+        assert overrides == ["image_column", "question_column", "label_column"]
+
+
+# ---------------------------------------------------------------------------
+# _levenshtein
+# ---------------------------------------------------------------------------
+
+
+class TestLevenshtein:
+    def test_identical_strings(self):
+        assert WinMLDocumentQuestionAnsweringEvaluator._levenshtein("abc", "abc") == 0
+
+    def test_empty_first(self):
+        assert WinMLDocumentQuestionAnsweringEvaluator._levenshtein("", "abc") == 3
+
+    def test_empty_second(self):
+        assert WinMLDocumentQuestionAnsweringEvaluator._levenshtein("abc", "") == 3
+
+    def test_both_empty(self):
+        assert WinMLDocumentQuestionAnsweringEvaluator._levenshtein("", "") == 0
+
+    def test_single_substitution(self):
+        assert WinMLDocumentQuestionAnsweringEvaluator._levenshtein("cat", "bat") == 1
+
+    def test_case_insensitive(self):
+        assert WinMLDocumentQuestionAnsweringEvaluator._levenshtein("Cat", "cat") == 0
+
+    def test_insertion(self):
+        assert WinMLDocumentQuestionAnsweringEvaluator._levenshtein("ab", "abc") == 1
+
+    def test_deletion(self):
+        assert WinMLDocumentQuestionAnsweringEvaluator._levenshtein("abc", "ab") == 1
+
+
+# ---------------------------------------------------------------------------
+# _max_anls
+# ---------------------------------------------------------------------------
+
+
+class TestMaxAnls:
+    def test_exact_match_returns_one(self):
+        score = WinMLDocumentQuestionAnsweringEvaluator._max_anls("answer", ["answer"])
+        assert score == pytest.approx(1.0)
+
+    def test_both_empty_returns_one(self):
+        score = WinMLDocumentQuestionAnsweringEvaluator._max_anls("", [""])
+        assert score == pytest.approx(1.0)
+
+    def test_completely_wrong_returns_zero(self):
+        # NLS >= 0.5 → score = 0
+        score = WinMLDocumentQuestionAnsweringEvaluator._max_anls("xyz", ["abcdefgh"])
+        assert score == 0.0
+
+    def test_multiple_refs_uses_best(self):
+        # "cat" vs ["dog", "cat"] — should pick exact match
+        score = WinMLDocumentQuestionAnsweringEvaluator._max_anls("cat", ["dog", "cat"])
+        assert score == pytest.approx(1.0)
+
+    def test_partial_match(self):
+        # "cats" vs ["cat"] — levenshtein=1, NLS=1/4=0.25 < 0.5 threshold → score=0.75
+        score = WinMLDocumentQuestionAnsweringEvaluator._max_anls("cats", ["cat"])
+        assert score == pytest.approx(0.75)
+
+    def test_case_insensitive_match(self):
+        # NLS computed on lowercased strings
+        score = WinMLDocumentQuestionAnsweringEvaluator._max_anls("CAT", ["cat"])
+        assert score == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# prepare_data: nested query dict flattening
+# ---------------------------------------------------------------------------
+
+
+class TestPrepareData:
+    def test_flattens_nested_query_dict(self):
+        """When question column holds a dict, the English value is extracted."""
+        from winml.modelkit.datasets import DatasetConfig
+        from winml.modelkit.eval import WinMLEvaluationConfig
+
+        rows = [
+            {
+                "image": MagicMock(),
+                "query": {"en": "What year?", "de": "Welches Jahr?"},
+                "answers": ["2020"],
+            },
+        ]
+
+        mock_ds = MagicMock()
+        mock_ds.__len__ = lambda self: 1
+        mock_ds.__iter__ = lambda self: iter(rows)
+        mock_ds.shuffle.return_value = mock_ds
+        mock_ds.select.return_value = mock_ds
+        mock_ds.column_names = ["image", "query", "answers"]
+        mock_ds.__getitem__ = lambda self, key: [r[key] for r in rows]
+
+        flattened_rows = [
+            {"image": rows[0]["image"], "query": "What year?", "answers": ["2020"]},
+        ]
+        flat_ds = MagicMock()
+        flat_ds.__len__ = lambda self: 1
+        flat_ds.__iter__ = lambda self: iter(flattened_rows)
+        flat_ds.shuffle.return_value = flat_ds
+        flat_ds.select.return_value = flat_ds
+        flat_ds.column_names = ["image", "query", "answers"]
+        flat_ds.__getitem__ = lambda self, key: [r[key] for r in flattened_rows]
+
+        mock_ds.map = MagicMock(return_value=flat_ds)
+
+        model = MagicMock()
+        model.config.label2id = None
+
+        config = WinMLEvaluationConfig(
+            model_id="test/model",
+            task="document-question-answering",
+            dataset=DatasetConfig(
+                path="fake/ds",
+                columns_mapping={
+                    "image_column": "image",
+                    "question_column": "query",
+                    "label_column": "answers",
+                },
+            ),
+        )
+
+        with (
+            patch("datasets.load_dataset", return_value=mock_ds),
+            patch("transformers.pipeline", return_value=MagicMock()),
+        ):
+            WinMLDocumentQuestionAnsweringEvaluator(config, model)
+
+        # map() was called (flattening happened)
+        assert mock_ds.map.called
+
+    def test_flat_string_question_not_modified(self):
+        """When question is already a string, map() is not called."""
+        from winml.modelkit.datasets import DatasetConfig
+        from winml.modelkit.eval import WinMLEvaluationConfig
+
+        rows = [
+            {"image": MagicMock(), "question": "Plain string question", "answers": ["yes"]},
+        ]
+
+        mock_ds = MagicMock()
+        mock_ds.__len__ = lambda self: 1
+        mock_ds.__iter__ = lambda self: iter(rows)
+        mock_ds.shuffle.return_value = mock_ds
+        mock_ds.select.return_value = mock_ds
+        mock_ds.column_names = ["image", "question", "answers"]
+        mock_ds.__getitem__ = lambda self, key: [r[key] for r in rows]
+        mock_ds.map = MagicMock(return_value=mock_ds)
+
+        model = MagicMock()
+        model.config.label2id = None
+
+        config = WinMLEvaluationConfig(
+            model_id="test/model",
+            task="document-question-answering",
+            dataset=DatasetConfig(
+                path="fake/ds",
+                columns_mapping={
+                    "image_column": "image",
+                    "question_column": "question",
+                    "label_column": "answers",
+                },
+            ),
+        )
+
+        with (
+            patch("datasets.load_dataset", return_value=mock_ds),
+            patch("transformers.pipeline", return_value=MagicMock()),
+        ):
+            WinMLDocumentQuestionAnsweringEvaluator(config, model)
+
+        mock_ds.map.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# compute
+# ---------------------------------------------------------------------------
+
+
+class TestCompute:
+    def test_returns_anls_key(self):
+        ev = make_evaluator()
+        ev.pipe = MagicMock(return_value=[{"answer": "a cat"}])
+        result = ev.compute()
+        assert "anls" in result
+
+    def test_exact_prediction_anls_is_one(self):
+        rows = [{"image": MagicMock(), "question": "Q?", "answers": ["exact answer"]}]
+        ev = make_evaluator(dataset_rows=rows)
+        ev.pipe = MagicMock(return_value=[{"answer": "exact answer"}])
+        result = ev.compute()
+        assert result["anls"] == pytest.approx(1.0)
+
+    def test_wrong_prediction_anls_is_zero(self):
+        rows = [{"image": MagicMock(), "question": "Q?", "answers": ["completely different text"]}]
+        ev = make_evaluator(dataset_rows=rows)
+        ev.pipe = MagicMock(return_value=[{"answer": "xyz"}])
+        result = ev.compute()
+        assert result["anls"] == 0.0
+
+    def test_averages_over_samples(self):
+        rows = [
+            {"image": MagicMock(), "question": "Q1?", "answers": ["exact"]},
+            {"image": MagicMock(), "question": "Q2?", "answers": ["completely different"]},
+        ]
+        ev = make_evaluator(dataset_rows=rows)
+
+        # First call: exact match (ANLS=1.0), second: wrong (ANLS=0.0)
+        ev.pipe = MagicMock(
+            side_effect=[
+                [{"answer": "exact"}],
+                [{"answer": "xyz"}],
+            ]
+        )
+        result = ev.compute()
+        assert result["anls"] == pytest.approx(0.5)
+
+    def test_string_label_treated_as_single_ref(self):
+        rows = [{"image": MagicMock(), "question": "Q?", "answers": "the answer"}]
+        ev = make_evaluator(dataset_rows=rows)
+        ev.pipe = MagicMock(return_value=[{"answer": "the answer"}])
+        result = ev.compute()
+        assert result["anls"] == pytest.approx(1.0)
+
+    def test_pipe_returns_dict_not_list(self):
+        rows = [{"image": MagicMock(), "question": "Q?", "answers": ["cat"]}]
+        ev = make_evaluator(dataset_rows=rows)
+        ev.pipe = MagicMock(return_value={"answer": "cat"})
+        result = ev.compute()
+        assert result["anls"] == pytest.approx(1.0)
+
+    def test_empty_dataset_returns_zero(self):
+        ev = make_evaluator()
+        ev.data = []
+        ev.pipe = MagicMock()
+        result = ev.compute()
+        assert result["anls"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Registry and default dataset
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_dqa_evaluator_in_registry(self):
+        from winml.modelkit.eval.evaluate import _EVALUATOR_REGISTRY
+
+        assert "document-question-answering" in _EVALUATOR_REGISTRY
+        assert (
+            _EVALUATOR_REGISTRY["document-question-answering"]
+            is WinMLDocumentQuestionAnsweringEvaluator
+        )
+
+    def test_dqa_default_dataset_in_registry(self):
+        from winml.modelkit.eval.evaluate import _DEFAULT_DATASETS
+
+        assert "document-question-answering" in _DEFAULT_DATASETS
+        ds = _DEFAULT_DATASETS["document-question-answering"]
+        assert ds.path == "nielsr/docvqa_1200_examples_donut"
+        assert "image_column" in ds.columns_mapping
+        assert "question_column" in ds.columns_mapping
+        assert "label_column" in ds.columns_mapping
+
+    def test_dqa_exported_from_eval_package(self):
+        from winml.modelkit import eval as eval_pkg
+
+        assert hasattr(eval_pkg, "WinMLDocumentQuestionAnsweringEvaluator")
+        assert (
+            eval_pkg.WinMLDocumentQuestionAnsweringEvaluator
+            is WinMLDocumentQuestionAnsweringEvaluator
+        )


### PR DESCRIPTION
## Summary

- Registers `document-question-answering` as an ONNX export task for `vision-encoder-decoder` via a new `VisionEncoderDecoderDocQAOnnxConfig`. The inputs are identical to `image-to-text` (`pixel_values` + `decoder_input_ids`) — the question is encoded into the decoder prompt by the processor at runtime.
- Reclassifies `naver-clova-ix/donut-base-finetuned-cord-v2` in the model registry from `image-to-text` to `document-question-answering`.
- Adds `WinMLDocumentQuestionAnsweringEvaluator` with a self-contained ANLS (Average Normalized Levenshtein Similarity) metric; handles nested `query` dicts from `nielsr/docvqa_1200_examples_donut`.
- Default eval dataset: `nielsr/docvqa_1200_examples_donut` (parquet-based, no loading script).
- Adds `"document-question-answering": "anls"` to `_TASK_HF_METRIC_KEY` in the PyTorch baseline script.
- 29 new unit tests; all 4302 unit tests pass.