### PR TITLE
fix(perf): replace sys.exit() with click exceptions for consistent exit codes

### DIFF
--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import json
 import logging
-import sys
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -565,22 +564,21 @@ def _perf_modules(
             ep=ep,
         )
     except Exception as e:
-        console.print(f"[red]Error generating module configs: {e}[/red]")
         if verbose:
             logger.exception("Module config generation failed")
-        sys.exit(3)
+        raise click.ClickException(f"Error generating module configs: {e}") from e
 
     if not module_configs:
-        console.print(f"[yellow]No modules matching '{module_class}' found[/yellow]")
-        sys.exit(0)
+        # User-error: --module pattern didn't match. Exit non-zero so CI
+        # doesn't silently treat a typo'd module name as success.
+        raise click.UsageError(f"No modules matching '{module_class}' found")
 
     console.print(f"[dim]Found {len(module_configs)} {module_class} instances[/dim]")
 
     # Instantiate parent with init weights (no pretrained download)
     model_type = module_configs[0].loader.model_type
     if not model_type:
-        console.print("[red]Error: module configs missing model_type[/red]")
-        sys.exit(3)
+        raise click.ClickException("module configs missing model_type")
     parent_model = _instantiate_parent_model(model_type, task=task)
 
     all_results: list[dict[str, Any]] = []
@@ -1394,11 +1392,11 @@ def perf(
             console.print(f"[green]Op-trace saved to:[/green] {trace_output}")
 
     except FileNotFoundError as e:
-        console.print(f"[red]Error:[/red] Model not found: {e}")
-        sys.exit(3)
+        # User-error: bad model path. UsageError so the exit code (2) matches
+        # the convention used by Click for argument problems.
+        raise click.UsageError(f"Model not found: {e}") from e
 
     except Exception as e:
-        console.print(f"[red]Error:[/red] Benchmark failed: {e}")
         if verbose:
             logger.exception("Benchmark failed")
-        sys.exit(4)
+        raise click.ClickException(f"Benchmark failed: {e}") from e

--- a/tests/unit/commands/test_perf_module.py
+++ b/tests/unit/commands/test_perf_module.py
@@ -35,6 +35,24 @@ class TestPerfModuleFlag:
         result = runner.invoke(main, ["perf", "--module", "BertAttention"])
         assert result.exit_code != 0
 
+    def test_module_no_match_exits_nonzero(self) -> None:
+        """--module CLASSNAME matching no submodules must exit non-zero.
+
+        Regression guard for #554: previously `sys.exit(0)` masked this
+        as success, which silently broke CI when a module name was typoed.
+        """
+        with patch(
+            "winml.modelkit.config.generate_hf_build_config",
+            return_value=[],
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                ["perf", "-m", "fake/model", "--module", "DoesNotExist"],
+            )
+        assert result.exit_code != 0, result.output
+        assert "No modules matching" in result.output
+
     def test_module_default_output_includes_class_name(self) -> None:
         """Default output path includes module class name."""
         # The single-model generate_output_path produces {slug}_perf.json

--- a/tests/unit/commands/test_perf_module.py
+++ b/tests/unit/commands/test_perf_module.py
@@ -41,9 +41,17 @@ class TestPerfModuleFlag:
         Regression guard for #554: previously `sys.exit(0)` masked this
         as success, which silently broke CI when a module name was typoed.
         """
-        with patch(
-            "winml.modelkit.config.generate_hf_build_config",
-            return_value=[],
+        # _perf_modules calls resolve_device() before generate_hf_build_config(),
+        # so mock both to keep the test hermetic (no hardware probe in CI).
+        with (
+            patch(
+                "winml.modelkit.sysinfo.resolve_device",
+                return_value=("cpu", ["cpu"]),
+            ),
+            patch(
+                "winml.modelkit.config.generate_hf_build_config",
+                return_value=[],
+            ),
         ):
             runner = CliRunner()
             result = runner.invoke(


### PR DESCRIPTION
## Summary

Five `sys.exit(N)` paths in `commands/perf.py` used inconsistent, non-standard exit codes — and most importantly, the no-modules-matched user-error path called `sys.exit(0)`, masking a typo as success and silently breaking CI.

This PR replaces all five with the proper Click exception types:

| Path | Before | After | Exit |
|---|---|---|---|
| Module config generation failed | `sys.exit(3)` | `click.ClickException` | 1 |
| **No modules matched `--module CLASSNAME`** | `sys.exit(0)` ← the bug | `click.UsageError` | **2** |
| Defensive: configs missing `model_type` | `sys.exit(3)` | `click.ClickException` | 1 |
| Model file not found | `sys.exit(3)` | `click.UsageError` | 2 |
| Generic benchmark failure | `sys.exit(4)` | `click.ClickException` | 1 |

User-facing errors now exit 2 (Click's `UsageError` convention), runtime failures exit 1, success exits 0 — matching the rest of the CLI. The now-unused `import sys` is also dropped.

Added `test_module_no_match_exits_nonzero` as a regression guard for the specific scenario the issue described.

End-to-end repro of the bug now behaves correctly:

```
$ winml perf -m microsoft/resnet-50 --module DoesNotExist --ep cpu --device cpu
Generating module configs for DoesNotExist...
Usage: winml perf [OPTIONS]
Try 'winml perf --help' for help.

Error: No modules matching 'DoesNotExist' found
$ echo $?
2
```

Closes #554