### PR TITLE
fix(pipeline): twine check fails on Metadata-Version 2.4 + non-package files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,12 +3,8 @@ name: Lint
 on:
   pull_request:
     branches: [main]
-    paths-ignore:
-      - '.pipelines/**'
   push:
     branches: [main]
-    paths-ignore:
-      - '.pipelines/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/modelkit-ci.yml
+++ b/.github/workflows/modelkit-ci.yml
@@ -3,12 +3,8 @@ name: ModelKit CI
 on:
   pull_request:
     branches: [main]
-    paths-ignore:
-      - '.pipelines/**'
   push:
     branches: [main]
-    paths-ignore:
-      - '.pipelines/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.pipelines/modelkit-official-build.yml
+++ b/.pipelines/modelkit-official-build.yml
@@ -88,11 +88,24 @@ extends:
                   artifactFeeds: 'windows.ai.toolkit/Modelkit'
                 displayName: 'Authenticate pip with Azure Artifacts'
 
-              - script: pip install build twine
+              - script: pip install --upgrade build twine packaging
                 displayName: 'Install build tools'
+
+              - script: |
+                  where python
+                  where twine
+                  python --version
+                  python -c "import sys; print('executable=', sys.executable)"
+                  python -c "import twine, packaging; print('twine=', twine.__version__, 'packaging=', packaging.__version__)"
+                  pip show twine packaging setuptools build readme_renderer
+                displayName: 'Diagnose tool versions'
 
               - script: python -m build --outdir "$(ob_outputDirectory)"
                 displayName: 'Build sdist and wheel'
+
+              - script: |
+                  python -c "import zipfile, sys, glob; w = glob.glob(r'$(ob_outputDirectory)\*.whl')[0]; print('wheel=', w); z = zipfile.ZipFile(w); m = [n for n in z.namelist() if n.endswith('METADATA')][0]; print('---METADATA (first 30 lines)---'); [print(l) for l in z.read(m).decode().splitlines()[:30]]"
+                displayName: 'Dump wheel METADATA headers'
 
               - script: twine check "$(ob_outputDirectory)\*"
                 continueOnError: true

--- a/.pipelines/modelkit-official-build.yml
+++ b/.pipelines/modelkit-official-build.yml
@@ -72,7 +72,7 @@ extends:
                 displayName: 'Check Python version'
 
               - powershell: |
-                  $rulesDir = "$(Build.SourcesDirectory)\ModelKitArtifacts\op_check_results\rules"
+                  $rulesDir = "$(Build.SourcesDirectory)\ModelKitArtifacts\rules_zip"
                   $destDir = "$(Build.SourcesDirectory)\src\winml\modelkit\analyze\rules\runtime_check_rules"
                   $outDir = "$(ob_outputDirectory)"
                   New-Item -ItemType Directory -Path $outDir -Force | Out-Null

--- a/.pipelines/modelkit-official-build.yml
+++ b/.pipelines/modelkit-official-build.yml
@@ -91,22 +91,9 @@ extends:
               - script: pip install --upgrade build twine packaging
                 displayName: 'Install build tools'
 
-              - script: |
-                  where python
-                  where twine
-                  python --version
-                  python -c "import sys; print('executable=', sys.executable)"
-                  python -c "import twine, packaging; print('twine=', twine.__version__, 'packaging=', packaging.__version__)"
-                  pip show twine packaging setuptools build readme_renderer
-                displayName: 'Diagnose tool versions'
-
               - script: python -m build --outdir "$(ob_outputDirectory)"
                 displayName: 'Build sdist and wheel'
 
-              - script: |
-                  python -c "import zipfile, sys, glob; w = glob.glob(r'$(ob_outputDirectory)\*.whl')[0]; print('wheel=', w); z = zipfile.ZipFile(w); m = [n for n in z.namelist() if n.endswith('METADATA')][0]; print('---METADATA (first 30 lines)---'); [print(l) for l in z.read(m).decode().splitlines()[:30]]"
-                displayName: 'Dump wheel METADATA headers'
-
-              - script: twine check "$(ob_outputDirectory)\*"
+              - script: twine check "$(ob_outputDirectory)\*.whl" "$(ob_outputDirectory)\*.tar.gz"
                 continueOnError: true
                 displayName: 'Validate packages for PyPI'


### PR DESCRIPTION
## Summary
- Narrow the `twine check` glob from `$(ob_outputDirectory)\*` to `*.whl` + `*.tar.gz` so rule zips that are staged into the same output directory aren't validated as Python packages.