### PR TITLE
fix: attach pipeline noise filter to image_processor logger

### DIFF
--- a/src/winml/modelkit/_warnings.py
+++ b/src/winml/modelkit/_warnings.py
@@ -65,7 +65,11 @@ def _configure() -> None:
             msg = record.getMessage()
             return not any(s in msg for s in self._SUPPRESSED)
 
-    logging.getLogger("transformers.pipelines.base").addFilter(_PipelineNoiseFilter())
+    for logger_name in (
+        "transformers.pipelines.base",
+        "transformers.models.auto.image_processing_auto",
+    ):
+        logging.getLogger(logger_name).addFilter(_PipelineNoiseFilter())
 
     # =========================================================================
     # Warning filters (for warnings.warn() calls)


### PR DESCRIPTION
Fixes #420.

## Summary

- `_PipelineNoiseFilter` listed `"Using a slow image processor"` in its `_SUPPRESSED` tuple but was only attached to `transformers.pipelines.base`. The message is emitted by `transformers.models.auto.image_processing_auto`, so the suppression never fired.
- Re-attach the filter to both loggers via a loop, restoring the behavior from 324407d.