### PR TITLE
chore(perf): validate iterations/warmup, reuse cli_utils for --model/--device/--ep

### DIFF
--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -1053,14 +1053,7 @@ def _run_onnx_benchmark(
 
 
 @click.command("perf")
-@click.option(
-    "-m",
-    "--model",
-    "model_id",
-    type=str,
-    default=None,
-    help="Model identifier: HuggingFace model ID or local .onnx file.",
-)
+@cli_utils.model_option(required=False)
 @click.option(
     "--task",
     type=str,
@@ -1069,25 +1062,19 @@ def _run_onnx_benchmark(
 )
 @click.option(
     "--iterations",
-    type=int,
+    type=click.IntRange(min=1),
     default=100,
     show_default=True,
-    help="Number of benchmark iterations",
+    help="Number of benchmark iterations (must be > 0)",
 )
 @click.option(
     "--warmup",
-    type=int,
+    type=click.IntRange(min=0),
     default=10,
     show_default=True,
-    help="Number of warmup iterations (excluded from statistics)",
+    help="Number of warmup iterations (excluded from statistics; must be >= 0)",
 )
-@click.option(
-    "--device",
-    type=click.Choice(["auto", "cpu", "gpu", "npu"], case_sensitive=False),
-    default="auto",
-    show_default=True,
-    help="Device to run benchmark on",
-)
+@cli_utils.device_option(required=False, default="auto", include_auto=True)
 @click.option(
     "--precision",
     type=str,
@@ -1095,14 +1082,9 @@ def _run_onnx_benchmark(
     show_default=True,
     help="Precision mode: auto, fp32, fp16, int8, int16, or w{x}a{y} (e.g., w8a16).",
 )
-@click.option(
-    "--ep",
-    "ep",
-    type=str,
-    default=None,
-    help="Force specific execution provider "
-    "(qnn, dml, migraphx, nv_tensorrt_rtx, vitisai, openvino, cpu). "
-    "Overrides device-to-provider mapping.",
+@cli_utils.ep_option(
+    required=False,
+    optional_message="Overrides device-to-provider mapping.",
 )
 @click.option(
     "--output",
@@ -1175,7 +1157,7 @@ def _run_onnx_benchmark(
 @click.pass_context
 def perf(
     ctx: click.Context,
-    model_id: str | None,
+    model: str | None,
     task: str | None,
     iterations: int,
     warmup: int,
@@ -1222,10 +1204,10 @@ def perf(
         # Operator-level profiling (QNN NPU)
         winml perf -m model.onnx --op-tracing basic
     """
-    if not model_id:
+    if not model:
         raise click.UsageError("A model is required via -m/--model.")
 
-    hf_model = model_id
+    hf_model = model
 
     # Apply build config defaults (CLI explicit options take precedence)
     if config_file is not None:


### PR DESCRIPTION
## Summary

- Validate numeric perf options at parse time using `click.IntRange`: `--iterations` must be `>= 1`, `--warmup` must be `>= 0`. Previously perf accepted `0` (or even negative) iterations and silently produced empty/garbage stats.
- Replace three hand-rolled Click option blocks with the shared `cli_utils` helpers already used by `run`, `serve`, `eval`, and `catalog`:
  - `--model -m` → `cli_utils.model_option(required=False)` (renames the perf-local kwarg from `model_id` to `model` to match the helper; downstream `BenchmarkConfig.model_id`, `generate_output_path`, and `_run_onnx_benchmark` are unaffected).
  - `--device` → `cli_utils.device_option(required=False, default="auto", include_auto=True)`.
  - `--ep` → `cli_utils.ep_option(required=False, optional_message="Overrides device-to-provider mapping.")`. Side benefit: `--ep` typos are now caught at parse time instead of failing deep in the build pipeline.

Net diff: `+12 / -30` lines in `src/winml/modelkit/commands/perf.py`.

Closes https://github.com/microsoft/WinML-ModelKit/issues/552