### PR TITLE
clean up: remove quantize from compile

### DIFF
--- a/src/winml/modelkit/commands/compile.py
+++ b/src/winml/modelkit/commands/compile.py
@@ -5,7 +5,7 @@
 """Compile command for winml CLI.
 
 This module provides the compile command that compiles ONNX models to
-EP-specific formats (e.g., QNN EPContext) with optional quantization.
+EP-specific formats (e.g., QNN EPContext).
 
 Usage:
     winml compile --model MODEL [OPTIONS]
@@ -14,7 +14,6 @@ Examples:
     winml compile -m model.onnx
     winml compile -m model.onnx --device npu
     winml compile -m model.onnx --device gpu --ep migraphx
-    winml compile -m model_qdq.onnx --no-quantize
 """
 
 from __future__ import annotations
@@ -72,11 +71,6 @@ console = Console()
     help="Force specific EP. Overrides device-to-provider mapping.",
 )
 @click.option(
-    "--quantize/--no-quantize",
-    default=True,
-    help="Enable/disable quantization (default: enabled)",
-)
-@click.option(
     "--validate/--no-validate",
     default=True,
     help="Validate compiled model (default: enabled)",
@@ -122,7 +116,6 @@ def compile(
     output_dir: Path | None,
     device: str,
     ep: str | None,
-    quantize: bool,
     validate: bool,
     verbose: bool,
     compiler: str,
@@ -134,8 +127,7 @@ def compile(
     r"""Compile ONNX model to EP-specific format.
 
     This command compiles an ONNX model to an EP-specific format (e.g., QNN
-    EPContext) with optional quantization. For pre-quantized models (containing
-    QDQ nodes), use --no-quantize.
+    EPContext).
 
     \b
     Examples:
@@ -147,9 +139,6 @@ def compile(
 
         # Compile for GPU with MIGraphX
         winml compile -m model.onnx --device gpu --ep migraphx
-
-        # Compile pre-quantized model
-        winml compile -m model_qdq.onnx --no-quantize
 
         # Compile using QAIRT SDK
         winml compile -m model.onnx --compiler qairt --qnn-sdk-root /path/to/sdk
@@ -208,14 +197,6 @@ def compile(
     config.ep_config.compiler = compiler
     config.ep_config.qnn_sdk_root = qnn_sdk_root
     config.ep_config.embed_context = embed
-
-    # Deprecation notice for --no-quantize
-    if not quantize:
-        console.print(
-            "[yellow]Note:[/yellow] --no-quantize has no effect. "
-            "Quantization is no longer performed during compile. "
-            "Use 'winml quantize' before 'winml compile' to control quantization."
-        )
 
     # Show info
     console.print(f"[bold blue]Input:[/bold blue] {model}")

--- a/src/winml/modelkit/compiler/configs.py
+++ b/src/winml/modelkit/compiler/configs.py
@@ -9,14 +9,10 @@ Design follows the automodel pattern:
 - Explicit over implicit
 - Factory methods for common configurations
 - No capability registry - just dataclasses
-
-Quantization concerns (QDQ, calibration) have been moved to
-WinMLQuantizationConfig in modelkit.quant.config (#241).
 """
 
 from __future__ import annotations
 
-import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -120,119 +116,55 @@ class WinMLCompileConfig:
         return cls(ep_config=EPConfig(provider=provider, enable_ep_context=False))
 
     @classmethod
-    def for_qnn(cls, quantize: bool | None = None) -> WinMLCompileConfig:
-        """Factory for QNN compilation.
-
-        Args:
-            quantize: Deprecated. Quantization is now handled by
-                WinMLQuantizationConfig. This parameter is ignored.
-
-        Returns:
-            WinMLCompileConfig configured for QNN EP.
-        """
-        if quantize is not None:
-            warnings.warn(
-                "The 'quantize' parameter is deprecated and ignored. "
-                "Use WinMLQuantizationConfig for quantization settings.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+    def for_qnn(cls) -> WinMLCompileConfig:
+        """Factory for QNN compilation."""
         return cls(ep_config=EPConfig(provider="qnn"))
 
     @classmethod
-    def for_cpu(cls, quantize: bool | None = None) -> WinMLCompileConfig:
+    def for_cpu(cls) -> WinMLCompileConfig:
         """Factory for CPU compilation (no EPContext)."""
-        if quantize is not None:
-            warnings.warn(
-                "The 'quantize' parameter is deprecated and ignored. "
-                "Use WinMLQuantizationConfig for quantization settings.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
         return cls(
             ep_config=EPConfig(provider="cpu", enable_ep_context=False),
         )
 
     @classmethod
-    def for_cuda(cls, quantize: bool | None = None) -> WinMLCompileConfig:
+    def for_cuda(cls) -> WinMLCompileConfig:
         """Factory for CUDA compilation."""
-        if quantize is not None:
-            warnings.warn(
-                "The 'quantize' parameter is deprecated and ignored. "
-                "Use WinMLQuantizationConfig for quantization settings.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
         return cls(
             ep_config=EPConfig(provider="cuda", enable_ep_context=False),
         )
 
     @classmethod
-    def for_dml(cls, quantize: bool | None = None) -> WinMLCompileConfig:
+    def for_dml(cls) -> WinMLCompileConfig:
         """Factory for DirectML compilation."""
-        if quantize is not None:
-            warnings.warn(
-                "The 'quantize' parameter is deprecated and ignored. "
-                "Use WinMLQuantizationConfig for quantization settings.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
         return cls(
             ep_config=EPConfig(provider="dml", enable_ep_context=False),
         )
 
     @classmethod
-    def for_nv_tensorrt_rtx(cls, quantize: bool | None = None) -> WinMLCompileConfig:
+    def for_nv_tensorrt_rtx(cls) -> WinMLCompileConfig:
         """Factory for NvTensorRTRTX compilation."""
-        if quantize is not None:
-            warnings.warn(
-                "The 'quantize' parameter is deprecated and ignored. "
-                "Use WinMLQuantizationConfig for quantization settings.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
         return cls(
             ep_config=EPConfig(provider="nv_tensorrt_rtx", enable_ep_context=False),
         )
 
     @classmethod
-    def for_openvino(cls, quantize: bool | None = None) -> WinMLCompileConfig:
+    def for_openvino(cls) -> WinMLCompileConfig:
         """Factory for OpenVINO compilation."""
-        if quantize is not None:
-            warnings.warn(
-                "The 'quantize' parameter is deprecated and ignored. "
-                "Use WinMLQuantizationConfig for quantization settings.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
         return cls(
             ep_config=EPConfig(provider="openvino", enable_ep_context=True),
         )
 
     @classmethod
-    def for_vitisai(cls, quantize: bool | None = None) -> WinMLCompileConfig:
+    def for_vitisai(cls) -> WinMLCompileConfig:
         """Factory for Vitis AI (AMD/Xilinx NPU) compilation."""
-        if quantize is not None:
-            warnings.warn(
-                "The 'quantize' parameter is deprecated and ignored. "
-                "Use WinMLQuantizationConfig for quantization settings.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
         return cls(
             ep_config=EPConfig(provider="vitisai", enable_ep_context=False),
         )
 
     @classmethod
-    def for_migraphx(cls, quantize: bool | None = None) -> WinMLCompileConfig:
+    def for_migraphx(cls) -> WinMLCompileConfig:
         """Factory for MIGraphX (AMD ROCm GPU) compilation."""
-        if quantize is not None:
-            warnings.warn(
-                "The 'quantize' parameter is deprecated and ignored. "
-                "Use WinMLQuantizationConfig for quantization settings.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
         return cls(
             ep_config=EPConfig(provider="migraphx", enable_ep_context=False),
         )
@@ -257,18 +189,7 @@ class WinMLCompileConfig:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> WinMLCompileConfig:
-        """Create from dictionary, ignoring unknown and legacy quant fields.
-
-        Legacy quantization fields (quantize, weight_type, activation_type,
-        per_channel, calibration_method, calibration_samples, etc.) are
-        silently ignored for backward compatibility.
-
-        Args:
-            data: Configuration dictionary.
-
-        Returns:
-            WinMLCompileConfig instance.
-        """
+        """Create from dictionary. Unknown keys are ignored."""
         ep_config = EPConfig(
             provider=data.get("execution_provider", "qnn"),
             provider_options=data.get("provider_options", {}),

--- a/tests/unit/compiler/test_compile_command.py
+++ b/tests/unit/compiler/test_compile_command.py
@@ -37,7 +37,6 @@ class TestCompileCommand:
         assert result.exit_code == 0
         assert "--model" in result.output
         assert "--device" in result.output
-        assert "--quantize" in result.output
         assert "--compiler" in result.output
         assert "--qnn-sdk-root" in result.output
 
@@ -54,41 +53,6 @@ class TestCompileCommand:
         # With --list should succeed without --model
         result = runner.invoke(main, ["compile", "--list"])
         assert result.exit_code == 0
-
-    @patch("winml.modelkit.compiler.compile_onnx")
-    def test_compile_no_quantize_is_noop(
-        self,
-        mock_compile_onnx: MagicMock,
-        runner: CliRunner,
-        tmp_path: Path,
-    ) -> None:
-        """Test --no-quantize is accepted but has no effect on compile config.
-
-        Quantization is now handled by quant module, not compiler.
-        The flag is kept for backward compat CLI but is a no-op.
-        """
-        model_path = tmp_path / "model.onnx"
-        self._create_simple_onnx(model_path)
-
-        mock_result = MagicMock()
-        mock_result.success = True
-        mock_result.output_path = tmp_path / "output.onnx"
-        mock_result.compile_time = 1.0
-        mock_result.total_time = 1.5
-        mock_compile_onnx.return_value = mock_result
-
-        result = runner.invoke(
-            main,
-            [
-                "compile",
-                "--model",
-                str(model_path),
-                "--no-quantize",
-            ],
-        )
-
-        assert result.exit_code == 0
-        assert mock_compile_onnx.called
 
     @patch("winml.modelkit.compiler.compile_onnx")
     def test_compile_compiler_qairt_sets_ep_config(

--- a/tests/unit/compiler/test_compiler_configs.py
+++ b/tests/unit/compiler/test_compiler_configs.py
@@ -4,8 +4,6 @@
 # --------------------------------------------------------------------------
 """Tests for compiler configuration classes."""
 
-import warnings
-
 import pytest
 
 from winml.modelkit.compiler import (
@@ -163,30 +161,6 @@ class TestCompileConfig:
         assert config.ep_config.enable_ep_context is True
         assert config.validate is True
 
-    def test_from_dict_ignores_legacy_fields(self):
-        """Test from_dict silently ignores legacy quant fields."""
-        data = {
-            "execution_provider": "qnn",
-            "quantize": True,
-            "weight_type": "uint8",
-            "activation_type": "uint8",
-            "per_channel": False,
-            "calibration_method": "minmax",
-            "calibration_samples": 100,
-            "calibration_load_path": "calibration_data.json",
-            "calibration_save_path": "calibration_out.json",
-            "validate": True,
-        }
-        config = WinMLCompileConfig.from_dict(data)
-
-        # EP fields parsed correctly
-        assert config.ep_config.provider == "qnn"
-        assert config.validate is True
-
-        # No quant attributes created
-        assert not hasattr(config, "qdq_config")
-        assert not hasattr(config, "calibration_config")
-
     def test_roundtrip(self):
         """Test to_dict -> from_dict roundtrip."""
         original = WinMLCompileConfig.for_qnn()
@@ -196,80 +170,6 @@ class TestCompileConfig:
         assert restored.ep_config.provider == original.ep_config.provider
         assert restored.ep_config.enable_ep_context == original.ep_config.enable_ep_context
         assert restored.validate == original.validate
-
-
-class TestDeprecationWarnings:
-    """Test deprecation warnings for quantize parameter."""
-
-    @pytest.mark.parametrize(
-        "factory_method",
-        [
-            "for_qnn",
-            "for_cpu",
-            "for_cuda",
-            "for_dml",
-            "for_nv_tensorrt_rtx",
-            "for_openvino",
-            "for_vitisai",
-            "for_migraphx",
-        ],
-    )
-    def test_quantize_true_emits_deprecation(self, factory_method: str):
-        """Passing quantize=True emits DeprecationWarning."""
-        factory = getattr(WinMLCompileConfig, factory_method)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            config = factory(quantize=True)
-            assert len(w) == 1
-            assert issubclass(w[0].category, DeprecationWarning)
-            assert "quantize" in str(w[0].message).lower()
-            assert "deprecated" in str(w[0].message).lower()
-            # Config is still created successfully
-            assert config is not None
-
-    @pytest.mark.parametrize(
-        "factory_method",
-        [
-            "for_qnn",
-            "for_cpu",
-            "for_cuda",
-            "for_dml",
-            "for_nv_tensorrt_rtx",
-            "for_openvino",
-            "for_vitisai",
-            "for_migraphx",
-        ],
-    )
-    def test_quantize_false_emits_deprecation(self, factory_method: str):
-        """Passing quantize=False also emits DeprecationWarning."""
-        factory = getattr(WinMLCompileConfig, factory_method)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            factory(quantize=False)
-            assert len(w) == 1
-            assert issubclass(w[0].category, DeprecationWarning)
-
-    @pytest.mark.parametrize(
-        "factory_method",
-        [
-            "for_qnn",
-            "for_cpu",
-            "for_cuda",
-            "for_dml",
-            "for_nv_tensorrt_rtx",
-            "for_openvino",
-            "for_vitisai",
-            "for_migraphx",
-        ],
-    )
-    def test_no_quantize_no_warning(self, factory_method: str):
-        """Not passing quantize param emits no warning."""
-        factory = getattr(WinMLCompileConfig, factory_method)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            factory()
-            deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
-            assert len(deprecation_warnings) == 0
 
 
 class TestCompileConfigUsagePatterns:


### PR DESCRIPTION
Given we are not released, no need to use deprecated which confuses user