### PR TITLE
fix(telemetry): scrub-then-cap, init/version regression tests

### DIFF
--- a/src/winml/modelkit/telemetry/utils.py
+++ b/src/winml/modelkit/telemetry/utils.py
@@ -113,24 +113,26 @@ _MESSAGE_CAP = 200
 
 
 def _format_exception_message(message: str | None) -> str:
-    """Run the scrubbing pipeline: path trim -> length cap -> PII scrub.
+    """Run the scrubbing pipeline: path trim -> PII scrub -> length cap.
 
-    Path trim is a token-level operation that only rewrites absolute paths
-    found in the message. Length cap truncates to ``_MESSAGE_CAP`` chars
-    with a trailing ``…`` marker. PII scrub replaces matching patterns
-    with ``<scrubbed>``.
+    Scrub runs *before* the length cap so PII straddling the cap boundary
+    is still recognized by the regexes. Capping first would split a token
+    or email mid-string and leak the surviving prefix (e.g. ``alice@exa…``
+    leaves ``alice`` exposed because the cropped fragment no longer
+    matches the email pattern).
     """
     if not message:
         return ""
     # Trim absolute paths token-by-token (keeps surrounding text intact).
     tokens = [_trim_path(tok) if _looks_like_path(tok) else tok for tok in message.split(" ")]
     result = " ".join(tokens)
-    # Length cap first (so PII runs on a bounded string; also prevents huge
-    # messages from dominating the regex cost).
+    # Scrub PII first so the cap can't split a sensitive token.
+    result = _scrub_pii(result)
+    # Cap last - bounds final size even if scrub expanded the string
+    # (each match becomes the 11-char ``<scrubbed>`` placeholder).
     if len(result) > _MESSAGE_CAP:
         result = result[: _MESSAGE_CAP - 1] + "…"
-    # PII scrub last (so truncation won't reveal partial PII).
-    return _scrub_pii(result)
+    return result
 
 
 def _looks_like_path(token: str) -> bool:

--- a/tests/unit/telemetry/test_click_group.py
+++ b/tests/unit/telemetry/test_click_group.py
@@ -227,6 +227,27 @@ def test_group_help_does_not_init_telemetry(enabled_telemetry):
     assert telemetry_mod._INSTANCE is None
 
 
+def test_group_version_does_not_init_telemetry(enabled_telemetry):
+    """``--version`` must short-circuit inside Click's parameter parsing
+    before any subcommand ``invoke`` runs, so the Telemetry singleton is
+    never built (mirrors ``--help``)."""
+
+    @click.group(cls=ActionGroup)
+    @click.version_option(version="1.2.3", prog_name="winml")
+    def cli():
+        pass
+
+    @cli.command()
+    def build():
+        click.echo("built")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--version"])
+    assert result.exit_code == 0
+    assert "1.2.3" in result.output
+    assert telemetry_mod._INSTANCE is None
+
+
 def test_subcommand_help_does_not_emit(enabled_telemetry):
     @click.group(cls=ActionGroup)
     def cli():

--- a/tests/unit/telemetry/test_telemetry_init.py
+++ b/tests/unit/telemetry/test_telemetry_init.py
@@ -37,3 +37,48 @@ def test_singleton_is_cached(clean_env, isolated_config, monkeypatch):
     t1 = Telemetry.get_or_init()
     t2 = Telemetry.get_or_init()
     assert t1 is t2
+
+
+def test_empty_ikey_skips_consent_prompt(clean_env, isolated_config, monkeypatch):
+    """Dev install: empty iKey must short-circuit before any consent prompt.
+
+    Pins the design contract: 'INSTRUMENTATION_KEY empty (dev build)
+    -> Telemetry stack never initializes; no prompt'. Setup uses an
+    interactive TTY and *no* stored consent so the only thing that can
+    keep ``_prompt_for_consent`` from running is the empty-iKey guard.
+    """
+    monkeypatch.setattr("winml.modelkit.telemetry.constants.INSTRUMENTATION_KEY", "")
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+
+    prompt_calls: list[int] = []
+    monkeypatch.setattr(
+        consent_mod,
+        "_prompt_for_consent",
+        lambda: prompt_calls.append(1) or "enabled",
+    )
+
+    t = Telemetry.get_or_init()
+    assert t.disabled is True
+    assert prompt_calls == []
+
+
+def test_init_swallows_resource_build_errors(clean_env, isolated_config, monkeypatch):
+    """Telemetry init failure must never propagate to the CLI.
+
+    If ``_build_resource`` (which touches the registry for the device ID)
+    raises, ``Telemetry.get_or_init()`` must return a disabled instance
+    rather than raise. Without this guard a registry permission error or
+    transient OS failure would crash every CLI invocation.
+    """
+    monkeypatch.setattr("winml.modelkit.telemetry.constants.INSTRUMENTATION_KEY", "o:test-key")
+    consent_mod._write_stored_consent("enabled")
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+
+    def boom(self):
+        raise RuntimeError("simulated init failure")
+
+    monkeypatch.setattr(Telemetry, "_build_resource", boom)
+
+    t = Telemetry.get_or_init()  # must NOT raise
+    assert t.disabled is True
+    assert t._logger is None

--- a/tests/unit/telemetry/test_utils_scrubbing.py
+++ b/tests/unit/telemetry/test_utils_scrubbing.py
@@ -127,3 +127,29 @@ def test_format_exception_message_empty_is_empty():
 def test_format_exception_message_none_safe():
     # Defensive: accepts None by returning empty string.
     assert _format_exception_message(None) == ""
+
+
+def test_format_exception_message_scrubs_pii_at_cap_boundary():
+    """Regression: PII straddling the 200-char cap must be scrubbed
+    before truncation. Cap-then-scrub would leak the email's local part
+    because the cropped fragment ``alice@exa…`` no longer matches the
+    email regex (no TLD). The ``<scrubbed>`` placeholder itself may be
+    truncated by the cap - what matters is that the original PII
+    fragments are gone."""
+    prefix = "x" * 195  # email lands across char 196 onward
+    msg = prefix + " alice@example.com"
+    result = _format_exception_message(msg)
+    assert "alice" not in result
+    assert "@" not in result
+    assert len(result) <= 200
+
+
+def test_format_exception_message_scrubs_long_token_at_cap_boundary():
+    """Regression: a long opaque token straddling the cap must be scrubbed
+    as a whole, not leak its in-cap prefix as a sub-24-char fragment."""
+    prefix = "x" * 180  # 30-char token starts at 181, ends at 210
+    msg = prefix + " token=abcdef0123456789abcdefghi9"
+    result = _format_exception_message(msg)
+    assert "abcdef0123456789" not in result
+    assert "<scrubbed>" in result
+    assert len(result) <= 200


### PR DESCRIPTION
## Summary

Follow-up fixes after the Phase 1+2+3 telemetry implementation review. Single commit; tightly coupled changes.

### Behavior fix

- **PII scrub before length cap** (`utils._format_exception_message`). Previous order was `path-trim → cap → scrub`, which let PII straddling the 200-char boundary leak its in-cap prefix because the cropped fragment (e.g. `alice@exa…`) no longer matched the email regex. New order is `path-trim → scrub → cap`. Cap still bounds final size even if scrub expands the string.

### Regression tests

- `test_empty_ikey_skips_consent_prompt` — pins the design contract that dev installs (empty `INSTRUMENTATION_KEY`) short-circuit before the prompt, even with TTY + no stored consent.
- `test_init_swallows_resource_build_errors` — pins that an `_build_resource` failure (e.g. registry permission error) returns a disabled instance instead of propagating.
- `test_group_version_does_not_init_telemetry` — pins that `--version` short-circuits before any subcommand `invoke`, mirroring the existing `--help` test.
- Two boundary regressions in `test_utils_scrubbing.py` — email and long-token straddling the 200-char cap.

### Out of scope (separate work)

- Long-token regex was deliberately weakened from the design (requires at least one digit). Privacy implications need separate review before any change.
- Stray untracked files (`_demo.py` shipped in `src/`, `*.data` files in repo root) are repo-hygiene cleanup for a separate PR.
- Post-prompt confirmation hint (originally in design line 315-327) was prototyped here but dropped after a survey of mainstream CLI tooling (.NET CLI, Homebrew, GitHub CLI, Vercel, Netlify) — none use a Y/N follow-up confirmation. The interactive Y/N prompt itself is also worth revisiting in a separate design discussion.
