### PR TITLE
feat(cli): show Rich gradient banner on winml / winml --help

### DIFF
--- a/src/winml/modelkit/cli.py
+++ b/src/winml/modelkit/cli.py
@@ -36,6 +36,96 @@ logger = logging.getLogger(__name__)
 
 _COMMANDS_DIR = Path(__file__).parent / "commands"
 
+# 5-row block-letter art for "WinML CLI".  '#' = filled pixel, ' ' = empty.
+# All letters use the same █ character so identical shapes (i vs I) look
+# consistent regardless of horizontal position.
+_LETTER_ART: dict[str, list[str]] = {
+    "W": ["#   #", "#   #", "# # #", "## ##", "#   #"],
+    "i": ["###", " # ", " # ", " # ", "###"],
+    "n": ["#   #", "##  #", "# # #", "#  ##", "#   #"],
+    "M": ["#   #", "## ##", "# # #", "#   #", "#   #"],
+    "L": ["#    ", "#    ", "#    ", "#    ", "#####"],
+    "C": ["####", "#   ", "#   ", "#   ", "####"],
+    "I": ["###", " # ", " # ", " # ", "###"],
+}
+# Two word segments; rendered with a wider gap between them.
+_SEGMENTS: list[list[str]] = [list("WinML"), list("CLI")]
+_LETTER_GAP = "  "  # between letters within a word
+_WORD_GAP = "    "  # between words
+
+# Gradient stops (left → right across the full banner width).
+_GRADIENT: list[tuple[float, tuple[int, int, int]]] = [
+    (0.00, (0, 230, 255)),  # cyan
+    (0.25, (0, 100, 255)),  # blue
+    (0.50, (130, 0, 255)),  # purple
+    (0.75, (255, 0, 180)),  # pink
+    (1.00, (255, 80, 80)),  # red
+]
+
+
+def _gradient_color(t: float) -> tuple[int, int, int]:
+    for i in range(len(_GRADIENT) - 1):
+        t0, c0 = _GRADIENT[i]
+        t1, c1 = _GRADIENT[i + 1]
+        if t <= t1:
+            s = (t - t0) / (t1 - t0)
+            return (
+                round(c0[0] + s * (c1[0] - c0[0])),
+                round(c0[1] + s * (c1[1] - c0[1])),
+                round(c0[2] + s * (c1[2] - c0[2])),
+            )
+    return _GRADIENT[-1][1]
+
+
+def _print_banner(version: str, *, _console: object | None = None) -> None:
+    """Print the WinML CLI gradient banner to stderr using Rich."""
+    from rich.console import Console  # lazy import - keeps startup fast
+    from rich.text import Text
+
+    # Compute total art width across both word segments.
+    art_w = len(_WORD_GAP) * (len(_SEGMENTS) - 1)
+    for seg in _SEGMENTS:
+        art_w += len(_LETTER_GAP) * (len(seg) - 1)
+        art_w += sum(len(_LETTER_ART[ch][0]) for ch in seg)
+    bar_w = art_w + 4
+    margin = "  "
+
+    con = _console or Console(stderr=True, highlight=False)
+    con.print()
+
+    for row_idx in range(5):
+        line = Text(margin)
+        col = 0
+        for seg_idx, seg in enumerate(_SEGMENTS):
+            if seg_idx > 0:
+                line.append(_WORD_GAP)
+                col += len(_WORD_GAP)
+            for letter_idx, letter in enumerate(seg):
+                if letter_idx > 0:
+                    line.append(_LETTER_GAP)
+                    col += len(_LETTER_GAP)
+                for ch in _LETTER_ART[letter][row_idx]:
+                    if ch == "#":
+                        r, g, b = _gradient_color(col / max(art_w - 1, 1))
+                        line.append("█", style=f"bold rgb({r},{g},{b})")
+                    else:
+                        line.append(" ")
+                    col += 1
+        con.print(line)
+
+    con.print()
+    bar = Text(margin)
+    for i in range(bar_w):
+        r, g, b = _gradient_color(i / max(bar_w - 1, 1))
+        bar.append("─", style=f"rgb({r},{g},{b})")
+    con.print(bar)
+
+    con.print()
+    con.print(f"{margin}[bold rgb(160,100,255)]Windows ML  ·  Model Conversion & Optimization[/]")
+    con.print(f"{margin}[dim]v{version}  ·  CPU · GPU · NPU[/]")
+    con.print()
+
+
 # Commands that are temporarily disabled from the CLI surface.
 # The modules remain on disk so tests and internal imports still work;
 # they simply do not appear in ``winml --help`` or accept user invocations.
@@ -114,6 +204,11 @@ class LazyGroup(ActionGroup):
                 discovered = attr
         return discovered
 
+    def format_help(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
+        """Emit banner to stderr, then delegate to normal help formatting."""
+        _print_banner(__version__)
+        super().format_help(ctx, formatter)
+
     def format_commands(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
         """Format command list using AST-parsed help (no module imports)."""
         commands = []
@@ -132,7 +227,7 @@ class LazyGroup(ActionGroup):
                 formatter.write_dl(rows)
 
 
-@click.group(cls=LazyGroup)
+@click.group(cls=LazyGroup, invoke_without_command=True)
 @click.version_option(version=__version__, prog_name="winml")
 @click.option(
     "--verbose",
@@ -173,6 +268,10 @@ def main(ctx: click.Context, verbose: int, quiet: bool, debug: bool) -> None:
     ctx.obj["quiet"] = quiet
 
     ctx.call_on_close(_shutdown_telemetry)
+
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+        ctx.exit(0)
 
 
 def _shutdown_telemetry() -> None:

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -35,6 +35,41 @@ def runner() -> CliRunner:
     return CliRunner()
 
 
+class TestBanner:
+    """Test that the ASCII art banner appears on stderr for no-args and --help."""
+
+    @pytest.fixture
+    def split_runner(self) -> CliRunner:
+        """Runner with separate stderr capture."""
+        return CliRunner()
+
+    def test_no_args_exits_zero(self, split_runner: CliRunner) -> None:
+        """winml with no arguments must exit 0."""
+        result = split_runner.invoke(main, [])
+        assert result.exit_code == 0
+
+    def test_no_args_prints_banner_to_stderr(self, split_runner: CliRunner) -> None:
+        """winml with no arguments must print the banner to stderr."""
+        result = split_runner.invoke(main, [])
+        assert "Windows ML" in result.stderr
+
+    def test_help_exits_zero(self, split_runner: CliRunner) -> None:
+        """winml --help must exit 0."""
+        result = split_runner.invoke(main, ["--help"])
+        assert result.exit_code == 0
+
+    def test_help_prints_banner_to_stderr(self, split_runner: CliRunner) -> None:
+        """winml --help must print the banner to stderr."""
+        result = split_runner.invoke(main, ["--help"])
+        assert "Windows ML" in result.stderr
+
+    def test_subcommand_help_has_no_banner(self, split_runner: CliRunner) -> None:
+        """Subcommand --help must NOT print the banner."""
+        result = split_runner.invoke(main, ["sys", "--help"])
+        assert result.exit_code == 0
+        assert "Windows ML" not in result.stderr
+
+
 class TestCLIBasics:
     """Test basic CLI functionality."""
 


### PR DESCRIPTION
Closes #414

## Summary

- Replaces the static ASCII-box banner with a Rich-powered gradient renderer: `WinML CLI` block letters colored cyan → blue → purple → pink → red left-to-right
- Both `winml` (no args) and `winml --help` now print the banner to stderr, then show Click help, and exit 0 — both cases are equivalent as described in the issue
- Fixes the two-I inconsistency from the `▌`/`▐` alternation approach by using `█` throughout, so identical letter shapes (the `i` in WinML and the `I` in CLI) render identically regardless of horizontal position
- Adds `invoke_without_command=True` so `winml` with no args exits 0 (was 2)
- Banner version is read dynamically from `__version__` (backed by `importlib.metadata`), not hardcoded
- Adds `TestBanner` regression suite (5 cases) in `tests/cli/test_main.py`

New look with banner:
<img width="539" height="519" alt="image" src="https://github.com/user-attachments/assets/449f6f0c-a982-42fb-9e1b-eaefdcef7830" />
