### PR TITLE
fix(perf): improve --module UX (reject .onnx, clarify help, suggest classes on typo)

### DIFF
--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -1128,8 +1128,10 @@ def _run_onnx_benchmark(
     "module_class",
     default=None,
     type=str,
-    help="HF module class name for per-module benchmarking (e.g., 'BertAttention'). "
-    "Builds and benchmarks each instance separately.",
+    help="PyTorch module class name (NOT a dotted module path) for per-module "
+    "benchmarking. Every instance of the class in the model is built and "
+    "benchmarked separately. Example: '--module BertAttention' (correct), "
+    "not '--module encoder.layer.0.attention' (a path, will not match).",
 )
 @click.option(
     "--monitor",

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -1225,6 +1225,17 @@ def perf(
     # MODULE MODE: per-module build + benchmark
     # =========================================================================
     if module_class:
+        # Reject --module on a pre-exported ONNX path. Submodule discovery
+        # walks a live nn.Module graph (torchinfo), which an ONNX file does
+        # not carry. Without this guard, the user sees a misleading
+        # "not a valid JSON file" error from AutoConfig.from_pretrained
+        # trying to load the .onnx as an HF config dir (issue #553).
+        if Path(hf_model).suffix.lower() == ".onnx":
+            raise click.UsageError(
+                f"--module is not supported for ONNX files. "
+                f"Submodule benchmarking requires a HuggingFace model ID "
+                f"(e.g., 'microsoft/resnet-50'), not '{hf_model}'."
+            )
         if shape_config_path:
             console.print(
                 "[yellow]Warning:[/yellow] --shape-config is not supported "

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -542,11 +542,12 @@ def _perf_modules(
             device-to-provider mapping when set.
         precision: Precision mode passed through to the build stage.
     """
+    import difflib
     import json as json_mod
     import tempfile
 
     from ..build import build_hf_model
-    from ..config import generate_hf_build_config
+    from ..config import SubmoduleClassNotFoundError, generate_hf_build_config
     from ..sysinfo import resolve_device
     from .build import _instantiate_parent_model
 
@@ -563,14 +564,25 @@ def _perf_modules(
             precision=precision,
             ep=ep,
         )
+    except SubmoduleClassNotFoundError as e:
+        # User-error: --module pattern didn't match. List what's available so
+        # the user can correct the typo without re-discovering classes manually.
+        msg = [f"No modules matching '{e.class_name}' found."]
+        suggestions = difflib.get_close_matches(e.class_name, e.available_classes, n=5)
+        if suggestions:
+            msg.append(f"Did you mean: {', '.join(suggestions)}?")
+        if e.available_classes:
+            msg.append("Available module class names in this model:")
+            msg.append("  " + "\n  ".join(e.available_classes))
+        raise click.UsageError("\n".join(msg)) from e
     except Exception as e:
         if verbose:
             logger.exception("Module config generation failed")
         raise click.ClickException(f"Error generating module configs: {e}") from e
 
     if not module_configs:
-        # User-error: --module pattern didn't match. Exit non-zero so CI
-        # doesn't silently treat a typo'd module name as success.
+        # Defense-in-depth: _find_submodules_by_class now raises on no match,
+        # but keep this branch for builders that might bypass it.
         raise click.UsageError(f"No modules matching '{module_class}' found")
 
     console.print(f"[dim]Found {len(module_configs)} {module_class} instances[/dim]")

--- a/src/winml/modelkit/config/__init__.py
+++ b/src/winml/modelkit/config/__init__.py
@@ -24,6 +24,7 @@ Example:
 
 from ..utils.config_utils import merge_config
 from .build import (
+    SubmoduleClassNotFoundError,
     WinMLBuildConfig,
     generate_build_config,
     generate_hf_build_config,
@@ -41,6 +42,7 @@ from .precision import (
 __all__ = [
     "VALID_EPS",
     "PrecisionPolicy",
+    "SubmoduleClassNotFoundError",
     "WinMLBuildConfig",
     "generate_build_config",
     "generate_hf_build_config",

--- a/src/winml/modelkit/config/build.py
+++ b/src/winml/modelkit/config/build.py
@@ -245,6 +245,22 @@ class WinMLBuildConfig:
 # =============================================================================
 
 
+class SubmoduleClassNotFoundError(LookupError):
+    """Raised when no submodule matches the requested class name.
+
+    Attributes:
+        class_name: The class name that was requested.
+        available_classes: Sorted list of submodule class names actually
+            present (and executed) in the traced model — used by callers to
+            render "did you mean…?" suggestions.
+    """
+
+    def __init__(self, class_name: str, available_classes: list[str]) -> None:
+        self.class_name = class_name
+        self.available_classes = available_classes
+        super().__init__(f"No submodule with class '{class_name}' found")
+
+
 @dataclass
 class SubmoduleInfo:
     """Info about a discovered submodule from torchinfo.
@@ -1053,12 +1069,16 @@ def _find_submodules_by_class(
         depth=10,
     )
 
-    # Collect torchinfo-discovered modules matching class_name
+    # Collect torchinfo-discovered modules matching class_name, plus the
+    # full set of executed class names — surfaced via SubmoduleClassNotFoundError
+    # so the CLI can suggest valid alternatives on a typo.
     torchinfo_modules: list[tuple[str, Any]] = []  # (full_path, layer_info)
+    executed_class_names: set[str] = set()
     for layer_info in model_info.summary_list:
-        if layer_info.class_name != class_name:
-            continue
         if not layer_info.executed:
+            continue
+        executed_class_names.add(layer_info.class_name)
+        if layer_info.class_name != class_name:
             continue
 
         # Build full dotted path by walking parent chain (matches named_modules())
@@ -1069,6 +1089,9 @@ def _find_submodules_by_class(
             node = node.parent_info
         full_path = ".".join(reversed(parts))
         torchinfo_modules.append((full_path, layer_info))
+
+    if not torchinfo_modules:
+        raise SubmoduleClassNotFoundError(class_name, sorted(executed_class_names))
 
     # Second pass: hook-based capture for complete multi-input I/O data.
     # torchinfo only captures the first input tensor per module; our hooks

--- a/tests/unit/commands/test_perf_module.py
+++ b/tests/unit/commands/test_perf_module.py
@@ -81,6 +81,39 @@ class TestPerfModuleFlag:
         assert result.exit_code != 0, result.output
         assert "No modules matching" in result.output
 
+    def test_module_no_match_lists_available_classes(self) -> None:
+        """SubmoduleClassNotFoundError surfaces the available class names
+        plus a `Did you mean…?` suggestion."""
+        from winml.modelkit.config import SubmoduleClassNotFoundError
+
+        with (
+            patch(
+                "winml.modelkit.sysinfo.resolve_device",
+                return_value=("cpu", ["cpu"]),
+            ),
+            patch(
+                "winml.modelkit.config.generate_hf_build_config",
+                side_effect=SubmoduleClassNotFoundError(
+                    "ResNetStag",  # typo of ResNetStage
+                    ["Conv2d", "Linear", "ResNetStage", "ResNetBottleNeckLayer"],
+                ),
+            ),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                ["perf", "-m", "fake/model", "--module", "ResNetStag"],
+            )
+        assert result.exit_code != 0, result.output
+        assert "No modules matching 'ResNetStag'" in result.output
+        # Close-match suggestion (difflib should pick ResNetStage).
+        assert "Did you mean" in result.output
+        assert "ResNetStage" in result.output
+        # Full list also shown.
+        assert "Available module class names" in result.output
+        assert "Conv2d" in result.output
+        assert "Linear" in result.output
+
     def test_module_default_output_includes_class_name(self) -> None:
         """Default output path includes module class name."""
         # The single-model generate_output_path produces {slug}_perf.json

--- a/tests/unit/commands/test_perf_module.py
+++ b/tests/unit/commands/test_perf_module.py
@@ -35,6 +35,26 @@ class TestPerfModuleFlag:
         result = runner.invoke(main, ["perf", "--module", "BertAttention"])
         assert result.exit_code != 0
 
+    def test_module_with_onnx_path_rejected(self, tmp_path: Path) -> None:
+        """--module on a .onnx path must fail with a clear UsageError.
+
+        Regression guard for #553: previously the CLI tried to load the
+        ONNX file as an HF config and surfaced a confusing "not a valid
+        JSON file" error.
+        """
+        onnx_file = tmp_path / "model.onnx"
+        onnx_file.write_bytes(b"fake")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["perf", "-m", str(onnx_file), "--module", "NoSuchClass"],
+        )
+        assert result.exit_code == 2, result.output
+        assert "--module is not supported for ONNX files" in result.output
+        # Specifically must NOT blame the model file with a JSON-config error.
+        assert "valid JSON" not in result.output
+
     def test_module_no_match_exits_nonzero(self) -> None:
         """--module CLASSNAME matching no submodules must exit non-zero.
 

--- a/tests/unit/config/test_build.py
+++ b/tests/unit/config/test_build.py
@@ -861,12 +861,12 @@ class TestBuildSubmoduleConfig:
 
 
 # =============================================================================
-# TestFindSubmodulesByClass - exercises the signature-fallback branch
+# TestFindSubmodulesByClass - signature-fallback and no-match paths
 # =============================================================================
 
 
 class TestFindSubmodulesByClass:
-    """Tests for _find_submodules_by_class signature-fallback branch."""
+    """Tests for _find_submodules_by_class branches."""
 
     def test_signature_fallback_when_hook_data_empty(self) -> None:
         """Empty hook_data triggers inspect.signature fallback for input_names."""
@@ -907,15 +907,6 @@ class TestFindSubmodulesByClass:
 
         assert len(results) == 1
         assert results[0].input_names == ["hidden_state"]
-
-
-# =============================================================================
-# TestFindSubmodulesByClass - no-match path surfaces available class names
-# =============================================================================
-
-
-class TestFindSubmodulesByClass:
-    """Tests for _find_submodules_by_class error reporting."""
 
     def test_no_match_raises_with_available_classes(self) -> None:
         """Wrong class name raises SubmoduleClassNotFoundError listing real classes."""

--- a/tests/unit/config/test_build.py
+++ b/tests/unit/config/test_build.py
@@ -24,12 +24,12 @@ import winml.modelkit.models  # noqa: F401
 from winml.modelkit.commands.config import config as config_command
 from winml.modelkit.compiler import EPConfig, WinMLCompileConfig
 from winml.modelkit.config import (
+    SubmoduleClassNotFoundError,
     WinMLBuildConfig,
     generate_build_config,
     generate_onnx_build_config,
 )
 from winml.modelkit.config.build import (
-    SubmoduleClassNotFoundError,
     SubmoduleInfo,
     _build_submodule_config,
     resolve_quant_compile_config,

--- a/tests/unit/config/test_build.py
+++ b/tests/unit/config/test_build.py
@@ -29,6 +29,7 @@ from winml.modelkit.config import (
     generate_onnx_build_config,
 )
 from winml.modelkit.config.build import (
+    SubmoduleClassNotFoundError,
     SubmoduleInfo,
     _build_submodule_config,
     resolve_quant_compile_config,
@@ -795,6 +796,55 @@ class TestBuildSubmoduleConfig:
 
         # Empty list is falsy, so input_tensors should be set to None
         assert result.export.input_tensors is None
+
+
+# =============================================================================
+# TestFindSubmodulesByClass - no-match path surfaces available class names
+# =============================================================================
+
+
+class TestFindSubmodulesByClass:
+    """Tests for _find_submodules_by_class error reporting."""
+
+    def test_no_match_raises_with_available_classes(self) -> None:
+        """Wrong class name raises SubmoduleClassNotFoundError listing real classes."""
+        import torch
+        from torch import nn
+
+        from winml.modelkit.config.build import _find_submodules_by_class
+
+        class Inner(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = nn.Linear(8, 16)
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return self.linear(x)
+
+        class Wrapper(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.inner = Inner()
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return self.inner(x)
+
+        model = Wrapper()
+
+        with pytest.raises(SubmoduleClassNotFoundError) as exc_info:
+            _find_submodules_by_class(
+                model,
+                "ResNetStage",  # doesn't exist in this model
+                input_shapes=[(1, 8)],
+                input_dtypes=["float32"],
+            )
+
+        err = exc_info.value
+        assert err.class_name == "ResNetStage"
+        # The real submodule classes must be reported, sorted.
+        assert "Inner" in err.available_classes
+        assert "Linear" in err.available_classes
+        assert err.available_classes == sorted(err.available_classes)
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Three related fixes to make `winml perf --module CLASSNAME` self-explanatory when things go wrong.

### 1. Reject `--module` on `.onnx` paths (Closes #553)

Previously, `winml perf -m foo.onnx --module SomeClass` failed with:

```
Generating module configs for SomeClass...
Error: Error generating module configs: It looks like the config file at 'foo.onnx' is not a valid JSON file.
```

The message blamed the model file — but the user's `.onnx` was fine; the real problem is that `--module` requires walking a live `nn.Module` graph (via torchinfo), which a frozen ONNX file can't provide. The CLI now rejects this combination upfront:

```
$ winml perf -m foo.onnx --module SomeClass --ep cpu --device cpu
Error: --module is not supported for ONNX files. Submodule benchmarking requires a HuggingFace model ID (e.g., 'microsoft/resnet-50'), not 'foo.onnx'.
$ echo $?
2
```

### 2. Clarify `--module` help text (Closes #195, doc-gap criterion)

The previous help text said `HF module class name (e.g., 'BertAttention')` — which doesn't make the distinction from a dotted module path obvious. Updated to:

```
--module TEXT   PyTorch module class name (NOT a dotted module path) for
                per-module benchmarking. Every instance of the class in
                the model is built and benchmarked separately. Example:
                '--module BertAttention' (correct), not
                '--module encoder.layer.0.attention' (a path, will not match).
```

### 3. Suggest valid class names on typo (#195, suggestion criterion)

When `--module` doesn't match anything, the CLI used to say only `No modules matching 'FooBar' found`. It now lists what's actually in the model and offers a close-match suggestion:

```
$ winml perf -m microsoft/resnet-50 --module ResNetStag
Error: No modules matching 'ResNetStag' found.
Did you mean: ResNetStage?
Available module class names in this model:
  BatchNorm2d
  Conv2d
  Linear
  ResNetBottleNeckLayer
  ResNetStage
  ...
```

Implementation: `_find_submodules_by_class` now raises a new `SubmoduleClassNotFoundError(class_name, available_classes)` carrying the executed class names discovered by torchinfo. `_perf_modules` catches it and renders a `click.UsageError` with `difflib.get_close_matches` suggestions plus the full sorted list.

## Out of scope

The CLIP forward-signature criterion of #195 (`CLIPEncoderLayer.forward()` requires `attention_mask` and `causal_attention_mask` kwargs that the random input generator doesn't supply) is a separate fix and tracked there.

## Tests

- `test_module_with_onnx_path_rejected` — guards #553 regression.
- `test_module_flag_in_help` — guards `--module` help-text presence.
- `test_module_no_match_lists_available_classes` — CLI-level: `SubmoduleClassNotFoundError` surfaces the available class names plus a `Did you mean…?` line.
- `TestFindSubmodulesByClass.test_no_match_raises_with_available_classes` — build-layer: the exception carries the right class names, sorted.

All affected suites pass.