### PR TITLE
test(export): add e2e tests + fix --input-specs feature-extraction crash

### DIFF
--- a/src/winml/modelkit/commands/export.py
+++ b/src/winml/modelkit/commands/export.py
@@ -242,66 +242,83 @@ def export(
             console.print(f"[bold red]Failed to load export config:[/bold red] {e}")
             raise click.ClickException(f"Failed to load export config: {e}") from e
 
-    # Load input/output specifications
+    # Load input/output specifications.
+    #
+    # We ALWAYS run Optimum auto-resolution because it provides authoritative
+    # output_tensors (names that match the actual ONNX graph). --input-specs
+    # then overrides input_tensors only; output_tensors stays from Optimum so
+    # tasks like feature-extraction don't trip torch.onnx.export with extra
+    # dataclass field names that aren't in the traced graph.
     input_tensors: list[InputTensorSpec] | None = None
     output_tensors: list[OutputTensorSpec] | None = None
+
+    # Load shape overrides from JSON
+    shape_overrides = None
+    if shape_config:
+        try:
+            with shape_config.open() as f:
+                shape_overrides = json.load(f)
+            if not isinstance(shape_overrides, dict):
+                raise click.ClickException(
+                    f"--shape-config must contain a JSON object, "
+                    f"got {type(shape_overrides).__name__}"
+                )
+        except json.JSONDecodeError as e:
+            raise click.ClickException(
+                f"Invalid JSON in --shape-config: {shape_config}: {e}"
+            ) from e
+        console.print(f"[dim]Shape overrides: {shape_overrides}[/dim]")
+
+    # Always auto-resolve input/output tensors via loader + Optimum
+    try:
+        from ..export import resolve_export_config as resolve_cfg
+
+        auto_export_cfg, _ = resolve_cfg(
+            model_id=model,
+            task=task,
+            shape_config=shape_overrides,
+        )
+        if auto_export_cfg.input_tensors:
+            input_tensors = auto_export_cfg.input_tensors
+            console.print(
+                f"[dim]Auto-resolved input specs: {[t.name for t in input_tensors]}[/dim]"
+            )
+        if auto_export_cfg.output_tensors:
+            output_tensors = auto_export_cfg.output_tensors
+            console.print(
+                f"[dim]Auto-resolved output specs: {[t.name for t in output_tensors]}[/dim]"
+            )
+    except Exception as e:
+        logger.debug("I/O tensor auto-resolution failed: %s", e)
+
+    # --input-specs overrides individual fields on the auto-resolved input_tensors.
+    # Names matched against auto-resolve get their dtype/shape patched; unknown
+    # names are appended. output_tensors are left untouched.
     if input_specs:
         try:
             with input_specs.open() as f:
                 input_specs_dict = json.load(f)
-            # Convert dict format to InputTensorSpec list
-            input_tensors = []
-            for name, spec in input_specs_dict.items():
-                input_tensors.append(
-                    InputTensorSpec(
-                        name=name,
-                        dtype=spec.get("dtype", "float32"),
-                        shape=tuple(spec.get("shape", [])) if spec.get("shape") else None,
-                    )
-                )
-            console.print(f"[dim]Loaded {len(input_tensors)} input specifications[/dim]")
         except Exception as e:
             console.print(f"[bold red]Failed to load input specs:[/bold red] {e}")
             raise click.ClickException(f"Failed to load input specs: {e}") from e
-    else:
-        # Load shape overrides from JSON (outside catch-all so errors propagate)
-        shape_overrides = None
-        if shape_config:
-            try:
-                with shape_config.open() as f:
-                    shape_overrides = json.load(f)
-                if not isinstance(shape_overrides, dict):
-                    raise click.ClickException(
-                        f"--shape-config must contain a JSON object, "
-                        f"got {type(shape_overrides).__name__}"
-                    )
-            except json.JSONDecodeError as e:
-                raise click.ClickException(
-                    f"Invalid JSON in --shape-config: {shape_config}: {e}"
-                ) from e
-            console.print(f"[dim]Shape overrides: {shape_overrides}[/dim]")
 
-        # Auto-resolve input/output tensors via loader + Optimum
-        try:
-            from ..export import resolve_export_config as resolve_cfg
-
-            auto_export_cfg, _ = resolve_cfg(
-                model_id=model,
-                task=task,
-                shape_config=shape_overrides,
-            )
-            if auto_export_cfg.input_tensors:
-                input_tensors = auto_export_cfg.input_tensors
-                console.print(
-                    f"[dim]Auto-resolved input specs: {[t.name for t in input_tensors]}[/dim]"
+        if input_tensors is None:
+            input_tensors = []
+        by_name = {t.name: t for t in input_tensors}
+        for name, spec in input_specs_dict.items():
+            shape = tuple(spec["shape"]) if spec.get("shape") else None
+            dtype = spec.get("dtype")
+            if name in by_name:
+                existing = by_name[name]
+                if dtype is not None:
+                    existing.dtype = dtype
+                if shape is not None:
+                    existing.shape = shape
+            else:
+                input_tensors.append(
+                    InputTensorSpec(name=name, dtype=dtype or "float32", shape=shape)
                 )
-            if auto_export_cfg.output_tensors:
-                output_tensors = auto_export_cfg.output_tensors
-                console.print(
-                    f"[dim]Auto-resolved output specs: {[t.name for t in output_tensors]}[/dim]"
-                )
-        except Exception as e:
-            logger.debug("I/O tensor auto-resolution failed: %s", e)
+        console.print(f"[dim]Applied input-spec overrides: {list(input_specs_dict.keys())}[/dim]")
 
     # Build WinMLExportConfig from loaded settings
     config_kwargs = {}

--- a/tests/e2e/test_export_e2e.py
+++ b/tests/e2e/test_export_e2e.py
@@ -1,0 +1,406 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""E2E tests for the export CLI command.
+
+These tests exercise the full ``winml export`` pipeline with a real model
+(``microsoft/resnet-50``) downloaded from HuggingFace Hub.
+
+Success criteria for any successful invocation:
+    * Command exits with code 0.
+    * The requested ONNX file exists at the given path.
+    * Test-specific extra invariants (per-case).
+
+Failure criteria for any failing invocation:
+    * Command exits with a non-zero code.
+    * No ONNX file is left at the requested path.
+
+Markers:
+    e2e:     Full end-to-end test with real models
+    slow:    Tests that take > 30 seconds
+    network: Requires network access to HuggingFace Hub
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import onnx
+import pytest
+from click.testing import CliRunner
+
+from winml.modelkit.commands.export import export
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+pytestmark = [pytest.mark.e2e, pytest.mark.slow, pytest.mark.network, pytest.mark.timeout(1800)]
+
+
+_MODEL = "microsoft/resnet-50"
+
+# Full WinMLBuildConfig used by ``-c PATH`` tests. Sets opset_version=18 so the
+# resulting ONNX model can be verified via its default-domain opset.
+_BUILD_CONFIG: dict = {
+    "export": {
+        "opset_version": 18,
+        "batch_size": 1,
+        "export_params": True,
+        "do_constant_folding": True,
+        "verbose": False,
+        "dynamo": False,
+        "enable_hierarchy_tags": True,
+        "clean_onnx": False,
+        "hierarchy_tag_format": "full",
+        "input_tensors": [
+            {
+                "name": "pixel_values",
+                "dtype": "float32",
+                "shape": [1, 3, 224, 224],
+                "value_range": [0, 1],
+            }
+        ],
+        "output_tensors": [{"name": "logits"}],
+    },
+    "optim": {},
+    "quant": None,
+    "compile": None,
+    "loader": {
+        "task": "image-classification",
+        "model_class": "AutoModelForImageClassification",
+        "model_type": "resnet",
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers (DRY)
+# ---------------------------------------------------------------------------
+
+
+def _invoke(args: list[str], *, catch: bool = False):
+    """Invoke the export CLI with a fresh runner and standard ctx.obj."""
+    runner = CliRunner()
+    return runner.invoke(export, args, obj={"debug": False}, catch_exceptions=catch)
+
+
+def _happy_args(onnx_path: Path, *extra: str) -> list[str]:
+    """Build the happy-path args ``-m <model> -o <onnx_path>`` plus any extras."""
+    return ["-m", _MODEL, "-o", str(onnx_path), *extra]
+
+
+def _assert_succeeds(args: list[str], onnx_path: Path) -> onnx.ModelProto:
+    """Assert exit==0, ONNX file is produced, and return the loaded model."""
+    result = _invoke(args)
+    assert result.exit_code == 0, f"export failed (exit {result.exit_code}):\n{result.output}"
+    assert onnx_path.exists(), f"ONNX model not found at {onnx_path}"
+    return onnx.load(str(onnx_path))
+
+
+def _assert_fails(args: list[str], onnx_path: Path) -> None:
+    """Assert exit!=0 and the ONNX file is absent."""
+    result = _invoke(args, catch=True)
+    assert result.exit_code != 0, f"expected failure, got exit=0:\n{result.output}"
+    assert not onnx_path.exists(), f"ONNX file unexpectedly present at {onnx_path}"
+
+
+def _opset_version(model: onnx.ModelProto) -> int:
+    """Return the default-domain (ai.onnx) opset version of the model."""
+    for opset in model.opset_import:
+        if opset.domain in ("", "ai.onnx"):
+            return opset.version
+    msg = "default-domain opset import not found"
+    raise AssertionError(msg)
+
+
+def _node_has_metadata(node: onnx.NodeProto, key: str) -> bool:
+    return any(prop.key == key for prop in node.metadata_props)
+
+
+def _nodes_missing_metadata(model: onnx.ModelProto, key: str) -> list[onnx.NodeProto]:
+    """Return the list of graph nodes that do NOT have ``key`` in metadata_props."""
+    return [n for n in model.graph.node if not _node_has_metadata(n, key)]
+
+
+def _nodes_with_metadata(model: onnx.ModelProto, key: str) -> list[onnx.NodeProto]:
+    """Return the list of graph nodes that have ``key`` in metadata_props."""
+    return [n for n in model.graph.node if _node_has_metadata(n, key)]
+
+
+def _assert_all_nodes_have(model: onnx.ModelProto, key: str) -> None:
+    """Assert every graph node has ``key`` in its metadata_props."""
+    nodes = list(model.graph.node)
+    assert nodes, "model has zero graph nodes"
+    missing = _nodes_missing_metadata(model, key)
+    assert not missing, (
+        f"{len(missing)}/{len(nodes)} nodes missing metadata_props key {key!r}; "
+        f"first few: {[(n.name, n.op_type) for n in missing[:5]]}"
+    )
+
+
+def _assert_no_node_has(model: onnx.ModelProto, key: str) -> None:
+    """Assert no graph node has ``key`` in its metadata_props."""
+    nodes = list(model.graph.node)
+    assert nodes, "model has zero graph nodes"
+    present = _nodes_with_metadata(model, key)
+    assert not present, (
+        f"{len(present)}/{len(nodes)} nodes unexpectedly have metadata_props key {key!r}; "
+        f"first few: {[(n.name, n.op_type) for n in present[:5]]}"
+    )
+
+
+def _assert_some_node_has(model: onnx.ModelProto, key: str) -> None:
+    """Assert at least one graph node has ``key`` in its metadata_props.
+
+    Use only for keys that are intentionally per-subset (e.g. onnxscript
+    rewriter rule_name, which only annotates rewritten nodes).
+    """
+    nodes = list(model.graph.node)
+    assert nodes, "model has zero graph nodes"
+    present = _nodes_with_metadata(model, key)
+    assert present, (
+        f"no node has metadata_props key {key!r}; "
+        f"sample keys observed: "
+        f"{sorted({p.key for n in nodes for p in n.metadata_props})[:10]}"
+    )
+
+
+def _output_names(model: onnx.ModelProto) -> list[str]:
+    return [out.name for out in model.graph.output]
+
+
+def _input_shape_dims(model: onnx.ModelProto) -> list[int]:
+    """Return the first input's shape as a list of int dim_values (or -1)."""
+    first = model.graph.input[0]
+    return [
+        d.dim_value if d.HasField("dim_value") else -1 for d in first.type.tensor_type.shape.dim
+    ]
+
+
+def _write_json(path: Path, payload: dict) -> Path:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+# ===========================================================================
+# --help
+# ===========================================================================
+
+
+class TestExportHelp:
+    """``winml export --help`` prints help and exits 0 without producing an ONNX."""
+
+    def test_help_works(self):
+        result = _invoke(["--help"])
+        assert result.exit_code == 0, f"--help failed:\n{result.output}"
+        # Help output should mention the command and at least one flag we care about
+        assert "--model" in result.output
+        assert "--output" in result.output
+
+
+# ===========================================================================
+# Happy path
+# ===========================================================================
+
+
+class TestExportHappyPath:
+    """Minimal: ``winml export -m microsoft/resnet-50 -o <tmp>/model.onnx``."""
+
+    def test_minimal_resnet50(self, tmp_path: Path):
+        onnx_path = tmp_path / "model.onnx"
+        model = _assert_succeeds(_happy_args(onnx_path), onnx_path)
+
+        # Every graph node must have winml.hierarchy.tag and winml.hierarchy.depth.
+        _assert_all_nodes_have(model, "winml.hierarchy.tag")
+        _assert_all_nodes_have(model, "winml.hierarchy.depth")
+
+
+# ===========================================================================
+# Required-option failures
+# ===========================================================================
+
+
+class TestExportRequiredOptions:
+    """``-m`` and ``-o`` are required; omitting either should fail cleanly."""
+
+    def test_missing_model_fails(self, tmp_path: Path):
+        onnx_path = tmp_path / "model.onnx"
+        _assert_fails(["-o", str(onnx_path)], onnx_path)
+
+    def test_missing_output_fails(self, tmp_path: Path):
+        # No -o supplied — assert nothing was written anywhere under tmp_path.
+        result = _invoke(["-m", _MODEL], catch=True)
+        assert result.exit_code != 0, (
+            f"expected failure for missing -o, got exit=0:\n{result.output}"
+        )
+        onnx_files = list(tmp_path.glob("*.onnx"))
+        assert not onnx_files, f"unexpected ONNX files in {tmp_path}: {onnx_files}"
+
+
+# ===========================================================================
+# Flag variants on the happy path
+# ===========================================================================
+
+
+class TestExportFlagVariants:
+    """Each flag below is layered onto the happy-path invocation."""
+
+    def test_verbose(self, tmp_path: Path):
+        onnx_path = tmp_path / "model.onnx"
+        _assert_succeeds(_happy_args(onnx_path, "-v"), onnx_path)
+
+    def test_with_report(self, tmp_path: Path):
+        onnx_path = tmp_path / "model.onnx"
+        _assert_succeeds(_happy_args(onnx_path, "--with-report"), onnx_path)
+        # Report files are named ``{stem}_htp_export_report.md`` and
+        # ``{stem}_htp_metadata.json`` in the output directory.
+        md_report = tmp_path / "model_htp_export_report.md"
+        json_report = tmp_path / "model_htp_metadata.json"
+        assert md_report.exists() or json_report.exists(), (
+            f"--with-report produced no report file in {tmp_path}; "
+            f"dir contents: {[p.name for p in tmp_path.iterdir()]}"
+        )
+
+    def test_clean_onnx(self, tmp_path: Path):
+        onnx_path = tmp_path / "model.onnx"
+        model = _assert_succeeds(_happy_args(onnx_path, "--clean-onnx"), onnx_path)
+        _assert_no_node_has(model, "winml.hierarchy.tag")
+        _assert_no_node_has(model, "winml.hierarchy.depth")
+
+    def test_no_hierarchy(self, tmp_path: Path):
+        onnx_path = tmp_path / "model.onnx"
+        model = _assert_succeeds(_happy_args(onnx_path, "--no-hierarchy"), onnx_path)
+        _assert_no_node_has(model, "winml.hierarchy.tag")
+        _assert_no_node_has(model, "winml.hierarchy.depth")
+
+    def test_dynamo(self, tmp_path: Path):
+        onnx_path = tmp_path / "model.onnx"
+        model = _assert_succeeds(_happy_args(onnx_path, "--dynamo"), onnx_path)
+        # Only rewritten nodes carry this key; "at least one" is the correct check.
+        _assert_some_node_has(model, "pkg.onnxscript.rewriter.rule_name")
+
+    def test_torch_module_warning(self, tmp_path: Path):
+        # --torch-module is currently a no-op; the command must still succeed
+        # but emit a warning identifying the option.
+        onnx_path = tmp_path / "model.onnx"
+        result = _invoke(_happy_args(onnx_path, "--torch-module", "LayerNorm,Embedding"))
+        assert result.exit_code == 0, f"export failed:\n{result.output}"
+        assert onnx_path.exists()
+        assert "torch-module" in result.output, (
+            f"expected warning mentioning '--torch-module' in output, got:\n{result.output}"
+        )
+
+
+# ===========================================================================
+# Task overrides (-t)
+# ===========================================================================
+
+
+class TestExportTaskOverride:
+    """``-t`` selects which Optimum OnnxConfig is used; outputs differ by task."""
+
+    def test_image_classification(self, tmp_path: Path):
+        onnx_path = tmp_path / "model.onnx"
+        model = _assert_succeeds(_happy_args(onnx_path, "-t", "image-classification"), onnx_path)
+        assert _output_names(model) == ["logits"], (
+            f"expected outputs ['logits'], got {_output_names(model)}"
+        )
+
+    def test_feature_extraction(self, tmp_path: Path):
+        onnx_path = tmp_path / "model.onnx"
+        model = _assert_succeeds(_happy_args(onnx_path, "-t", "feature-extraction"), onnx_path)
+        assert _output_names(model) == ["last_hidden_state"], (
+            f"expected outputs ['last_hidden_state'], got {_output_names(model)}"
+        )
+
+    def test_translation_fails(self, tmp_path: Path):
+        # ResNet-50 is a vision model and does not support translation.
+        onnx_path = tmp_path / "model.onnx"
+        _assert_fails(_happy_args(onnx_path, "-t", "translation"), onnx_path)
+
+
+# ===========================================================================
+# Config files: --shape-config / --export-config / -c
+# ===========================================================================
+
+
+class TestExportConfigFiles:
+    """Validate the three JSON-config inputs and their interactions."""
+
+    def test_shape_config(self, tmp_path: Path):
+        onnx_path = tmp_path / "model.onnx"
+        width, height = 448, 896
+        shape_cfg = _write_json(tmp_path / "shape.json", {"width": width, "height": height})
+        model = _assert_succeeds(
+            _happy_args(onnx_path, "--shape-config", str(shape_cfg)), onnx_path
+        )
+        # ONNX vision models use NCHW layout: [batch, channels, height, width]
+        assert _input_shape_dims(model) == [1, 3, height, width], (
+            f"expected input shape [1, 3, {height}, {width}], got {_input_shape_dims(model)}"
+        )
+
+    def test_input_specs(self, tmp_path: Path):
+        onnx_path = tmp_path / "model.onnx"
+        shape = [1, 3, 448, 896]
+        specs = _write_json(
+            tmp_path / "specs.json",
+            {"pixel_values": {"dtype": "float32", "shape": shape}},
+        )
+        model = _assert_succeeds(_happy_args(onnx_path, "--input-specs", str(specs)), onnx_path)
+        assert _input_shape_dims(model) == shape, (
+            f"expected input shape {shape}, got {_input_shape_dims(model)}"
+        )
+
+    def test_input_specs_with_feature_extraction(self, tmp_path: Path):
+        # Regression: --input-specs must not bypass Optimum-driven output_tensors
+        # resolution. For ResNet feature-extraction the dataclass exposes
+        # last_hidden_state + pooler_output but the ONNX graph has only the
+        # former — passing both names to torch.onnx.export raises
+        # "number of output names provided (2) exceeded number of outputs (1)".
+        onnx_path = tmp_path / "model.onnx"
+        shape = [1, 3, 448, 896]
+        specs = _write_json(
+            tmp_path / "specs.json",
+            {"pixel_values": {"dtype": "float32", "shape": shape}},
+        )
+        model = _assert_succeeds(
+            _happy_args(onnx_path, "--input-specs", str(specs), "-t", "feature-extraction"),
+            onnx_path,
+        )
+        assert _input_shape_dims(model) == shape, (
+            f"expected input shape {shape}, got {_input_shape_dims(model)}"
+        )
+        assert _output_names(model) == ["last_hidden_state"], (
+            f"expected outputs ['last_hidden_state'], got {_output_names(model)}"
+        )
+
+    def test_export_config(self, tmp_path: Path):
+        onnx_path = tmp_path / "model.onnx"
+        export_cfg = _write_json(tmp_path / "export.json", {"opset_version": 18})
+        model = _assert_succeeds(
+            _happy_args(onnx_path, "--export-config", str(export_cfg)), onnx_path
+        )
+        assert _opset_version(model) == 18, (
+            f"expected opset 18 from --export-config, got {_opset_version(model)}"
+        )
+
+    def test_build_config(self, tmp_path: Path):
+        onnx_path = tmp_path / "model.onnx"
+        cfg = _write_json(tmp_path / "build.json", _BUILD_CONFIG)
+        model = _assert_succeeds(_happy_args(onnx_path, "-c", str(cfg)), onnx_path)
+        assert _opset_version(model) == 18, (
+            f"expected opset 18 from -c build config, got {_opset_version(model)}"
+        )
+
+    def test_build_config_with_dynamo(self, tmp_path: Path):
+        onnx_path = tmp_path / "model.onnx"
+        cfg = _write_json(tmp_path / "build.json", _BUILD_CONFIG)
+        model = _assert_succeeds(_happy_args(onnx_path, "-c", str(cfg), "--dynamo"), onnx_path)
+        assert _opset_version(model) == 18, (
+            f"expected opset 18 with -c + --dynamo, got {_opset_version(model)}"
+        )
+        _assert_some_node_has(model, "pkg.onnxscript.rewriter.rule_name")


### PR DESCRIPTION
Addresses #494 and #495.

## Summary

Adds end-to-end coverage for `winml export` in `tests/e2e/test_export_e2e.py` (19 cases on `microsoft/resnet-50`). Building these tests surfaced a real regression in `commands/export.py`, also fixed in this PR.

## Test cases

All cases use `microsoft/resnet-50` and write to a `tmp_path`-managed ONNX file. The CLI snippet below abbreviates `microsoft/resnet-50` as `<MODEL>` and the output path as `<OUT>`. Success cases require exit 0 + the ONNX file present; failure cases require non-zero exit + ONNX absent. Each goal reduces to "the option(s) under test are *effective*"; for multi-option cases the goal also fixes the expected precedence.

| Test | CLI | Goal |
|---|---|---|
| `TestExportHelp::test_help_works` | `winml export --help` | `--help` is effective: help text renders and the command exits 0 without running an export. |
| `TestExportHappyPath::test_minimal_resnet50` | `winml export -m <MODEL> -o <OUT>` | Required args are effective end-to-end; hierarchy metadata is on by default (every node carries `winml.hierarchy.tag` + `winml.hierarchy.depth`). |
| `TestExportRequiredOptions::test_missing_model_fails` | `winml export -o <OUT>` | `-m` is genuinely required: omitting it fails cleanly without producing an ONNX. |
| `TestExportRequiredOptions::test_missing_output_fails` | `winml export -m <MODEL>` | `-o` is genuinely required: omitting it fails cleanly without producing an ONNX. |
| `TestExportFlagVariants::test_verbose` | `... -v` | `-v` is effective and does not break the export. |
| `TestExportFlagVariants::test_with_report` | `... --with-report` | `--with-report` is effective: a report file is generated. |
| `TestExportFlagVariants::test_clean_onnx` | `... --clean-onnx` | `--clean-onnx` is effective: hierarchy metadata is stripped from every node. |
| `TestExportFlagVariants::test_no_hierarchy` | `... --no-hierarchy` | The `--no-hierarchy` alias is effective and equivalent to `--clean-onnx`. |
| `TestExportFlagVariants::test_dynamo` | `... --dynamo` | `--dynamo` is effective: the onnxscript rewriter runs and tags rewritten nodes. |
| `TestExportFlagVariants::test_torch_module_warning` | `... --torch-module LayerNorm,Embedding` | `--torch-module` is parsed and its current "not yet wired" warning surfaces in CLI output; export still succeeds. |
| `TestExportTaskOverride::test_image_classification` | `... -t image-classification` | `-t image-classification` is effective: it selects the classification head and the ONNX output reflects that task. |
| `TestExportTaskOverride::test_feature_extraction` | `... -t feature-extraction` | `-t feature-extraction` is effective: it selects the encoder head and the ONNX output reflects that task. |
| `TestExportTaskOverride::test_translation_fails` | `... -t translation` | `-t` is effective at validation: a task unsupported by the model is rejected cleanly. |
| `TestExportConfigFiles::test_shape_config` | `... --shape-config shape.json` | `--shape-config` is effective: the JSON `width`/`height` flow into the ONNX input shape. |
| `TestExportConfigFiles::test_input_specs` | `... --input-specs specs.json` | `--input-specs` is effective: the per-input `shape`/`dtype` flow into the ONNX input. |
| `TestExportConfigFiles::test_input_specs_with_feature_extraction` | `... --input-specs specs.json -t feature-extraction` | **Both args effective in their own lanes** (regression for the bug below): `--input-specs` controls the input side, `-t` controls the output side — neither clobbers the other. |
| `TestExportConfigFiles::test_export_config` | `... --export-config export.json` | `--export-config` is effective: JSON fields like `opset_version` reach the produced ONNX. |
| `TestExportConfigFiles::test_build_config` | `... -c build.json` | `-c` is effective: a full `WinMLBuildConfig` JSON drives the export (e.g. `opset_version` is honoured). |
| `TestExportConfigFiles::test_build_config_with_dynamo` | `... -c build.json --dynamo` | Both args effective with **CLI > config** precedence: `-c` sets opset 18 (build config), and the explicit CLI `--dynamo` overrides the same field set to `false` in the build config. |

## Bug fix: `--input-specs` no longer clobbers Optimum output_tensors

`winml export -m microsoft/resnet-50 -o temp/rn_fe.onnx --input-specs ./temp/spec.json -v --task feature-extraction` was failing with:

```
RuntimeError: number of output names provided (2) exceeded number of outputs (1)
Error: Export failed: number of output names provided (2) exceeded number of outputs (1)
```

### Why

`commands/export.py` had two mutually-exclusive code paths for resolving input/output tensors:

* `--input-specs` branch: loaded `input_tensors` from the JSON and stopped there.
* Else branch: called Optimum's `resolve_export_config()`, which fills in **both** `input_tensors` AND `output_tensors` (the authoritative ONNX-graph output names from `OnnxConfig`).

When `--input-specs` was used, Optimum auto-resolution was skipped, so `output_tensors` stayed `None`. The exporter then fell back to `infer_output_names`, which reflects the model's Python dataclass. For ResNet `feature-extraction` the dataclass `BaseModelOutputWithPoolingAndNoAttention` has **two** fields (`last_hidden_state`, `pooler_output`), but the ONNX graph emits only `last_hidden_state`. `torch.onnx.export` got 2 names for 1 output and crashed.

The exporter even warns about this hazard at `htp/exporter.py:421-423`:
> *"Trust config output names — they come from Optimum's OnnxConfig which knows the actual ONNX graph outputs. `infer_output_names` may return extra fields from the model's dataclass output."*
…but the auto-resolve path was the only thing supplying those trusted names.

This is why `--input-specs` alone (no `-t`) historically *appeared* to work: resnet-50 auto-detects to `image-classification`, whose dataclass has a single `logits` field, accidentally matching the ONNX graph's single output. The bug is invisible whenever the dataclass field count equals the ONNX output count.

### Fix

* Optimum auto-resolution now **always** runs first, populating `input_tensors` and `output_tensors`.
* `--input-specs` is now an **override**: it patches `dtype`/`shape` on matching `InputTensorSpec` items by name and appends entries for unknown names. `output_tensors` is left to Optimum.
* `--shape-config` is no longer suppressed when `--input-specs` is also given.