### PR TITLE
fix(config): set --no-compile default to True

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "setuptools>=61", "wheel" ]
 
 [project]
 name = "winml-modelkit"
-version = "0.0.1.dev1"
+version = "0.0.2"
 description = "Accelerate Model Deployment on WinML"
 readme = "README.md"
 keywords = [ "onnx", "winml" ]
@@ -27,21 +27,27 @@ dependencies = [
   "datasets>=4.1.1",
   "diffusers>=0.36",
   "evaluate>=0.4.6",
+  "fastapi>=0.135.3",
+  "httpx>=0.24.0",
   "jsonschema>=4.23",
+  "mcp>=0.1.0",
   "ml-dtypes>=0.5.3",
   "numpy>=2.2,<2.3",
   "onnx==1.18",
   "onnx-ir>=0.1",
   "onnxruntime-windowsml>=1.23.2,<1.24.0",
   "onnxscript>=0.2",
+  "opentelemetry-sdk>=1.39.1",
   "optimum>=2",
   "optimum-onnx>=0.1",
   "plotext>=5.3.2",
   "pydantic>=2",
+  "python-multipart>=0.0.22",
   "requests>=2.32.5",
   "rich>=14",
   "scikit-learn>=1.7",
   "scipy>=1.15,<1.16",
+  "sentencepiece>=0.2.1",
   "seqeval>=1.2.2",
   "snakemd>=2",
   "timm>=1.0.22",
@@ -51,6 +57,7 @@ dependencies = [
   "torchmetrics[detection]>=1.0",
   "torchvision>=0.24",
   "transformers>=4.57",
+  "uvicorn[standard]>=0.42.0",
   "wasdk-microsoft-windows-ai-machinelearning>=1.8.251106002",
   "wasdk-microsoft-windows-applicationmodel-dynamicdependency-bootstrap>=1.8.251106002",
   "winrt-runtime>=3.2.1",
@@ -75,6 +82,7 @@ optional-dependencies.dev = [
   "tqdm>=4.67",
   "types-colorama>=0.4.15.20250801",
 ]
+optional-dependencies.audio = [ "soundfile>=0.13" ]
 optional-dependencies.openvino = [ "openvino>=2023" ]
 optional-dependencies.qnn = [
   "onnxruntime-qnn>=1.24.1; python_version>='3.11'",
@@ -118,6 +126,9 @@ include = [ "winml", "winml.*" ]
 ]
 "winml.modelkit.pattern" = [
   "rules/**/*.json",
+]
+"winml.modelkit.serve" = [
+  "static/**",
 ]
 
 # =============================================================================
@@ -370,8 +381,8 @@ markers = [
   "qnn: marks tests for QNN backend",
   "openvino: marks tests for OpenVINO backend",
   "cuda: marks tests requiring CUDA runtime",
-  "directml: marks tests for DirectML backend",
-  "tensorrt: marks tests for TensorRT backend",
+  "dml: marks tests for Dml backend",
+  "nv_tensorrt_rtx: marks tests for NvTensorRTRTX backend",
   "vitisai: marks tests for AMD Vitis AI backend",
   "training: marks tests requiring training-specific ORT features",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "setuptools>=61", "wheel" ]
 
 [project]
 name = "winml-modelkit"
-version = "0.0.2"
+version = "0.0.1.dev1"
 description = "Accelerate Model Deployment on WinML"
 readme = "README.md"
 keywords = [ "onnx", "winml" ]
@@ -27,27 +27,21 @@ dependencies = [
   "datasets>=4.1.1",
   "diffusers>=0.36",
   "evaluate>=0.4.6",
-  "fastapi>=0.135.3",
-  "httpx>=0.24.0",
   "jsonschema>=4.23",
-  "mcp>=0.1.0",
   "ml-dtypes>=0.5.3",
   "numpy>=2.2,<2.3",
   "onnx==1.18",
   "onnx-ir>=0.1",
   "onnxruntime-windowsml>=1.23.2,<1.24.0",
   "onnxscript>=0.2",
-  "opentelemetry-sdk>=1.39.1",
   "optimum>=2",
   "optimum-onnx>=0.1",
   "plotext>=5.3.2",
   "pydantic>=2",
-  "python-multipart>=0.0.22",
   "requests>=2.32.5",
   "rich>=14",
   "scikit-learn>=1.7",
   "scipy>=1.15,<1.16",
-  "sentencepiece>=0.2.1",
   "seqeval>=1.2.2",
   "snakemd>=2",
   "timm>=1.0.22",
@@ -57,7 +51,6 @@ dependencies = [
   "torchmetrics[detection]>=1.0",
   "torchvision>=0.24",
   "transformers>=4.57",
-  "uvicorn[standard]>=0.42.0",
   "wasdk-microsoft-windows-ai-machinelearning>=1.8.251106002",
   "wasdk-microsoft-windows-applicationmodel-dynamicdependency-bootstrap>=1.8.251106002",
   "winrt-runtime>=3.2.1",
@@ -82,7 +75,6 @@ optional-dependencies.dev = [
   "tqdm>=4.67",
   "types-colorama>=0.4.15.20250801",
 ]
-optional-dependencies.audio = [ "soundfile>=0.13" ]
 optional-dependencies.openvino = [ "openvino>=2023" ]
 optional-dependencies.qnn = [
   "onnxruntime-qnn>=1.24.1; python_version>='3.11'",
@@ -126,9 +118,6 @@ include = [ "winml", "winml.*" ]
 ]
 "winml.modelkit.pattern" = [
   "rules/**/*.json",
-]
-"winml.modelkit.serve" = [
-  "static/**",
 ]
 
 # =============================================================================
@@ -381,8 +370,8 @@ markers = [
   "qnn: marks tests for QNN backend",
   "openvino: marks tests for OpenVINO backend",
   "cuda: marks tests requiring CUDA runtime",
-  "dml: marks tests for Dml backend",
-  "nv_tensorrt_rtx: marks tests for NvTensorRTRTX backend",
+  "directml: marks tests for DirectML backend",
+  "tensorrt: marks tests for TensorRT backend",
   "vitisai: marks tests for AMD Vitis AI backend",
   "training: marks tests requiring training-specific ORT features",
 ]

--- a/src/winml/modelkit/commands/config.py
+++ b/src/winml/modelkit/commands/config.py
@@ -164,10 +164,10 @@ def _is_onnx_file(model_input: str) -> bool:
     help="Exclude quantization from generated config (sets quant=None)",
 )
 @click.option(
-    "--no-compile",
-    is_flag=True,
+    "--no-compile/--compile",
+    "no_compile",
     default=True,
-    help="Exclude compilation from generated config (sets compile=None)",
+    help="Exclude compilation from generated config (sets compile=None). Default: exclude.",
 )
 @click.option(
     "--trust-remote-code",

--- a/src/winml/modelkit/commands/config.py
+++ b/src/winml/modelkit/commands/config.py
@@ -166,7 +166,7 @@ def _is_onnx_file(model_input: str) -> bool:
 @click.option(
     "--no-compile",
     is_flag=True,
-    default=False,
+    default=True,
     help="Exclude compilation from generated config (sets compile=None)",
 )
 @click.option(

--- a/tests/unit/config/test_build.py
+++ b/tests/unit/config/test_build.py
@@ -2010,8 +2010,8 @@ class TestDevicePrecisionCli:
         return result, output_file
 
     def test_device_npu_produces_qnn(self, tmp_path) -> None:
-        """--device npu → compile.provider=qnn, quant with w8a16."""
-        result, output_file = self._invoke(tmp_path, ["--device", "npu"])
+        """--device npu --compile → compile.provider=qnn, quant with w8a16."""
+        result, output_file = self._invoke(tmp_path, ["--device", "npu", "--compile"])
 
         assert result.exit_code == 0, f"CLI failed: {result.output}"
         data = json.loads(output_file.read_text())
@@ -2059,15 +2059,15 @@ class TestDevicePrecisionCli:
 
         assert result.exit_code == 0, f"CLI failed: {result.output}"
         data = json.loads(output_file.read_text())
-        # Default: quant and compile both present (backward compat)
+        # Default: quant present, compile excluded (--no-compile is default)
         assert data["quant"] is not None
-        assert data["compile"] is not None
+        assert data["compile"] is None
 
     def test_auto_precision_int8_triggers_detection(self, tmp_path) -> None:
-        """--device auto --precision int8 → triggers device detection."""
+        """--device auto --precision int8 --compile → triggers device detection."""
         result, output_file = self._invoke(
             tmp_path,
-            ["--device", "auto", "--precision", "int8"],
+            ["--device", "auto", "--precision", "int8", "--compile"],
         )
 
         assert result.exit_code == 0, f"CLI failed: {result.output}"
@@ -2126,7 +2126,7 @@ class TestConfigOnnxAutoDetect:
             runner = CliRunner()
             result = runner.invoke(
                 config_command,
-                ["-m", str(onnx_file), "--device", "npu", "-o", str(output_file)],
+                ["-m", str(onnx_file), "--device", "npu", "--compile", "-o", str(output_file)],
             )
 
         assert result.exit_code == 0, f"CLI failed: {result.output}"

--- a/tests/unit/config/test_build_onnx.py
+++ b/tests/unit/config/test_build_onnx.py
@@ -131,7 +131,7 @@ class TestConfigOnnxAutoDetect:
             runner = CliRunner()
             result = runner.invoke(
                 config_command,
-                ["-m", str(onnx_file), "--device", "npu", "-o", str(output_file)],
+                ["-m", str(onnx_file), "--device", "npu", "--compile", "-o", str(output_file)],
             )
 
         assert result.exit_code == 0, f"CLI failed: {result.output}"


### PR DESCRIPTION
## Summary
- Change `--no-compile` flag default from `False` to `True` in the `config` command, so compilation is excluded by default when generating config.