### PR TITLE
Eval: Update baseline cache

### DIFF
--- a/scripts/e2e_eval/cache/baseline_cache.json
+++ b/scripts/e2e_eval/cache/baseline_cache.json
@@ -299,16 +299,6 @@
     "elapsed": 711.6,
     "command": "python.exe run_pytorch_baseline.py --model segformer-b0-finetuned-cityscapes-1024-1024 --task image-segmentation --device cpu --num-samples 500 --dataset cityscapes --split validation --columns-mapping {\"annotation_column\": \"semantic_segmentation\"} --label-mapping-file cityscapes_label_to_train_id.json"
   },
-  "sentence-transformers/all-MiniLM-L6-v2|feature-extraction|mteb/stsbenchmark-sts||test|100": {
-    "status": "PASS",
-    "metric": {
-      "metric": "cosine_spearman",
-      "value": 81.3502,
-      "num_samples": 100
-    },
-    "elapsed": 19.1,
-    "command": "python.exe run_pytorch_baseline.py --model all-MiniLM-L6-v2 --task feature-extraction --device cpu --num-samples 100 --dataset stsbenchmark-sts --split test --columns-mapping {\"input_column_1\": \"sentence1\", \"input_column_2\": \"sentence2\", \"score_column\": \"score\"}"
-  },
   "sentence-transformers/all-MiniLM-L6-v2|feature-extraction|mteb/stsbenchmark-sts||test|1000": {
     "status": "PASS",
     "metric": {
@@ -832,52 +822,52 @@
   "Salesforce/blip-image-captioning-base|image-to-text|lmms-lab/flickr30k||test|500": {
     "status": "PASS",
     "metric": {
-      "metric": "accuracy",
+      "metric": "cider",
       "value": 0.3965,
       "num_samples": 500
     },
-    "elapsed": 586.9,
-    "command": "python.exe run_pytorch_baseline.py --model blip-image-captioning-base --task image-to-text --device cpu --num-samples 500 --dataset flickr30k --split test --columns-mapping {\"input_column\": \"image\", \"label_column\": \"caption\"}"
+    "elapsed": 600.7,
+    "command": "python.exe run_pytorch_baseline.py --model blip-image-captioning-base --task image-to-text --device cpu --num-samples 500 --dataset flickr30k --split test --columns-mapping {\"input_column\": \"image\", \"label_column\": \"caption\"} --winml-metric-key cider"
   },
   "microsoft/trocr-base-handwritten|image-to-text|Teklia/IAM-line||test|500": {
     "status": "PASS",
     "metric": {
-      "metric": "accuracy",
+      "metric": "cer",
       "value": 0.0476,
       "num_samples": 500
     },
-    "elapsed": 999.5,
-    "command": "python.exe run_pytorch_baseline.py --model trocr-base-handwritten --task image-to-text --device cpu --num-samples 500 --dataset IAM-line --split test --columns-mapping {\"input_column\": \"image\", \"label_column\": \"text\"}"
+    "elapsed": 1532.5,
+    "command": "python.exe run_pytorch_baseline.py --model trocr-base-handwritten --task image-to-text --device cpu --num-samples 500 --dataset IAM-line --split test --columns-mapping {\"input_column\": \"image\", \"label_column\": \"text\"} --winml-metric-key cer"
   },
   "microsoft/trocr-large-handwritten|image-to-text|Teklia/IAM-line||test|500": {
     "status": "PASS",
     "metric": {
-      "metric": "accuracy",
+      "metric": "cer",
       "value": 0.0361,
       "num_samples": 500
     },
-    "elapsed": 1750.8,
-    "command": "python.exe run_pytorch_baseline.py --model trocr-large-handwritten --task image-to-text --device cpu --num-samples 500 --dataset IAM-line --split test --columns-mapping {\"input_column\": \"image\", \"label_column\": \"text\"}"
+    "elapsed": 2329.6,
+    "command": "python.exe run_pytorch_baseline.py --model trocr-large-handwritten --task image-to-text --device cpu --num-samples 500 --dataset IAM-line --split test --columns-mapping {\"input_column\": \"image\", \"label_column\": \"text\"} --winml-metric-key cer"
   },
   "microsoft/trocr-base-printed|image-to-text|priyank-m/SROIE_2019_text_recognition||test|500": {
     "status": "PASS",
     "metric": {
-      "metric": "accuracy",
+      "metric": "cer",
       "value": 0.0113,
       "num_samples": 500
     },
-    "elapsed": 825.6,
-    "command": "python.exe run_pytorch_baseline.py --model trocr-base-printed --task image-to-text --device cpu --num-samples 500 --dataset SROIE_2019_text_recognition --split test --columns-mapping {\"input_column\": \"image\", \"label_column\": \"text\"}"
+    "elapsed": 1045.3,
+    "command": "python.exe run_pytorch_baseline.py --model trocr-base-printed --task image-to-text --device cpu --num-samples 500 --dataset SROIE_2019_text_recognition --split test --columns-mapping {\"input_column\": \"image\", \"label_column\": \"text\"} --winml-metric-key cer"
   },
   "microsoft/trocr-large-printed|image-to-text|priyank-m/SROIE_2019_text_recognition||test|200": {
     "status": "PASS",
     "metric": {
-      "metric": "accuracy",
+      "metric": "cer",
       "value": 0.0037,
       "num_samples": 200
     },
-    "elapsed": 592.2,
-    "command": "python.exe run_pytorch_baseline.py --model trocr-large-printed --task image-to-text --device cpu --num-samples 200 --dataset SROIE_2019_text_recognition --split test --columns-mapping {\"input_column\": \"image\", \"label_column\": \"text\"}"
+    "elapsed": 725.5,
+    "command": "python.exe run_pytorch_baseline.py --model trocr-large-printed --task image-to-text --device cpu --num-samples 200 --dataset SROIE_2019_text_recognition --split test --columns-mapping {\"input_column\": \"image\", \"label_column\": \"text\"} --winml-metric-key cer"
   },
   "cross-encoder/nli-deberta-v3-small|zero-shot-classification|fancyzhx/ag_news||test|200": {
     "status": "PASS",
@@ -898,26 +888,6 @@
     },
     "elapsed": 320.9,
     "command": "python.exe run_pytorch_baseline.py --model xlm-roberta-large-xnli --task zero-shot-classification --device cpu --num-samples 200 --dataset ag_news --split test --columns-mapping {\"input_column\": \"text\", \"label_column\": \"label\", \"candidate_labels\": Tech\"}"
-  },
-  "MoritzLaurer/DeBERTa-v3-large-mnli-fever-anli-ling-wanli|zero-shot-classification|fancyzhx/ag_news||test|200": {
-    "status": "PASS",
-    "metric": {
-      "metric": "accuracy",
-      "value": 0.71,
-      "num_samples": 200
-    },
-    "elapsed": 496.6,
-    "command": "python.exe run_pytorch_baseline.py --model DeBERTa-v3-large-mnli-fever-anli-ling-wanli --task zero-shot-classification --device cpu --num-samples 200 --dataset ag_news --split test --columns-mapping {\"input_column\": \"text\", \"label_column\": \"label\", \"candidate_labels\": Tech\"}"
-  },
-  "MoritzLaurer/deberta-v3-large-zeroshot-v2.0|zero-shot-classification|fancyzhx/ag_news||test|200": {
-    "status": "PASS",
-    "metric": {
-      "metric": "accuracy",
-      "value": 0.865,
-      "num_samples": 200
-    },
-    "elapsed": 495.6,
-    "command": "python.exe run_pytorch_baseline.py --model deberta-v3-large-zeroshot-v2.0 --task zero-shot-classification --device cpu --num-samples 200 --dataset ag_news --split test --columns-mapping {\"input_column\": \"text\", \"label_column\": \"label\", \"candidate_labels\": Tech\"}"
   },
   "MoritzLaurer/mDeBERTa-v3-base-mnli-xnli|zero-shot-classification|fancyzhx/ag_news||test|200": {
     "status": "PASS",
@@ -958,5 +928,15 @@
     },
     "elapsed": 284.0,
     "command": "python.exe run_pytorch_baseline.py --model deberta-v3-large-zeroshot-v2.0 --task zero-shot-classification --device cpu --num-samples 100 --dataset ag_news --split test --columns-mapping {\"input_column\": \"text\", \"label_column\": \"label\", \"candidate_labels\": Tech\"}"
+  },
+  "microsoft/deberta-xlarge-mnli|text-classification|nyu-mll/glue|mnli|validation_matched|100": {
+    "status": "PASS",
+    "metric": {
+      "metric": "accuracy",
+      "value": 0.92,
+      "num_samples": 100
+    },
+    "elapsed": 124.3,
+    "command": "python.exe run_pytorch_baseline.py --model deberta-xlarge-mnli --task text-classification --device cpu --num-samples 100 --dataset glue --split validation_matched --dataset-config mnli --columns-mapping {\"input_column\": \"premise\", \"second_input_column\": \"hypothesis\"} --winml-metric-key accuracy"
   }
 }

--- a/scripts/e2e_eval/run_eval.py
+++ b/scripts/e2e_eval/run_eval.py
@@ -847,6 +847,9 @@ def _run_pytorch_baseline(entry: ModelEntry, device: str, timeout: int) -> dict:
         args += ["--columns-mapping", json.dumps(ds_config["columns_mapping"])]
     if ds_config.get("label_mapping_file"):
         args += ["--label-mapping-file", ds_config["label_mapping_file"]]
+    winml_key = ds_config.get("winml_metric_key") or ds_config.get("metric")
+    if winml_key:
+        args += ["--winml-metric-key", winml_key]
 
     proc = _run_subprocess(args, timeout)
     metric = _parse_metric_from_stdout(proc["stdout"]) if proc["exit_code"] == 0 else None

--- a/scripts/e2e_eval/run_pytorch_baseline.py
+++ b/scripts/e2e_eval/run_pytorch_baseline.py
@@ -51,24 +51,6 @@ def _emit_result(metric: str, value: float, num_samples: int) -> None:
     print(json.dumps({"metric": metric, "value": round(value, 6), "num_samples": num_samples}))
 
 
-# Primary metric key returned by the HuggingFace ``evaluate`` library per task.
-_TASK_HF_METRIC_KEY: dict[str, str] = {
-    "image-classification": "accuracy",
-    "text-classification": "accuracy",
-    "sequence-classification": "accuracy",
-    "automatic-speech-recognition": "wer",
-    "token-classification": "overall_f1",
-    "question-answering": "f1",
-    "object-detection": "map",
-    "image-segmentation": "mean_iou",
-    "feature-extraction": "cosine_spearman",
-    "sentence-similarity": "cosine_spearman",
-    "image-feature-extraction": "knn_top1_accuracy",
-    "fill-mask": "pseudo_perplexity",
-    "zero-shot-image-classification": "top1_accuracy",
-}
-
-
 # ---------------------------------------------------------------------------
 # Model and dataset helpers
 # ---------------------------------------------------------------------------
@@ -121,24 +103,6 @@ def _build_dataset_config(ds_dict: dict, num_samples: int):
     )
 
 
-def _extract_metric(metrics: dict, task: str, metric_label: str) -> tuple[str, float]:
-    """Return (label, value) for the primary metric of this task.
-
-    Uses ``_TASK_HF_METRIC_KEY`` to locate the value inside the HF evaluator
-    dict, then emits it under the label from the registry config.
-    """
-    hf_key = _TASK_HF_METRIC_KEY.get(task, "accuracy")
-    if hf_key in metrics:
-        return metric_label, float(metrics[hf_key])
-    # Fallback: first score-range value (0-1), skipping timing/throughput fields
-    # that HF evaluator injects (total_time_in_seconds, samples_per_second, etc.).
-    skip_keys = {"total_time_in_seconds", "samples_per_second", "latency_in_seconds"}
-    for k, v in metrics.items():
-        if k not in skip_keys and isinstance(v, (int, float)) and 0.0 <= v <= 1.0:
-            return metric_label, float(v)
-    raise ValueError(f"No score metric found in evaluator output for task '{task}': {metrics}")
-
-
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
@@ -178,6 +142,14 @@ def parse_args() -> argparse.Namespace:
         "--label-mapping-file",
         default=None,
         help="Path to JSON label mapping file (dataset label -> model ID)",
+    )
+    parser.add_argument(
+        "--winml-metric-key",
+        required=True,
+        help="Lookup key for the primary metric in the evaluator output dict. "
+        "Used as both the lookup key and the emitted label. Mirrors registry's "
+        "``dataset_config.winml_metric_key`` (or ``dataset_config.metric`` when "
+        "the former is absent).",
     )
     return parser.parse_args()
 
@@ -219,6 +191,7 @@ def main() -> None:
             **({"dataset_config": args.dataset_config} if args.dataset_config else {}),
             **({"columns_mapping": columns_mapping} if columns_mapping else {}),
             **({"label_mapping_file": args.label_mapping_file} if args.label_mapping_file else {}),
+            "winml_metric_key": args.winml_metric_key,
         }
     else:
         ds_config_dict = get_dataset_config(args.model, task)
@@ -231,7 +204,11 @@ def main() -> None:
         sys.exit(1)
 
     num_samples = args.num_samples or ds_config_dict.get("num_samples") or 100
-    metric_label = ds_config_dict.get("metric", _TASK_HF_METRIC_KEY.get(task, "accuracy"))
+    winml_metric_key = (
+        ds_config_dict.get("winml_metric_key")
+        or ds_config_dict.get("metric")
+        or args.winml_metric_key
+    )
 
     _out(f"Task: {task} | Model: {model_id} | Device: {args.device} | Samples: {num_samples}")
     ds_name = ds_config_dict.get("dataset")
@@ -260,9 +237,9 @@ def main() -> None:
 
         metrics = task_evaluator.compute()
 
-        metric_name, value = _extract_metric(metrics, task, metric_label)
+        value = float(metrics[winml_metric_key])
         # Emit result as last stdout line (parsed by run_eval.py accuracy phase)
-        _emit_result(metric_name, value, num_samples)
+        _emit_result(winml_metric_key, value, num_samples)
     except Exception as exc:
         _out(f"ERROR: evaluation failed: {exc}")
         import traceback

--- a/scripts/e2e_eval/testsets/models_with_acc.json
+++ b/scripts/e2e_eval/testsets/models_with_acc.json
@@ -50,6 +50,8 @@
     "dataset_config": {
       "path": "nyu-mll/glue",
       "name": "mnli",
+      "split": "validation_matched",
+      "samples": 100,
       "metric": "accuracy",
       "columns_mapping": {
         "input_column": "premise",
@@ -66,6 +68,7 @@
     "dataset_config": {
       "path": "nyu-mll/glue",
       "name": "mnli",
+      "split": "validation_matched",
       "metric": "accuracy",
       "columns_mapping": {
         "input_column": "premise",
@@ -548,7 +551,7 @@
       "path": "mteb/stsbenchmark-sts",
       "split": "test",
       "metric": "cosine_spearman",
-      "wmk_metric_key": "cosine_spearman",
+      "winml_metric_key": "cosine_spearman",
       "columns_mapping": {
         "input_column_1": "sentence1",
         "input_column_2": "sentence2",
@@ -566,7 +569,7 @@
       "path": "mteb/stsbenchmark-sts",
       "split": "test",
       "metric": "cosine_spearman",
-      "wmk_metric_key": "cosine_spearman",
+      "winml_metric_key": "cosine_spearman",
       "columns_mapping": {
         "input_column_1": "sentence1",
         "input_column_2": "sentence2",
@@ -584,7 +587,7 @@
       "path": "mteb/stsbenchmark-sts",
       "split": "test",
       "metric": "cosine_spearman",
-      "wmk_metric_key": "cosine_spearman",
+      "winml_metric_key": "cosine_spearman",
       "columns_mapping": {
         "input_column_1": "sentence1",
         "input_column_2": "sentence2",
@@ -602,7 +605,7 @@
       "path": "mteb/stsbenchmark-sts",
       "split": "test",
       "metric": "cosine_spearman",
-      "wmk_metric_key": "cosine_spearman",
+      "winml_metric_key": "cosine_spearman",
       "columns_mapping": {
         "input_column_1": "sentence1",
         "input_column_2": "sentence2",
@@ -620,7 +623,7 @@
       "path": "mteb/stsbenchmark-sts",
       "split": "test",
       "metric": "cosine_spearman",
-      "wmk_metric_key": "cosine_spearman",
+      "winml_metric_key": "cosine_spearman",
       "columns_mapping": {
         "input_column_1": "sentence1",
         "input_column_2": "sentence2",
@@ -638,7 +641,7 @@
       "path": "mteb/stsbenchmark-sts",
       "split": "test",
       "metric": "cosine_spearman",
-      "wmk_metric_key": "cosine_spearman",
+      "winml_metric_key": "cosine_spearman",
       "columns_mapping": {
         "input_column_1": "sentence1",
         "input_column_2": "sentence2",
@@ -656,7 +659,7 @@
       "path": "mteb/stsbenchmark-sts",
       "split": "test",
       "metric": "cosine_spearman",
-      "wmk_metric_key": "cosine_spearman",
+      "winml_metric_key": "cosine_spearman",
       "columns_mapping": {
         "input_column_1": "sentence1",
         "input_column_2": "sentence2",
@@ -674,7 +677,7 @@
       "path": "mteb/stsbenchmark-sts",
       "split": "test",
       "metric": "cosine_spearman",
-      "wmk_metric_key": "cosine_spearman",
+      "winml_metric_key": "cosine_spearman",
       "columns_mapping": {
         "input_column_1": "sentence1",
         "input_column_2": "sentence2",
@@ -692,7 +695,7 @@
       "path": "mteb/stsbenchmark-sts",
       "split": "test",
       "metric": "cosine_spearman",
-      "wmk_metric_key": "cosine_spearman",
+      "winml_metric_key": "cosine_spearman",
       "columns_mapping": {
         "input_column_1": "sentence1",
         "input_column_2": "sentence2",
@@ -710,7 +713,7 @@
       "path": "mteb/stsbenchmark-sts",
       "split": "test",
       "metric": "cosine_spearman",
-      "wmk_metric_key": "cosine_spearman",
+      "winml_metric_key": "cosine_spearman",
       "columns_mapping": {
         "input_column_1": "sentence1",
         "input_column_2": "sentence2",
@@ -728,7 +731,7 @@
       "path": "mteb/stsbenchmark-sts",
       "split": "test",
       "metric": "cosine_spearman",
-      "wmk_metric_key": "cosine_spearman",
+      "winml_metric_key": "cosine_spearman",
       "columns_mapping": {
         "input_column_1": "sentence1",
         "input_column_2": "sentence2",
@@ -746,7 +749,7 @@
       "path": "mteb/stsbenchmark-sts",
       "split": "test",
       "metric": "cosine_spearman",
-      "wmk_metric_key": "cosine_spearman",
+      "winml_metric_key": "cosine_spearman",
       "columns_mapping": {
         "input_column_1": "sentence1",
         "input_column_2": "sentence2",
@@ -764,7 +767,7 @@
       "path": "mteb/stsbenchmark-sts",
       "split": "test",
       "metric": "cosine_spearman",
-      "wmk_metric_key": "cosine_spearman",
+      "winml_metric_key": "cosine_spearman",
       "columns_mapping": {
         "input_column_1": "sentence1",
         "input_column_2": "sentence2",
@@ -782,7 +785,7 @@
       "path": "mteb/stsbenchmark-sts",
       "split": "test",
       "metric": "cosine_spearman",
-      "wmk_metric_key": "cosine_spearman",
+      "winml_metric_key": "cosine_spearman",
       "columns_mapping": {
         "input_column_1": "sentence1",
         "input_column_2": "sentence2",
@@ -800,7 +803,7 @@
       "path": "mteb/stsbenchmark-sts",
       "split": "test",
       "metric": "cosine_spearman",
-      "wmk_metric_key": "cosine_spearman",
+      "winml_metric_key": "cosine_spearman",
       "columns_mapping": {
         "input_column_1": "sentence1",
         "input_column_2": "sentence2",
@@ -818,7 +821,7 @@
       "path": "mteb/stsbenchmark-sts",
       "split": "test",
       "metric": "cosine_spearman",
-      "wmk_metric_key": "cosine_spearman",
+      "winml_metric_key": "cosine_spearman",
       "columns_mapping": {
         "input_column_1": "sentence1",
         "input_column_2": "sentence2",
@@ -836,7 +839,7 @@
       "path": "mteb/stsbenchmark-sts",
       "split": "test",
       "metric": "cosine_spearman",
-      "wmk_metric_key": "cosine_spearman",
+      "winml_metric_key": "cosine_spearman",
       "columns_mapping": {
         "input_column_1": "sentence1",
         "input_column_2": "sentence2",
@@ -854,7 +857,7 @@
       "path": "rajpurkar/squad",
       "split": "validation",
       "metric": "f1",
-      "wmk_metric_key": "f1",
+      "winml_metric_key": "f1",
       "columns_mapping": {
         "question_column": "question",
         "context_column": "context",
@@ -873,7 +876,7 @@
       "path": "rajpurkar/squad",
       "split": "validation",
       "metric": "f1",
-      "wmk_metric_key": "f1",
+      "winml_metric_key": "f1",
       "columns_mapping": {
         "question_column": "question",
         "context_column": "context",
@@ -892,7 +895,7 @@
       "path": "rajpurkar/squad_v2",
       "split": "validation",
       "metric": "f1",
-      "wmk_metric_key": "f1",
+      "winml_metric_key": "f1",
       "columns_mapping": {
         "question_column": "question",
         "context_column": "context",
@@ -911,7 +914,7 @@
       "path": "rajpurkar/squad_v2",
       "split": "validation",
       "metric": "f1",
-      "wmk_metric_key": "f1",
+      "winml_metric_key": "f1",
       "columns_mapping": {
         "question_column": "question",
         "context_column": "context",
@@ -930,7 +933,7 @@
       "path": "rajpurkar/squad",
       "split": "validation",
       "metric": "f1",
-      "wmk_metric_key": "f1",
+      "winml_metric_key": "f1",
       "columns_mapping": {
         "question_column": "question",
         "context_column": "context",
@@ -949,7 +952,7 @@
       "path": "rajpurkar/squad_v2",
       "split": "validation",
       "metric": "f1",
-      "wmk_metric_key": "f1",
+      "winml_metric_key": "f1",
       "columns_mapping": {
         "question_column": "question",
         "context_column": "context",
@@ -968,7 +971,7 @@
       "path": "rajpurkar/squad_v2",
       "split": "validation",
       "metric": "f1",
-      "wmk_metric_key": "f1",
+      "winml_metric_key": "f1",
       "columns_mapping": {
         "question_column": "question",
         "context_column": "context",
@@ -987,7 +990,7 @@
       "path": "rajpurkar/squad_v2",
       "split": "validation",
       "metric": "f1",
-      "wmk_metric_key": "f1",
+      "winml_metric_key": "f1",
       "columns_mapping": {
         "question_column": "question",
         "context_column": "context",
@@ -1006,7 +1009,7 @@
       "path": "KorQuAD/squad_kor_v1",
       "split": "validation",
       "metric": "f1",
-      "wmk_metric_key": "f1",
+      "winml_metric_key": "f1",
       "columns_mapping": {
         "question_column": "question",
         "context_column": "context",

--- a/src/winml/modelkit/models/winml/sequence_classification.py
+++ b/src/winml/modelkit/models/winml/sequence_classification.py
@@ -56,10 +56,11 @@ class WinMLModelForSequenceClassification(WinMLPreTrainedModel):
             SequenceClassifierOutput with logits
         """
         # Build inputs dict - only include non-None values
+        accepted_inputs = set(self.io_config.get("input_names", []))
         inputs: dict[str, Any] = {"input_ids": input_ids}
-        if attention_mask is not None:
+        if attention_mask is not None and "attention_mask" in accepted_inputs:
             inputs["attention_mask"] = attention_mask
-        if token_type_ids is not None:
+        if token_type_ids is not None and "token_type_ids" in accepted_inputs:
             inputs["token_type_ids"] = token_type_ids
 
         # Use base class helpers for validation, formatting, and inference


### PR DESCRIPTION
1. Update the metric name and metric key in the baseline cache. Currently there is some mis alignment between the baseline cache and the ONNX metric during comparison
2. Fix the evaluation error for `microsoft/deberta-xlarge-mnli`. The failure was caused by 2 problems: 1) wrong validation dataset split 2) exported `microsoft/deberta-xlarge-mnli` has no `token_type_ids` input but we still pass to it.