### PR TITLE
fix(perf): add --no-compile flag and fix inference wrapper EP

### DIFF
--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -76,6 +76,7 @@ class BenchmarkConfig:
     batch_size: int = 1
     output_path: Path | None = None
     no_quantize: bool = False
+    no_compile: bool = True
     rebuild: bool = False
     ignore_cache: bool = False
     monitor: bool = False
@@ -344,6 +345,7 @@ class PerfBenchmark:
             "use_cache": use_cache,
             "force_rebuild": force_rebuild,
             "shape_config": self.config.shape_config,
+            "no_compile": self.config.no_compile,
         }
 
         if is_onnx:
@@ -500,6 +502,7 @@ def _perf_modules(
     warmup: int,
     batch_size: int,
     no_quantize: bool,
+    no_compile: bool,
     output: Path | None,
     verbose: bool,
     console: Console,
@@ -519,6 +522,7 @@ def _perf_modules(
         warmup: Number of warmup iterations.
         batch_size: Batch size for input generation.
         no_quantize: If True, skip quantization and compilation.
+        no_compile: If True, skip EP compilation (no EPContext generation).
         output: Output JSON path, or None for auto-generated path.
         verbose: If True, log exceptions at DEBUG level.
         console: Rich console for output.
@@ -582,6 +586,8 @@ def _perf_modules(
         # Skip quant/compile for faster iteration when requested
         if no_quantize:
             cfg.quant = None
+            cfg.compile = None
+        elif no_compile:
             cfg.compile = None
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -1090,6 +1096,12 @@ def _run_onnx_benchmark(
     help="Skip quantization during model build",
 )
 @click.option(
+    "--no-compile/--compile",
+    "no_compile",
+    default=True,
+    help="Skip EP compilation during model build (no EPContext generation). Default: skip.",
+)
+@click.option(
     "--rebuild",
     is_flag=True,
     default=False,
@@ -1151,6 +1163,7 @@ def perf(
     batch_size: int,
     shape_config_path: Path | None,
     no_quantize: bool,
+    no_compile: bool,
     rebuild: bool,
     ignore_cache: bool,
     module_class: str | None,
@@ -1246,6 +1259,7 @@ def perf(
             warmup=warmup,
             batch_size=batch_size,
             no_quantize=no_quantize,
+            no_compile=no_compile,
             output=output,
             verbose=verbose,
             console=console,
@@ -1288,6 +1302,7 @@ def perf(
         batch_size=batch_size,
         output_path=output,
         no_quantize=no_quantize,
+        no_compile=no_compile,
         rebuild=rebuild,
         ignore_cache=ignore_cache,
         monitor=monitor,

--- a/src/winml/modelkit/models/auto.py
+++ b/src/winml/modelkit/models/auto.py
@@ -363,6 +363,11 @@ class WinMLAutoModel:
             ep=kwargs.get("ep"),
         )
 
+        # Apply stage overrides AFTER policy resolution (policy runs inside
+        # generate_hf_build_config and would overwrite compile/quant otherwise).
+        if kwargs.get("no_compile"):
+            build_config.compile = None
+
         resolved_task = build_config.loader.task
         logger.debug("Generated config with task: %s", resolved_task)
 
@@ -427,7 +432,7 @@ class WinMLAutoModel:
             onnx_path=onnx_path,
             config=hf_config,  # HF PretrainedConfig for pipeline compatibility
             device=device,  # pass user's original device string; WinMLSession handles "auto"
-            ep=resolved_ep,
+            ep=kwargs.get("ep"),  # user's explicit --ep only; device policy handles the rest
         )
         model._build_config = config  # resolved build config (task, quant, compile)
         return model

--- a/tests/unit/commands/test_perf_cli.py
+++ b/tests/unit/commands/test_perf_cli.py
@@ -328,3 +328,143 @@ class TestPerfUnifiedPipeline:
             benchmark._load_model()
 
         assert mock_from_onnx.call_args.kwargs["ep"] == "qnn"
+
+    def test_no_compile_default_is_true(self) -> None:
+        """--no-compile should be on by default (perf skips compile)."""
+        config = BenchmarkConfig(model_id="microsoft/resnet-50")
+        assert config.no_compile is True
+
+    def test_no_compile_passed_to_from_pretrained(self) -> None:
+        """no_compile flag should be forwarded to from_pretrained via kwargs."""
+        config = BenchmarkConfig(
+            model_id="microsoft/resnet-50",
+            device="cpu",
+            no_compile=True,
+        )
+        benchmark = PerfBenchmark(config)
+
+        with patch(
+            "winml.modelkit.models.auto.WinMLAutoModel.from_pretrained",
+            return_value=MagicMock(),
+        ) as mock_fp:
+            benchmark._load_model()
+
+        assert mock_fp.call_args.kwargs.get("no_compile") is True
+
+    def test_compile_enabled_passed_to_from_pretrained(self) -> None:
+        """no_compile=False (--compile) should forward False to from_pretrained."""
+        config = BenchmarkConfig(
+            model_id="microsoft/resnet-50",
+            device="cpu",
+            no_compile=False,
+        )
+        benchmark = PerfBenchmark(config)
+
+        with patch(
+            "winml.modelkit.models.auto.WinMLAutoModel.from_pretrained",
+            return_value=MagicMock(),
+        ) as mock_fp:
+            benchmark._load_model()
+
+        assert mock_fp.call_args.kwargs.get("no_compile") is False
+
+    def test_no_compile_passed_to_from_onnx(self, tmp_path: Path) -> None:
+        """no_compile flag should be forwarded to from_onnx via kwargs."""
+        onnx_file = tmp_path / "model.onnx"
+        onnx_file.write_bytes(b"fake onnx")
+
+        config = BenchmarkConfig(
+            model_id=str(onnx_file),
+            device="cpu",
+            no_compile=True,
+        )
+        benchmark = PerfBenchmark(config)
+
+        with patch(
+            "winml.modelkit.models.auto.WinMLAutoModel.from_onnx",
+            return_value=MagicMock(),
+        ) as mock_fo:
+            benchmark._load_model()
+
+        assert mock_fo.call_args.kwargs.get("no_compile") is True
+
+
+# =============================================================================
+# CLI FLAG TESTS
+# =============================================================================
+
+
+class TestPerfCompileFlag:
+    """Test --no-compile / --compile CLI flag behaviour."""
+
+    def test_no_compile_in_help(self, runner: CliRunner) -> None:
+        """--no-compile flag should appear in help output."""
+        result = runner.invoke(perf, ["--help"])
+        assert result.exit_code == 0
+        assert "--no-compile" in result.output
+
+    def test_compile_toggle_in_help(self, runner: CliRunner) -> None:
+        """--compile toggle should appear in help output."""
+        result = runner.invoke(perf, ["--help"])
+        assert result.exit_code == 0
+        assert "--compile" in result.output
+
+    def test_cli_no_compile_default_passes_true(self, runner: CliRunner, tmp_path: Path) -> None:
+        """CLI default (no flag) should pass no_compile=True to PerfBenchmark."""
+        onnx_file = tmp_path / "model.onnx"
+        onnx_file.write_bytes(b"fake onnx")
+
+        with (
+            patch(
+                "winml.modelkit.commands.perf._run_onnx_benchmark",
+                return_value=MagicMock(),
+            ),
+            patch("winml.modelkit.commands.perf.display_console_report"),
+            patch("winml.modelkit.commands.perf.write_json_report"),
+            patch("winml.modelkit.commands.perf.PerfBenchmark") as mock_cls,
+        ):
+            mock_cls.return_value.run.return_value = MagicMock()
+            runner.invoke(
+                perf,
+                ["-m", str(onnx_file), "-o", str(tmp_path / "out.json")],
+                obj={},
+            )
+
+        # The ONNX path uses _run_onnx_benchmark, not PerfBenchmark, so verify
+        # via BenchmarkConfig default instead.
+        config = BenchmarkConfig(model_id="x")
+        assert config.no_compile is True
+
+    def test_cli_compile_flag_sets_no_compile_false(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """Passing --compile should forward no_compile=False to from_pretrained."""
+        with (
+            patch(
+                "winml.modelkit.models.auto.WinMLAutoModel.from_pretrained",
+                return_value=MagicMock(),
+            ) as mock_fp,
+            patch("winml.modelkit.commands.perf.display_console_report"),
+            patch("winml.modelkit.commands.perf.write_json_report"),
+        ):
+            mock_fp.return_value._session = MagicMock()
+            mock_fp.return_value.io_config = {
+                "input_names": [],
+                "output_names": [],
+                "input_shapes": [],
+                "input_types": [],
+            }
+            runner.invoke(
+                perf,
+                [
+                    "-m",
+                    "microsoft/resnet-50",
+                    "--compile",
+                    "-o",
+                    str(tmp_path / "out.json"),
+                ],
+                obj={},
+            )
+
+        if mock_fp.called:
+            assert mock_fp.call_args.kwargs.get("no_compile") is False

--- a/tests/unit/commands/test_perf_cli.py
+++ b/tests/unit/commands/test_perf_cli.py
@@ -410,30 +410,30 @@ class TestPerfCompileFlag:
         assert "--compile" in result.output
 
     def test_cli_no_compile_default_passes_true(self, runner: CliRunner, tmp_path: Path) -> None:
-        """CLI default (no flag) should pass no_compile=True to PerfBenchmark."""
-        onnx_file = tmp_path / "model.onnx"
-        onnx_file.write_bytes(b"fake onnx")
-
+        """CLI default (no flag) should pass no_compile=True to from_pretrained."""
         with (
             patch(
-                "winml.modelkit.commands.perf._run_onnx_benchmark",
+                "winml.modelkit.models.auto.WinMLAutoModel.from_pretrained",
                 return_value=MagicMock(),
-            ),
+            ) as mock_fp,
             patch("winml.modelkit.commands.perf.display_console_report"),
             patch("winml.modelkit.commands.perf.write_json_report"),
-            patch("winml.modelkit.commands.perf.PerfBenchmark") as mock_cls,
         ):
-            mock_cls.return_value.run.return_value = MagicMock()
+            mock_fp.return_value._session = MagicMock()
+            mock_fp.return_value.io_config = {
+                "input_names": [],
+                "output_names": [],
+                "input_shapes": [],
+                "input_types": [],
+            }
             runner.invoke(
                 perf,
-                ["-m", str(onnx_file), "-o", str(tmp_path / "out.json")],
+                ["-m", "microsoft/resnet-50", "-o", str(tmp_path / "out.json")],
                 obj={},
             )
 
-        # The ONNX path uses _run_onnx_benchmark, not PerfBenchmark, so verify
-        # via BenchmarkConfig default instead.
-        config = BenchmarkConfig(model_id="x")
-        assert config.no_compile is True
+        mock_fp.assert_called_once()
+        assert mock_fp.call_args.kwargs.get("no_compile") is True
 
     def test_cli_compile_flag_sets_no_compile_false(
         self, runner: CliRunner, tmp_path: Path
@@ -466,5 +466,5 @@ class TestPerfCompileFlag:
                 obj={},
             )
 
-        if mock_fp.called:
-            assert mock_fp.call_args.kwargs.get("no_compile") is False
+        mock_fp.assert_called_once()
+        assert mock_fp.call_args.kwargs.get("no_compile") is False

--- a/tests/unit/commands/test_perf_module.py
+++ b/tests/unit/commands/test_perf_module.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
 from click.testing import CliRunner
 
 from winml.modelkit.cli import main
@@ -44,3 +46,82 @@ class TestPerfModuleFlag:
         module_path = Path(f"{slug}_{module_class}_perf.json")
         assert module_class in str(module_path)
         assert str(module_path) != str(path)
+
+
+class TestPerfModulesNoCompile:
+    """Test no_compile/no_quantize stage overrides inside _perf_modules."""
+
+    def _run_perf_modules(self, *, no_quantize: bool, no_compile: bool):
+        """Invoke _perf_modules with mocked internals; return build call kwargs."""
+        from winml.modelkit.commands.perf import _perf_modules
+        from winml.modelkit.config import WinMLBuildConfig
+
+        cfg = WinMLBuildConfig()
+        cfg.loader.task = "image-classification"
+        cfg.loader.model_type = "bert"
+        cfg.loader.module_path = "encoder.layer.0"
+
+        build_calls = []
+
+        def fake_build(config, **_):
+            build_calls.append({"compile": config.compile, "quant": config.quant})
+            return MagicMock(final_onnx_path="out.onnx")
+
+        with (
+            patch(
+                "winml.modelkit.config.generate_hf_build_config",
+                return_value=[cfg],
+            ),
+            patch(
+                "winml.modelkit.commands.build._instantiate_parent_model",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "winml.modelkit.build.build_hf_model",
+                side_effect=fake_build,
+            ),
+            patch("winml.modelkit.session.WinMLSession") as mock_sess,
+        ):
+            mock_sess.return_value.io_config = {
+                "input_names": [],
+                "output_names": [],
+                "input_shapes": [],
+                "input_types": [],
+            }
+            mock_sess.return_value.device = "cpu"
+            _perf_modules(
+                hf_model="bert-base-uncased",
+                module_class="BertAttention",
+                task=None,
+                iterations=1,
+                warmup=0,
+                batch_size=1,
+                no_quantize=no_quantize,
+                no_compile=no_compile,
+                output=None,
+                verbose=False,
+                console=MagicMock(),
+            )
+
+        return build_calls
+
+    def test_no_compile_only_clears_compile(self):
+        """no_compile=True, no_quantize=False: only compile should be cleared."""
+        calls = self._run_perf_modules(no_quantize=False, no_compile=True)
+        assert calls, "build_hf_model was never called"
+        assert calls[0]["compile"] is None, "compile should be None when no_compile=True"
+        assert calls[0]["quant"] is not None, "quant should be untouched when no_quantize=False"
+
+    def test_no_quantize_clears_both(self):
+        """no_quantize=True: both compile and quant should be cleared."""
+        calls = self._run_perf_modules(no_quantize=True, no_compile=False)
+        assert calls, "build_hf_model was never called"
+        assert calls[0]["compile"] is None
+        assert calls[0]["quant"] is None
+
+    def test_neither_flag_preserves_both(self):
+        """No flags: both compile and quant should remain as configured."""
+        calls = self._run_perf_modules(no_quantize=False, no_compile=False)
+        assert calls, "build_hf_model was never called"
+        assert calls[0]["compile"] is not None
+        assert calls[0]["quant"] is not None

--- a/tests/unit/models/auto/test_from_pretrained_kwargs.py
+++ b/tests/unit/models/auto/test_from_pretrained_kwargs.py
@@ -1,0 +1,190 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Tests for WinMLAutoModel.from_pretrained kwarg handling.
+
+Covers two fixes:
+1. EP fix: inference wrapper must receive the user's explicit --ep, not the
+   compile-time resolved_ep derived from --device.
+2. no_compile: build_config.compile must be set to None after policy resolution
+   when no_compile=True is passed, because generate_hf_build_config's device
+   policy (STEP 4.5) always overwrites compile after the override merge.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Patch targets for auto.py
+# - Module-level imports: patch via winml.modelkit.models.auto.<name>
+# - Local (in-function) imports: patch via the source module
+_AUTO = "winml.modelkit.models.auto"
+_GENERATE_HF_BUILD_CONFIG = "winml.modelkit.config.generate_hf_build_config"
+_BUILD_HF_MODEL = "winml.modelkit.build.build_hf_model"
+
+
+def _make_build_config(compile_provider: str | None = "qnn"):
+    """Return a minimal WinMLBuildConfig with controllable compile field."""
+    from winml.modelkit.compiler.configs import EPConfig, WinMLCompileConfig
+    from winml.modelkit.config import WinMLBuildConfig
+
+    cfg = WinMLBuildConfig()
+    cfg.compile = (
+        WinMLCompileConfig(ep_config=EPConfig(provider=compile_provider))
+        if compile_provider
+        else None
+    )
+    cfg.loader.task = "image-classification"
+    return cfg
+
+
+def _mock_winml_class():
+    """MagicMock that works as a class: has __name__ set."""
+    m = MagicMock()
+    m.__name__ = "MockWinMLClass"
+    return m
+
+
+def _base_patches(build_cfg, build_side_effect=None, winml_class=None):
+    """Return a list of context managers that stub out the heavy internals."""
+    if winml_class is None:
+        winml_class = _mock_winml_class()
+    return [
+        patch(_GENERATE_HF_BUILD_CONFIG, return_value=build_cfg),
+        patch(
+            f"{_AUTO}.load_hf_model",
+            return_value=(MagicMock(), MagicMock(model_type="resnet"), MagicMock()),
+        ),
+        patch(f"{_AUTO}.get_cache_dir", return_value=MagicMock()),
+        patch(f"{_AUTO}.get_model_dir", return_value=MagicMock()),
+        patch(f"{_AUTO}.get_cache_key", return_value="key"),
+        patch(
+            _BUILD_HF_MODEL,
+            side_effect=build_side_effect,
+            return_value=MagicMock(final_onnx_path="model.onnx"),
+        ),
+        patch(f"{_AUTO}.get_winml_class", return_value=winml_class),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# EP fix tests
+# ---------------------------------------------------------------------------
+
+
+class TestFromPretrainedEpFix:
+    """Inference wrapper must NOT receive the compile-derived EP.
+
+    Before the fix, from_pretrained passed ep=resolved_ep (e.g. "qnn") to
+    the inference wrapper even when the user only specified --device npu.
+    This caused WinMLSession to enter explicit-EP mode and log a warning on
+    machines without QNN hardware.
+
+    After the fix, ep=kwargs.get("ep") is passed, so:
+    - No explicit --ep  → wrapper gets ep=None  → device policy applies
+    - Explicit --ep qnn → wrapper gets ep="qnn" → explicit mode (intended)
+    """
+
+    def _call_and_capture_wrapper_ep(self, extra_kwargs: dict):
+        from winml.modelkit.models.auto import WinMLAutoModel
+
+        build_cfg = _make_build_config(compile_provider="qnn")
+        mock_winml_class = _mock_winml_class()
+        patches = _base_patches(build_cfg, winml_class=mock_winml_class)
+
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+        ):
+            WinMLAutoModel.from_pretrained("some/model", **extra_kwargs)
+
+        return mock_winml_class.call_args.kwargs.get("ep")
+
+    def test_no_explicit_ep_wrapper_gets_none(self):
+        """Without --ep, inference wrapper should receive ep=None (device policy)."""
+        ep = self._call_and_capture_wrapper_ep({"device": "npu"})
+        assert ep is None, (
+            f"Expected ep=None (device policy), got ep={ep!r}. "
+            "The wrapper should not receive the compile-derived EP."
+        )
+
+    def test_explicit_ep_forwarded_to_wrapper(self):
+        """With --ep qnn, inference wrapper should receive ep='qnn'."""
+        ep = self._call_and_capture_wrapper_ep({"device": "npu", "ep": "qnn"})
+        assert ep == "qnn", f"Expected ep='qnn' (user's explicit EP), got ep={ep!r}."
+
+    def test_no_ep_no_device_wrapper_gets_none(self):
+        """Without --ep or --device, wrapper should receive ep=None."""
+        ep = self._call_and_capture_wrapper_ep({})
+        assert ep is None
+
+
+# ---------------------------------------------------------------------------
+# no_compile kwarg tests
+# ---------------------------------------------------------------------------
+
+
+class TestFromPretrainedNoCompile:
+    """build_config.compile must be None when no_compile=True.
+
+    generate_hf_build_config's STEP 4.5 always re-sets compile from device
+    policy, so the override dict approach doesn't work. The fix applies
+    no_compile AFTER generate_hf_build_config returns.
+    """
+
+    def _call_and_capture_compile(self, extra_kwargs: dict):
+        from winml.modelkit.models.auto import WinMLAutoModel
+
+        build_cfg = _make_build_config(compile_provider="qnn")
+        captured = {}
+
+        def fake_build(**kwargs):
+            captured["compile"] = kwargs["config"].compile
+            return MagicMock(final_onnx_path="model.onnx")
+
+        patches = _base_patches(build_cfg, build_side_effect=fake_build)
+
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+        ):
+            WinMLAutoModel.from_pretrained("some/model", **extra_kwargs)
+
+        return captured.get("compile")
+
+    def test_no_compile_true_clears_compile(self):
+        """no_compile=True must set build_config.compile=None before build."""
+        compile_val = self._call_and_capture_compile({"no_compile": True})
+        assert compile_val is None, (
+            f"build_config.compile should be None when no_compile=True, got {compile_val!r}"
+        )
+
+    def test_no_compile_false_preserves_compile(self):
+        """no_compile=False must leave build_config.compile intact."""
+        compile_val = self._call_and_capture_compile({"no_compile": False})
+        assert compile_val is not None, (
+            "build_config.compile should not be cleared when no_compile=False"
+        )
+
+    def test_no_compile_absent_preserves_compile(self):
+        """Omitting no_compile kwarg must leave build_config.compile intact."""
+        compile_val = self._call_and_capture_compile({})
+        assert compile_val is not None, (
+            "build_config.compile should not be cleared when no_compile is not passed"
+        )

--- a/tests/unit/models/auto/test_from_pretrained_kwargs.py
+++ b/tests/unit/models/auto/test_from_pretrained_kwargs.py
@@ -14,7 +14,11 @@ Covers two fixes:
 
 from __future__ import annotations
 
+import contextlib
 from unittest.mock import MagicMock, patch
+
+from winml.modelkit.compiler import EPConfig, WinMLCompileConfig
+from winml.modelkit.config import WinMLBuildConfig
 
 
 # ---------------------------------------------------------------------------
@@ -31,9 +35,6 @@ _BUILD_HF_MODEL = "winml.modelkit.build.build_hf_model"
 
 def _make_build_config(compile_provider: str | None = "qnn"):
     """Return a minimal WinMLBuildConfig with controllable compile field."""
-    from winml.modelkit.compiler.configs import EPConfig, WinMLCompileConfig
-    from winml.modelkit.config import WinMLBuildConfig
-
     cfg = WinMLBuildConfig()
     cfg.compile = (
         WinMLCompileConfig(ep_config=EPConfig(provider=compile_provider))
@@ -52,7 +53,7 @@ def _mock_winml_class():
 
 
 def _base_patches(build_cfg, build_side_effect=None, winml_class=None):
-    """Return a list of context managers that stub out the heavy internals."""
+    """Return a list of patch context managers for from_pretrained internals."""
     if winml_class is None:
         winml_class = _mock_winml_class()
     return [
@@ -96,17 +97,10 @@ class TestFromPretrainedEpFix:
 
         build_cfg = _make_build_config(compile_provider="qnn")
         mock_winml_class = _mock_winml_class()
-        patches = _base_patches(build_cfg, winml_class=mock_winml_class)
 
-        with (
-            patches[0],
-            patches[1],
-            patches[2],
-            patches[3],
-            patches[4],
-            patches[5],
-            patches[6],
-        ):
+        with contextlib.ExitStack() as stack:
+            for p in _base_patches(build_cfg, winml_class=mock_winml_class):
+                stack.enter_context(p)
             WinMLAutoModel.from_pretrained("some/model", **extra_kwargs)
 
         return mock_winml_class.call_args.kwargs.get("ep")
@@ -153,17 +147,9 @@ class TestFromPretrainedNoCompile:
             captured["compile"] = kwargs["config"].compile
             return MagicMock(final_onnx_path="model.onnx")
 
-        patches = _base_patches(build_cfg, build_side_effect=fake_build)
-
-        with (
-            patches[0],
-            patches[1],
-            patches[2],
-            patches[3],
-            patches[4],
-            patches[5],
-            patches[6],
-        ):
+        with contextlib.ExitStack() as stack:
+            for p in _base_patches(build_cfg, build_side_effect=fake_build):
+                stack.enter_context(p)
             WinMLAutoModel.from_pretrained("some/model", **extra_kwargs)
 
         return captured.get("compile")


### PR DESCRIPTION
## Summary

- **EP warning fix** (`auto.py`): `from_pretrained` was passing `ep=resolved_ep` (the compile-time EP derived from `--device`, e.g. `"qnn"`) to the inference wrapper. This caused `WinMLSession` to enter explicit-EP mode and log `WARNING: EP 'qnn' (QNNExecutionProvider) not found` on machines without QNN hardware. Fixed to pass `ep=kwargs.get("ep")` (user's explicit `--ep` only).

- **`--no-compile/--compile` flag** (`perf.py`): adds a toggle matching the `build` command convention — default `True` (skip compile). The override is applied *after* `generate_hf_build_config` returns because the device policy in STEP 4.5 always re-sets `compile`, so an override dict passed earlier would be silently overwritten.

- **Tests**: 8 new cases in `test_perf_cli.py` (flag presence in help, kwarg forwarding for both `from_pretrained` and `from_onnx`, CLI toggle); new file `test_from_pretrained_kwargs.py` with 6 cases covering the EP fix and `no_compile` behaviour.