### PR TITLE
fix: force utf-8 stdout/stderr on package import

### DIFF
--- a/src/winml/modelkit/__init__.py
+++ b/src/winml/modelkit/__init__.py
@@ -29,8 +29,16 @@ Usage:
 """
 
 import logging
+import sys
 from importlib.metadata import PackageNotFoundError, version
 
+
+# Force utf-8 stdout/stderr so emoji and Unicode output (rich console, logs,
+# CLI banners) does not raise UnicodeEncodeError on Windows shells that start
+# Python with a charmap codec (e.g., PYTHONIOENCODING=cp1252).
+for _stream in (sys.stdout, sys.stderr):
+    if hasattr(_stream, "reconfigure"):
+        _stream.reconfigure(encoding="utf-8")
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 

--- a/tests/unit/test_init_encoding.py
+++ b/tests/unit/test_init_encoding.py
@@ -1,0 +1,49 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Reproduces the cp1252 emoji UnicodeEncodeError that occurs on Windows
+consoles initialized with PYTHONIOENCODING=cp1252 (the common default for
+non-utf-8 Windows shells).
+
+Importing winml.modelkit must reconfigure sys.stdout/sys.stderr to utf-8
+so downstream emoji / Unicode output (rich console, log messages, etc.)
+never raises UnicodeEncodeError at runtime.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+EMOJI_PROGRAM = "import winml.modelkit; print('\\U0001f680')"
+
+
+def test_winml_modelkit_import_makes_emoji_print_safe_under_cp1252() -> None:
+    """A subprocess started with PYTHONIOENCODING=cp1252 must be able to
+    print an emoji after ``import winml.modelkit``.
+
+    Without the fix in winml.modelkit.__init__, the child process raises:
+        UnicodeEncodeError: 'charmap' codec can't encode character '\\U0001f680'
+    """
+    saved = os.environ.get("PYTHONIOENCODING")
+    os.environ["PYTHONIOENCODING"] = "cp1252"
+    try:
+        result = subprocess.run(  # noqa: S603 -- trusted args (sys.executable + constant)
+            [sys.executable, "-c", EMOJI_PROGRAM],
+            capture_output=True,
+            check=False,
+        )
+    finally:
+        if saved is None:
+            os.environ.pop("PYTHONIOENCODING", None)
+        else:
+            os.environ["PYTHONIOENCODING"] = saved
+
+    stderr = result.stderr.decode("utf-8", errors="replace")
+    assert result.returncode == 0, (
+        f"emoji print under cp1252 failed (rc={result.returncode}):\n{stderr}"
+    )
+    assert "UnicodeEncodeError" not in stderr, stderr


### PR DESCRIPTION
## Summary

- On Windows shells started with a charmap codec (most commonly `PYTHONIOENCODING=cp1252`), any emoji or non-Latin-1 character emitted via `print`, `rich.Console`, or logging raised `UnicodeEncodeError: 'charmap' codec can't encode character ...` — affecting CLI banners, progress output, and analyzer reports.
- `winml/modelkit/__init__.py` now reconfigures `sys.stdout`/`sys.stderr` to utf-8 on import (guarded with `hasattr(..., "reconfigure")` so wrapped streams under pytest capture/pipelines are left alone).
- Added `tests/unit/test_init_encoding.py`: a subprocess UT that sets `PYTHONIOENCODING=cp1252`, runs `import winml.modelkit; print('\U0001f680')`, and asserts the child exits cleanly. The test fails on `main` with the exact charmap error and passes with this fix.