### PR TITLE
feat(telemetry): add TELEMETRY_ENABLED in-source kill-switch

### DIFF
--- a/src/winml/modelkit/telemetry/constants.py
+++ b/src/winml/modelkit/telemetry/constants.py
@@ -8,6 +8,13 @@
 INSTRUMENTATION_KEY is intentionally empty in source. The official build
 pipeline replaces it with the real iKey before packaging the wheel. Tests
 that need to exercise the emission path monkeypatch this constant.
+
+TELEMETRY_ENABLED is the in-source master switch. Flip it to ``False``
+to disable the entire telemetry stack regardless of iKey / consent /
+stored config — useful for local debugging and for emergency disable
+in a hotfix without rebuilding consent state.
 """
 
 INSTRUMENTATION_KEY = ""
+
+TELEMETRY_ENABLED = True

--- a/src/winml/modelkit/telemetry/telemetry.py
+++ b/src/winml/modelkit/telemetry/telemetry.py
@@ -117,6 +117,9 @@ class Telemetry:
         must never propagate to the CLI.
         """
         try:
+            if not constants.TELEMETRY_ENABLED:
+                _clear_cache_quietly()
+                return
             if not constants.INSTRUMENTATION_KEY:
                 _clear_cache_quietly()
                 return

--- a/tests/unit/telemetry/test_constants.py
+++ b/tests/unit/telemetry/test_constants.py
@@ -11,3 +11,12 @@ def test_instrumentation_key_is_empty_in_source():
     from winml.modelkit.telemetry import constants
 
     assert constants.INSTRUMENTATION_KEY == ""
+
+
+def test_telemetry_enabled_default_is_true():
+    """Guard the master switch default. Set ``TELEMETRY_ENABLED = False``
+    in source only as a deliberate kill-switch; this test prevents it
+    being flipped off and forgotten."""
+    from winml.modelkit.telemetry import constants
+
+    assert constants.TELEMETRY_ENABLED is True

--- a/tests/unit/telemetry/test_telemetry_init.py
+++ b/tests/unit/telemetry/test_telemetry_init.py
@@ -23,6 +23,41 @@ def test_empty_ikey_makes_telemetry_disabled(clean_env, isolated_config, monkeyp
     assert t._logger is None
 
 
+def test_telemetry_enabled_false_makes_telemetry_disabled(clean_env, isolated_config, monkeypatch):
+    """The in-source master switch must short-circuit even when iKey and
+    stored consent would otherwise enable emission."""
+    monkeypatch.setattr(
+        "winml.modelkit.telemetry.constants.INSTRUMENTATION_KEY", "test-tenant-1234"
+    )
+    monkeypatch.setattr("winml.modelkit.telemetry.constants.TELEMETRY_ENABLED", False)
+    consent_mod._write_stored_consent("enabled")
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    t = Telemetry.get_or_init()
+    assert t.disabled is True
+    assert t._logger is None
+
+
+def test_telemetry_enabled_false_skips_consent_prompt(clean_env, isolated_config, monkeypatch):
+    """The master switch must short-circuit before any consent prompt
+    so a hotfix kill-switch can't accidentally hang a TTY."""
+    monkeypatch.setattr(
+        "winml.modelkit.telemetry.constants.INSTRUMENTATION_KEY", "test-tenant-1234"
+    )
+    monkeypatch.setattr("winml.modelkit.telemetry.constants.TELEMETRY_ENABLED", False)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+
+    prompt_calls: list[int] = []
+    monkeypatch.setattr(
+        consent_mod,
+        "_prompt_for_consent",
+        lambda: prompt_calls.append(1) or "enabled",
+    )
+
+    t = Telemetry.get_or_init()
+    assert t.disabled is True
+    assert prompt_calls == []
+
+
 def test_consent_disabled_makes_telemetry_disabled(clean_env, isolated_config, monkeypatch):
     monkeypatch.setattr(
         "winml.modelkit.telemetry.constants.INSTRUMENTATION_KEY", "test-tenant-1234"


### PR DESCRIPTION
## Summary
- Add `TELEMETRY_ENABLED: bool = True` to `telemetry/constants.py` as an in-source master switch.
- `Telemetry._try_init` now checks `TELEMETRY_ENABLED` before iKey / consent; when `False`, short-circuits and clears the persistent cache.
- Two unit tests cover override-vs-iKey+consent and no-prompt-when-off; one guard test on the default value.

Closes #577