### PR TITLE
fix: multiple analyze/compile bugs and noisy warnings

### DIFF
--- a/src/winml/modelkit/analyze/core/doc_constraint_checker.py
+++ b/src/winml/modelkit/analyze/core/doc_constraint_checker.py
@@ -181,7 +181,7 @@ class DocConstraintChecker:
             logger.debug(f"Failed to map {node.op_type}: {description}")
             return None, description
         except Exception as e:
-            logger.warning(f"Error mapping {node.op_type}: {e}")
+            logger.debug(f"Error mapping {node.op_type}: {e}")
             return None, str(e)
 
     def get_op_constraints(self, op_type: str) -> pd.DataFrame | None:
@@ -291,7 +291,7 @@ class DocConstraintChecker:
         # Get the checker function
         checker_func = self.CHECKER_FUNCTIONS.get(checker_name)
         if checker_func is None:
-            logger.warning(f"Unknown checker function: {checker_name}")
+            logger.debug(f"Unknown checker function: {checker_name}")
             return False, f"Unknown checker function: {checker_name}"
 
         # Get the tensor to check
@@ -365,7 +365,7 @@ class DocConstraintChecker:
                     pattern_match=pattern_match,
                 )
             # Operator truly not in DB or unsupported
-            logger.warning(f"Mapping failed for {op_type}: {error_desc}")
+            logger.debug(f"Mapping failed for {op_type}: {error_desc}")
             return PatternRuntime(
                 pattern_id=pattern_match.pattern.pattern_id,
                 result=RuntimeTestResult(
@@ -402,7 +402,7 @@ class DocConstraintChecker:
 
         if matching_rows.empty:
             actual_dtype = self._get_node_actual_dtype(node)
-            logger.warning(
+            logger.debug(
                 f"No constraints found for operator "
                 f"'{target_op}' with dtype category "
                 f"'{dtype_category}' (actual dtype: "

--- a/src/winml/modelkit/analyze/core/pattern_extractor.py
+++ b/src/winml/modelkit/analyze/core/pattern_extractor.py
@@ -251,7 +251,7 @@ class PatternExtractor:
 
         # Create PatternMatcher instance - may raise InvalidPatternMatcherModelError
         try:
-            matcher = PatternMatcher(model_proto)
+            matcher = PatternMatcher(model_proto, model_path=self._model.model_path)
         except InvalidPatternMatcherModelError as e:
             # Model is invalid for pattern matching (e.g., nodes with empty names)
             logger.warning("Model validation failed for pattern matching: %s", str(e))

--- a/src/winml/modelkit/analyze/core/runtime_checker_query.py
+++ b/src/winml/modelkit/analyze/core/runtime_checker_query.py
@@ -187,7 +187,7 @@ def _expand_snapshot_payload(
 
     base_opset = payload.get(SNAPSHOT_BASE_OPSET_KEY)
     if not isinstance(base_opset, int):
-        logger.warning(
+        logger.debug(
             "Delta snapshot %s in %s missing integer %s; applying delta on empty base.",
             file_name,
             zip_path,
@@ -199,7 +199,7 @@ def _expand_snapshot_payload(
     if visited is None:
         visited = set()
     if token in visited:
-        logger.warning(
+        logger.debug(
             "Detected cyclic snapshot chain while loading %s from %s; "
             "applying delta on empty base.",
             file_name,
@@ -215,7 +215,7 @@ def _expand_snapshot_payload(
 
     base_raw = _read_json_from_zip(base_zip_path, base_file_name)
     if base_raw is None:
-        logger.warning(
+        logger.debug(
             "Base snapshot %s not found in %s (from %s); applying delta on empty base.",
             base_file_name,
             base_zip_path,
@@ -336,7 +336,7 @@ class LazyDomainTables:
                     columns_file_name=base_columns_file_name,
                 )
             else:
-                logger.warning(
+                logger.debug(
                     "Delta table snapshot %s in %s missing integer %s; "
                     "base fallback disabled for this table.",
                     self._file_name,
@@ -462,7 +462,7 @@ class _LazyNegRules(dict):  # type: ignore[type-arg]
             if self._set_error_on_missing:
                 self[EG_RULE_ERROR_KEY] = "negative_rule_file_not_found"
                 self[EG_RULE_DEBUG_DETAILS_KEY] = str(self._rule_file)
-                logger.warning(f"Negative rule file not found: {self._rule_file}")
+                logger.debug(f"Negative rule file not found: {self._rule_file}")
             else:
                 logger.debug(f"Negative rule file not found: {self._rule_file}")
             return
@@ -916,7 +916,7 @@ def get_query_conditions_for_node(
                 conditions[column_name] = None
                 conditions[f"{column_name}_is_none"] = True
             else:
-                logger.warning(
+                logger.debug(
                     "Node %s (name: %s): required attribute '%s' missing and has no default",
                     node.op_type,
                     node.name,
@@ -1003,7 +1003,7 @@ def get_query_conditions_for_node(
             if input_name in optional_input_names:
                 # Mark as optional/undefined - is_constant is True
                 # since the value is known (None/not provided)
-                logger.warning(
+                logger.debug(
                     "Node %s (name: %s): input '%s' is optional"
                     " and not provided, setting value to None",
                     node.op_type,
@@ -1259,7 +1259,7 @@ class RuntimeCheckerQuery:
                 )
         except Exception as e:
             # If standard shape inference fails, use original model
-            logger.warning(f"Shape inference failed: {e}. Using original model.")
+            logger.debug(f"Shape inference failed: {e}. Using original model.")
             self.model_proto = model_proto
 
         self.ep_name = ep_name
@@ -1671,7 +1671,7 @@ class RuntimeCheckerQuery:
             model = self._build_single_node_model(node, op_domain, opset_version)
             input_feed = self._generate_node_inputs(node)
         except Exception as e:
-            logger.warning(
+            logger.debug(
                 "Failed to build single-node model for local EP check on %s (%s): %s",
                 node.name,
                 node.op_type,

--- a/src/winml/modelkit/analyze/core/runtime_checker_query.py
+++ b/src/winml/modelkit/analyze/core/runtime_checker_query.py
@@ -25,6 +25,7 @@ from ...onnx import (
     infer_onnx_shapes,
     remove_optional_from_type_annotation,
 )
+from ...onnx.external_data import try_load_external_initializer_array
 from ...pattern.base import (
     get_pattern_input_generator,
     get_registered_pattern_input_generators,
@@ -629,103 +630,6 @@ def _normalize_type_var_annotation(type_value: str) -> str:
         return SupportedONNXType.from_onnx_type(type_value).annotation
     except ValueError:
         return SupportedONNXType.normalize_annotation(type_value)
-
-
-# Query conditions are later normalized with make_hashable, which materializes
-# numpy arrays. Keep external initializer loading bounded until the broader
-# condition pipeline can stay lazy end-to-end.
-MAX_EXTERNAL_INITIALIZER_BYTES_FOR_QUERY = 1024 * 1024
-
-
-def _get_external_tensor_info(tensor: onnx.TensorProto) -> tuple[str | None, int, int | None]:
-    """Extract location, offset, and length metadata for an external tensor."""
-    info = {entry.key: entry.value for entry in tensor.external_data}
-    location = info.get("location")
-    offset = int(info.get("offset", "0"))
-    length = int(info["length"]) if "length" in info else None
-    return location, offset, length
-
-
-def _tensor_proto_dtype_to_np_dtype(tensor_type: int) -> np.dtype[Any]:
-    """Convert a TensorProto dtype enum to a numpy dtype."""
-    try:
-        from onnx.helper import tensor_dtype_to_np_dtype as onnx_tensor_dtype_to_np_dtype
-    except ImportError:
-        from onnx.mapping import TENSOR_TYPE_TO_NP_TYPE
-
-        return np.dtype(TENSOR_TYPE_TO_NP_TYPE[tensor_type])
-
-    return np.dtype(onnx_tensor_dtype_to_np_dtype(tensor_type))
-
-
-def try_load_external_initializer_array(
-    tensor: onnx.TensorProto,
-    model_path: str | Path | None,
-) -> np.ndarray | None:
-    """Load a small external initializer from disk for runtime-query conditions.
-
-    Returns None when the model path is unavailable, metadata is incomplete,
-    the sidecar file is missing, or the tensor is too large for the current
-    hash-based condition pipeline.
-    """
-    if tensor.data_location != onnx.TensorProto.EXTERNAL or model_path is None:
-        return None
-
-    location, offset, length = _get_external_tensor_info(tensor)
-    if location is None:
-        return None
-
-    model_path = Path(model_path)
-    data_path = Path(location)
-    if not data_path.is_absolute():
-        data_path = model_path.parent / data_path
-    if not data_path.exists():
-        return None
-
-    try:
-        np_dtype = _tensor_proto_dtype_to_np_dtype(tensor.data_type)
-        shape = tuple(tensor.dims)
-        numel = int(np.prod(shape)) if shape else 1
-        expected_bytes = numel * np_dtype.itemsize
-        if length is not None and length < expected_bytes:
-            logger.debug(
-                "External initializer %s length %s is smaller than expected %s",
-                tensor.name,
-                length,
-                expected_bytes,
-            )
-            return None
-        if expected_bytes > MAX_EXTERNAL_INITIALIZER_BYTES_FOR_QUERY:
-            logger.debug(
-                "Skipping external initializer %s for query conditions because %s bytes exceeds %s",
-                tensor.name,
-                expected_bytes,
-                MAX_EXTERNAL_INITIALIZER_BYTES_FOR_QUERY,
-            )
-            return None
-
-        with data_path.open("rb") as f:
-            f.seek(offset)
-            arr = np.fromfile(f, dtype=np_dtype, count=numel)
-
-        if arr.size != numel:
-            logger.debug(
-                "External initializer %s only yielded %s elements, expected %s",
-                tensor.name,
-                arr.size,
-                numel,
-            )
-            return None
-
-        return arr.reshape(shape)
-    except Exception as e:
-        logger.debug(
-            "Failed to read external initializer %s from %s: %s",
-            tensor.name,
-            data_path,
-            e,
-        )
-        return None
 
 
 def _get_pattern_type_var_conditions(

--- a/src/winml/modelkit/analyze/core/runtime_checker_query.py
+++ b/src/winml/modelkit/analyze/core/runtime_checker_query.py
@@ -658,7 +658,7 @@ def _tensor_proto_dtype_to_np_dtype(tensor_type: int) -> np.dtype[Any]:
     return np.dtype(onnx_tensor_dtype_to_np_dtype(tensor_type))
 
 
-def _try_load_external_initializer_array(
+def try_load_external_initializer_array(
     tensor: onnx.TensorProto,
     model_path: str | Path | None,
 ) -> np.ndarray | None:
@@ -1032,7 +1032,7 @@ def get_query_conditions_for_node(
             # the relevant signal for whether bytes were loaded into this proto.
             external_arr = None
             if init.data_location == onnx.TensorProto.EXTERNAL and not init.raw_data:
-                external_arr = _try_load_external_initializer_array(init, model_path)
+                external_arr = try_load_external_initializer_array(init, model_path)
 
                 if external_arr is not None:
                     update_conditions_(

--- a/src/winml/modelkit/commands/compile.py
+++ b/src/winml/modelkit/commands/compile.py
@@ -45,6 +45,13 @@ console = Console()
     help="Input ONNX model file (required unless --list)",
 )
 @click.option(
+    "--output",
+    "-o",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Output file path (e.g., model_compiled.onnx)",
+)
+@click.option(
     "--output-dir",
     type=click.Path(path_type=Path),
     default=None,
@@ -111,6 +118,7 @@ console = Console()
 def compile(
     ctx: click.Context,
     model: Path | None,
+    output: Path | None,
     output_dir: Path | None,
     device: str,
     ep: str | None,
@@ -218,12 +226,16 @@ def compile(
     console.print(f"[bold blue]Compiler:[/bold blue] {compiler}")
     if qnn_sdk_root:
         console.print(f"[bold blue]SDK root:[/bold blue] {qnn_sdk_root}")
-    if output_dir:
+    # Resolve output path: -o (file) takes precedence over --output-dir
+    resolved_output = output or output_dir
+    if output:
+        console.print(f"[bold blue]Output:[/bold blue] {output}")
+    elif output_dir:
         console.print(f"[bold blue]Output dir:[/bold blue] {output_dir}")
 
     try:
         console.print("\n[bold]Compiling model...[/bold]")
-        result = compile_onnx(model, output_path=output_dir, config=config)
+        result = compile_onnx(model, output_path=resolved_output, config=config)
 
         if result.success:
             if config.ep_config.enable_ep_context and not result.output_path:

--- a/src/winml/modelkit/compiler/stages/compile.py
+++ b/src/winml/modelkit/compiler/stages/compile.py
@@ -223,10 +223,15 @@ class CompileStage(BaseStage):
             context.add_warning("EPContext model not found in work directory")
             return
 
-        # Determine final output filename using original model name
-        original_stem = context.model_path.stem
-        final_ctx_name = f"{original_stem}_{device}_ctx.onnx"
-        final_ctx_path = output_dir / final_ctx_name
+        # Determine final output filename
+        # If user specified a file path (has .onnx suffix), use it as-is
+        user_output = context.config.get("output_path")
+        if user_output and Path(user_output).suffix:
+            final_ctx_path = Path(user_output)
+        else:
+            original_stem = context.model_path.stem
+            final_ctx_name = f"{original_stem}_{device}_ctx.onnx"
+            final_ctx_path = output_dir / final_ctx_name
 
         # Ensure output directory exists
         output_dir.mkdir(parents=True, exist_ok=True)
@@ -245,7 +250,8 @@ class CompileStage(BaseStage):
         final_bin_name = None
         for f in src_ctx_path.parent.iterdir():
             if f.name.startswith(src_ctx_path.stem) and f.suffix == ".bin":
-                final_bin_name = f"{original_stem}_{device}_ctx{f.name[len(src_ctx_path.stem) :]}"
+                bin_suffix = f.name[len(src_ctx_path.stem) :]
+                final_bin_name = f"{final_ctx_path.stem}{bin_suffix}"
                 final_bin_path = output_dir / final_bin_name
                 if f != final_bin_path:
                     shutil.copy2(f, final_bin_path)

--- a/src/winml/modelkit/onnx/external_data.py
+++ b/src/winml/modelkit/onnx/external_data.py
@@ -23,7 +23,6 @@ from typing import Any
 
 import numpy as np
 import onnx
-from onnx import external_data_helper
 
 from .persistence import load_onnx, save_onnx
 
@@ -48,13 +47,9 @@ def _get_external_tensor_info(tensor: onnx.TensorProto) -> tuple[str | None, int
 def _tensor_proto_dtype_to_np_dtype(tensor_type: int) -> np.dtype[Any]:
     """Convert a TensorProto dtype enum to a numpy dtype."""
     try:
-        from onnx.helper import tensor_dtype_to_np_dtype as onnx_tensor_dtype_to_np_dtype
+        return np.dtype(onnx.helper.tensor_dtype_to_np_dtype(tensor_type))
     except ImportError:
-        from onnx.mapping import TENSOR_TYPE_TO_NP_TYPE
-
-        return np.dtype(TENSOR_TYPE_TO_NP_TYPE[tensor_type])
-
-    return np.dtype(onnx_tensor_dtype_to_np_dtype(tensor_type))
+        return np.dtype(onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[tensor_type])
 
 
 def try_load_external_initializer_array(
@@ -141,10 +136,10 @@ def get_external_data_files(model_path: str | Path) -> list[str]:
     """
     file_names: set[str] = set()
     model = load_onnx(model_path, load_weights=False, validate=False)
-    for tensor in external_data_helper._get_all_tensors(model):
-        if external_data_helper.uses_external_data(tensor):
+    for tensor in onnx.external_data_helper._get_all_tensors(model):
+        if onnx.external_data_helper.uses_external_data(tensor):
             file_names.add(
-                external_data_helper.ExternalDataInfo(tensor).location,
+                onnx.external_data_helper.ExternalDataInfo(tensor).location,
             )
     return sorted(file_names)
 

--- a/src/winml/modelkit/onnx/external_data.py
+++ b/src/winml/modelkit/onnx/external_data.py
@@ -19,13 +19,112 @@ from __future__ import annotations
 import logging
 import shutil
 from pathlib import Path
+from typing import Any
 
+import numpy as np
+import onnx
 from onnx import external_data_helper
 
 from .persistence import load_onnx, save_onnx
 
 
 logger = logging.getLogger(__name__)
+
+
+# Pattern matching and runtime-query helpers later materialize numpy arrays.
+# Keep external initializer loading bounded until those pipelines stay lazy.
+MAX_EXTERNAL_INITIALIZER_BYTES_FOR_QUERY = 1024 * 1024
+
+
+def _get_external_tensor_info(tensor: onnx.TensorProto) -> tuple[str | None, int, int | None]:
+    """Extract location, offset, and length metadata for an external tensor."""
+    info = {entry.key: entry.value for entry in tensor.external_data}
+    location = info.get("location")
+    offset = int(info.get("offset", "0"))
+    length = int(info["length"]) if "length" in info else None
+    return location, offset, length
+
+
+def _tensor_proto_dtype_to_np_dtype(tensor_type: int) -> np.dtype[Any]:
+    """Convert a TensorProto dtype enum to a numpy dtype."""
+    try:
+        from onnx.helper import tensor_dtype_to_np_dtype as onnx_tensor_dtype_to_np_dtype
+    except ImportError:
+        from onnx.mapping import TENSOR_TYPE_TO_NP_TYPE
+
+        return np.dtype(TENSOR_TYPE_TO_NP_TYPE[tensor_type])
+
+    return np.dtype(onnx_tensor_dtype_to_np_dtype(tensor_type))
+
+
+def try_load_external_initializer_array(
+    tensor: onnx.TensorProto,
+    model_path: str | Path | None,
+) -> np.ndarray | None:
+    """Load a small external initializer from disk.
+
+    Returns None when the model path is unavailable, metadata is incomplete,
+    the sidecar file is missing, or the tensor is too large for the current
+    value-materialization pipeline.
+    """
+    if tensor.data_location != onnx.TensorProto.EXTERNAL or model_path is None:
+        return None
+
+    location, offset, length = _get_external_tensor_info(tensor)
+    if location is None:
+        return None
+
+    model_path = Path(model_path)
+    data_path = Path(location)
+    if not data_path.is_absolute():
+        data_path = model_path.parent / data_path
+    if not data_path.exists():
+        return None
+
+    try:
+        np_dtype = _tensor_proto_dtype_to_np_dtype(tensor.data_type)
+        shape = tuple(tensor.dims)
+        numel = int(np.prod(shape)) if shape else 1
+        expected_bytes = numel * np_dtype.itemsize
+        if length is not None and length < expected_bytes:
+            logger.debug(
+                "External initializer %s length %s is smaller than expected %s",
+                tensor.name,
+                length,
+                expected_bytes,
+            )
+            return None
+        if expected_bytes > MAX_EXTERNAL_INITIALIZER_BYTES_FOR_QUERY:
+            logger.debug(
+                "Skipping external initializer %s because %s bytes exceeds %s",
+                tensor.name,
+                expected_bytes,
+                MAX_EXTERNAL_INITIALIZER_BYTES_FOR_QUERY,
+            )
+            return None
+
+        with data_path.open("rb") as f:
+            f.seek(offset)
+            arr = np.fromfile(f, dtype=np_dtype, count=numel)
+
+        if arr.size != numel:
+            logger.debug(
+                "External initializer %s only yielded %s elements, expected %s",
+                tensor.name,
+                arr.size,
+                numel,
+            )
+            return None
+
+        return arr.reshape(shape)
+    except Exception as e:
+        logger.debug(
+            "Failed to read external initializer %s from %s: %s",
+            tensor.name,
+            data_path,
+            e,
+        )
+        return None
 
 
 def get_external_data_files(model_path: str | Path) -> list[str]:
@@ -95,12 +194,16 @@ def copy_onnx_model(
 
     logger.debug(
         "Copied ONNX model with external data: %s -> %s (%d data files)",
-        src.name, dst.name, len(external_files),
+        src.name,
+        dst.name,
+        len(external_files),
     )
 
 
 def _copy_single_external(
-    src: Path, dst: Path, data_filename: str,
+    src: Path,
+    dst: Path,
+    data_filename: str,
 ) -> None:
     """Copy model with a single external data file efficiently.
 
@@ -132,6 +235,7 @@ def _copy_single_external(
     # has_existing_external check would force re-externalization on a
     # graph-only model (no loaded weights), corrupting the output.
     import onnx
+
     onnx.save_model(model, str(dst))
 
 

--- a/src/winml/modelkit/onnx/external_data.py
+++ b/src/winml/modelkit/onnx/external_data.py
@@ -23,6 +23,7 @@ from typing import Any
 
 import numpy as np
 import onnx
+from onnx import external_data_helper
 
 from .persistence import load_onnx, save_onnx
 
@@ -47,9 +48,13 @@ def _get_external_tensor_info(tensor: onnx.TensorProto) -> tuple[str | None, int
 def _tensor_proto_dtype_to_np_dtype(tensor_type: int) -> np.dtype[Any]:
     """Convert a TensorProto dtype enum to a numpy dtype."""
     try:
-        return np.dtype(onnx.helper.tensor_dtype_to_np_dtype(tensor_type))
+        from onnx.helper import tensor_dtype_to_np_dtype as onnx_tensor_dtype_to_np_dtype
     except ImportError:
-        return np.dtype(onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[tensor_type])
+        from onnx.mapping import TENSOR_TYPE_TO_NP_TYPE
+
+        return np.dtype(TENSOR_TYPE_TO_NP_TYPE[tensor_type])
+
+    return np.dtype(onnx_tensor_dtype_to_np_dtype(tensor_type))
 
 
 def try_load_external_initializer_array(
@@ -136,10 +141,10 @@ def get_external_data_files(model_path: str | Path) -> list[str]:
     """
     file_names: set[str] = set()
     model = load_onnx(model_path, load_weights=False, validate=False)
-    for tensor in onnx.external_data_helper._get_all_tensors(model):
-        if onnx.external_data_helper.uses_external_data(tensor):
+    for tensor in external_data_helper._get_all_tensors(model):
+        if external_data_helper.uses_external_data(tensor):
             file_names.add(
-                onnx.external_data_helper.ExternalDataInfo(tensor).location,
+                external_data_helper.ExternalDataInfo(tensor).location,
             )
     return sorted(file_names)
 

--- a/src/winml/modelkit/pattern/base.py
+++ b/src/winml/modelkit/pattern/base.py
@@ -1257,10 +1257,7 @@ class PatternMatcher:
             try:
                 check_onnx_model(self.model)
             except onnx.checker.ValidationError as e:
-                raise InvalidPatternMatcherModelError(
-                    f"Model failed ONNX validation: {e}",
-                    error_tag=_MODEL_TAG_INVALID_PATTERN_MATCHER_MODEL,
-                ) from e
+                logger.debug("Model failed ONNX checker validation (non-fatal): %s", e)
             # Warn about nodes with empty names; they get auto-generated names
             # (node_{idx}) in _build_lookups and are added to all lookup structures,
             # so pattern matching proceeds normally via tensor connectivity.
@@ -1320,7 +1317,15 @@ class PatternMatcher:
         for initializer in self.graph.initializer:
             self.producer_lookup.setdefault(initializer.name, (initializer.name, 0, "Initializer"))
             if initializer.name:
-                self.tensor_values[initializer.name] = numpy_helper.to_array(initializer)
+                try:
+                    self.tensor_values[initializer.name] = numpy_helper.to_array(initializer)
+                except Exception:
+                    # External data not loaded — skip tensor value extraction.
+                    # Pattern matching still works via graph topology; only
+                    # value-based constraint checks will be skipped for this tensor.
+                    logger.debug(
+                        "Skipping tensor value for '%s': external data not loaded", initializer.name
+                    )
 
         for node_idx, node in enumerate(self.graph.node):
             node_name = node.name or f"node_{node_idx}"
@@ -1335,9 +1340,15 @@ class PatternMatcher:
                         tensor_proto = attr.t
                         for output_name in node.output:
                             if output_name:
-                                self.tensor_values[output_name] = numpy_helper.to_array(
-                                    tensor_proto
-                                )
+                                try:
+                                    self.tensor_values[output_name] = numpy_helper.to_array(
+                                        tensor_proto
+                                    )
+                                except Exception:
+                                    logger.debug(
+                                        "Skipping constant '%s': external data not loaded",
+                                        output_name,
+                                    )
                                 # Add shape and type for constant
                                 self.tensor_shapes[output_name] = tuple(tensor_proto.dims)
                                 self.tensor_types[output_name] = self._elem_type_to_str(

--- a/src/winml/modelkit/pattern/base.py
+++ b/src/winml/modelkit/pattern/base.py
@@ -177,6 +177,7 @@ from onnx import ModelProto, numpy_helper
 from onnx.defs import OpSchema
 
 from ..onnx import ONNXDomain, SupportedONNXType, check_onnx_model, infer_onnx_shapes
+from ..onnx.external_data import try_load_external_initializer_array
 from .match import InputInfo, PatternMatchResult, SkeletonMatchResult
 from .op_input_gen import InputShapeConstraint
 from .op_input_gen.op_input_gen import OpInputGenerator
@@ -1332,13 +1333,6 @@ class PatternMatcher:
             if not initializer.name:
                 continue
             if initializer.data_location == onnx.TensorProto.EXTERNAL and not initializer.raw_data:
-                # External data not loaded — try resolving the sidecar file lazily
-                # via the runtime-checker query helper. Lazy import avoids the
-                # circular dependency between pattern.base and analyze.core.
-                from ..analyze.core.runtime_checker_query import (
-                    try_load_external_initializer_array,
-                )
-
                 external_arr = try_load_external_initializer_array(initializer, self.model_path)
                 if external_arr is not None:
                     self.tensor_values[initializer.name] = external_arr

--- a/src/winml/modelkit/pattern/base.py
+++ b/src/winml/modelkit/pattern/base.py
@@ -1332,17 +1332,11 @@ class PatternMatcher:
             if not initializer.name:
                 continue
             if initializer.data_location == onnx.TensorProto.EXTERNAL and not initializer.raw_data:
-                # External data not loaded — try resolving the sidecar file lazily
-                # via the runtime-checker query helper. Lazy import avoids the
-                # circular dependency between pattern.base and analyze.core.
-                from ..analyze.core.runtime_checker_query import (
-                    try_load_external_initializer_array,
-                )
-
-                external_arr = try_load_external_initializer_array(initializer, self.model_path)
-                if external_arr is not None:
-                    self.tensor_values[initializer.name] = external_arr
-                else:
+                try:
+                    if self.model_path is not None:
+                        onnx.load_external_data_for_tensor(initializer, str(self.model_path.parent))
+                    self.tensor_values[initializer.name] = numpy_helper.to_array(initializer)
+                except Exception:
                     # Pattern matching still works via graph topology; only
                     # value-based constraint checks will be skipped for this tensor.
                     logger.debug(

--- a/src/winml/modelkit/pattern/base.py
+++ b/src/winml/modelkit/pattern/base.py
@@ -168,6 +168,7 @@ import logging
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -1207,7 +1208,12 @@ class PatternMatcher:
     results = matcher.match()  # Returns list[PatternMatchResult]
     """
 
-    def __init__(self, onnx_model: ModelProto, raise_on_invalid_model: bool = True) -> None:
+    def __init__(
+        self,
+        onnx_model: ModelProto,
+        raise_on_invalid_model: bool = True,
+        model_path: str | Path | None = None,
+    ) -> None:
         """Initialize the pattern matcher with an ONNX model.
 
         This performs shape inference and builds all lookup dictionaries upfront
@@ -1215,12 +1221,19 @@ class PatternMatcher:
 
         Args:
             onnx_model: The ONNX model to search for patterns in.
+            raise_on_invalid_model: Whether to validate the model and log issues.
+            model_path: Optional path to the source ONNX model on disk. When provided,
+                external-data initializers whose payloads are not loaded into the
+                proto will be lazily resolved from sidecar files (subject to the
+                size limits in the runtime-checker query helper) so that
+                value-based pattern constraints can still be evaluated.
         """
         # Run shape inference to populate value_info with type information
         # This is critical for type inference and shape lookups
 
         self.model = infer_onnx_shapes(onnx_model)
         self.graph = self.model.graph
+        self.model_path = Path(model_path) if model_path is not None else None
 
         # Registered patterns: pattern class name -> pattern instance
         self.patterns: dict[str, Pattern] = {}
@@ -1316,16 +1329,28 @@ class PatternMatcher:
         # Build tensor values from initializers
         for initializer in self.graph.initializer:
             self.producer_lookup.setdefault(initializer.name, (initializer.name, 0, "Initializer"))
-            if initializer.name:
-                try:
-                    self.tensor_values[initializer.name] = numpy_helper.to_array(initializer)
-                except Exception:
-                    # External data not loaded — skip tensor value extraction.
+            if not initializer.name:
+                continue
+            if initializer.data_location == onnx.TensorProto.EXTERNAL and not initializer.raw_data:
+                # External data not loaded — try resolving the sidecar file lazily
+                # via the runtime-checker query helper. Lazy import avoids the
+                # circular dependency between pattern.base and analyze.core.
+                from ..analyze.core.runtime_checker_query import (
+                    try_load_external_initializer_array,
+                )
+
+                external_arr = try_load_external_initializer_array(initializer, self.model_path)
+                if external_arr is not None:
+                    self.tensor_values[initializer.name] = external_arr
+                else:
                     # Pattern matching still works via graph topology; only
                     # value-based constraint checks will be skipped for this tensor.
                     logger.debug(
-                        "Skipping tensor value for '%s': external data not loaded", initializer.name
+                        "Skipping tensor value for '%s': external data not loaded",
+                        initializer.name,
                     )
+            else:
+                self.tensor_values[initializer.name] = numpy_helper.to_array(initializer)
 
         for node_idx, node in enumerate(self.graph.node):
             node_name = node.name or f"node_{node_idx}"
@@ -1340,15 +1365,9 @@ class PatternMatcher:
                         tensor_proto = attr.t
                         for output_name in node.output:
                             if output_name:
-                                try:
-                                    self.tensor_values[output_name] = numpy_helper.to_array(
-                                        tensor_proto
-                                    )
-                                except Exception:
-                                    logger.debug(
-                                        "Skipping constant '%s': external data not loaded",
-                                        output_name,
-                                    )
+                                self.tensor_values[output_name] = numpy_helper.to_array(
+                                    tensor_proto
+                                )
                                 # Add shape and type for constant
                                 self.tensor_shapes[output_name] = tuple(tensor_proto.dims)
                                 self.tensor_types[output_name] = self._elem_type_to_str(

--- a/src/winml/modelkit/pattern/rules/default.json
+++ b/src/winml/modelkit/pattern/rules/default.json
@@ -22,7 +22,7 @@
       "description": "GELU activation using Erf approximation - Variant 1",
       "alternatives": [
         {
-          "pattern_to_id": "SUBGRAPH/GeluPattern",
+          "pattern_to_id": "SUBGRAPH/SingleGeluPattern",
           "pattern_class": "SingleGeluPattern",
           "module": "winml.modelkit.pattern.gelu_patterns",
           "priority": 1,
@@ -40,7 +40,7 @@
       "description": "GELU activation using Erf approximation - Variant 2",
       "alternatives": [
         {
-          "pattern_to_id": "SUBGRAPH/GeluPattern",
+          "pattern_to_id": "SUBGRAPH/SingleGeluPattern",
           "pattern_class": "SingleGeluPattern",
           "module": "winml.modelkit.pattern.gelu_patterns",
           "priority": 1,
@@ -58,7 +58,7 @@
       "description": "GELU activation using Erf approximation - Variant 3",
       "alternatives": [
         {
-          "pattern_to_id": "SUBGRAPH/GeluPattern",
+          "pattern_to_id": "SUBGRAPH/SingleGeluPattern",
           "pattern_class": "SingleGeluPattern",
           "module": "winml.modelkit.pattern.gelu_patterns",
           "priority": 1,
@@ -76,7 +76,7 @@
       "description": "GELU activation using Mul instead of Div - Variant 4",
       "alternatives": [
         {
-          "pattern_to_id": "SUBGRAPH/GeluPattern",
+          "pattern_to_id": "SUBGRAPH/SingleGeluPattern",
           "pattern_class": "SingleGeluPattern",
           "module": "winml.modelkit.pattern.gelu_patterns",
           "priority": 1,
@@ -94,7 +94,7 @@
       "description": "MatMul followed by Add (bias)",
       "alternatives": [
         {
-          "pattern_to_id": "SUBGRAPH/GemmPattern",
+          "pattern_to_id": "SUBGRAPH/ReshapeGemmReshapePattern",
           "pattern_class": "ReshapeGemmReshapePattern",
           "module": "winml.modelkit.pattern.gemm_patterns",
           "priority": 1,
@@ -102,7 +102,7 @@
           "reason": "Use Gemm operator outperforms MatMul+Add"
         },
         {
-          "pattern_to_id": "SUBGRAPH/GemmPattern",
+          "pattern_to_id": "SUBGRAPH/Conv2DInplaceLinear4DPattern",
           "pattern_class": "Conv2DInplaceLinear4DPattern",
           "module": "winml.modelkit.pattern.conv2d_inplace_linear_patterns",
           "priority": 2,
@@ -110,7 +110,7 @@
           "reason": "Use 1x1 Conv2D for Qualcomm NPU acceleration (4D NHWC inputs)"
         },
         {
-          "pattern_to_id": "SUBGRAPH/GemmPattern",
+          "pattern_to_id": "SUBGRAPH/Conv2DInplaceLinear3DPattern",
           "pattern_class": "Conv2DInplaceLinear3DPattern",
           "module": "winml.modelkit.pattern.conv2d_inplace_linear_patterns",
           "priority": 2,
@@ -118,7 +118,7 @@
           "reason": "Use 1x1 Conv2D for Qualcomm NPU acceleration (3D sequence inputs)"
         },
         {
-          "pattern_to_id": "SUBGRAPH/GemmPattern",
+          "pattern_to_id": "SUBGRAPH/Conv2DInplaceLinear2DPattern",
           "pattern_class": "Conv2DInplaceLinear2DPattern",
           "module": "winml.modelkit.pattern.conv2d_inplace_linear_patterns",
           "priority": 2,

--- a/tests/unit/analyze/core/test_runtime_checker_query_helpers.py
+++ b/tests/unit/analyze/core/test_runtime_checker_query_helpers.py
@@ -16,9 +16,9 @@ from winml.modelkit.analyze.core import runtime_checker_query as runtime_checker
 from winml.modelkit.analyze.core.runtime_checker_query import (
     RuntimeCheckerQuery,
     _build_table_filter_conditions,
-    _try_load_external_initializer_array,
     get_query_conditions_for_node,
     node_to_pattern_match,
+    try_load_external_initializer_array,
 )
 from winml.modelkit.analyze.exceptions import OpOptionalInputSupportError
 from winml.modelkit.analyze.utils.model_utils import DUMMY_FLOAT
@@ -210,7 +210,7 @@ class TestGetQueryConditionsForNode:
         )
         graph_only_model = onnx.load(str(model_path), load_external_data=False)
 
-        loaded = _try_load_external_initializer_array(
+        loaded = try_load_external_initializer_array(
             graph_only_model.graph.initializer[0],
             model_path,
         )

--- a/tests/unit/analyze/core/test_unified_pattern_config.py
+++ b/tests/unit/analyze/core/test_unified_pattern_config.py
@@ -65,7 +65,7 @@ class TestUnifiedPatternConfig:
 
         alt = alternatives[0]
         assert isinstance(alt, PatternAlternative)
-        assert alt.pattern_to_id == "SUBGRAPH/GeluPattern"
+        assert alt.pattern_to_id == "SUBGRAPH/SingleGeluPattern"
         assert alt.pattern_class == "SingleGeluPattern"
         assert alt.module == "winml.modelkit.pattern.gelu_patterns"
         assert alt.priority == 1
@@ -88,9 +88,36 @@ class TestUnifiedPatternConfig:
 
         # Verify the alternative
         alt = alternatives[0]
-        assert alt.pattern_to_id == "SUBGRAPH/GeluPattern"
+        assert alt.pattern_to_id == "SUBGRAPH/SingleGeluPattern"
         assert alt.pattern_class == "SingleGeluPattern"
         assert alt.module == "winml.modelkit.pattern.gelu_patterns"
+
+    def test_gemm_alternatives_have_distinct_pattern_to_id(self):
+        """Test that GemmPattern alternatives use distinct pattern_to_id values.
+
+        Before the fix, all alternatives had pattern_to_id == "SUBGRAPH/GemmPattern"
+        (same as the source), causing information engine lookup failures.
+        """
+        config = UnifiedPatternConfig()
+        patterns = config.get_skeleton_patterns()
+
+        matmuladd_pattern = next(
+            (p for p in patterns if p.__class__.__name__ == "MatMulAddPattern"), None
+        )
+        assert matmuladd_pattern is not None, "MatMulAddPattern not found"
+
+        alternatives = config.get_alternatives(matmuladd_pattern)
+        assert len(alternatives) == 4
+
+        # Each alternative should have a unique pattern_to_id matching its class
+        expected_ids = {
+            "SUBGRAPH/ReshapeGemmReshapePattern",
+            "SUBGRAPH/Conv2DInplaceLinear4DPattern",
+            "SUBGRAPH/Conv2DInplaceLinear3DPattern",
+            "SUBGRAPH/Conv2DInplaceLinear2DPattern",
+        }
+        actual_ids = {alt.pattern_to_id for alt in alternatives}
+        assert actual_ids == expected_ids
 
     def test_alternatives_sorted_by_priority(self):
         """Test that alternatives are sorted by priority (highest first)."""
@@ -152,7 +179,7 @@ class TestUnifiedPatternConfig:
         assert isinstance(alt, PatternAlternative)
 
         # Verify the new fields are present
-        assert alt.pattern_to_id == "SUBGRAPH/GeluPattern"
+        assert alt.pattern_to_id == "SUBGRAPH/SingleGeluPattern"
         assert alt.pattern_class == "SingleGeluPattern"
         assert alt.module == "winml.modelkit.pattern.gelu_patterns"
         assert alt.priority == 1

--- a/tests/unit/analyze/pattern/test_make_hashable.py
+++ b/tests/unit/analyze/pattern/test_make_hashable.py
@@ -1,0 +1,63 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Tests for make_hashable with numpy.ndarray support."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from winml.modelkit.pattern.utils import make_hashable
+
+
+class TestMakeHashableNumpyArray:
+    """Tests for numpy.ndarray handling in make_hashable."""
+
+    def test_1d_array_becomes_hashable_tuple(self):
+        """A 1-D numpy array should be converted to a tuple."""
+        arr = np.array([1, 2, 3])
+        result = make_hashable(arr)
+        assert isinstance(result, tuple)
+        assert result == (1, 2, 3)
+
+    def test_array_can_be_used_in_set(self):
+        """Converted arrays should be usable as set elements (hashable)."""
+        a = make_hashable(np.array([1, 2]))
+        b = make_hashable(np.array([3, 4]))
+        c = make_hashable(np.array([1, 2]))
+        s = {a, b, c}
+        assert len(s) == 2
+
+    def test_array_can_be_used_as_dict_key(self):
+        """Converted arrays should be usable as dict keys."""
+        key = make_hashable(np.array([10, 20]))
+        d = {key: "value"}
+        assert d[key] == "value"
+
+    def test_float_array_replaces_with_dummy(self):
+        """Float elements in arrays should follow replace_float_with_dummy."""
+        arr = np.array([1.5, 2.5])
+        result = make_hashable(arr, replace_float_with_dummy=True)
+        from winml.modelkit.pattern.utils import DUMMY_FLOAT
+
+        assert all(v == DUMMY_FLOAT for v in result)
+
+    def test_float_array_preserves_values_when_no_replace(self):
+        """Float elements should be preserved when replace_float_with_dummy=False."""
+        arr = np.array([1.5, 2.5])
+        result = make_hashable(arr, replace_float_with_dummy=False)
+        assert result == (1.5, 2.5)
+
+    def test_nested_list_containing_array(self):
+        """A list containing a numpy array should recursively convert."""
+        nested = [np.array([1, 2]), "hello"]
+        result = make_hashable(nested)
+        assert isinstance(result, tuple)
+        assert result[0] == (1, 2)
+        assert result[1] == "hello"
+
+    def test_empty_array(self):
+        """An empty numpy array should become an empty tuple."""
+        result = make_hashable(np.array([]))
+        assert result == ()

--- a/tests/unit/analyze/pattern/test_pattern_matcher_robustness.py
+++ b/tests/unit/analyze/pattern/test_pattern_matcher_robustness.py
@@ -7,13 +7,12 @@
 from __future__ import annotations
 
 import numpy as np
-import onnx
-from onnx import TensorProto, helper, numpy_helper
+from onnx import ModelProto, TensorProto, helper, load, numpy_helper, save
 
 from winml.modelkit.pattern.base import PatternMatcher
 
 
-def _make_simple_model() -> onnx.ModelProto:
+def _make_simple_model() -> ModelProto:
     """Create a minimal valid ONNX model."""
     x = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 4])
     y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 4])
@@ -67,7 +66,7 @@ class TestPatternMatcherExternalData:
         model.graph.initializer.append(w_tensor)
 
         model_path = tmp_path / "model.onnx"
-        onnx.save(
+        save(
             model,
             str(model_path),
             save_as_external_data=True,
@@ -76,7 +75,7 @@ class TestPatternMatcherExternalData:
         )
 
         # Reload without external data (simulates how analyzer loads)
-        model_no_ext = onnx.load(str(model_path), load_external_data=False)
+        model_no_ext = load(str(model_path), load_external_data=False)
 
         # Delete the external data file to simulate it being inaccessible
         (tmp_path / "model.onnx.data").unlink()

--- a/tests/unit/analyze/pattern/test_pattern_matcher_robustness.py
+++ b/tests/unit/analyze/pattern/test_pattern_matcher_robustness.py
@@ -1,0 +1,88 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Tests for PatternMatcher robustness against invalid/incomplete models."""
+
+from __future__ import annotations
+
+import numpy as np
+import onnx
+from onnx import TensorProto, helper, numpy_helper
+
+from winml.modelkit.pattern.base import PatternMatcher
+
+
+def _make_simple_model() -> onnx.ModelProto:
+    """Create a minimal valid ONNX model."""
+    x = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 4])
+    y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 4])
+    node = helper.make_node("Identity", ["X"], ["Y"], name="id0")
+    graph = helper.make_graph([node], "test", [x], [y])
+    return helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+
+
+class TestPatternMatcherOnnxValidationFailure:
+    """PatternMatcher should not abort when onnx.checker fails."""
+
+    def test_invalid_model_does_not_raise(self):
+        """A model that fails onnx.checker should still be matchable.
+
+        Before the fix, this raised InvalidPatternMatcherModelError.
+        """
+        # Build a model with an intentionally invalid node (unknown op in
+        # default domain, which onnx.checker rejects)
+        x = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 4])
+        y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 4])
+        node = helper.make_node("NotARealOp", ["X"], ["Y"], name="bad_node")
+        graph = helper.make_graph([node], "bad_graph", [x], [y])
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+
+        # Should NOT raise — validation failure is logged, not raised
+        matcher = PatternMatcher(model, raise_on_invalid_model=True)
+        assert "bad_node" in matcher.node_lookup
+
+
+class TestPatternMatcherExternalData:
+    """PatternMatcher should handle models with missing external data."""
+
+    def test_missing_external_data_does_not_raise(self, tmp_path):
+        """Initializer referencing a non-existent external file should not crash.
+
+        Before the fix, numpy_helper.to_array raised because the external
+        data file was missing.
+        """
+        # Create a model with an initializer that claims external data
+        x = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 4])
+        y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 4])
+        node = helper.make_node("Add", ["X", "W"], ["Y"], name="add0")
+        graph = helper.make_graph([node], "ext_data_graph", [x], [y])
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+
+        # Add an initializer with real data first, then save with external data.
+        # Use a large-enough tensor so ONNX actually externalizes it
+        # (small tensors may be kept inline).
+        w_array = np.ones([256, 256], dtype=np.float32)
+        w_tensor = numpy_helper.from_array(w_array, name="W")
+        model.graph.initializer.append(w_tensor)
+
+        model_path = tmp_path / "model.onnx"
+        onnx.save(
+            model,
+            str(model_path),
+            save_as_external_data=True,
+            all_tensors_to_one_file=True,
+            location="model.onnx.data",
+        )
+
+        # Reload without external data (simulates how analyzer loads)
+        model_no_ext = onnx.load(str(model_path), load_external_data=False)
+
+        # Delete the external data file to simulate it being inaccessible
+        (tmp_path / "model.onnx.data").unlink()
+
+        # Should NOT raise — missing external data is skipped gracefully
+        matcher = PatternMatcher(model_no_ext, raise_on_invalid_model=True)
+        assert "add0" in matcher.node_lookup
+        # The tensor value should not be populated (data is unavailable)
+        assert "W" not in matcher.tensor_values

--- a/tests/unit/compiler/test_compile_command.py
+++ b/tests/unit/compiler/test_compile_command.py
@@ -134,6 +134,89 @@ class TestCompileCommand:
         assert config.ep_config.compiler == "qairt"
         assert config.ep_config.qnn_sdk_root == sdk_root
 
+    def test_compile_help_shows_output_option(self, runner: CliRunner) -> None:
+        """Test compile --help shows -o/--output option."""
+        result = runner.invoke(main, ["compile", "--help"])
+        assert result.exit_code == 0
+        assert "--output" in result.output or "-o" in result.output
+
+    @patch("winml.modelkit.compiler.compile_onnx")
+    def test_compile_output_passes_file_path(
+        self,
+        mock_compile_onnx: MagicMock,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        """Test -o passes a file path to compile_onnx as output_path.
+
+        Before the fix, -o was not a recognized option and Click raised an error.
+        """
+        model_path = tmp_path / "model.onnx"
+        self._create_simple_onnx(model_path)
+        output_file = tmp_path / "compiled.onnx"
+
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.output_path = output_file
+        mock_result.compile_time = 1.0
+        mock_result.total_time = 1.5
+        mock_compile_onnx.return_value = mock_result
+
+        result = runner.invoke(
+            main,
+            [
+                "compile",
+                "-m",
+                str(model_path),
+                "-o",
+                str(output_file),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert mock_compile_onnx.called
+        # output_path should be the file path, not a directory
+        call_kwargs = mock_compile_onnx.call_args.kwargs
+        assert call_kwargs["output_path"] == output_file
+
+    @patch("winml.modelkit.compiler.compile_onnx")
+    def test_compile_output_takes_precedence_over_output_dir(
+        self,
+        mock_compile_onnx: MagicMock,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        """Test -o takes precedence over --output-dir when both are given."""
+        model_path = tmp_path / "model.onnx"
+        self._create_simple_onnx(model_path)
+        output_file = tmp_path / "compiled.onnx"
+        output_dir = tmp_path / "some_dir"
+
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.output_path = output_file
+        mock_result.compile_time = 1.0
+        mock_result.total_time = 1.5
+        mock_compile_onnx.return_value = mock_result
+
+        result = runner.invoke(
+            main,
+            [
+                "compile",
+                "-m",
+                str(model_path),
+                "-o",
+                str(output_file),
+                "--output-dir",
+                str(output_dir),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        # -o should win over --output-dir
+        call_kwargs = mock_compile_onnx.call_args.kwargs
+        assert call_kwargs["output_path"] == output_file
+
     def _create_simple_onnx(self, path: Path) -> None:
         """Create a simple ONNX model for testing."""
         import onnx

--- a/tests/unit/compiler/test_compiler_stages.py
+++ b/tests/unit/compiler/test_compiler_stages.py
@@ -473,6 +473,95 @@ class TestCompileStageFinalizeOutput:
         assert len(context.warnings) == 1
         assert "EPContext model not found" in context.warnings[0]
 
+    def test_finalize_output_respects_user_file_path(self, tmp_path):
+        """Test that -o file path is used as the final output filename.
+
+        Before the fix, _finalize_output always generated
+        '{original_stem}_{device}_ctx.onnx', ignoring the user-specified
+        output path.
+        """
+        from winml.modelkit.compiler import CompileContext, CompileStage
+
+        work_dir = tmp_path / "work"
+        output_dir = tmp_path / "output"
+        work_dir.mkdir()
+        output_dir.mkdir()
+
+        original_model_path = tmp_path / "mymodel.onnx"
+        create_simple_model(original_model_path)
+
+        # User wants: output/compiled.onnx (not output/mymodel_qnn_ctx.onnx)
+        user_output = output_dir / "compiled.onnx"
+
+        # Create EPContext in work_dir
+        ctx_path = work_dir / "model_to_compile_qnn_ctx.onnx"
+        create_epcontext_onnx(ctx_path, "model_to_compile_qnn_ctx.bin", embed_mode=1)
+
+        context = CompileContext(
+            model_path=original_model_path,
+            config={
+                "execution_provider": "qnn",
+                "output_path": str(user_output),
+            },
+            work_dir=work_dir,
+        )
+
+        stage = CompileStage()
+        stage._finalize_output(context, ctx_path.parent / "model_to_compile.onnx", output_dir)
+
+        # Should use the user-specified filename, not the auto-generated one
+        assert context.output_path == user_output
+        assert user_output.exists()
+        # The auto-generated name should NOT exist
+        auto_name = output_dir / "mymodel_qnn_ctx.onnx"
+        assert not auto_name.exists()
+
+    def test_finalize_output_bin_uses_user_stem(self, tmp_path):
+        """Test that .bin companion file uses the user-specified stem.
+
+        Before the fix, .bin was always named '{original_stem}_{device}_ctx.bin'
+        even when the user specified a custom output filename.
+        """
+        from winml.modelkit.compiler import CompileContext, CompileStage
+
+        work_dir = tmp_path / "work"
+        output_dir = tmp_path / "output"
+        work_dir.mkdir()
+        output_dir.mkdir()
+
+        original_model_path = tmp_path / "mymodel.onnx"
+        create_simple_model(original_model_path)
+
+        user_output = output_dir / "compiled.onnx"
+
+        # Create EPContext with external bin (embed_mode=0)
+        ctx_path = work_dir / "model_to_compile_qnn_ctx.onnx"
+        old_bin_name = "model_to_compile_qnn_ctx.bin"
+        create_epcontext_onnx(ctx_path, old_bin_name, embed_mode=0)
+
+        # Create the bin file
+        (work_dir / old_bin_name).write_bytes(b"fake binary")
+
+        context = CompileContext(
+            model_path=original_model_path,
+            config={
+                "execution_provider": "qnn",
+                "output_path": str(user_output),
+            },
+            work_dir=work_dir,
+        )
+
+        stage = CompileStage()
+        stage._finalize_output(context, ctx_path.parent / "model_to_compile.onnx", output_dir)
+
+        # Bin should use the user-specified stem: "compiled.bin"
+        expected_bin = output_dir / "compiled.bin"
+        assert expected_bin.exists(), (
+            f"Expected {expected_bin}, found: {list(output_dir.iterdir())}"
+        )
+        # The old auto-generated name should NOT exist
+        assert not (output_dir / "mymodel_qnn_ctx.bin").exists()
+
 
 class TestCompilerPipeline:
     """Test Compiler class pipeline configuration."""


### PR DESCRIPTION
## Summary

Fixes several bugs encountered during model analysis and compilation, plus silences noisy warnings that polluted user-facing output.

## Changes

### 1. Fix `PatternMatcher` crash on ONNX validation failure

`onnx.checker.check_model()` is strict — many valid, functional models fail it (custom ops, EPContext nodes, etc.). This was aborting the entire pattern matching.

**Before:**
```
PatternMatchingValidator: Pattern matching failed - Model validation failed during pattern matching initialization
```

**After:** Validation failure is logged at `debug` level. Pattern matching proceeds normally via graph topology.

---

### 2. Fix `PatternMatcher` crash on missing external data

When models are loaded with `load_external_data=False` (as the analyzer does), `numpy_helper.to_array()` crashes on initializers whose data is in external files.

**Before:**
```
ERROR: Analysis failed: Data of TensorProto (tensor name: convnext.embeddings.patch_embeddings.weight) should be stored in model_opt.onnx.data, but it doesn't exist
```

**After:** Missing external data is gracefully skipped with a debug log. Pattern matching works via graph topology; only value-based constraint checks are skipped for those tensors.

---

### 3. Fix `winml compile -o` option missing

There was no way to specify an output file name for `winml compile`.

**Before:**
```
$ winml compile -m model.onnx --ep qnn -o output.onnx
Error: No such option: -o
```

**After:** Added `--output`/`-o` option. `-o` (file path) takes precedence over `--output-dir` (directory).

---

### 4. Fix compile ignoring user-specified output filename

Even after adding `-o`, `_finalize_output()` always generated the filename as `{stem}_{device}_ctx.onnx`.

**Before:**
```
$ winml compile -m model.onnx --ep qnn -o model_compiled.onnx
Output: model_opt_int8_qnn_ctx.onnx    # -o ignored
```

**After:**
```
$ winml compile -m model.onnx --ep qnn -o model_compiled.onnx
Output: model_compiled.onnx            # -o respected
```

The `.bin` companion file also follows the user-specified stem.

---

### 5. Fix `pattern_to_id` mismatch in `default.json` alternatives

Gelu and Gemm alternatives all had `pattern_to_id` set to the **source** pattern's ID (e.g., `"SUBGRAPH/GeluPattern"`), instead of the **target** pattern's ID. This caused the information engine to fail to look up alternatives.

**Before:**
```
WARNING  Action target pattern 'SUBGRAPH/SingleGeluPattern' not found in alternatives for 'SUBGRAPH/GeluPattern'
WARNING  Action target pattern 'SUBGRAPH/ReshapeGemmReshapePattern' not found in alternatives for 'SUBGRAPH/GemmPattern'
```

**After:** Each alternative now has a distinct `pattern_to_id` matching its target class (e.g., `"SUBGRAPH/SingleGeluPattern"`, `"SUBGRAPH/ReshapeGemmReshapePattern"`). Consistent with how LayerNorm and ReshapeTransposeReshape alternatives were already defined.

---

### 6. Downgrade noisy warnings to debug

Multiple warnings in `doc_constraint_checker.py` and `runtime_checker_query.py` fired for expected/benign conditions (unmapped ops, missing rule files, optional inputs, shape inference failures). These are now `debug` level to keep user output clean.

**Before:**
```
WARNING  Mapping failed for Erf: ONNX operator
WARNING  Negative rule file not found: VitisAIExecutionProvider_NPU_ai.onnx_opset17_negative_rules.json
WARNING  No constraints found for operator 'Erf' with dtype category ...
```

**After:** Clean output. Details available with `--verbose`.

## Tests added

| Test file | Tests | Covers |
|---|---|---|
| `test_pattern_matcher_robustness.py` | 2 | Invalid model non-fatal, missing external data graceful |
| `test_compile_command.py` | 3 | `-o` in help, `-o` passes file path, `-o` precedence over `--output-dir` |
| `test_compiler_stages.py` | 2 | `_finalize_output` respects user file path, `.bin` uses user stem |
| `test_unified_pattern_config.py` | 1 | Gemm alternatives have distinct `pattern_to_id` values |
| `test_make_hashable.py` | 7 | ndarray → tuple, set/dict usage, float replacement, nesting, empty |