### PR TITLE
fix(perf): per-module benchmark works for ResNet (and similar HF models)

### DIFF
--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -576,12 +576,23 @@ def _perf_modules(
 
     console.print(f"[dim]Found {len(module_configs)} {module_class} instances[/dim]")
 
-    # Instantiate parent with init weights (no pretrained download)
+    # Instantiate parent with init weights (no pretrained download).
+    # Submodule configs intentionally drop `loader.task`, so re-resolve the
+    # parent task from the model_id — the same path `generate_hf_build_config`
+    # used to compute module_path. Without this, models whose architectures
+    # field differs from the first supported task for their model_type (e.g.
+    # microsoft/resnet-50: architectures=ResNetForImageClassification but
+    # supported_tasks[0]=feature-extraction) instantiate the wrong parent
+    # class and get_submodule() raises AttributeError.
     model_type = module_configs[0].loader.model_type
     if not model_type:
         console.print("[red]Error: module configs missing model_type[/red]")
         sys.exit(3)
-    parent_model = _instantiate_parent_model(model_type, task=task)
+
+    from ..loader import resolve_loader_config
+
+    parent_loader_cfg, _, _ = resolve_loader_config(model_id=hf_model, task=task)
+    parent_model = _instantiate_parent_model(model_type, task=parent_loader_cfg.task)
 
     all_results: list[dict[str, Any]] = []
     for i, cfg in enumerate(module_configs):

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -578,11 +578,10 @@ def _perf_modules(
     # Instantiate parent with init weights (no pretrained download).
     # Submodule configs intentionally drop `loader.task`, so re-resolve the
     # parent task from the model_id — the same path `generate_hf_build_config`
-    # used to compute module_path. Without this, models whose architectures
-    # field differs from the first supported task for their model_type (e.g.
-    # microsoft/resnet-50: architectures=ResNetForImageClassification but
-    # supported_tasks[0]=feature-extraction) instantiate the wrong parent
-    # class and get_submodule() raises AttributeError.
+    # used to compute module_path. Without this, models whose `architectures`
+    # field maps to a different task than `get_supported_tasks(model_type)[0]`
+    # instantiate the wrong parent class and `get_submodule()` raises
+    # AttributeError.
     model_type = module_configs[0].loader.model_type
     if not model_type:
         raise click.ClickException("module configs missing model_type")

--- a/src/winml/modelkit/config/build.py
+++ b/src/winml/modelkit/config/build.py
@@ -259,6 +259,9 @@ class SubmoduleInfo:
         output_shapes: Shape of each output tensor (e.g., [[1,16,64]])
         input_dtypes: Dtype of each input tensor (e.g., ["float32", "float32"])
         output_dtypes: Dtype of each output tensor (e.g., ["float32"])
+        input_names: Forward-arg names for each input (e.g., ["hidden_state"]
+            or ["pixel_values"]). Empty when hook capture didn't run; callers
+            then fall back to generic ``input_{i}`` names.
     """
 
     class_name: str
@@ -267,6 +270,7 @@ class SubmoduleInfo:
     output_shapes: list[list[int]]
     input_dtypes: list[str]
     output_dtypes: list[str]
+    input_names: list[str] = field(default_factory=list)
 
 
 # =============================================================================
@@ -814,10 +818,20 @@ def _build_submodule_config(
         - Inherited optim/compile from parent
         - Quant with task=None, model_name=None (RandomDataset fallback)
     """
-    # Build InputTensorSpec for EACH input tensor (not just the first)
+
+    # Build InputTensorSpec for EACH input tensor (not just the first).
+    # Use the submodule's actual forward-arg names so build_hf_model can
+    # call submodule(**kwargs) correctly (e.g., ResNetStage expects `input`,
+    # ResNetBottleNeckLayer expects `hidden_state`). Fall back to generic
+    # input_{i} only when names were not discovered.
+    def _input_name(i: int) -> str:
+        if i < len(sub_info.input_names) and sub_info.input_names[i]:
+            return sub_info.input_names[i]
+        return f"input_{i}"
+
     input_tensors = [
         InputTensorSpec(
-            name=f"input_{i}",
+            name=_input_name(i),
             shape=tuple(shape),
             dtype=sub_info.input_dtypes[i] if i < len(sub_info.input_dtypes) else None,
         )
@@ -1081,12 +1095,14 @@ def _find_submodules_by_class(
     results = []
     for full_path, layer_info in torchinfo_modules:
         io_info = hook_data.get(full_path)
+        layer_input_names: list[str] = []
         if io_info and io_info.input_shapes:
             # Prefer hook-captured data (has complete multi-input info)
             layer_input_shapes = io_info.input_shapes
             layer_output_shapes = io_info.output_shapes
             layer_input_dtypes = io_info.input_dtypes
             layer_output_dtypes = io_info.output_dtypes
+            layer_input_names = io_info.input_names
         else:
             # Fall back to torchinfo data (single input only)
             layer_input_shapes = [layer_info.input_size] if layer_info.input_size else []
@@ -1102,6 +1118,18 @@ def _find_submodules_by_class(
             layer_input_dtypes = [param_dtype] * len(layer_input_shapes)
             layer_output_dtypes = [param_dtype] * len(layer_output_shapes)
 
+            # Without hook data, derive names from the forward signature so
+            # build_hf_model can invoke the submodule with the correct kwargs.
+            import inspect as _inspect
+
+            try:
+                sig = _inspect.signature(layer_info.module.forward)
+                layer_input_names = [p.name for p in sig.parameters.values() if p.name != "self"][
+                    : len(layer_input_shapes)
+                ]
+            except (TypeError, ValueError):
+                layer_input_names = []
+
         results.append(
             SubmoduleInfo(
                 class_name=layer_info.class_name,
@@ -1110,6 +1138,7 @@ def _find_submodules_by_class(
                 output_shapes=layer_output_shapes,
                 input_dtypes=layer_input_dtypes,
                 output_dtypes=layer_output_dtypes,
+                input_names=layer_input_names,
             )
         )
 

--- a/src/winml/modelkit/config/build.py
+++ b/src/winml/modelkit/config/build.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 
 import copy
 import hashlib
+import inspect
 import json
 import logging
 from dataclasses import dataclass, field
@@ -821,9 +822,9 @@ def _build_submodule_config(
 
     # Build InputTensorSpec for EACH input tensor (not just the first).
     # Use the submodule's actual forward-arg names so build_hf_model can
-    # call submodule(**kwargs) correctly (e.g., ResNetStage expects `input`,
-    # ResNetBottleNeckLayer expects `hidden_state`). Fall back to generic
-    # input_{i} only when names were not discovered.
+    # call submodule(**kwargs) correctly — submodule forward args may be
+    # positional (e.g. `input`) or keyword (e.g. `hidden_state`). Fall back
+    # to generic input_{i} only when names were not discovered.
     def _input_name(i: int) -> str:
         if i < len(sub_info.input_names) and sub_info.input_names[i]:
             return sub_info.input_names[i]
@@ -1120,10 +1121,8 @@ def _find_submodules_by_class(
 
             # Without hook data, derive names from the forward signature so
             # build_hf_model can invoke the submodule with the correct kwargs.
-            import inspect as _inspect
-
             try:
-                sig = _inspect.signature(layer_info.module.forward)
+                sig = inspect.signature(layer_info.module.forward)
                 layer_input_names = [p.name for p in sig.parameters.values() if p.name != "self"][
                     : len(layer_input_shapes)
                 ]

--- a/tests/unit/commands/test_perf_module.py
+++ b/tests/unit/commands/test_perf_module.py
@@ -75,6 +75,12 @@ class TestPerfModuleParameterForwarding:
         fake_session = MagicMock()
         fake_session.perf.side_effect = RuntimeError("test-skip-benchmark")
 
+        # _perf_modules calls resolve_loader_config(model_id=...) to recover the
+        # parent task (submodule configs strip it). Stub it so "fake/model" never
+        # hits the HF Hub.
+        fake_loader_cfg = MagicMock()
+        fake_loader_cfg.task = "fill-mask"
+
         with (
             patch(
                 "winml.modelkit.sysinfo.resolve_device",
@@ -84,6 +90,10 @@ class TestPerfModuleParameterForwarding:
                 "winml.modelkit.config.generate_hf_build_config",
                 return_value=[fake_cfg],
             ) as mock_gen,
+            patch(
+                "winml.modelkit.loader.resolve_loader_config",
+                return_value=(fake_loader_cfg, MagicMock(), MagicMock()),
+            ),
             patch(
                 "winml.modelkit.commands.build._instantiate_parent_model",
                 return_value=MagicMock(),

--- a/tests/unit/config/test_build.py
+++ b/tests/unit/config/test_build.py
@@ -796,6 +796,117 @@ class TestBuildSubmoduleConfig:
         # Empty list is falsy, so input_tensors should be set to None
         assert result.export.input_tensors is None
 
+    def test_input_names_propagate(self, parent_config: WinMLBuildConfig) -> None:
+        """SubmoduleInfo.input_names propagate to InputTensorSpec.name."""
+        sub_info = SubmoduleInfo(
+            class_name="ResNetBottleNeckLayer",
+            module_path="encoder.stages.0.layers.0",
+            input_shapes=[[1, 64, 32, 32]],
+            output_shapes=[[1, 256, 32, 32]],
+            input_dtypes=["float32"],
+            output_dtypes=["float32"],
+            input_names=["hidden_state"],
+        )
+
+        result = _build_submodule_config(sub_info, parent_config)
+
+        assert result.export.input_tensors is not None
+        assert result.export.input_tensors[0].name == "hidden_state"
+
+    def test_input_names_fallback(self, parent_config: WinMLBuildConfig) -> None:
+        """Missing, short, or empty-string input_names fall back to input_{i}."""
+        # Case 1: empty input_names → input_0
+        sub_info_empty = SubmoduleInfo(
+            class_name="Conv2d",
+            module_path="encoder.conv",
+            input_shapes=[[1, 64, 32, 32]],
+            output_shapes=[[1, 128, 16, 16]],
+            input_dtypes=["float32"],
+            output_dtypes=["float32"],
+            input_names=[],
+        )
+        result_empty = _build_submodule_config(sub_info_empty, parent_config)
+        assert result_empty.export.input_tensors is not None
+        assert result_empty.export.input_tensors[0].name == "input_0"
+
+        # Case 2: input_names shorter than input_shapes → known name then fallback
+        sub_info_short = SubmoduleInfo(
+            class_name="CrossAttention",
+            module_path="decoder.cross_attn",
+            input_shapes=[[1, 16, 64], [1, 16, 64]],
+            output_shapes=[[1, 16, 64]],
+            input_dtypes=["float32", "float32"],
+            output_dtypes=["float32"],
+            input_names=["hidden_state"],
+        )
+        result_short = _build_submodule_config(sub_info_short, parent_config)
+        assert result_short.export.input_tensors is not None
+        assert result_short.export.input_tensors[0].name == "hidden_state"
+        assert result_short.export.input_tensors[1].name == "input_1"
+
+        # Case 3: empty-string entry → input_{i}
+        sub_info_blank = SubmoduleInfo(
+            class_name="Conv2d",
+            module_path="encoder.conv",
+            input_shapes=[[1, 64, 32, 32]],
+            output_shapes=[[1, 128, 16, 16]],
+            input_dtypes=["float32"],
+            output_dtypes=["float32"],
+            input_names=[""],
+        )
+        result_blank = _build_submodule_config(sub_info_blank, parent_config)
+        assert result_blank.export.input_tensors is not None
+        assert result_blank.export.input_tensors[0].name == "input_0"
+
+
+# =============================================================================
+# TestFindSubmodulesByClass - exercises the signature-fallback branch
+# =============================================================================
+
+
+class TestFindSubmodulesByClass:
+    """Tests for _find_submodules_by_class signature-fallback branch."""
+
+    def test_signature_fallback_when_hook_data_empty(self) -> None:
+        """Empty hook_data triggers inspect.signature fallback for input_names."""
+        import torch
+        from torch import nn
+
+        from winml.modelkit.config.build import _find_submodules_by_class
+
+        class SignatureFallbackSubmodule(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = nn.Linear(8, 16)
+
+            def forward(self, hidden_state: torch.Tensor) -> torch.Tensor:
+                return self.linear(hidden_state)
+
+        class SignatureFallbackWrapper(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.layer = SignatureFallbackSubmodule()
+
+            def forward(self, hidden_state: torch.Tensor) -> torch.Tensor:
+                return self.layer(hidden_state)
+
+        model = SignatureFallbackWrapper()
+
+        # Force the fallback path by short-circuiting hook capture.
+        with patch(
+            "winml.modelkit.inspect.module_io_capture.capture_module_io",
+            return_value={},
+        ):
+            results = _find_submodules_by_class(
+                model,
+                "SignatureFallbackSubmodule",
+                input_shapes=[(1, 8)],
+                input_dtypes=["float32"],
+            )
+
+        assert len(results) == 1
+        assert results[0].input_names == ["hidden_state"]
+
 
 # =============================================================================
 # TestConfigCliOverride - CLI tests for --config flag


### PR DESCRIPTION
## Summary

Fixes `winml perf --module <ClassName>` on HuggingFace models like `microsoft/resnet-50`, which previously failed with `AttributeError: <Parent> has no attribute '<...>'` and, once that was past, `forward() missing 1 required positional argument`.

Two root causes:

1. **Wrong parent class instantiated.** `_perf_modules` passed the CLI `task` (typically `None`) to `_instantiate_parent_model`. When the model_type's first supported task differs from the architectures-derived task used by `generate_hf_build_config`, the parent class mismatches the recorded `module_path`. For `microsoft/resnet-50`, build configs use `ResNetForImageClassification` (paths prefixed with `resnet.`), but perf was instantiating bare `ResNetModel` → `AttributeError: ResNetModel has no attribute 'resnet'`. Fix: re-resolve the parent task from the model_id via `resolve_loader_config`, matching the path used to compute `module_path`.

2. **Wrong input tensor names.** `_build_submodule_config` hardcoded input names as `input_0`, `input_1`, …, but PyTorch submodules expect specific positional/keyword names (e.g., `ResNetStage.forward(input)`, `ResNetBottleNeckLayer.forward(hidden_state)`, `ResNetEmbeddings.forward(pixel_values)`). Calling `submodule(input_0=tensor)` raises `forward() missing 1 required positional argument`. Fix: propagate forward-arg names through `SubmoduleInfo.input_names` (sourced from the existing hook-capture data, with a `inspect.signature` fallback) and use them when building `InputTensorSpec`. Falls back to `input_{i}` only when names can't be discovered.

End-to-end on a CPU box:

```
$ winml perf -m microsoft/resnet-50 --module ResNetStage --ep cpu --device cpu
                Per-Module Perf: ResNetStage
| Module Path             | Mean (ms) | P90 (ms) | Min  | Max  |
| resnet.encoder.stages.0 |      4.16 |     5.22 | 3.30 | 5.22 |
| resnet.encoder.stages.1 |     14.04 |    24.09 | 8.69 | 24.09 |
| resnet.encoder.stages.2 |      7.41 |     8.65 | 4.93 | 8.65 |
| resnet.encoder.stages.3 |      5.20 |     7.09 | 3.59 | 7.09 |
```

Closes https://github.com/microsoft/WinML-ModelKit/issues/192