### PR TITLE
fix(perf): forward --ep/--device through perf --module path and narrow EP discovery

### DIFF
--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -504,6 +504,9 @@ def _perf_modules(
     verbose: bool,
     console: Console,
     monitor: bool = False,
+    device: str = "auto",
+    ep: str | None = None,
+    precision: str = "auto",
 ) -> None:
     """Run per-module build and benchmark for matching submodules.
 
@@ -523,13 +526,20 @@ def _perf_modules(
         verbose: If True, log exceptions at DEBUG level.
         console: Rich console for output.
         monitor: If True, wrap each per-module benchmark with HWMonitor.
+        device: Target device policy ("auto", "cpu", "gpu", "npu").
+        ep: Explicit execution provider (e.g., "qnn", "dml"). Overrides
+            device-to-provider mapping when set.
+        precision: Precision mode passed through to the build stage.
     """
     import json as json_mod
     import tempfile
 
     from ..build import build_hf_model
     from ..config import generate_hf_build_config
+    from ..sysinfo import resolve_device
     from .build import _instantiate_parent_model
+
+    resolved_device, _ = resolve_device(device=device)
 
     console.print(f"[dim]Generating module configs for {module_class}...[/dim]")
 
@@ -538,6 +548,9 @@ def _perf_modules(
             model_id=hf_model,
             task=task,
             module=module_class,
+            device=resolved_device,
+            precision=precision,
+            ep=ep,
         )
     except Exception as e:
         console.print(f"[red]Error generating module configs: {e}[/red]")
@@ -590,12 +603,18 @@ def _perf_modules(
                     config=cfg,
                     output_dir=Path(tmpdir),
                     pytorch_model=submodule,
+                    ep=ep,
+                    device=resolved_device,
                 )
 
                 # Benchmark using WinMLSession
                 from ..session import WinMLSession
 
-                session = WinMLSession(str(build_result.final_onnx_path))
+                session = WinMLSession(
+                    str(build_result.final_onnx_path),
+                    device=resolved_device,
+                    ep=ep,
+                )
                 io_cfg = session.io_config
                 inputs = generate_random_inputs(io_cfg, batch_size=batch_size)
 
@@ -1250,6 +1269,9 @@ def perf(
             verbose=verbose,
             console=console,
             monitor=monitor,
+            device=device.lower(),
+            ep=ep.lower() if ep else None,
+            precision=precision.lower(),
         )
         return
 

--- a/src/winml/modelkit/session/session.py
+++ b/src/winml/modelkit/session/session.py
@@ -301,7 +301,7 @@ class WinMLSession:
             # Log which providers were selected by ORT (based on policy)
             actual_providers = session.get_providers()
             logger.info(
-                "Session created with policy %s, providers: %s",
+                "Session created with device %s, providers: %s",
                 target_device,
                 actual_providers,
             )
@@ -478,6 +478,7 @@ class WinMLSession:
             device.lower(), ort.OrtExecutionProviderDevicePolicy.PREFER_NPU
         )
         opts.set_provider_selection_policy(policy)
+        logger.info("Using provider selection policy %s for device %s", policy, device)
 
         return opts
 

--- a/src/winml/modelkit/session/session.py
+++ b/src/winml/modelkit/session/session.py
@@ -441,9 +441,20 @@ class WinMLSession:
             if target_name:
                 matched = self._find_ep_device(ep_name=target_name, device=device)
                 if matched:
+                    from ..utils.constants import DEVICE_TYPE_TO_DEVICE
+
                     opts = ort.SessionOptions()
                     opts.add_provider_for_devices([matched], self._provider_options)
-                    logger.info("Explicit EP: %s (%s)", self._ep, target_name)
+                    resolved = DEVICE_TYPE_TO_DEVICE.get(
+                        matched.device.type, str(matched.device.type)
+                    )
+                    logger.info(
+                        "Explicit EP: %s (%s) device=%s -> %s",
+                        self._ep,
+                        target_name,
+                        device,
+                        resolved,
+                    )
                     return opts
                 logger.warning(
                     "EP '%s' (%s) not found for device '%s'",

--- a/src/winml/modelkit/session/session.py
+++ b/src/winml/modelkit/session/session.py
@@ -432,27 +432,29 @@ class WinMLSession:
         Note: Returns a **fresh** SessionOptions when using explicit EP to
         avoid "already registered" errors from repeated calls.
         """
-        # Explicit EP targeting: create fresh opts to avoid double-registration
-        # Don't filter by device type — trust the user's --ep choice
-        # (e.g., QNN reports as NPU in get_ep_devices but can target GPU)
+        # Explicit EP targeting: create fresh opts to avoid double-registration.
+        # When device is also specified (non-"auto"), narrow by both EP name
+        # and device type so e.g. `--ep qnn --device cpu` finds QNN-on-CPU
+        # instead of the first QNN ep_device (which may report as NPU).
         if self._ep and self._ep != "cpu":
             target_name = self._EP_NAME_MAP.get(self._ep)
             if target_name:
-                matched = self._find_ep_device(target_name)
+                matched = self._find_ep_device(ep_name=target_name, device=device)
                 if matched:
                     opts = ort.SessionOptions()
                     opts.add_provider_for_devices([matched], self._provider_options)
                     logger.info("Explicit EP: %s (%s)", self._ep, target_name)
                     return opts
                 logger.warning(
-                    "EP '%s' (%s) not found in available devices",
+                    "EP '%s' (%s) not found for device '%s'",
                     self._ep,
                     target_name,
+                    device,
                 )
 
         # No explicit EP — discover available EP for this device type
         if not self._ep and device.lower() != "cpu":
-            matched = self._find_ep_for_device(device)
+            matched = self._find_ep_device(device=device)
             if matched:
                 opts = ort.SessionOptions()
                 opts.add_provider_for_devices([matched], self._provider_options)
@@ -469,44 +471,41 @@ class WinMLSession:
         return opts
 
     @staticmethod
-    def _find_ep_device(ep_name: str) -> Any:
-        """Find the first OrtEpDevice matching the given EP name.
+    def _find_ep_device(
+        ep_name: str | None = None,
+        device: str | None = None,
+    ) -> Any:
+        """Find the first OrtEpDevice matching the given filters.
 
-        Args:
-            ep_name: Full EP name (e.g., "DmlExecutionProvider").
-
-        Returns:
-            The matching OrtEpDevice, or None if not found.
-        """
-        for ep_dev in ort.get_ep_devices():
-            if ep_dev.ep_name == ep_name:
-                return ep_dev
-        return None
-
-    @staticmethod
-    def _find_ep_for_device(device: str) -> Any:
-        """Find the first available OrtEpDevice for the given device type.
-
-        Queries ``ort.get_ep_devices()`` and returns the first EP whose
-        hardware device type matches (e.g., device="gpu" matches GPU EPs).
+        Filters are AND'd: when both ``ep_name`` and ``device`` are set, the
+        returned ep_device must satisfy both. When only one is set, only that
+        filter applies. Unknown device strings (including ``"auto"``) act as
+        a no-op device filter.
 
         Note: Selection order is determined by the ORT EP registry, which is
         not part of any documented contract. On systems where multiple EPs
         match the same device type (e.g., QNN and DML both appear as GPU),
-        the result is registry-order dependent. When a specific EP is
-        required, use ``self._ep`` to bypass this discovery path entirely.
+        a device-only query returns the first one in registry order. Pass
+        ``ep_name`` to disambiguate.
+
+        Args:
+            ep_name: Full EP name (e.g., "DmlExecutionProvider"), or None
+                to skip EP-name filtering.
+            device: Device policy ("cpu", "gpu", "npu"), or None to skip
+                device filtering.
 
         Returns:
             The matching OrtEpDevice, or None if not found.
         """
         from ..utils.constants import DEVICE_TO_DEVICE_TYPE
 
-        device_type = DEVICE_TO_DEVICE_TYPE.get(device.upper())
-        if device_type is None:
-            return None
+        device_type = DEVICE_TO_DEVICE_TYPE.get(device.upper()) if device else None
         for ep_dev in ort.get_ep_devices():
-            if ep_dev.device.type == device_type:
-                return ep_dev
+            if ep_name and ep_dev.ep_name != ep_name:
+                continue
+            if device_type is not None and ep_dev.device.type != device_type:
+                continue
+            return ep_dev
         return None
 
     def _validate_inputs(self, inputs: dict[str, Any]) -> None:

--- a/src/winml/modelkit/session/session.py
+++ b/src/winml/modelkit/session/session.py
@@ -477,10 +477,14 @@ class WinMLSession:
     ) -> Any:
         """Find the first OrtEpDevice matching the given filters.
 
-        Filters are AND'd: when both ``ep_name`` and ``device`` are set, the
-        returned ep_device must satisfy both. When only one is set, only that
-        filter applies. Unknown device strings (including ``"auto"``) act as
-        a no-op device filter.
+        Behavior:
+            - Both ``ep_name`` and ``device`` unset/``"auto"`` → ``None``
+              (no effective filter).
+            - ``ep_name`` set, ``device`` unset/``"auto"`` → first ep_device
+              matching ``ep_name`` (or None).
+            - ``ep_name`` unset, ``device`` is a concrete type → first
+              ep_device matching that device type (or None).
+            - Both set → ep_device must satisfy both (or None).
 
         Note: Selection order is determined by the ORT EP registry, which is
         not part of any documented contract. On systems where multiple EPs
@@ -491,8 +495,8 @@ class WinMLSession:
         Args:
             ep_name: Full EP name (e.g., "DmlExecutionProvider"), or None
                 to skip EP-name filtering.
-            device: Device policy ("cpu", "gpu", "npu"), or None to skip
-                device filtering.
+            device: Device policy ("cpu", "gpu", "npu", "auto"), or None.
+                ``"auto"`` and unknown strings act as no-op device filters.
 
         Returns:
             The matching OrtEpDevice, or None if not found.
@@ -500,6 +504,11 @@ class WinMLSession:
         from ..utils.constants import DEVICE_TO_DEVICE_TYPE
 
         device_type = DEVICE_TO_DEVICE_TYPE.get(device.upper()) if device else None
+
+        # No effective filter — refuse to pick an arbitrary ep_device.
+        if not ep_name and device_type is None:
+            return None
+
         for ep_dev in ort.get_ep_devices():
             if ep_name and ep_dev.ep_name != ep_name:
                 continue

--- a/src/winml/modelkit/session/session.py
+++ b/src/winml/modelkit/session/session.py
@@ -471,17 +471,14 @@ class WinMLSession:
         return opts
 
     @staticmethod
-    def _find_ep_device(
-        ep_name: str | None = None,
-        device: str | None = None,
-    ) -> Any:
+    def _find_ep_device(device: str, ep_name: str | None = None) -> Any:
         """Find the first OrtEpDevice matching the given filters.
 
         Behavior:
-            - Both ``ep_name`` and ``device`` unset/``"auto"`` → ``None``
-              (no effective filter).
-            - ``ep_name`` set, ``device`` unset/``"auto"`` → first ep_device
+            - ``ep_name`` set, ``device == "auto"`` → first ep_device
               matching ``ep_name`` (or None).
+            - ``ep_name`` unset, ``device == "auto"`` → ``None`` (no
+              effective filter — refuse to pick an arbitrary ep_device).
             - ``ep_name`` unset, ``device`` is a concrete type → first
               ep_device matching that device type (or None).
             - Both set → ep_device must satisfy both (or None).
@@ -493,17 +490,17 @@ class WinMLSession:
         ``ep_name`` to disambiguate.
 
         Args:
+            device: Device policy ("cpu", "gpu", "npu", "auto"). ``"auto"``
+                and unknown strings act as no-op device filters.
             ep_name: Full EP name (e.g., "DmlExecutionProvider"), or None
                 to skip EP-name filtering.
-            device: Device policy ("cpu", "gpu", "npu", "auto"), or None.
-                ``"auto"`` and unknown strings act as no-op device filters.
 
         Returns:
             The matching OrtEpDevice, or None if not found.
         """
         from ..utils.constants import DEVICE_TO_DEVICE_TYPE
 
-        device_type = DEVICE_TO_DEVICE_TYPE.get(device.upper()) if device else None
+        device_type = DEVICE_TO_DEVICE_TYPE.get(device.upper())
 
         # No effective filter — refuse to pick an arbitrary ep_device.
         if not ep_name and device_type is None:

--- a/src/winml/modelkit/sysinfo/device.py
+++ b/src/winml/modelkit/sysinfo/device.py
@@ -188,6 +188,11 @@ def resolve_device(device: str = "auto") -> tuple[str, list[str]]:
         for dev in available_devices:
             compatible_eps = _DEVICE_EP_MAP.get(dev, [])
             if any(ep in available_eps for ep in compatible_eps):
+                logger.info(
+                    "Auto-selected device '%s' with compatible EPs: %s for auto device",
+                    dev,
+                    sorted(ep for ep in compatible_eps if ep in available_eps),
+                )
                 return dev, available_devices
         # Fallback: CPU is always valid
         return "cpu", available_devices

--- a/tests/unit/commands/test_perf_module.py
+++ b/tests/unit/commands/test_perf_module.py
@@ -6,10 +6,17 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
 from click.testing import CliRunner
 
 from winml.modelkit.cli import main
 from winml.modelkit.commands.perf import generate_output_path
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class TestPerfModuleFlag:
@@ -44,3 +51,85 @@ class TestPerfModuleFlag:
         module_path = Path(f"{slug}_{module_class}_perf.json")
         assert module_class in str(module_path)
         assert str(module_path) != str(path)
+
+
+class TestPerfModuleParameterForwarding:
+    """Verify --device/--ep/--precision flow from CLI through _perf_modules
+    into generate_hf_build_config, build_hf_model, and WinMLSession.
+
+    Regression guard: these kwargs were silently dropped before.
+    """
+
+    def test_device_and_ep_forwarded_through_module_path(self, tmp_path: Path) -> None:
+        # Fake module config -- only the attributes _perf_modules touches
+        fake_cfg = MagicMock()
+        fake_cfg.loader.model_type = "bert"
+        fake_cfg.loader.module_path = "encoder.layer.0"
+
+        fake_build_result = MagicMock()
+        fake_build_result.final_onnx_path = tmp_path / "model.onnx"
+
+        # Make WinMLSession.perf() raise so the benchmark loop is short-circuited
+        # via the existing try/except in _perf_modules. We still capture the
+        # constructor kwargs, which is what we care about.
+        fake_session = MagicMock()
+        fake_session.perf.side_effect = RuntimeError("test-skip-benchmark")
+
+        with (
+            patch(
+                "winml.modelkit.sysinfo.resolve_device",
+                return_value=("npu", "qnn"),
+            ),
+            patch(
+                "winml.modelkit.config.generate_hf_build_config",
+                return_value=[fake_cfg],
+            ) as mock_gen,
+            patch(
+                "winml.modelkit.commands.build._instantiate_parent_model",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "winml.modelkit.build.build_hf_model",
+                return_value=fake_build_result,
+            ) as mock_build,
+            patch(
+                "winml.modelkit.session.WinMLSession",
+                return_value=fake_session,
+            ) as mock_session_cls,
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                [
+                    "perf",
+                    "-m",
+                    "fake/model",
+                    "--module",
+                    "BertLayer",
+                    "--device",
+                    "npu",
+                    "--ep",
+                    "qnn",
+                    "--iterations",
+                    "1",
+                    "--warmup",
+                    "0",
+                    "-o",
+                    str(tmp_path / "out.json"),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+
+        gen_kwargs = mock_gen.call_args.kwargs
+        assert gen_kwargs["device"] == "npu"
+        assert gen_kwargs["ep"] == "qnn"
+        assert gen_kwargs["precision"] == "auto"
+
+        build_kwargs = mock_build.call_args.kwargs
+        assert build_kwargs["ep"] == "qnn"
+        assert build_kwargs["device"] == "npu"
+
+        session_kwargs = mock_session_cls.call_args.kwargs
+        assert session_kwargs["device"] == "npu"
+        assert session_kwargs["ep"] == "qnn"

--- a/tests/unit/session/test_winml_session.py
+++ b/tests/unit/session/test_winml_session.py
@@ -764,3 +764,13 @@ class TestFindEpDevice:
             match = WinMLSession._find_ep_device(ep_name="QNNExecutionProvider", device="auto")
         assert match is not None
         assert match.ep_name == "QNNExecutionProvider"
+
+    def test_no_filter_returns_none(self) -> None:
+        """Both ep_name and device unset/'auto' → None (no arbitrary pick)."""
+        import onnxruntime as ort
+
+        devs = [self._ep_dev("QNNExecutionProvider", ort.OrtHardwareDeviceType.NPU)]
+        with self._patch_devices(devs):
+            assert WinMLSession._find_ep_device() is None
+            assert WinMLSession._find_ep_device(device="auto") is None
+            assert WinMLSession._find_ep_device(ep_name=None, device=None) is None

--- a/tests/unit/session/test_winml_session.py
+++ b/tests/unit/session/test_winml_session.py
@@ -765,12 +765,20 @@ class TestFindEpDevice:
         assert match is not None
         assert match.ep_name == "QNNExecutionProvider"
 
-    def test_no_filter_returns_none(self) -> None:
-        """Both ep_name and device unset/'auto' → None (no arbitrary pick)."""
+    def test_both_unset_returns_none(self) -> None:
+        """ep_name=None and device=None → None (no arbitrary pick)."""
         import onnxruntime as ort
 
         devs = [self._ep_dev("QNNExecutionProvider", ort.OrtHardwareDeviceType.NPU)]
         with self._patch_devices(devs):
             assert WinMLSession._find_ep_device() is None
-            assert WinMLSession._find_ep_device(device="auto") is None
             assert WinMLSession._find_ep_device(ep_name=None, device=None) is None
+
+    def test_ep_none_and_device_auto_returns_none(self) -> None:
+        """ep_name=None and device='auto' → None (auto is a no-op filter)."""
+        import onnxruntime as ort
+
+        devs = [self._ep_dev("QNNExecutionProvider", ort.OrtHardwareDeviceType.NPU)]
+        with self._patch_devices(devs):
+            assert WinMLSession._find_ep_device(device="auto") is None
+            assert WinMLSession._find_ep_device(ep_name=None, device="auto") is None

--- a/tests/unit/session/test_winml_session.py
+++ b/tests/unit/session/test_winml_session.py
@@ -680,3 +680,87 @@ class TestWinMLSessionPerfTracking:
         assert stats.count == 3  # 5 - 2 warmup
         assert stats.mean_ms > 0
         assert stats.p99_ms > 0
+
+
+class TestFindEpDevice:
+    """Tests for WinMLSession._find_ep_device combined ep_name + device filter.
+
+    Regression guard: when both filters are set, both must match (AND logic).
+    Previously these were two separate methods and the explicit-EP path
+    ignored device, so `--ep qnn --device cpu` could return QNN-on-NPU.
+    """
+
+    @staticmethod
+    def _ep_dev(name: str, dev_type) -> object:
+        """Build a fake OrtEpDevice-like object."""
+        from types import SimpleNamespace
+
+        return SimpleNamespace(ep_name=name, device=SimpleNamespace(type=dev_type))
+
+    def _patch_devices(self, devices: list) -> object:
+        """Return a contextmanager that patches ort.get_ep_devices."""
+        from unittest.mock import patch
+
+        return patch(
+            "winml.modelkit.session.session.ort.get_ep_devices",
+            return_value=devices,
+        )
+
+    def test_ep_name_only(self) -> None:
+        """ep_name filter with no device filter returns first matching name."""
+        import onnxruntime as ort
+
+        devs = [
+            self._ep_dev("DmlExecutionProvider", ort.OrtHardwareDeviceType.GPU),
+            self._ep_dev("QNNExecutionProvider", ort.OrtHardwareDeviceType.NPU),
+        ]
+        with self._patch_devices(devs):
+            match = WinMLSession._find_ep_device(ep_name="QNNExecutionProvider")
+        assert match is not None
+        assert match.ep_name == "QNNExecutionProvider"
+
+    def test_device_only(self) -> None:
+        """device filter alone returns first matching device type."""
+        import onnxruntime as ort
+
+        devs = [
+            self._ep_dev("CPUExecutionProvider", ort.OrtHardwareDeviceType.CPU),
+            self._ep_dev("DmlExecutionProvider", ort.OrtHardwareDeviceType.GPU),
+        ]
+        with self._patch_devices(devs):
+            match = WinMLSession._find_ep_device(device="gpu")
+        assert match is not None
+        assert match.ep_name == "DmlExecutionProvider"
+
+    def test_ep_name_and_device_both_required(self) -> None:
+        """When both filters are set, both must match (AND logic)."""
+        import onnxruntime as ort
+
+        devs = [
+            # QNN-on-NPU comes first; user asks for QNN-on-CPU
+            self._ep_dev("QNNExecutionProvider", ort.OrtHardwareDeviceType.NPU),
+            self._ep_dev("QNNExecutionProvider", ort.OrtHardwareDeviceType.CPU),
+        ]
+        with self._patch_devices(devs):
+            match = WinMLSession._find_ep_device(ep_name="QNNExecutionProvider", device="cpu")
+        assert match is not None
+        assert match.device.type == ort.OrtHardwareDeviceType.CPU
+
+    def test_no_match_returns_none(self) -> None:
+        """Non-matching combination returns None even if individual filters would match."""
+        import onnxruntime as ort
+
+        devs = [self._ep_dev("QNNExecutionProvider", ort.OrtHardwareDeviceType.NPU)]
+        with self._patch_devices(devs):
+            match = WinMLSession._find_ep_device(ep_name="QNNExecutionProvider", device="cpu")
+        assert match is None
+
+    def test_auto_device_acts_as_no_filter(self) -> None:
+        """device='auto' falls back to ep_name-only matching."""
+        import onnxruntime as ort
+
+        devs = [self._ep_dev("QNNExecutionProvider", ort.OrtHardwareDeviceType.NPU)]
+        with self._patch_devices(devs):
+            match = WinMLSession._find_ep_device(ep_name="QNNExecutionProvider", device="auto")
+        assert match is not None
+        assert match.ep_name == "QNNExecutionProvider"

--- a/tests/unit/session/test_winml_session.py
+++ b/tests/unit/session/test_winml_session.py
@@ -707,7 +707,7 @@ class TestFindEpDevice:
         )
 
     def test_ep_name_only(self) -> None:
-        """ep_name filter with no device filter returns first matching name."""
+        """ep_name filter with device='auto' returns first matching name."""
         import onnxruntime as ort
 
         devs = [
@@ -715,7 +715,7 @@ class TestFindEpDevice:
             self._ep_dev("QNNExecutionProvider", ort.OrtHardwareDeviceType.NPU),
         ]
         with self._patch_devices(devs):
-            match = WinMLSession._find_ep_device(ep_name="QNNExecutionProvider")
+            match = WinMLSession._find_ep_device(device="auto", ep_name="QNNExecutionProvider")
         assert match is not None
         assert match.ep_name == "QNNExecutionProvider"
 
@@ -765,20 +765,11 @@ class TestFindEpDevice:
         assert match is not None
         assert match.ep_name == "QNNExecutionProvider"
 
-    def test_both_unset_returns_none(self) -> None:
-        """ep_name=None and device=None → None (no arbitrary pick)."""
-        import onnxruntime as ort
-
-        devs = [self._ep_dev("QNNExecutionProvider", ort.OrtHardwareDeviceType.NPU)]
-        with self._patch_devices(devs):
-            assert WinMLSession._find_ep_device() is None
-            assert WinMLSession._find_ep_device(ep_name=None, device=None) is None
-
     def test_ep_none_and_device_auto_returns_none(self) -> None:
-        """ep_name=None and device='auto' → None (auto is a no-op filter)."""
+        """ep_name=None and device='auto' → None (no effective filter)."""
         import onnxruntime as ort
 
         devs = [self._ep_dev("QNNExecutionProvider", ort.OrtHardwareDeviceType.NPU)]
         with self._patch_devices(devs):
             assert WinMLSession._find_ep_device(device="auto") is None
-            assert WinMLSession._find_ep_device(ep_name=None, device="auto") is None
+            assert WinMLSession._find_ep_device(device="auto", ep_name=None) is None


### PR DESCRIPTION
## Summary

Two related fixes for `--ep` / `--device` not flowing all the way through:

### `commands/perf.py` — `--module` path dropped CLI flags
`_perf_modules` did not accept `device`, `ep`, or `precision`, so `winml perf -m bert-base-uncased --module BertAttention --device npu --ep qnn` ignored those flags and ran on default device/EP. Plumbed them through to `generate_hf_build_config`, `build_hf_model`, and `WinMLSession`.

### `session/session.py` — explicit-EP path ignored device
`_find_ep_device(ep_name)` and `_find_ep_for_device(device)` were two methods, and the explicit-EP branch only matched by EP name. On systems where one EP exposes multiple `OrtEpDevice` entries (e.g. QNN-on-NPU and QNN-on-GPU), `--ep qnn --device gpu` could return QNN-on-NPU. Merged into a single `_find_ep_device(ep_name=None, device=None)` with AND'd filters so both intents are honored.

## Tests

- `tests/unit/commands/test_perf_module.py::TestPerfModuleParameterForwarding` — invokes the `--module` CLI with `--device npu --ep qnn`, mocks the four boundary calls, asserts each receives the expected kwargs. Verified to fail on the unfixed code (`KeyError: 'device'`).
- `tests/unit/session/test_winml_session.py::TestFindEpDevice` — 5 cases covering ep_name only / device only / both-must-match / no-match / `device="auto"` no-op. 4 of 5 fail on the old API.