### PR TITLE
Support ep option for eval command

### DIFF
--- a/scripts/e2e_eval/cache/baseline_cache.json
+++ b/scripts/e2e_eval/cache/baseline_cache.json
@@ -1,4 +1,834 @@
 {
+  "ProsusAI/finbert|text-classification|privet1mir/finbert_dataset||val|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "accuracy",
+      "value": 0.728,
+      "num_samples": 1000
+    },
+    "elapsed": 59.2,
+    "command": "python.exe run_pytorch_baseline.py --model finbert --task text-classification --device cpu --num-samples 1000 --dataset finbert_dataset --split val"
+  },
+  "cardiffnlp/twitter-roberta-base-sentiment-latest|text-classification|tweet_eval|sentiment||1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "accuracy",
+      "value": 0.769,
+      "num_samples": 1000
+    },
+    "elapsed": 91.5,
+    "command": "python.exe run_pytorch_baseline.py --model twitter-roberta-base-sentiment-latest --task text-classification --device cpu --num-samples 1000 --dataset tweet_eval --dataset-config sentiment --columns-mapping {\"input_column\": \"text\"}"
+  },
+  "distilbert/distilbert-base-uncased-finetuned-sst-2-english|text-classification|nyu-mll/glue|sst2||1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "accuracy",
+      "value": 0.91055,
+      "num_samples": 1000
+    },
+    "elapsed": 39.1,
+    "command": "python.exe run_pytorch_baseline.py --model distilbert-base-uncased-finetuned-sst-2-english --task text-classification --device cpu --num-samples 1000 --dataset glue --dataset-config sst2 --columns-mapping {\"input_column\": \"sentence\"}"
+  },
+  "dslim/bert-base-NER|token-classification|BramVanroy/conll2003|||1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "overall_f1",
+      "value": 0.956618,
+      "num_samples": 1000
+    },
+    "elapsed": 75.7,
+    "command": "python.exe run_pytorch_baseline.py --model bert-base-NER --task token-classification --device cpu --num-samples 1000 --dataset conll2003 --columns-mapping {\"label_column\": \"ner_tags\"}"
+  },
+  "dbmdz/bert-large-cased-finetuned-conll03-english|token-classification|BramVanroy/conll2003|||1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "overall_f1",
+      "value": 0.961688,
+      "num_samples": 1000
+    },
+    "elapsed": 244.6,
+    "command": "python.exe run_pytorch_baseline.py --model bert-large-cased-finetuned-conll03-english --task token-classification --device cpu --num-samples 1000 --dataset conll2003 --columns-mapping {\"label_column\": \"ner_tags\"}"
+  },
+  "Babelscape/wikineural-multilingual-ner|token-classification|BramVanroy/conll2003|||1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "overall_f1",
+      "value": 0.774846,
+      "num_samples": 1000
+    },
+    "elapsed": 75.0,
+    "command": "python.exe run_pytorch_baseline.py --model wikineural-multilingual-ner --task token-classification --device cpu --num-samples 1000 --dataset conll2003 --columns-mapping {\"label_column\": \"ner_tags\"}"
+  },
+  "w11wo/indonesian-roberta-base-posp-tagger|token-classification|~/.cache/winml/eval_datasets/build_indonlu_posp|||1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "overall_f1",
+      "value": 0.964084,
+      "num_samples": 1000
+    },
+    "elapsed": 64.2,
+    "command": "python.exe run_pytorch_baseline.py --model indonesian-roberta-base-posp-tagger --task token-classification --device cpu --num-samples 1000 --dataset build_indonlu_posp --columns-mapping {\"label_column\": \"pos_tags\"}"
+  },
+  "Isotonic/distilbert_finetuned_ai4privacy_v2|token-classification|~/.cache/winml/eval_datasets/build_ai4privacy|||1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "overall_f1",
+      "value": 0.789084,
+      "num_samples": 1000
+    },
+    "elapsed": 63.8,
+    "command": "python.exe run_pytorch_baseline.py --model distilbert_finetuned_ai4privacy_v2 --task token-classification --device cpu --num-samples 1000 --dataset build_ai4privacy --columns-mapping {\"label_column\": \"ner_tags\"}"
+  },
+  "google/vit-base-patch16-224|image-classification|timm/mini-imagenet||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "accuracy",
+      "value": 0.784,
+      "num_samples": 1000
+    },
+    "elapsed": 181.3,
+    "command": "python.exe run_pytorch_baseline.py --model vit-base-patch16-224 --task image-classification --device cpu --num-samples 1000 --dataset mini-imagenet --split test"
+  },
+  "apple/mobilevit-small|image-classification|timm/mini-imagenet||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "accuracy",
+      "value": 0.776,
+      "num_samples": 1000
+    },
+    "elapsed": 98.5,
+    "command": "python.exe run_pytorch_baseline.py --model mobilevit-small --task image-classification --device cpu --num-samples 1000 --dataset mini-imagenet --split test"
+  },
+  "rizvandwiki/gender-classification|image-classification|~/.cache/winml/eval_datasets/build_fairface|||1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "accuracy",
+      "value": 0.812,
+      "num_samples": 1000
+    },
+    "elapsed": 166.1,
+    "command": "python.exe run_pytorch_baseline.py --model gender-classification --task image-classification --device cpu --num-samples 1000 --dataset build_fairface --columns-mapping {\"label_column\": \"gender\"}"
+  },
+  "microsoft/resnet-50|image-classification|timm/mini-imagenet||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "accuracy",
+      "value": 0.784,
+      "num_samples": 1000
+    },
+    "elapsed": 106.8,
+    "command": "python.exe run_pytorch_baseline.py --model resnet-50 --task image-classification --device cpu --num-samples 1000 --dataset mini-imagenet --split test"
+  },
+  "Intel/bert-base-uncased-mrpc|text-classification|nyu-mll/glue|mrpc||1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "accuracy",
+      "value": 0.860294,
+      "num_samples": 1000
+    },
+    "elapsed": 45.6,
+    "command": "python.exe run_pytorch_baseline.py --model bert-base-uncased-mrpc --task text-classification --device cpu --num-samples 1000 --dataset glue --dataset-config mrpc --columns-mapping {\"input_column\": \"sentence1\", \"second_input_column\": \"sentence2\"}"
+  },
+  "facebook/convnext-tiny-224|image-classification|timm/mini-imagenet||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "accuracy",
+      "value": 0.812,
+      "num_samples": 1000
+    },
+    "elapsed": 88.5,
+    "command": "python.exe run_pytorch_baseline.py --model convnext-tiny-224 --task image-classification --device cpu --num-samples 1000 --dataset mini-imagenet --split test"
+  },
+  "dima806/fairface_age_image_detection|image-classification|~/.cache/winml/eval_datasets/build_fairface|||1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "accuracy",
+      "value": 0.594,
+      "num_samples": 1000
+    },
+    "elapsed": 181.3,
+    "command": "python.exe run_pytorch_baseline.py --model fairface_age_image_detection --task image-classification --device cpu --num-samples 1000 --dataset build_fairface --columns-mapping {\"label_column\": \"age\"}"
+  },
+  "facebook/detr-resnet-50|object-detection|detection-datasets/coco||val|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "map",
+      "value": 0.4331,
+      "num_samples": 1000
+    },
+    "elapsed": 1539.2,
+    "command": "python.exe run_pytorch_baseline.py --model detr-resnet-50 --task object-detection --device cpu --num-samples 1000 --dataset coco --split val --columns-mapping {\"annotation_column\": \"objects\", \"bbox_key\": \"bbox\", \"category_key\": \"category\", \"box_format\": \"xyxy\"}"
+  },
+  "hustvl/yolos-small|object-detection|detection-datasets/coco||val|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "map",
+      "value": 0.387323,
+      "num_samples": 1000
+    },
+    "elapsed": 1870.9,
+    "command": "python.exe run_pytorch_baseline.py --model yolos-small --task object-detection --device cpu --num-samples 1000 --dataset coco --split val --columns-mapping {\"annotation_column\": \"objects\", \"bbox_key\": \"bbox\", \"category_key\": \"category\", \"box_format\": \"xyxy\"}"
+  },
+  "PekingU/rtdetr_r50vd_coco_o365|object-detection|detection-datasets/coco||val|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "map",
+      "value": 0.54762,
+      "num_samples": 1000
+    },
+    "elapsed": 985.7,
+    "command": "python.exe run_pytorch_baseline.py --model rtdetr_r50vd_coco_o365 --task object-detection --device cpu --num-samples 1000 --dataset coco --split val --columns-mapping {\"annotation_column\": \"objects\", \"bbox_key\": \"bbox\", \"category_key\": \"category\", \"box_format\": \"xyxy\"} --label-mapping-file coco_to_rtdetr_labels.json"
+  },
+  "PekingU/rtdetr_r101vd_coco_o365|object-detection|detection-datasets/coco||val|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "map",
+      "value": 0.564741,
+      "num_samples": 1000
+    },
+    "elapsed": 1541.1,
+    "command": "python.exe run_pytorch_baseline.py --model rtdetr_r101vd_coco_o365 --task object-detection --device cpu --num-samples 1000 --dataset coco --split val --columns-mapping {\"annotation_column\": \"objects\", \"bbox_key\": \"bbox\", \"category_key\": \"category\", \"box_format\": \"xyxy\"} --label-mapping-file coco_to_rtdetr_labels.json"
+  },
+  "PekingU/rtdetr_v2_r18vd|object-detection|detection-datasets/coco||val|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "map",
+      "value": 0.479367,
+      "num_samples": 1000
+    },
+    "elapsed": 545.7,
+    "command": "python.exe run_pytorch_baseline.py --model rtdetr_v2_r18vd --task object-detection --device cpu --num-samples 1000 --dataset coco --split val --columns-mapping {\"annotation_column\": \"objects\", \"bbox_key\": \"bbox\", \"category_key\": \"category\", \"box_format\": \"xyxy\"} --label-mapping-file coco_to_rtdetr_labels.json"
+  },
+  "valentinafeve/yolos-fashionpedia|object-detection|detection-datasets/fashionpedia||val|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "map",
+      "value": 0.110661,
+      "num_samples": 1000
+    },
+    "elapsed": 653.6,
+    "command": "python.exe run_pytorch_baseline.py --model yolos-fashionpedia --task object-detection --device cpu --num-samples 1000 --dataset fashionpedia --split val --columns-mapping {\"annotation_column\": \"objects\", \"bbox_key\": \"bbox\", \"category_key\": \"category\", \"box_format\": \"xyxy\"}"
+  },
+  "microsoft/table-transformer-detection|object-detection|~/.cache/winml/eval_datasets/build_pubtables1m_detection||validation|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "map",
+      "value": 0.988714,
+      "num_samples": 1000
+    },
+    "elapsed": 457.7,
+    "command": "python.exe run_pytorch_baseline.py --model table-transformer-detection --task object-detection --device cpu --num-samples 1000 --dataset build_pubtables1m_detection --split validation --columns-mapping {\"annotation_column\": \"objects\", \"bbox_key\": \"bbox\", \"category_key\": \"category\", \"box_format\": \"xyxy\"}"
+  },
+  "TahaDouaji/detr-doc-table-detection|object-detection|~/.cache/winml/eval_datasets/build_pubtables1m_detection||validation|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "map",
+      "value": 0.670707,
+      "num_samples": 1000
+    },
+    "elapsed": 1339.8,
+    "command": "python.exe run_pytorch_baseline.py --model detr-doc-table-detection --task object-detection --device cpu --num-samples 1000 --dataset build_pubtables1m_detection --split validation --columns-mapping {\"annotation_column\": \"objects\", \"bbox_key\": \"bbox\", \"category_key\": \"category\", \"box_format\": \"xyxy\"} --label-mapping-file pubtables_to_table_labels.json"
+  },
+  "microsoft/table-transformer-structure-recognition|object-detection|~/.cache/winml/eval_datasets/build_pubtables1m_structure||validation|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "map",
+      "value": 0.880184,
+      "num_samples": 1000
+    },
+    "elapsed": 584.4,
+    "command": "python.exe run_pytorch_baseline.py --model table-transformer-structure-recognition --task object-detection --device cpu --num-samples 1000 --dataset build_pubtables1m_structure --split validation --columns-mapping {\"annotation_column\": \"objects\", \"bbox_key\": \"bbox\", \"category_key\": \"category\", \"box_format\": \"xyxy\"}"
+  },
+  "nvidia/segformer-b0-finetuned-ade-512-512|image-segmentation|danjacobellis/scene_parse_150||validation|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "mean_iou",
+      "value": 0.347483,
+      "num_samples": 1000
+    },
+    "elapsed": 768.3,
+    "command": "python.exe run_pytorch_baseline.py --model segformer-b0-finetuned-ade-512-512 --task image-segmentation --device cpu --num-samples 1000 --dataset scene_parse_150 --split validation --columns-mapping {\"annotation_column\": \"annotation\"} --label-mapping-file ade20k_gt_to_model_label.json"
+  },
+  "nvidia/segformer-b1-finetuned-ade-512-512|image-segmentation|danjacobellis/scene_parse_150||validation|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "mean_iou",
+      "value": 0.397277,
+      "num_samples": 1000
+    },
+    "elapsed": 858.7,
+    "command": "python.exe run_pytorch_baseline.py --model segformer-b1-finetuned-ade-512-512 --task image-segmentation --device cpu --num-samples 1000 --dataset scene_parse_150 --split validation --columns-mapping {\"annotation_column\": \"annotation\"} --label-mapping-file ade20k_gt_to_model_label.json"
+  },
+  "nvidia/segformer-b2-finetuned-ade-512-512|image-segmentation|danjacobellis/scene_parse_150||validation|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "mean_iou",
+      "value": 0.439225,
+      "num_samples": 1000
+    },
+    "elapsed": 1580.7,
+    "command": "python.exe run_pytorch_baseline.py --model segformer-b2-finetuned-ade-512-512 --task image-segmentation --device cpu --num-samples 1000 --dataset scene_parse_150 --split validation --columns-mapping {\"annotation_column\": \"annotation\"} --label-mapping-file ade20k_gt_to_model_label.json"
+  },
+  "nvidia/segformer-b5-finetuned-ade-640-640|image-segmentation|danjacobellis/scene_parse_150||validation|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "mean_iou",
+      "value": 0.473467,
+      "num_samples": 1000
+    },
+    "elapsed": 3264.5,
+    "command": "python.exe run_pytorch_baseline.py --model segformer-b5-finetuned-ade-640-640 --task image-segmentation --device cpu --num-samples 1000 --dataset scene_parse_150 --split validation --columns-mapping {\"annotation_column\": \"annotation\"} --label-mapping-file ade20k_gt_to_model_label.json"
+  },
+  "mattmdjaga/segformer_b2_clothes|image-segmentation|mattmdjaga/human_parsing_dataset||train|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "mean_iou",
+      "value": 0.77979,
+      "num_samples": 1000
+    },
+    "elapsed": 1194.7,
+    "command": "python.exe run_pytorch_baseline.py --model segformer_b2_clothes --task image-segmentation --device cpu --num-samples 1000 --dataset human_parsing_dataset --split train --columns-mapping {\"annotation_column\": \"mask\"}"
+  },
+  "nvidia/segformer-b0-finetuned-cityscapes-1024-1024|image-segmentation|Chris1/cityscapes||validation|500": {
+    "status": "PASS",
+    "metric": {
+      "metric": "mean_iou",
+      "value": 0.582264,
+      "num_samples": 500
+    },
+    "elapsed": 711.6,
+    "command": "python.exe run_pytorch_baseline.py --model segformer-b0-finetuned-cityscapes-1024-1024 --task image-segmentation --device cpu --num-samples 500 --dataset cityscapes --split validation --columns-mapping {\"annotation_column\": \"semantic_segmentation\"} --label-mapping-file cityscapes_label_to_train_id.json"
+  },
+  "sentence-transformers/all-MiniLM-L6-v2|feature-extraction|mteb/stsbenchmark-sts||test|100": {
+    "status": "PASS",
+    "metric": {
+      "metric": "cosine_spearman",
+      "value": 81.3502,
+      "num_samples": 100
+    },
+    "elapsed": 19.1,
+    "command": "python.exe run_pytorch_baseline.py --model all-MiniLM-L6-v2 --task feature-extraction --device cpu --num-samples 100 --dataset stsbenchmark-sts --split test --columns-mapping {\"input_column_1\": \"sentence1\", \"input_column_2\": \"sentence2\", \"score_column\": \"score\"}"
+  },
+  "sentence-transformers/all-MiniLM-L6-v2|feature-extraction|mteb/stsbenchmark-sts||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "cosine_spearman",
+      "value": 81.9722,
+      "num_samples": 1000
+    },
+    "elapsed": 35.0,
+    "command": "python.exe run_pytorch_baseline.py --model all-MiniLM-L6-v2 --task feature-extraction --device cpu --num-samples 1000 --dataset stsbenchmark-sts --split test --columns-mapping {\"input_column_1\": \"sentence1\", \"input_column_2\": \"sentence2\", \"score_column\": \"score\"}"
+  },
+  "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2|feature-extraction|mteb/stsbenchmark-sts||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "cosine_spearman",
+      "value": 84.2763,
+      "num_samples": 1000
+    },
+    "elapsed": 57.2,
+    "command": "python.exe run_pytorch_baseline.py --model paraphrase-multilingual-MiniLM-L12-v2 --task feature-extraction --device cpu --num-samples 1000 --dataset stsbenchmark-sts --split test --columns-mapping {\"input_column_1\": \"sentence1\", \"input_column_2\": \"sentence2\", \"score_column\": \"score\"}"
+  },
+  "BAAI/bge-small-en-v1.5|feature-extraction|mteb/stsbenchmark-sts||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "cosine_spearman",
+      "value": 86.6245,
+      "num_samples": 1000
+    },
+    "elapsed": 53.9,
+    "command": "python.exe run_pytorch_baseline.py --model bge-small-en-v1.5 --task feature-extraction --device cpu --num-samples 1000 --dataset stsbenchmark-sts --split test --columns-mapping {\"input_column_1\": \"sentence1\", \"input_column_2\": \"sentence2\", \"score_column\": \"score\"}"
+  },
+  "Intel/bert-base-uncased-mrpc|feature-extraction|mteb/stsbenchmark-sts||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "cosine_spearman",
+      "value": 40.6543,
+      "num_samples": 1000
+    },
+    "elapsed": 133.2,
+    "command": "python.exe run_pytorch_baseline.py --model bert-base-uncased-mrpc --task feature-extraction --device cpu --num-samples 1000 --dataset stsbenchmark-sts --split test --columns-mapping {\"input_column_1\": \"sentence1\", \"input_column_2\": \"sentence2\", \"score_column\": \"score\"}"
+  },
+  "google-bert/bert-base-multilingual-cased|feature-extraction|mteb/stsbenchmark-sts||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "cosine_spearman",
+      "value": 50.7072,
+      "num_samples": 1000
+    },
+    "elapsed": 132.8,
+    "command": "python.exe run_pytorch_baseline.py --model bert-base-multilingual-cased --task feature-extraction --device cpu --num-samples 1000 --dataset stsbenchmark-sts --split test --columns-mapping {\"input_column_1\": \"sentence1\", \"input_column_2\": \"sentence2\", \"score_column\": \"score\"}"
+  },
+  "BAAI/bge-base-en-v1.5|feature-extraction|mteb/stsbenchmark-sts||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "cosine_spearman",
+      "value": 86.8972,
+      "num_samples": 1000
+    },
+    "elapsed": 138.4,
+    "command": "python.exe run_pytorch_baseline.py --model bge-base-en-v1.5 --task feature-extraction --device cpu --num-samples 1000 --dataset stsbenchmark-sts --split test --columns-mapping {\"input_column_1\": \"sentence1\", \"input_column_2\": \"sentence2\", \"score_column\": \"score\"}"
+  },
+  "sentence-transformers/all-mpnet-base-v2|sentence-similarity|mteb/stsbenchmark-sts||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "cosine_spearman",
+      "value": 83.068,
+      "num_samples": 1000
+    },
+    "elapsed": 127.7,
+    "command": "python.exe run_pytorch_baseline.py --model all-mpnet-base-v2 --task sentence-similarity --device cpu --num-samples 1000 --dataset stsbenchmark-sts --split test --columns-mapping {\"input_column_1\": \"sentence1\", \"input_column_2\": \"sentence2\", \"score_column\": \"score\"}"
+  },
+  "sentence-transformers/multi-qa-mpnet-base-dot-v1|sentence-similarity|mteb/stsbenchmark-sts||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "cosine_spearman",
+      "value": 72.7122,
+      "num_samples": 1000
+    },
+    "elapsed": 128.3,
+    "command": "python.exe run_pytorch_baseline.py --model multi-qa-mpnet-base-dot-v1 --task sentence-similarity --device cpu --num-samples 1000 --dataset stsbenchmark-sts --split test --columns-mapping {\"input_column_1\": \"sentence1\", \"input_column_2\": \"sentence2\", \"score_column\": \"score\"}"
+  },
+  "sentence-transformers/paraphrase-multilingual-mpnet-base-v2|sentence-similarity|mteb/stsbenchmark-sts||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "cosine_spearman",
+      "value": 86.9678,
+      "num_samples": 1000
+    },
+    "elapsed": 126.5,
+    "command": "python.exe run_pytorch_baseline.py --model paraphrase-multilingual-mpnet-base-v2 --task sentence-similarity --device cpu --num-samples 1000 --dataset stsbenchmark-sts --split test --columns-mapping {\"input_column_1\": \"sentence1\", \"input_column_2\": \"sentence2\", \"score_column\": \"score\"}"
+  },
+  "BAAI/bge-base-en-v1.5|sentence-similarity|mteb/stsbenchmark-sts||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "cosine_spearman",
+      "value": 86.8972,
+      "num_samples": 1000
+    },
+    "elapsed": 122.2,
+    "command": "python.exe run_pytorch_baseline.py --model bge-base-en-v1.5 --task sentence-similarity --device cpu --num-samples 1000 --dataset stsbenchmark-sts --split test --columns-mapping {\"input_column_1\": \"sentence1\", \"input_column_2\": \"sentence2\", \"score_column\": \"score\"}"
+  },
+  "BAAI/bge-large-en-v1.5|sentence-similarity|mteb/stsbenchmark-sts||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "cosine_spearman",
+      "value": 88.1202,
+      "num_samples": 1000
+    },
+    "elapsed": 439.4,
+    "command": "python.exe run_pytorch_baseline.py --model bge-large-en-v1.5 --task sentence-similarity --device cpu --num-samples 1000 --dataset stsbenchmark-sts --split test --columns-mapping {\"input_column_1\": \"sentence1\", \"input_column_2\": \"sentence2\", \"score_column\": \"score\"}"
+  },
+  "BAAI/bge-small-en-v1.5|sentence-similarity|mteb/stsbenchmark-sts||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "cosine_spearman",
+      "value": 86.6245,
+      "num_samples": 1000
+    },
+    "elapsed": 52.1,
+    "command": "python.exe run_pytorch_baseline.py --model bge-small-en-v1.5 --task sentence-similarity --device cpu --num-samples 1000 --dataset stsbenchmark-sts --split test --columns-mapping {\"input_column_1\": \"sentence1\", \"input_column_2\": \"sentence2\", \"score_column\": \"score\"}"
+  },
+  "sentence-transformers/all-MiniLM-L6-v2|sentence-similarity|mteb/stsbenchmark-sts||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "cosine_spearman",
+      "value": 81.9722,
+      "num_samples": 1000
+    },
+    "elapsed": 33.9,
+    "command": "python.exe run_pytorch_baseline.py --model all-MiniLM-L6-v2 --task sentence-similarity --device cpu --num-samples 1000 --dataset stsbenchmark-sts --split test --columns-mapping {\"input_column_1\": \"sentence1\", \"input_column_2\": \"sentence2\", \"score_column\": \"score\"}"
+  },
+  "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2|sentence-similarity|mteb/stsbenchmark-sts||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "cosine_spearman",
+      "value": 84.2763,
+      "num_samples": 1000
+    },
+    "elapsed": 54.5,
+    "command": "python.exe run_pytorch_baseline.py --model paraphrase-multilingual-MiniLM-L12-v2 --task sentence-similarity --device cpu --num-samples 1000 --dataset stsbenchmark-sts --split test --columns-mapping {\"input_column_1\": \"sentence1\", \"input_column_2\": \"sentence2\", \"score_column\": \"score\"}"
+  },
+  "laion/CLIP-ViT-B-32-laion2B-s34B-b79K|feature-extraction|mteb/stsbenchmark-sts||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "cosine_spearman",
+      "value": 70.2973,
+      "num_samples": 1000
+    },
+    "elapsed": 75.8,
+    "command": "python.exe run_pytorch_baseline.py --model CLIP-ViT-B-32-laion2B-s34B-b79K --task feature-extraction --device cpu --num-samples 1000 --dataset stsbenchmark-sts --split test --columns-mapping {\"input_column_1\": \"sentence1\", \"input_column_2\": \"sentence2\", \"score_column\": \"score\"}"
+  },
+  "openai/clip-vit-base-patch16|feature-extraction|mteb/stsbenchmark-sts||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "cosine_spearman",
+      "value": 64.5723,
+      "num_samples": 1000
+    },
+    "elapsed": 75.7,
+    "command": "python.exe run_pytorch_baseline.py --model clip-vit-base-patch16 --task feature-extraction --device cpu --num-samples 1000 --dataset stsbenchmark-sts --split test --columns-mapping {\"input_column_1\": \"sentence1\", \"input_column_2\": \"sentence2\", \"score_column\": \"score\"}"
+  },
+  "openai/clip-vit-base-patch32|feature-extraction|mteb/stsbenchmark-sts||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "cosine_spearman",
+      "value": 61.7897,
+      "num_samples": 1000
+    },
+    "elapsed": 85.0,
+    "command": "python.exe run_pytorch_baseline.py --model clip-vit-base-patch32 --task feature-extraction --device cpu --num-samples 1000 --dataset stsbenchmark-sts --split test --columns-mapping {\"input_column_1\": \"sentence1\", \"input_column_2\": \"sentence2\", \"score_column\": \"score\"}"
+  },
+  "distilbert/distilbert-base-cased-distilled-squad|question-answering|rajpurkar/squad||validation|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "f1",
+      "value": 86.526843,
+      "num_samples": 1000
+    },
+    "elapsed": 133.7,
+    "command": "python.exe run_pytorch_baseline.py --model distilbert-base-cased-distilled-squad --task question-answering --device cpu --num-samples 1000 --dataset squad --split validation --columns-mapping {\"question_column\": \"question\", \"context_column\": \"context\", \"id_column\": \"id\", \"label_column\": \"answers\"}"
+  },
+  "distilbert/distilbert-base-uncased-distilled-squad|question-answering|rajpurkar/squad||validation|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "f1",
+      "value": 86.242759,
+      "num_samples": 1000
+    },
+    "elapsed": 129.7,
+    "command": "python.exe run_pytorch_baseline.py --model distilbert-base-uncased-distilled-squad --task question-answering --device cpu --num-samples 1000 --dataset squad --split validation --columns-mapping {\"question_column\": \"question\", \"context_column\": \"context\", \"id_column\": \"id\", \"label_column\": \"answers\"}"
+  },
+  "google-bert/bert-large-uncased-whole-word-masking-finetuned-squad|question-answering|rajpurkar/squad||validation|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "f1",
+      "value": 92.053349,
+      "num_samples": 1000
+    },
+    "elapsed": 692.0,
+    "command": "python.exe run_pytorch_baseline.py --model bert-large-uncased-whole-word-masking-finetuned-squad --task question-answering --device cpu --num-samples 1000 --dataset squad --split validation --columns-mapping {\"question_column\": \"question\", \"context_column\": \"context\", \"id_column\": \"id\", \"label_column\": \"answers\"}"
+  },
+  "deepset/roberta-base-squad2|question-answering|rajpurkar/squad_v2||validation|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "f1",
+      "value": 83.346319,
+      "num_samples": 1000
+    },
+    "elapsed": 256.9,
+    "command": "python.exe run_pytorch_baseline.py --model roberta-base-squad2 --task question-answering --device cpu --num-samples 1000 --dataset squad_v2 --split validation --columns-mapping {\"question_column\": \"question\", \"context_column\": \"context\", \"id_column\": \"id\", \"label_column\": \"answers\"}"
+  },
+  "deepset/tinyroberta-squad2|question-answering|rajpurkar/squad_v2||validation|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "f1",
+      "value": 81.874959,
+      "num_samples": 1000
+    },
+    "elapsed": 199.4,
+    "command": "python.exe run_pytorch_baseline.py --model tinyroberta-squad2 --task question-answering --device cpu --num-samples 1000 --dataset squad_v2 --split validation --columns-mapping {\"question_column\": \"question\", \"context_column\": \"context\", \"id_column\": \"id\", \"label_column\": \"answers\"}"
+  },
+  "deepset/bert-large-uncased-whole-word-masking-squad2|question-answering|rajpurkar/squad_v2||validation|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "f1",
+      "value": 84.404731,
+      "num_samples": 1000
+    },
+    "elapsed": 1580.5,
+    "command": "python.exe run_pytorch_baseline.py --model bert-large-uncased-whole-word-masking-squad2 --task question-answering --device cpu --num-samples 1000 --dataset squad_v2 --split validation --columns-mapping {\"question_column\": \"question\", \"context_column\": \"context\", \"id_column\": \"id\", \"label_column\": \"answers\"}"
+  },
+  "monologg/koelectra-small-v2-distilled-korquad-384|question-answering|KorQuAD/squad_kor_v1||validation|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "f1",
+      "value": 46.068571,
+      "num_samples": 1000
+    },
+    "elapsed": 280.0,
+    "command": "python.exe run_pytorch_baseline.py --model koelectra-small-v2-distilled-korquad-384 --task question-answering --device cpu --num-samples 1000 --dataset squad_kor_v1 --split validation --columns-mapping {\"question_column\": \"question\", \"context_column\": \"context\", \"id_column\": \"id\", \"label_column\": \"answers\"}"
+  },
+  "timpal0l/mdeberta-v3-base-squad2|question-answering|rajpurkar/squad_v2||validation|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "f1",
+      "value": 82.729949,
+      "num_samples": 1000
+    },
+    "elapsed": 603.3,
+    "command": "python.exe run_pytorch_baseline.py --model mdeberta-v3-base-squad2 --task question-answering --device cpu --num-samples 1000 --dataset squad_v2 --split validation --columns-mapping {\"question_column\": \"question\", \"context_column\": \"context\", \"id_column\": \"id\", \"label_column\": \"answers\"}"
+  },
+  "ahotrod/electra_large_discriminator_squad2_512|question-answering|rajpurkar/squad_v2||validation|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "f1",
+      "value": 90.953759,
+      "num_samples": 1000
+    },
+    "elapsed": 840.9,
+    "command": "python.exe run_pytorch_baseline.py --model electra_large_discriminator_squad2_512 --task question-answering --device cpu --num-samples 1000 --dataset squad_v2 --split validation --columns-mapping {\"question_column\": \"question\", \"context_column\": \"context\", \"id_column\": \"id\", \"label_column\": \"answers\"}"
+  },
+  "microsoft/swin-large-patch4-window7-224|image-classification|timm/mini-imagenet||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "accuracy",
+      "value": 0.837,
+      "num_samples": 1000
+    },
+    "elapsed": 449.7,
+    "command": "python.exe run_pytorch_baseline.py --model swin-large-patch4-window7-224 --task image-classification --device cpu --num-samples 1000 --dataset mini-imagenet --split test"
+  },
+  "facebook/dinov2-small|image-feature-extraction|timm/mini-imagenet||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "knn_top1_accuracy",
+      "value": 86.2,
+      "num_samples": 1000
+    },
+    "elapsed": 141.5,
+    "command": "python.exe run_pytorch_baseline.py --model dinov2-small --task image-feature-extraction --device cpu --num-samples 1000 --dataset mini-imagenet --split test"
+  },
+  "facebook/dinov2-base|image-feature-extraction|timm/mini-imagenet||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "knn_top1_accuracy",
+      "value": 89.5,
+      "num_samples": 1000
+    },
+    "elapsed": 316.5,
+    "command": "python.exe run_pytorch_baseline.py --model dinov2-base --task image-feature-extraction --device cpu --num-samples 1000 --dataset mini-imagenet --split test"
+  },
+  "facebook/dino-vits16|image-feature-extraction|timm/mini-imagenet||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "knn_top1_accuracy",
+      "value": 79.7,
+      "num_samples": 1000
+    },
+    "elapsed": 94.2,
+    "command": "python.exe run_pytorch_baseline.py --model dino-vits16 --task image-feature-extraction --device cpu --num-samples 1000 --dataset mini-imagenet --split test"
+  },
+  "facebook/dino-vitb16|image-feature-extraction|timm/mini-imagenet||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "knn_top1_accuracy",
+      "value": 83.2,
+      "num_samples": 1000
+    },
+    "elapsed": 248.6,
+    "command": "python.exe run_pytorch_baseline.py --model dino-vitb16 --task image-feature-extraction --device cpu --num-samples 1000 --dataset mini-imagenet --split test"
+  },
+  "google/vit-base-patch16-224-in21k|image-feature-extraction|timm/mini-imagenet||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "knn_top1_accuracy",
+      "value": 91.9,
+      "num_samples": 1000
+    },
+    "elapsed": 231.2,
+    "command": "python.exe run_pytorch_baseline.py --model vit-base-patch16-224-in21k --task image-feature-extraction --device cpu --num-samples 1000 --dataset mini-imagenet --split test"
+  },
+  "StanfordAIMI/dinov2-base-xray-224|image-feature-extraction|Ewakaa/pneumonia_classification_chest_xray||test|582": {
+    "status": "PASS",
+    "metric": {
+      "metric": "knn_top1_accuracy",
+      "value": 93.6426,
+      "num_samples": 582
+    },
+    "elapsed": 166.0,
+    "command": "python.exe run_pytorch_baseline.py --model dinov2-base-xray-224 --task image-feature-extraction --device cpu --num-samples 582 --dataset pneumonia_classification_chest_xray --split test"
+  },
+  "facebook/dinov2-large|image-feature-extraction|timm/mini-imagenet||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "knn_top1_accuracy",
+      "value": 91.1,
+      "num_samples": 1000
+    },
+    "elapsed": 890.6,
+    "command": "python.exe run_pytorch_baseline.py --model dinov2-large --task image-feature-extraction --device cpu --num-samples 1000 --dataset mini-imagenet --split test"
+  },
+  "microsoft/rad-dino|image-feature-extraction|Ewakaa/pneumonia_classification_chest_xray||test|582": {
+    "status": "PASS",
+    "metric": {
+      "metric": "knn_top1_accuracy",
+      "value": 94.6735,
+      "num_samples": 582
+    },
+    "elapsed": 894.7,
+    "command": "python.exe run_pytorch_baseline.py --model rad-dino --task image-feature-extraction --device cpu --num-samples 582 --dataset pneumonia_classification_chest_xray --split test"
+  },
+  "google-bert/bert-base-uncased|fill-mask|Salesforce/wikitext|wikitext-2-raw-v1|test|100": {
+    "status": "PASS",
+    "metric": {
+      "metric": "pseudo_perplexity",
+      "value": 4.2981,
+      "num_samples": 100
+    },
+    "elapsed": 1319.8,
+    "command": "python.exe run_pytorch_baseline.py --model bert-base-uncased --task fill-mask --device cpu --num-samples 100 --dataset wikitext --split test --dataset-config wikitext-2-raw-v1 --columns-mapping {\"input_column\": \"text\"}"
+  },
+  "distilbert/distilbert-base-uncased|fill-mask|Salesforce/wikitext|wikitext-2-raw-v1|test|100": {
+    "status": "PASS",
+    "metric": {
+      "metric": "pseudo_perplexity",
+      "value": 6.6132,
+      "num_samples": 100
+    },
+    "elapsed": 1097.7,
+    "command": "python.exe run_pytorch_baseline.py --model distilbert-base-uncased --task fill-mask --device cpu --num-samples 100 --dataset wikitext --split test --dataset-config wikitext-2-raw-v1 --columns-mapping {\"input_column\": \"text\"}"
+  },
+  "FacebookAI/roberta-base|fill-mask|Salesforce/wikitext|wikitext-2-raw-v1|test|100": {
+    "status": "PASS",
+    "metric": {
+      "metric": "pseudo_perplexity",
+      "value": 5.2706,
+      "num_samples": 100
+    },
+    "elapsed": 2029.2,
+    "command": "python.exe run_pytorch_baseline.py --model roberta-base --task fill-mask --device cpu --num-samples 100 --dataset wikitext --split test --dataset-config wikitext-2-raw-v1 --columns-mapping {\"input_column\": \"text\"}"
+  },
+  "google-bert/bert-base-multilingual-uncased|fill-mask|Salesforce/wikitext|wikitext-2-raw-v1|test|100": {
+    "status": "PASS",
+    "metric": {
+      "metric": "pseudo_perplexity",
+      "value": 4.4645,
+      "num_samples": 100
+    },
+    "elapsed": 2645.6,
+    "command": "python.exe run_pytorch_baseline.py --model bert-base-multilingual-uncased --task fill-mask --device cpu --num-samples 100 --dataset wikitext --split test --dataset-config wikitext-2-raw-v1 --columns-mapping {\"input_column\": \"text\"}"
+  },
+  "google-bert/bert-base-multilingual-cased|fill-mask|Salesforce/wikitext|wikitext-2-raw-v1|test|100": {
+    "status": "PASS",
+    "metric": {
+      "metric": "pseudo_perplexity",
+      "value": 5.2262,
+      "num_samples": 100
+    },
+    "elapsed": 2758.9,
+    "command": "python.exe run_pytorch_baseline.py --model bert-base-multilingual-cased --task fill-mask --device cpu --num-samples 100 --dataset wikitext --split test --dataset-config wikitext-2-raw-v1 --columns-mapping {\"input_column\": \"text\"}"
+  },
+  "FacebookAI/xlm-roberta-base|fill-mask|Salesforce/wikitext|wikitext-2-raw-v1|test|100": {
+    "status": "PASS",
+    "metric": {
+      "metric": "pseudo_perplexity",
+      "value": 3.6435,
+      "num_samples": 100
+    },
+    "elapsed": 4921.4,
+    "command": "python.exe run_pytorch_baseline.py --model xlm-roberta-base --task fill-mask --device cpu --num-samples 100 --dataset wikitext --split test --dataset-config wikitext-2-raw-v1 --columns-mapping {\"input_column\": \"text\"}"
+  },
+  "FacebookAI/roberta-large|fill-mask|Salesforce/wikitext|wikitext-2-raw-v1|test|100": {
+    "status": "PASS",
+    "metric": {
+      "metric": "pseudo_perplexity",
+      "value": 5.3352,
+      "num_samples": 100
+    },
+    "elapsed": 5541.0,
+    "command": "python.exe run_pytorch_baseline.py --model roberta-large --task fill-mask --device cpu --num-samples 100 --dataset wikitext --split test --dataset-config wikitext-2-raw-v1 --columns-mapping {\"input_column\": \"text\"}"
+  },
+  "FacebookAI/xlm-roberta-large|fill-mask|Salesforce/wikitext|wikitext-2-raw-v1|test|100": {
+    "status": "PASS",
+    "metric": {
+      "metric": "pseudo_perplexity",
+      "value": 2.677,
+      "num_samples": 100
+    },
+    "elapsed": 10591.2,
+    "command": "python.exe run_pytorch_baseline.py --model xlm-roberta-large --task fill-mask --device cpu --num-samples 100 --dataset wikitext --split test --dataset-config wikitext-2-raw-v1 --columns-mapping {\"input_column\": \"text\"}"
+  },
+  "openai/clip-vit-base-patch32|zero-shot-image-classification|uoft-cs/cifar100||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "top1_accuracy",
+      "value": 58.4,
+      "num_samples": 1000
+    },
+    "elapsed": 134.9,
+    "command": "python.exe run_pytorch_baseline.py --model clip-vit-base-patch32 --task zero-shot-image-classification --device cpu --num-samples 1000 --dataset cifar100 --split test --columns-mapping {\"input_column\": \"img\", \"label_column\": \"fine_label\"}"
+  },
+  "openai/clip-vit-large-patch14|zero-shot-image-classification|uoft-cs/cifar100||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "top1_accuracy",
+      "value": 73.6,
+      "num_samples": 1000
+    },
+    "elapsed": 997.8,
+    "command": "python.exe run_pytorch_baseline.py --model clip-vit-large-patch14 --task zero-shot-image-classification --device cpu --num-samples 1000 --dataset cifar100 --split test --columns-mapping {\"input_column\": \"img\", \"label_column\": \"fine_label\"}"
+  },
+  "openai/clip-vit-large-patch14-336|zero-shot-image-classification|uoft-cs/cifar100||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "top1_accuracy",
+      "value": 73.4,
+      "num_samples": 1000
+    },
+    "elapsed": 2398.7,
+    "command": "python.exe run_pytorch_baseline.py --model clip-vit-large-patch14-336 --task zero-shot-image-classification --device cpu --num-samples 1000 --dataset cifar100 --split test --columns-mapping {\"input_column\": \"img\", \"label_column\": \"fine_label\"}"
+  },
+  "openai/clip-vit-base-patch16|zero-shot-image-classification|uoft-cs/cifar100||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "top1_accuracy",
+      "value": 62.6,
+      "num_samples": 1000
+    },
+    "elapsed": 244.4,
+    "command": "python.exe run_pytorch_baseline.py --model clip-vit-base-patch16 --task zero-shot-image-classification --device cpu --num-samples 1000 --dataset cifar100 --split test --columns-mapping {\"input_column\": \"img\", \"label_column\": \"fine_label\"}"
+  },
+  "laion/CLIP-ViT-B-32-laion2B-s34B-b79K|zero-shot-image-classification|uoft-cs/cifar100||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "top1_accuracy",
+      "value": 73.0,
+      "num_samples": 1000
+    },
+    "elapsed": 128.4,
+    "command": "python.exe run_pytorch_baseline.py --model CLIP-ViT-B-32-laion2B-s34B-b79K --task zero-shot-image-classification --device cpu --num-samples 1000 --dataset cifar100 --split test --columns-mapping {\"input_column\": \"img\", \"label_column\": \"fine_label\"}"
+  },
+  "laion/CLIP-ViT-H-14-laion2B-s32B-b79K|zero-shot-image-classification|uoft-cs/cifar100||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "top1_accuracy",
+      "value": 78.7,
+      "num_samples": 1000
+    },
+    "elapsed": 1830.9,
+    "command": "python.exe run_pytorch_baseline.py --model CLIP-ViT-H-14-laion2B-s32B-b79K --task zero-shot-image-classification --device cpu --num-samples 1000 --dataset cifar100 --split test --columns-mapping {\"input_column\": \"img\", \"label_column\": \"fine_label\"}"
+  },
+  "google/siglip-so400m-patch14-384|zero-shot-image-classification|uoft-cs/cifar100||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "top1_accuracy",
+      "value": 80.9,
+      "num_samples": 1000
+    },
+    "elapsed": 3541.7,
+    "command": "python.exe run_pytorch_baseline.py --model siglip-so400m-patch14-384 --task zero-shot-image-classification --device cpu --num-samples 1000 --dataset cifar100 --split test --columns-mapping {\"input_column\": \"img\", \"label_column\": \"fine_label\"}"
+  },
+  "google/siglip-base-patch16-224|zero-shot-image-classification|uoft-cs/cifar100||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "top1_accuracy",
+      "value": 68.8,
+      "num_samples": 1000
+    },
+    "elapsed": 252.3,
+    "command": "python.exe run_pytorch_baseline.py --model siglip-base-patch16-224 --task zero-shot-image-classification --device cpu --num-samples 1000 --dataset cifar100 --split test --columns-mapping {\"input_column\": \"img\", \"label_column\": \"fine_label\"}"
+  },
+  "patrickjohncyh/fashion-clip|zero-shot-image-classification|zalando-datasets/fashion_mnist||test|1000": {
+    "status": "PASS",
+    "metric": {
+      "metric": "top1_accuracy",
+      "value": 74.3,
+      "num_samples": 1000
+    },
+    "elapsed": 222.8,
+    "command": "python.exe run_pytorch_baseline.py --model fashion-clip --task zero-shot-image-classification --device cpu --num-samples 1000 --dataset fashion_mnist --split test --columns-mapping {\"input_column\": \"image\"}"
+  },
   "cross-encoder/nli-deberta-v3-small|zero-shot-classification|fancyzhx/ag_news||test|200": {
     "status": "PASS",
     "metric": {

--- a/scripts/e2e_eval/run_eval.py
+++ b/scripts/e2e_eval/run_eval.py
@@ -1265,6 +1265,7 @@ def main() -> None:
                 device=args.device,
                 eval_types_run=[args.eval_type],
                 accuracy_result=None,
+                ep=args.ep,
             )
             write_result_json(timeout_result, result_path)
             results.append(timeout_result)
@@ -1360,7 +1361,9 @@ def main() -> None:
             interrupted = True
             break
 
-        result = build_eval_result(entry, perf_proc, args.device, eval_types_run, accuracy_result)
+        result = build_eval_result(
+            entry, perf_proc, args.device, eval_types_run, accuracy_result, ep=args.ep
+        )
         results.append(result)
 
         # Write eval_result.json immediately (crash-safe, facts only)

--- a/scripts/e2e_eval/utils/reporter.py
+++ b/scripts/e2e_eval/utils/reporter.py
@@ -61,11 +61,10 @@ def build_eval_result(
             "error": perf_proc.get("error_summary", ""),
         }
 
-    return {
+    result = {
         "model": entry.hf_id,
         "task": entry.task,
         "device": device,
-        "ep": ep,
         "model_type": entry.model_type,
         "group": entry.group,
         "priority": entry.priority,
@@ -76,6 +75,10 @@ def build_eval_result(
         "perf": perf_section,
         "accuracy": accuracy_result,
     }
+    # Optional fields: only include when explicitly provided by the user.
+    if ep is not None:
+        result["ep"] = ep
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/e2e_eval/utils/reporter.py
+++ b/scripts/e2e_eval/utils/reporter.py
@@ -37,12 +37,15 @@ def build_eval_result(
     device: str,
     eval_types_run: list[str],
     accuracy_result: dict | None = None,
+    ep: str | None = None,
 ) -> dict:
     """Build a unified eval_result dict (facts only, no derived fields).
 
     perf_proc is the raw subprocess result from run_model(), or None when
     eval_types_run is ["accuracy"] (accuracy-only mode, perf phase skipped).
     accuracy_result is the accuracy sub-section dict (or None if not run).
+    ep is the explicit execution provider (e.g., "qnn", "dml"), or None when
+    not specified (device-to-provider mapping was used).
     """
     perf_section: dict | None = None
     if perf_proc is not None:
@@ -62,6 +65,7 @@ def build_eval_result(
         "model": entry.hf_id,
         "task": entry.task,
         "device": device,
+        "ep": ep,
         "model_type": entry.model_type,
         "group": entry.group,
         "priority": entry.priority,
@@ -340,6 +344,8 @@ def generate_html_report(
             {
                 "hf_id": hf_id,
                 "task": task,
+                "device": r.get("device", ""),
+                "ep": r.get("ep"),
                 "model_type": r.get("model_type", ""),
                 "group": r.get("group", ""),
                 "priority": r.get("priority", ""),
@@ -359,6 +365,15 @@ def generate_html_report(
                 ),
                 "delta_display": (
                     format_delta(acc) if acc and not acc.get("skipped") else ""
+                ),
+                "metric": (
+                    {
+                        "name": (acc.get("winml_metric") or {}).get("metric"),
+                        "baseline": (acc.get("pytorch_baseline_metric") or {}).get("value"),
+                        "winml": (acc.get("winml_metric") or {}).get("value"),
+                    }
+                    if acc and not acc.get("skipped")
+                    else None
                 ),
             }
         )

--- a/src/winml/modelkit/commands/eval.py
+++ b/src/winml/modelkit/commands/eval.py
@@ -67,15 +67,7 @@ logger = logging.getLogger(__name__)
     show_default=True,
     help="Device to run on. 'auto' detects the best available device.",
 )
-@click.option(
-    "--ep",
-    "ep",
-    type=str,
-    default=None,
-    help="Force specific execution provider "
-    "(qnn, dml, migraphx, nv_tensorrt_rtx, vitisai, openvino, cpu). "
-    "Overrides device-to-provider mapping.",
-)
+@cli_utils.ep_option(required=False)
 @click.option(
     "--samples",
     type=int,
@@ -247,7 +239,7 @@ def eval(
         model_id=model_id,
         task=task,
         device=resolved_device,
-        ep=ep.lower() if ep else None,
+        ep=ep,
         dataset=ds_config,
         output_path=output,
     )

--- a/src/winml/modelkit/commands/eval.py
+++ b/src/winml/modelkit/commands/eval.py
@@ -68,6 +68,15 @@ logger = logging.getLogger(__name__)
     help="Device to run on. 'auto' detects the best available device.",
 )
 @click.option(
+    "--ep",
+    "ep",
+    type=str,
+    default=None,
+    help="Force specific execution provider "
+    "(qnn, dml, migraphx, nv_tensorrt_rtx, vitisai, openvino, cpu). "
+    "Overrides device-to-provider mapping.",
+)
+@click.option(
     "--samples",
     type=int,
     default=100,
@@ -135,6 +144,7 @@ def eval(
     dataset_name: str | None,
     task: str | None,
     device: str,
+    ep: str | None,
     samples: int,
     split: str,
     shuffle: bool,
@@ -173,6 +183,8 @@ def eval(
         build_cfg = cli_utils.load_build_config(config_file)
         if build_cfg.loader and not cli_utils.is_cli_provided(ctx, "task"):
             task = build_cfg.loader.task
+        if build_cfg.compile and not cli_utils.is_cli_provided(ctx, "ep"):
+            ep = build_cfg.compile.ep_config.provider
         if build_cfg.quant:
             if not cli_utils.is_cli_provided(ctx, "samples"):
                 samples = build_cfg.quant.samples
@@ -235,6 +247,7 @@ def eval(
         model_id=model_id,
         task=task,
         device=resolved_device,
+        ep=ep.lower() if ep else None,
         dataset=ds_config,
         output_path=output,
     )

--- a/src/winml/modelkit/eval/config.py
+++ b/src/winml/modelkit/eval/config.py
@@ -45,6 +45,8 @@ class WinMLEvaluationConfig:
             None = build from model_id.
         task: HF pipeline task. Auto-detected from model_id if omitted.
         device: Target device for inference.
+        ep: Explicit execution provider (e.g., "qnn", "dml"). Overrides
+            device-to-provider mapping when provided.
         dataset: Dataset configuration.
         output_path: Path to write JSON results.
 
@@ -59,6 +61,7 @@ class WinMLEvaluationConfig:
     model_path: str | dict[str, str] | None = None
     task: str | None = None
     device: str = "cpu"
+    ep: str | None = None
     dataset: DatasetConfig = field(default_factory=DatasetConfig)
     output_path: Path | None = None
 
@@ -72,6 +75,8 @@ class WinMLEvaluationConfig:
         if self.task is not None:
             result["task"] = self.task
         result["device"] = self.device
+        if self.ep is not None:
+            result["ep"] = self.ep
         result["dataset"] = self.dataset.to_dict()
         if self.output_path is not None:
             result["output_path"] = str(self.output_path)
@@ -96,6 +101,7 @@ class WinMLEvaluationConfig:
             model_path=data.get("model_path"),
             task=data.get("task"),
             device=data.get("device", "cpu"),
+            ep=data.get("ep"),
             dataset=dataset,
             output_path=(Path(data["output_path"]) if data.get("output_path") else None),
         )

--- a/src/winml/modelkit/eval/evaluate.py
+++ b/src/winml/modelkit/eval/evaluate.py
@@ -184,6 +184,7 @@ def _load_model(config: WinMLEvaluationConfig) -> WinMLPreTrainedModel:
             onnx_path=config.model_path,
             task=config.task,
             device=config.device,
+            ep=config.ep,
             skip_build=True,
             hf_config=hf_config,
         )
@@ -194,6 +195,7 @@ def _load_model(config: WinMLEvaluationConfig) -> WinMLPreTrainedModel:
         config.model_id,
         task=config.task,
         device=config.device,
+        ep=config.ep,
     )
 
 

--- a/tests/unit/eval/test_eval.py
+++ b/tests/unit/eval/test_eval.py
@@ -693,6 +693,200 @@ class TestEvalCli:
         assert result.exit_code != 0
         assert "broken model" in result.output
 
+    def test_cli_ep_passed_through(self):
+        """`--ep <name>` must propagate to WinMLEvaluationConfig.ep."""
+        from winml.modelkit.commands.eval import eval as eval_cmd
+
+        runner = CliRunner()
+        with (
+            patch("winml.modelkit.sysinfo.resolve_device", return_value=("npu", ["npu", "cpu"])),
+            patch("winml.modelkit.eval.evaluate") as mock_evaluate,
+        ):
+            mock_evaluate.return_value = EvalResult(
+                config=WinMLEvaluationConfig(),
+                metrics={},
+            )
+            result = runner.invoke(
+                eval_cmd,
+                ["-m", "test/model", "--dataset", "imagenet-1k", "--ep", "qnn"],
+                catch_exceptions=False,
+            )
+
+            assert result.exit_code == 0, result.output
+            config = mock_evaluate.call_args[0][0]
+            assert config.ep == "qnn"
+
+    def test_cli_ep_invalid_value_rejected(self):
+        """Unknown --ep value must be rejected by Click Choice validation."""
+        from winml.modelkit.commands.eval import eval as eval_cmd
+
+        runner = CliRunner()
+        result = runner.invoke(
+            eval_cmd,
+            ["-m", "test/model", "--dataset", "imagenet-1k", "--ep", "bogus_ep"],
+        )
+        assert result.exit_code != 0
+        assert "bogus_ep" in result.output.lower() or "invalid" in result.output.lower()
+
+    def test_cli_ep_from_build_config(self, tmp_path):
+        """When --ep is omitted, ep is read from build_cfg.compile.ep_config.provider."""
+        from winml.modelkit.commands.eval import eval as eval_cmd
+
+        config_file = tmp_path / "build.yaml"
+        config_file.touch()
+
+        fake_build_cfg = MagicMock()
+        fake_build_cfg.loader = None
+        fake_build_cfg.compile.ep_config.provider = "dml"
+        fake_build_cfg.quant = None
+
+        runner = CliRunner()
+        with (
+            patch("winml.modelkit.sysinfo.resolve_device", return_value=("gpu", ["gpu", "cpu"])),
+            patch(
+                "winml.modelkit.utils.cli.load_build_config",
+                return_value=fake_build_cfg,
+            ),
+            patch("winml.modelkit.eval.evaluate") as mock_evaluate,
+        ):
+            mock_evaluate.return_value = EvalResult(
+                config=WinMLEvaluationConfig(),
+                metrics={},
+            )
+            result = runner.invoke(
+                eval_cmd,
+                [
+                    "-m",
+                    "test/model",
+                    "--dataset",
+                    "imagenet-1k",
+                    "--config",
+                    str(config_file),
+                ],
+                catch_exceptions=False,
+            )
+
+            assert result.exit_code == 0, result.output
+            config = mock_evaluate.call_args[0][0]
+            assert config.ep == "dml"
+
+    def test_cli_ep_overrides_build_config(self, tmp_path):
+        """Explicit --ep on the CLI must take precedence over build config value."""
+        from winml.modelkit.commands.eval import eval as eval_cmd
+
+        config_file = tmp_path / "build.yaml"
+        config_file.touch()
+
+        fake_build_cfg = MagicMock()
+        fake_build_cfg.loader = None
+        fake_build_cfg.compile.ep_config.provider = "dml"
+        fake_build_cfg.quant = None
+
+        runner = CliRunner()
+        with (
+            patch("winml.modelkit.sysinfo.resolve_device", return_value=("npu", ["npu", "cpu"])),
+            patch(
+                "winml.modelkit.utils.cli.load_build_config",
+                return_value=fake_build_cfg,
+            ),
+            patch("winml.modelkit.eval.evaluate") as mock_evaluate,
+        ):
+            mock_evaluate.return_value = EvalResult(
+                config=WinMLEvaluationConfig(),
+                metrics={},
+            )
+            result = runner.invoke(
+                eval_cmd,
+                [
+                    "-m",
+                    "test/model",
+                    "--dataset",
+                    "imagenet-1k",
+                    "--config",
+                    str(config_file),
+                    "--ep",
+                    "qnn",
+                ],
+                catch_exceptions=False,
+            )
+
+            assert result.exit_code == 0, result.output
+            config = mock_evaluate.call_args[0][0]
+            assert config.ep == "qnn"
+
+
+class TestBuildEvalResultEpField:
+    """Tests for build_eval_result handling of the optional `ep` field."""
+
+    @staticmethod
+    def _load_reporter():
+        """Load scripts/e2e_eval/utils/reporter.py via importlib (not on sys.path)."""
+        import importlib.util
+        import sys
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parents[3]
+        utils_dir = repo_root / "scripts" / "e2e_eval" / "utils"
+
+        # Pre-load the sibling module reporter.py imports relatively.
+        if "_e2e_classifier" not in sys.modules:
+            spec_c = importlib.util.spec_from_file_location(
+                "_e2e_classifier", utils_dir / "classifier.py"
+            )
+            mod_c = importlib.util.module_from_spec(spec_c)
+            sys.modules["_e2e_classifier"] = mod_c
+            spec_c.loader.exec_module(mod_c)
+
+        # Stub the relative import target so reporter.py's `from .classifier ...` works.
+        pkg_name = "_e2e_reporter_pkg"
+        if pkg_name not in sys.modules:
+            pkg = type(sys)(pkg_name)
+            pkg.__path__ = [str(utils_dir)]
+            sys.modules[pkg_name] = pkg
+            sys.modules[f"{pkg_name}.classifier"] = sys.modules["_e2e_classifier"]
+
+        spec = importlib.util.spec_from_file_location(
+            f"{pkg_name}.reporter", utils_dir / "reporter.py"
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def _make_entry(self):
+        entry = MagicMock()
+        entry.hf_id = "test/model"
+        entry.task = "image-classification"
+        entry.model_type = "resnet"
+        entry.group = "Test"
+        entry.priority = "P0"
+        return entry
+
+    def test_ep_omitted_when_none(self):
+        reporter = self._load_reporter()
+
+        result = reporter.build_eval_result(
+            entry=self._make_entry(),
+            perf_proc=None,
+            device="cpu",
+            eval_types_run=["accuracy"],
+            accuracy_result=None,
+            ep=None,
+        )
+        assert "ep" not in result
+
+    def test_ep_present_when_provided(self):
+        reporter = self._load_reporter()
+
+        result = reporter.build_eval_result(
+            entry=self._make_entry(),
+            perf_proc=None,
+            device="npu",
+            eval_types_run=["accuracy"],
+            accuracy_result=None,
+            ep="qnn",
+        )
+        assert result["ep"] == "qnn"
+
 
 class TestDefaultDatasetImmutability:
     """Tests that module-level _DEFAULT_DATASETS are not corrupted."""

--- a/tests/unit/eval/test_eval.py
+++ b/tests/unit/eval/test_eval.py
@@ -836,6 +836,7 @@ class TestLoadModel:
             "test/model",
             task="image-classification",
             device="cpu",
+            ep=None,
         )
         assert result is mock_model
 


### PR DESCRIPTION
1. Add --ep option to `winml eval` command. This allows the user to specify the ep to use.
2. Fix the evaluate baseline cache which is mistakenly cleared by an earlier commit.