### PR TITLE
refactor: remove stale analyzer_version field from AnalysisOutput

### DIFF
--- a/src/winml/modelkit/analyze/analyzer.py
+++ b/src/winml/modelkit/analyze/analyzer.py
@@ -479,7 +479,6 @@ class ONNXStaticAnalyzer:
             >>> config = AnalyzerConfig(enable_information=True)
             >>> analyzer = ONNXStaticAnalyzer(config=config)
         """
-        from . import __version__
         from .core.information_engine import InformationEngine
         from .core.output_aggregator import OutputAggregator
 
@@ -487,7 +486,7 @@ class ONNXStaticAnalyzer:
 
         # Initialize core components
         self.information_engine_cls = InformationEngine
-        self.output_aggregator = OutputAggregator(analyzer_version=__version__)
+        self.output_aggregator = OutputAggregator()
 
         logger.info("Initialized ONNXStaticAnalyzer with config: %s", self.config)
 

--- a/src/winml/modelkit/analyze/core/output_aggregator.py
+++ b/src/winml/modelkit/analyze/core/output_aggregator.py
@@ -38,19 +38,11 @@ class OutputAggregator:
     - Include runtime check results and information
 
     FR-026-031: Complete output assembly with metadata, results, and information
-
-    Attributes:
-        analyzer_version: Version string for output
     """
 
-    def __init__(self, analyzer_version: str = "0.1.0") -> None:
-        """Initialize aggregator.
-
-        Args:
-            analyzer_version: Version string for output (default: "0.1.0")
-        """
-        self.analyzer_version = analyzer_version
-        logger.info("Initialized OutputAggregator with version %s", analyzer_version)
+    def __init__(self) -> None:
+        """Initialize aggregator."""
+        logger.info("Initialized OutputAggregator")
 
     def aggregate(
         self,
@@ -71,13 +63,12 @@ class OutputAggregator:
             AnalysisOutput: Complete analysis output ready for JSON serialization
 
         Output Structure:
-            - analyzer_version: Version string
             - analysis_timestamp: Current datetime
             - metadata: Model metadata (path, opset, operator stats)
             - results: List of EPSupport objects
 
         Example:
-            >>> aggregator = OutputAggregator("0.1.0")
+            >>> aggregator = OutputAggregator()
             >>> metadata = ModelStats(
             ...     model_path="model.onnx",
             ...     opset_version=13,
@@ -125,7 +116,6 @@ class OutputAggregator:
         # Create final output
         output_build_start = time.perf_counter()
         output = AnalysisOutput(
-            analyzer_version=self.analyzer_version,
             metadata=metadata,
             results=results,
         )

--- a/src/winml/modelkit/analyze/models/output.py
+++ b/src/winml/modelkit/analyze/models/output.py
@@ -103,13 +103,11 @@ class AnalysisOutput(BaseModel):
     """Aggregated analysis results for JSON serialization.
 
     Attributes:
-        analyzer_version: Analyzer version
         analysis_timestamp: When analysis ran
         metadata: Model metadata and statistics
         results: Analysis results
     """
 
-    analyzer_version: str = Field(..., description="Analyzer version")
     analysis_timestamp: datetime = Field(
         default_factory=datetime.now, description="Analysis timestamp"
     )

--- a/tests/mock_data/analyze/output.json
+++ b/tests/mock_data/analyze/output.json
@@ -1,5 +1,4 @@
 {
-  "analyzer_version": "0.1.0",
   "analysis_timestamp": "2025-12-03T14:30:00.123456",
   "metadata": {
     "model_path": "/path/to/resnet50.onnx",

--- a/tests/unit/analyze/core/test_output_aggregator.py
+++ b/tests/unit/analyze/core/test_output_aggregator.py
@@ -110,22 +110,6 @@ def sample_information() -> dict[str, list[Information]]:
     return {"QNNExecutionProvider": [info]}
 
 
-class TestOutputAggregatorInit:
-    """Tests for OutputAggregator initialization."""
-
-    def test_init_default_version(self) -> None:
-        """Test initialization with default version."""
-        aggregator = OutputAggregator()
-
-        assert aggregator.analyzer_version == "0.1.0"
-
-    def test_init_custom_version(self) -> None:
-        """Test initialization with custom version."""
-        aggregator = OutputAggregator(analyzer_version="1.2.3")
-
-        assert aggregator.analyzer_version == "1.2.3"
-
-
 class TestOutputAggregatorAggregate:
     """Tests for aggregate method."""
 
@@ -136,7 +120,7 @@ class TestOutputAggregatorAggregate:
         sample_information: dict[IHVType, list[Information]],
     ) -> None:
         """Test aggregate creates AnalysisOutput."""
-        aggregator = OutputAggregator(analyzer_version="0.1.0")
+        aggregator = OutputAggregator()
 
         output = aggregator.aggregate(
             metadata=sample_metadata,
@@ -145,7 +129,6 @@ class TestOutputAggregatorAggregate:
         )
 
         assert isinstance(output, AnalysisOutput)
-        assert output.analyzer_version == "0.1.0"
         assert output.metadata == sample_metadata
         assert len(output.results) == 1
         assert output.results[0].ihv_type == IHVType.QC
@@ -493,7 +476,7 @@ class TestOutputAggregatorIntegration:
         sample_information: dict[str, list[Information]],
     ) -> None:
         """Test complete aggregation workflow with single IHV."""
-        aggregator = OutputAggregator(analyzer_version="1.0.0")
+        aggregator = OutputAggregator()
 
         output = aggregator.aggregate(
             metadata=sample_metadata,
@@ -501,7 +484,6 @@ class TestOutputAggregatorIntegration:
             information_list=sample_information,
         )
 
-        assert output.analyzer_version == "1.0.0"
         assert output.metadata.model_path == "test.onnx"
         assert len(output.results) == 1
 
@@ -584,6 +566,5 @@ class TestOutputAggregatorIntegration:
 
         assert isinstance(json_str, str)
         assert len(json_str) > 0
-        assert "analyzer_version" in json_str
         assert "metadata" in json_str
         assert "results" in json_str

--- a/tests/unit/analyze/models/test_output.py
+++ b/tests/unit/analyze/models/test_output.py
@@ -160,7 +160,6 @@ class TestAnalysisOutputValidation:
     def test_valid_analysis_output(self):
         """Test that valid AnalysisOutput is accepted."""
         output = AnalysisOutput(
-            analyzer_version="1.0.0",
             metadata=ModelStats(
                 model_path="/models/resnet50.onnx",
                 opset_version=13,
@@ -187,13 +186,11 @@ class TestAnalysisOutputValidation:
 
         assert output.metadata.model_path == "/models/resnet50.onnx"
         assert len(output.results) == 1
-        assert output.analyzer_version == "1.0.0"
 
     def test_unique_ihv_types_validation(self):
         """Test that IHV types must be unique in results."""
         # Valid: unique IHV types
         output = AnalysisOutput(
-            analyzer_version="1.0.0",
             metadata=ModelStats(
                 model_path="/test.onnx",
                 opset_version=13,
@@ -234,7 +231,6 @@ class TestAnalysisOutputValidation:
         # Invalid: duplicate IHV types
         with pytest.raises(ValidationError, match="Duplicate IHV types found"):
             AnalysisOutput(
-                analyzer_version="1.0.0",
                 metadata=ModelStats(
                     model_path="/test.onnx",
                     opset_version=13,
@@ -275,7 +271,6 @@ class TestAnalysisOutputValidation:
         """Test that results list has max 4 items."""
         # Valid: 4 results
         output = AnalysisOutput(
-            analyzer_version="1.0.0",
             metadata=ModelStats(
                 model_path="/test.onnx",
                 opset_version=13,
@@ -340,7 +335,6 @@ class TestAnalysisOutputValidation:
     def test_model_dump_json_serialization(self):
         """Test that model_dump_json() produces valid JSON."""
         output = AnalysisOutput(
-            analyzer_version="1.0.0",
             metadata=ModelStats(
                 model_path="/models/test.onnx",
                 opset_version=14,
@@ -374,7 +368,6 @@ class TestAnalysisOutputValidation:
         assert parsed["metadata"]["opset_version"] == 14
         assert parsed["metadata"]["total_operators"] == 3
         assert parsed["metadata"]["operator_counts"]["Conv"] == 1
-        assert parsed["analyzer_version"] == "1.0.0"
 
     def test_comprehensive_output_with_all_fields(self):
         """Test AnalysisOutput with all fields populated."""
@@ -390,7 +383,6 @@ class TestAnalysisOutputValidation:
         )
 
         output = AnalysisOutput(
-            analyzer_version="1.0.0",
             metadata=ModelStats(
                 model_path="/models/comprehensive.onnx",
                 opset_version=15,
@@ -444,4 +436,3 @@ class TestAnalysisOutputValidation:
 
         assert "metadata" in parsed
         assert "results" in parsed
-        assert "analyzer_version" in parsed

--- a/tests/unit/analyze/test_analyze_onnx.py
+++ b/tests/unit/analyze/test_analyze_onnx.py
@@ -88,7 +88,6 @@ def _make_mock_output(
         information=information or [],
     )
     return AnalysisOutput(
-        analyzer_version="0.1.0",
         metadata=metadata,
         results=[ep_support],
     )

--- a/tests/unit/analyze/test_analyzer.py
+++ b/tests/unit/analyze/test_analyzer.py
@@ -84,7 +84,6 @@ class TestAnalysisResult:
         )
 
         return AnalysisOutput(
-            analyzer_version="0.1.0",
             metadata=metadata,
             results=[ihv_support],
         )
@@ -126,7 +125,6 @@ class TestAnalysisResult:
             detected_pattern_count={},
         )
         output = AnalysisOutput(
-            analyzer_version="0.1.0",
             metadata=metadata,
             results=[],
         )
@@ -164,7 +162,6 @@ class TestAnalysisResult:
             detected_pattern_count={},
         )
         output = AnalysisOutput(
-            analyzer_version="0.1.0",
             metadata=metadata,
             results=[],
         )
@@ -202,7 +199,6 @@ class TestAnalysisResult:
             detected_pattern_count={},
         )
         output = AnalysisOutput(
-            analyzer_version="0.1.0",
             metadata=metadata,
             results=[],
         )
@@ -324,7 +320,6 @@ class TestAnalysisResult:
             detected_pattern_count={},
         )
         output = AnalysisOutput(
-            analyzer_version="0.1.0",
             metadata=metadata,
             results=[],
         )
@@ -439,15 +434,14 @@ class TestAnalysisResult:
         result = AnalysisResult(output=mock_output)
         json_str = result.to_json()
         assert isinstance(json_str, str)
-        assert "analyzer_version" in json_str
-        assert "0.1.0" in json_str
+        assert "metadata" in json_str
+        assert "results" in json_str
 
     def test_to_dict(self, mock_output: AnalysisOutput) -> None:
         """Test to_dict exports dictionary."""
         result = AnalysisResult(output=mock_output)
         data = result.to_dict()
         assert isinstance(data, dict)
-        assert data["analyzer_version"] == "0.1.0"
         assert data["metadata"]["opset_version"] == 13
 
     def test_get_optimization_config_no_actions(self, mock_output: AnalysisOutput) -> None:

--- a/tests/unit/analyze/test_static_analyzer_cli.py
+++ b/tests/unit/analyze/test_static_analyzer_cli.py
@@ -58,7 +58,6 @@ def mock_analyzer_result() -> Mock:
     mock_result.output.results = []  # empty EP results list (iterable)
     mock_result.to_json.return_value = json.dumps(
         {
-            "analyzer_version": "0.1.0",
             "analysis_timestamp": "2025-12-05T12:00:00",
             "metadata": {
                 "model_path": "test.onnx",
@@ -82,7 +81,6 @@ def mock_analyzer_partial_support() -> Mock:
     mock_result.output.results = []  # empty EP results list (iterable)
     mock_result.to_json.return_value = json.dumps(
         {
-            "analyzer_version": "0.1.0",
             "analysis_timestamp": "2025-12-05T12:00:00",
             "metadata": {
                 "model_path": "test.onnx",
@@ -520,7 +518,7 @@ class TestAnalyzeCommandOutput:
 
         # Verify file contains valid JSON
         content = json.loads(output_file.read_text())
-        assert "analyzer_version" in content
+        assert "metadata" in content
 
     @patch("winml.modelkit.analyze.ONNXStaticAnalyzer")
     def test_output_file_not_written_on_error(


### PR DESCRIPTION
## Summary

- Removes the `analyzer_version` field from `AnalysisOutput` and drops the
  `analyzer_version` parameter from `OutputAggregator.__init__`.
- The field was a hardcoded `"0.1.0"` that never got bumped, did not
  correspond to the PyPI package version (`winml-modelkit` is at `0.0.2`),
  and provided no provenance signal in emitted analysis JSON.
- Updates `analyzer.py` to stop passing the now-removed argument, plus all
  unit tests and the `tests/mock_data/analyze/output.json` mock.

Fixes #589