### PR TITLE
docs(analyze): add rule zip setup path for external contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,20 @@ uv run pre-commit install
 
 This installs all dependencies and enables [pre-commit hooks](https://pre-commit.com/) that automatically check license headers, formatting (Ruff), trailing whitespace, and YAML syntax on every commit.
 
+### Runtime check rules (for `analyze` development)
+
+If you are working on the analyzer (`winml analyze`, `src/winml/modelkit/analyze/`), you need to populate the runtime check rule zips locally. Without them, the analyzer logs a warning and treats affected operators as unknown — analysis results are incomplete but commands do not crash.
+
+External contributors (without `gim-home` org access) should download the rule zips from the **latest** [WinML-ModelKit release](https://github.com/microsoft/WinML-ModelKit/releases/latest) into `src/winml/modelkit/analyze/rules/runtime_check_rules/`:
+
+```bash
+gh release download --repo microsoft/WinML-ModelKit --pattern '*.zip' --dir src/winml/modelkit/analyze/rules/runtime_check_rules
+```
+
+Each asset is named `{EP}_{Device}_{Domain}_opset{N}.zip`; download only the combinations relevant to your work.
+
+For all setup options (including the internal `gim-home` download script and the `MODELKIT_RULES_DIR` override), see [`src/winml/modelkit/analyze/rules/runtime_check_rules/README.md`](./src/winml/modelkit/analyze/rules/runtime_check_rules/README.md).
+
 ## Coding conventions and standards
 
 ### Python code style

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,9 +20,9 @@ uv run pre-commit install
 
 This installs all dependencies and enables [pre-commit hooks](https://pre-commit.com/) that automatically check license headers, formatting (Ruff), trailing whitespace, and YAML syntax on every commit.
 
-### Runtime check rules (for `analyze` development)
+### Runtime check rules
 
-If you are working on the analyzer (`winml analyze`, `src/winml/modelkit/analyze/`), you need to populate the runtime check rule zips locally. Without them, the analyzer logs a warning and treats affected operators as unknown — analysis results are incomplete but commands do not crash.
+When running ModelKit from a source tree (`uv run winml ...`), you need to populate the runtime check rule zips locally.
 
 External contributors (without `gim-home` org access) should download the rule zips from the **latest** [WinML-ModelKit release](https://github.com/microsoft/WinML-ModelKit/releases/latest) into `src/winml/modelkit/analyze/rules/runtime_check_rules/`:
 
@@ -30,7 +30,7 @@ External contributors (without `gim-home` org access) should download the rule z
 gh release download --repo microsoft/WinML-ModelKit --pattern '*.zip' --dir src/winml/modelkit/analyze/rules/runtime_check_rules
 ```
 
-Each asset is named `{EP}_{Device}_{Domain}_opset{N}.zip`; download only the combinations relevant to your work.
+Each asset is named `{EP}_{Device}_{Domain}_opset{N}.zip`. The command above pulls all of them; pick a subset if you only need specific EP/device/opset combinations.
 
 For all setup options (including the internal `gim-home` download script and the `MODELKIT_RULES_DIR` override), see [`src/winml/modelkit/analyze/rules/runtime_check_rules/README.md`](./src/winml/modelkit/analyze/rules/runtime_check_rules/README.md).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,17 +22,7 @@ This installs all dependencies and enables [pre-commit hooks](https://pre-commit
 
 ### Runtime check rules
 
-When running ModelKit from a source tree (`uv run winml ...`), you need to populate the runtime check rule zips locally.
-
-External contributors (without `gim-home` org access) should download the rule zips from the **latest** [WinML-ModelKit release](https://github.com/microsoft/WinML-ModelKit/releases/latest) into `src/winml/modelkit/analyze/rules/runtime_check_rules/`:
-
-```bash
-gh release download --repo microsoft/WinML-ModelKit --pattern '*.zip' --dir src/winml/modelkit/analyze/rules/runtime_check_rules
-```
-
-Each asset is named `{EP}_{Device}_{Domain}_opset{N}.zip`. The command above pulls all of them; pick a subset if you only need specific EP/device/opset combinations.
-
-For all setup options (including the internal `gim-home` download script and the `MODELKIT_RULES_DIR` override), see [`src/winml/modelkit/analyze/rules/runtime_check_rules/README.md`](./src/winml/modelkit/analyze/rules/runtime_check_rules/README.md).
+When running ModelKit from a source tree (`uv run winml ...`), you need to populate the runtime check rule zips locally. See [`src/winml/modelkit/analyze/rules/runtime_check_rules/README.md`](./src/winml/modelkit/analyze/rules/runtime_check_rules/README.md) for setup options (GitHub release for external contributors, `gim-home` script for Microsoft internal, `MODELKIT_RULES_DIR` override).
 
 ## Coding conventions and standards
 

--- a/scripts/download_rules.py
+++ b/scripts/download_rules.py
@@ -4,7 +4,12 @@
 # --------------------------------------------------------------------------
 """Download runtime check rule zips from gim-home/ModelKitArtifacts.
 
-Requires gh CLI with an account that has access to gim-home org.
+For Microsoft internal use only. Requires gh CLI authenticated with an account
+that has access to the gim-home org.
+
+External contributors should instead download rule zips from the latest
+WinML-ModelKit GitHub release; see
+src/winml/modelkit/analyze/rules/runtime_check_rules/README.md.
 
 Usage:
     uv run python scripts/download_rules.py --account <account>
@@ -41,7 +46,12 @@ def _get_clone_url(account: str | None = None) -> str:
             "ERROR: gh account is required.\n"
             "Specify via --account or GH_ACCOUNT env var:\n"
             "  uv run python scripts/download_rules.py --account <account>\n"
-            "  GH_ACCOUNT=<account> uv run python scripts/download_rules.py",
+            "  GH_ACCOUNT=<account> uv run python scripts/download_rules.py\n"
+            "\n"
+            "This script is for Microsoft internal use (gim-home org access required).\n"
+            "External contributors: download rule zips from the latest GitHub release:\n"
+            "  gh release download --repo microsoft/WinML-ModelKit --pattern '*.zip' \\\n"
+            "    --dir src/winml/modelkit/analyze/rules/runtime_check_rules",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/src/winml/modelkit/analyze/rules/runtime_check_rules/README.md
+++ b/src/winml/modelkit/analyze/rules/runtime_check_rules/README.md
@@ -8,7 +8,7 @@ The zip files are **not tracked by git**. They are hosted in a separate repo.
 
 ### Option 1: Download from the latest GitHub release (for external contributors)
 
-Rule zips are published as individual assets on the **latest** [WinML-ModelKit release](https://github.com/microsoft/WinML-ModelKit/releases/latest). No special access required — this is the recommended path for external contributors who do not have `gim-home` org membership.
+Rule zips are published as individual assets on the **latest** [WinML-ModelKit release](https://github.com/microsoft/WinML-ModelKit/releases/latest). No special access required.
 
 Each asset is named `{EP}_{Device}_{Domain}_opset{N}.zip` (for example, `QNNExecutionProvider_NPU_ai.onnx_opset17.zip`). Download only the combinations you need and place them in this directory.
 

--- a/src/winml/modelkit/analyze/rules/runtime_check_rules/README.md
+++ b/src/winml/modelkit/analyze/rules/runtime_check_rules/README.md
@@ -6,9 +6,23 @@ The zip files are **not tracked by git**. They are hosted in a separate repo.
 
 ## Setup
 
-### Option 1: Download script (recommended)
+### Option 1: Download from the latest GitHub release (for external contributors)
 
-Requires [GitHub CLI](https://cli.github.com) (`gh`) with an account that has access to `gim-home`.
+Rule zips are published as individual assets on the **latest** [WinML-ModelKit release](https://github.com/microsoft/WinML-ModelKit/releases/latest). No special access required — this is the recommended path for external contributors who do not have `gim-home` org membership.
+
+Each asset is named `{EP}_{Device}_{Domain}_opset{N}.zip` (for example, `QNNExecutionProvider_NPU_ai.onnx_opset17.zip`). Download only the combinations you need and place them in this directory.
+
+To download all assets from the latest release with [GitHub CLI](https://cli.github.com):
+
+```bash
+gh release download --repo microsoft/WinML-ModelKit --pattern '*.zip' --dir src/winml/modelkit/analyze/rules/runtime_check_rules
+```
+
+`gh release download` defaults to the latest release. Pin to a specific tag with `--tag <version>` (for example, `--tag v0.0.1`) if you need a reproducible snapshot.
+
+### Option 2: Download script (Microsoft internal)
+
+For Microsoft developers with access to the `gim-home` org. Requires [GitHub CLI](https://cli.github.com) (`gh`) authenticated with such an account.
 
 ```bash
 uv run python scripts/download_rules.py --account <your_gim-home_account>
@@ -18,11 +32,11 @@ The script uses the specified `gh` account's token to authenticate, does a spars
 
 Use `--force` to re-download all files even if they already exist locally.
 
-### Option 2: Manual copy
+### Option 3: Manual copy (Microsoft internal)
 
 Copy all `*.zip` files from [`gim-home/ModelKitArtifacts/op_check_results/rules/`](https://github.com/gim-home/ModelKitArtifacts/tree/main/op_check_results/rules) into this directory.
 
-### Option 3: Use external rules directory via environment variable
+### Option 4: Use external rules directory via environment variable
 
 Set `MODELKIT_RULES_DIR` to one or more directories containing runtime rule zip files.
 
@@ -33,7 +47,7 @@ Important: relative paths are resolved from `src/winml/modelkit/analyze/utils/` 
 
 Multiple directories are supported using `os.pathsep` (`;` on Windows, `:` on Unix-like systems).
 
-### Option 4: Expand rule zips via CLI command
+### Option 5: Expand rule zips via CLI command
 
 You can materialize delta snapshots to full payloads in-place with:
 


### PR DESCRIPTION
## Summary

- Adds a new top option in [`runtime_check_rules/README.md`](src/winml/modelkit/analyze/rules/runtime_check_rules/README.md) instructing external contributors to download rule zips from the **latest** [WinML-ModelKit release](https://github.com/microsoft/WinML-ModelKit/releases/latest). Existing `gim-home`-based options are demoted to "Microsoft internal" and renumbered.
- Adds a "Runtime check rules subsection to [`CONTRIBUTING.md`](CONTRIBUTING.md) so external contributors know they need rule zips and where to get them.
- Updates [`scripts/download_rules.py`](scripts/download_rules.py) docstring and the "missing account" error message to direct external users to the release download.

Fixes #415