### PR TITLE
Eval: Add functional correctness e2e test and fix issues found

### DIFF
--- a/scripts/e2e_eval/run_pytorch_baseline.py
+++ b/scripts/e2e_eval/run_pytorch_baseline.py
@@ -217,7 +217,6 @@ def main() -> None:
     _out(f"Dataset: {ds_name} / {ds_cfg} [{ds_split}]")
 
     try:
-        from winml.modelkit.eval.base_evaluator import WinMLEvaluator
         from winml.modelkit.eval.config import WinMLEvaluationConfig
 
         pytorch_model = _load_pytorch_model(model_id, task, args.device)
@@ -230,9 +229,9 @@ def main() -> None:
             dataset=dataset_config,
         )
 
-        from winml.modelkit.eval.evaluate import _EVALUATOR_REGISTRY
+        from winml.modelkit.eval.evaluate import get_evaluator_class
 
-        evaluator_cls = _EVALUATOR_REGISTRY.get(task, WinMLEvaluator)
+        evaluator_cls = get_evaluator_class(task)
         task_evaluator = evaluator_cls(eval_config, pytorch_model)
 
         metrics = task_evaluator.compute()

--- a/src/winml/modelkit/commands/eval.py
+++ b/src/winml/modelkit/commands/eval.py
@@ -197,14 +197,16 @@ def eval(
     cfg = _build_eval_config(ctx, config_file, column, label_mapping)
 
     if show_schema:
-        from ..eval import WinMLEvaluator
-        from ..eval.evaluate import _EVALUATOR_REGISTRY
+        from ..eval.evaluate import get_evaluator_class
 
         if cfg.task is None:
             raise click.UsageError(
                 "--schema requires --task. Example: winml eval --schema --task object-detection"
             )
-        cls = _EVALUATOR_REGISTRY.get(cfg.task, WinMLEvaluator)
+        try:
+            cls = get_evaluator_class(cfg.task)
+        except ValueError as e:
+            raise click.UsageError(str(e)) from e
         _print_schema(cfg.task, cls.schema_info())
         return
 
@@ -248,7 +250,24 @@ def _build_eval_config(
     from ..eval import WinMLEvaluationConfig
     from ..utils.config_utils import merge_config
 
-    cfg = WinMLEvaluationConfig()
+    # Initialize config object from CLI ctx params.
+    p = ctx.params
+    cfg = WinMLEvaluationConfig(
+        task=p.get("task"),
+        device=p.get("device"),
+        precision=p.get("precision"),
+        ep=p.get("ep"),
+        output_path=p.get("output"),
+        dataset=DatasetConfig(
+            path=p.get("dataset_path"),
+            name=p.get("dataset_name"),
+            split=p.get("split"),
+            samples=p.get("samples"),
+            shuffle=p.get("shuffle"),
+            streaming=p.get("streaming"),
+            build_script=p.get("dataset_script"),
+        ),
+    )
 
     # ── Config file layer (only explicitly-present keys) ──
     if config_file is not None:

--- a/src/winml/modelkit/eval/__init__.py
+++ b/src/winml/modelkit/eval/__init__.py
@@ -10,7 +10,7 @@ Provides accuracy evaluation using HuggingFace pipeline + evaluate library.
 
 from .base_evaluator import WinMLEvaluator
 from .config import WinMLEvaluationConfig
-from .evaluate import EvalResult, evaluate
+from .evaluate import EvalResult, evaluate, get_evaluator_class
 from .feature_extraction_evaluator import WinMLFeatureExtractionEvaluator
 from .fill_mask_evaluator import WinMLFillMaskEvaluator
 from .image_feature_extraction_evaluator import WinMLImageFeatureExtractionEvaluator
@@ -53,4 +53,5 @@ __all__ = [
     "WinMLZeroShotClassificationEvaluator",
     "WinMLZeroShotImageClassificationEvaluator",
     "evaluate",
+    "get_evaluator_class",
 ]

--- a/src/winml/modelkit/eval/config.py
+++ b/src/winml/modelkit/eval/config.py
@@ -60,7 +60,7 @@ class WinMLEvaluationConfig:
     model_id: str | None = None
     model_path: str | dict[str, str] | None = None
     task: str | None = None
-    device: str = "cpu"
+    device: str = "auto"
     precision: str = "auto"
     ep: str | None = None
     dataset: DatasetConfig = field(default_factory=DatasetConfig)
@@ -105,7 +105,7 @@ class WinMLEvaluationConfig:
             model_id=data.get("model_id"),
             model_path=data.get("model_path"),
             task=data.get("task"),
-            device=data.get("device", "cpu"),
+            device=data.get("device", "auto"),
             precision=data.get("precision", "auto"),
             ep=data.get("ep"),
             dataset=dataset,

--- a/src/winml/modelkit/eval/evaluate.py
+++ b/src/winml/modelkit/eval/evaluate.py
@@ -114,8 +114,8 @@ _DEFAULT_DATASETS: dict[str, dict] = {
             "label_column": "answers",
         },
     },
-    "feature-extraction": _FE_DEFAULT,
-    "sentence-similarity": _FE_DEFAULT,
+    "feature-extraction": dict(_FE_DEFAULT),
+    "sentence-similarity": dict(_FE_DEFAULT),
     "image-feature-extraction": {
         "path": "timm/mini-imagenet",
         "split": "test",
@@ -233,7 +233,10 @@ def evaluate(config: WinMLEvaluationConfig) -> EvalResult:
         import json as _json
 
         logger.warning(
-            "--dataset is not specified, use default dataset for task '%s':\n%s",
+            "--dataset is not specified; using default dataset for task '%s'. "
+            "Any user-supplied --split / --column / --streaming / --dataset-name "
+            "(or equivalent fields in the eval config) are ignored — the keys "
+            "below take precedence:\n%s",
             config.task,
             _json.dumps(default, indent=2),
         )

--- a/src/winml/modelkit/eval/evaluate.py
+++ b/src/winml/modelkit/eval/evaluate.py
@@ -12,7 +12,6 @@ from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any
 
-from ..datasets.config import DatasetConfig
 from .base_evaluator import WinMLEvaluator
 from .config import WinMLEvaluationConfig
 from .feature_extraction_evaluator import WinMLFeatureExtractionEvaluator
@@ -34,6 +33,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _EVALUATOR_REGISTRY: dict[str, type[WinMLEvaluator]] = {
+    "image-classification": WinMLEvaluator,
     "text-classification": WinMLTextClassificationEvaluator,
     "sequence-classification": WinMLTextClassificationEvaluator,
     "next-sentence-prediction": WinMLTextClassificationEvaluator,
@@ -50,109 +50,102 @@ _EVALUATOR_REGISTRY: dict[str, type[WinMLEvaluator]] = {
     "zero-shot-image-classification": WinMLZeroShotImageClassificationEvaluator,
 }
 
-_FE_DEFAULT = DatasetConfig(
-    path="mteb/stsbenchmark-sts",
-    split="test",
-    samples=100,
-    shuffle=True,
-    streaming=True,
-    columns_mapping={
+
+def get_evaluator_class(task: str) -> type[WinMLEvaluator]:
+    """Return the evaluator class for *task*, or raise ValueError if unsupported."""
+    cls = _EVALUATOR_REGISTRY.get(task)
+    if cls is None:
+        supported = ", ".join(sorted(_EVALUATOR_REGISTRY))
+        raise ValueError(
+            f"Task '{task}' is not supported by `winml eval`. "
+            f"Supported tasks: {supported}."
+        )
+    return cls
+
+_FE_DEFAULT = {
+    "path": "mteb/stsbenchmark-sts",
+    "split": "test",
+    "streaming": True,
+    "columns_mapping": {
         "input_column_1": "sentence1",
         "input_column_2": "sentence2",
         "score_column": "score",
     },
-)
+}
 
-_DEFAULT_DATASETS: dict[str, DatasetConfig] = {
-    "image-classification": DatasetConfig(
-        path="timm/mini-imagenet",
-        split="test",
-        samples=100,
-        shuffle=True,
-    ),
-    "text-classification": DatasetConfig(
-        path="nyu-mll/glue",
-        name="mrpc",
-        split="validation",
-        samples=100,
-        shuffle=True,
-        columns_mapping={
+_DEFAULT_DATASETS: dict[str, dict] = {
+    "image-classification": {
+        "path": "timm/mini-imagenet",
+        "split": "test",
+    },
+    "text-classification": {
+        "path": "nyu-mll/glue",
+        "name": "mrpc",
+        "split": "validation",
+        "columns_mapping": {
             "input_column": "sentence1",
             "second_input_column": "sentence2",
         },
-    ),
-    "token-classification": DatasetConfig(
-        path="BramVanroy/conll2003",
-        split="validation",
-        samples=100,
-        shuffle=True,
-        columns_mapping={
+    },
+    "token-classification": {
+        "path": "BramVanroy/conll2003",
+        "split": "validation",
+        "columns_mapping": {
             "label_column": "ner_tags",
         },
-    ),
-    "object-detection": DatasetConfig(
-        path="detection-datasets/coco",
-        split="val",
-        samples=100,
-        shuffle=True,
-        columns_mapping={
+    },
+    "object-detection": {
+        "path": "detection-datasets/coco",
+        "split": "val",
+        "columns_mapping": {
             "annotation_column": "objects",
             "bbox_key": "bbox",
             "category_key": "category",
             "box_format": "xyxy",
         },
-    ),
-    "question-answering": DatasetConfig(
-        path="rajpurkar/squad",
-        split="validation",
-        samples=100,
-        shuffle=True,
-        columns_mapping={
+    },
+    "question-answering": {
+        "path": "rajpurkar/squad",
+        "split": "validation",
+        "columns_mapping": {
             "question_column": "question",
             "context_column": "context",
             "id_column": "id",
             "label_column": "answers",
         },
-    ),
+    },
     "feature-extraction": _FE_DEFAULT,
     "sentence-similarity": _FE_DEFAULT,
-    "image-feature-extraction": DatasetConfig(
-        path="timm/mini-imagenet",
-        split="test",
-        samples=1000,
-        shuffle=True,
-    ),
-    "fill-mask": DatasetConfig(
-        path="Salesforce/wikitext",
-        name="wikitext-2-raw-v1",
-        split="test",
-        samples=100,
-        shuffle=True,
-        streaming=True,
-        columns_mapping={"input_column": "text"},
-    ),
-    "zero-shot-classification": DatasetConfig(
-        path="fancyzhx/ag_news",
-        split="test",
-        samples=100,
-        shuffle=True,
-        columns_mapping={
+    "image-feature-extraction": {
+        "path": "timm/mini-imagenet",
+        "split": "test",
+        "samples": 1000,
+    },
+    "fill-mask": {
+        "path": "Salesforce/wikitext",
+        "name": "wikitext-2-raw-v1",
+        "split": "test",
+        "streaming": True,
+        "columns_mapping": {"input_column": "text"},
+    },
+    "zero-shot-classification": {
+        "path": "fancyzhx/ag_news",
+        "split": "test",
+        "columns_mapping": {
             "input_column": "text",
             "label_column": "label",
             "candidate_labels": "World,Sports,Business,Sci/Tech",
             "hypothesis_template": "This text is about {}.",
         },
-    ),
-    "zero-shot-image-classification": DatasetConfig(
-        path="uoft-cs/cifar100",
-        split="test",
-        samples=100,
-        shuffle=True,
-        columns_mapping={
+    },
+    "zero-shot-image-classification": {
+        "path": "uoft-cs/cifar100",
+        "split": "test",
+        "columns_mapping": {
             "input_column": "img",
             "label_column": "fine_label",
         },
-    ),
+    },
 }
 
 
@@ -236,14 +229,17 @@ def evaluate(config: WinMLEvaluationConfig) -> EvalResult:
             raise ValueError(
                 f"No dataset provided and no default for task '{config.task}'. Use --dataset."
             )
-        config.dataset = deepcopy(default)
-        logger.info(
-            "Using default dataset for %s: %s",
+        for k, v in default.items():
+            setattr(config.dataset, k, deepcopy(v))
+        import json as _json
+
+        logger.warning(
+            "--dataset is not specified, use default dataset for task '%s':\n%s",
             config.task,
-            default.path,
+            _json.dumps(default, indent=2),
         )
 
-    cls = _EVALUATOR_REGISTRY.get(config.task, WinMLEvaluator)
+    cls = get_evaluator_class(config.task)
     task_evaluator = cls(config, model)
     metrics = task_evaluator.compute()
 

--- a/src/winml/modelkit/eval/evaluate.py
+++ b/src/winml/modelkit/eval/evaluate.py
@@ -119,7 +119,6 @@ _DEFAULT_DATASETS: dict[str, dict] = {
     "image-feature-extraction": {
         "path": "timm/mini-imagenet",
         "split": "test",
-        "samples": 1000,
     },
     "fill-mask": {
         "path": "Salesforce/wikitext",

--- a/tests/e2e/test_eval_e2e.py
+++ b/tests/e2e/test_eval_e2e.py
@@ -42,7 +42,10 @@ if TYPE_CHECKING:
     from click.testing import CliRunner
 
 
-pytestmark = [pytest.mark.e2e]
+# 900 s per-test timeout (overrides the global 300 s in pyproject.toml).
+# Cold runs build the model end-to-end (export -> optimize -> quantize ->
+# compile), which can exceed 300 s for larger composite models (e.g. BLIP).
+pytestmark = [pytest.mark.e2e, pytest.mark.timeout(900)]
 
 # 10 samples keeps each e2e run short while giving enough signal for
 # range-based assertions. Shuffle uses a fixed seed=42 (see
@@ -421,28 +424,32 @@ class TestEvalModelInputForms:
         hf_id = "openai/clip-vit-base-patch32"
         task = "zero-shot-image-classification"
 
+        # Warm cache. zero-shot-image-classification is a composite task: the
+        # builder decomposes CLIP into two sub-models (image encoder +
+        # text encoder), each cached under its own sub-task in the same
+        # directory. No top-level manifest carries the composite task name,
+        # so cache discovery below must use the sub-task names.
         _invoke(runner, ["-m", hf_id, "--task", task, "--samples", SAMPLES])
 
-        cache_dir = find_cache_dir(hf_id, task=task)
-        assert cache_dir is not None, "expected cache after warm run"
+        # Locate each sub-encoder's ONNX via its sub-task. find_cache_dir /
+        # _find_build_artifacts filter by manifest["task"], so use the
+        # sub-task names rather than the composite task here.
+        from winml.modelkit.inference.engine import _find_build_artifacts
 
-        image_candidates = list(cache_dir.glob("*image*encoder*.onnx")) + list(
-            cache_dir.glob("*vision*.onnx"),
+        image_sub_task = "image-feature-extraction"
+        text_sub_task = "feature-extraction"
+
+        cache_dir = find_cache_dir(hf_id, task=image_sub_task)
+        assert cache_dir is not None, (
+            f"expected image-encoder cache after warm run (task={image_sub_task})"
         )
-        text_candidates = [
-            p for p in cache_dir.glob("*text*.onnx")
-            if "encoder" in p.name.lower() or "text" in p.name.lower()
-        ]
-        if not image_candidates or not text_candidates:
-            pytest.skip(
-                f"split-encoder ONNX files not found in {cache_dir}; "
-                "build may produce a monolithic ONNX for this model.",
-            )
+        image_onnx, _ = _find_build_artifacts(cache_dir, task=image_sub_task)
+        text_onnx, _ = _find_build_artifacts(cache_dir, task=text_sub_task)
 
         out = tmp_path / "result.json"
         _invoke(runner, [
-            "-m", f"image-encoder={image_candidates[0]}",
-            "-m", f"text-encoder={text_candidates[0]}",
+            "-m", f"image-encoder={image_onnx}",
+            "-m", f"text-encoder={text_onnx}",
             "--model-id", hf_id,
             "--task", task,
             "--samples", SAMPLES,

--- a/tests/e2e/test_eval_e2e.py
+++ b/tests/e2e/test_eval_e2e.py
@@ -1,0 +1,713 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""E2E functional tests for the `winml eval` CLI command.
+
+Plan: ``temp/eval_e2e_commands.md``.
+
+Each test invokes ``winml eval`` end-to-end against a real (small) model +
+~4 dataset samples and asserts exit code + expected output keys + finite
+metric values. These tests do NOT assert metric magnitudes — that's the
+accuracy regression suite under ``scripts/e2e_eval/run_eval.py``.
+
+Markers:
+    e2e: Auto-skipped unless ``pytest -m e2e`` is passed.
+
+Group layout (see plan for rationale):
+    A. Per-task success (13 cases)
+    B. Alternative model-input forms (2 cases)
+    C. Output behavior (1 case)
+    D. ``--schema`` parametrized (13 sub-tests)
+    E. ``--device`` / ``--ep`` (2 cases)
+    F. Additional options & branches (8 cases)
+    G. CLI-validation error paths (5 cases, fast)
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from typing import TYPE_CHECKING
+
+import pytest
+
+from winml.modelkit.commands.eval import eval as eval_cmd
+
+from .conftest import find_cache_dir
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from click.testing import CliRunner
+
+
+pytestmark = [pytest.mark.e2e]
+
+SAMPLES = "4"
+ADE20K_LABEL_MAP = "scripts/e2e_eval/datasets/ade20k_gt_to_model_label.json"
+
+
+@pytest.fixture
+def tiny_textcls_script(tmp_path: "Path") -> "Path":
+    """Write a minimal dataset-build script to disk and return its path.
+
+    Used to exercise the ``--dataset-script`` CLI code path without
+    committing a build-script artifact to the repo.
+
+    The script writes a 10-row text-classification dataset with non-default
+    columns (``text_a``, ``text_b``) so the test must also pass
+    ``--column input_column=text_a --column second_input_column=text_b``.
+    """
+    script = tmp_path / "build_tiny_textcls.py"
+    script.write_text(
+        '''import argparse
+from datasets import Dataset
+
+ROWS = [
+    {"text_a": "The movie was great.", "text_b": "I loved the film.", "label": 1},
+    {"text_a": "Terrible weather today.", "text_b": "It is raining heavily.", "label": 0},
+    {"text_a": "The cat sat on the mat.", "text_b": "A feline rested on the rug.", "label": 1},
+    {"text_a": "Stocks are rising.", "text_b": "I went to the supermarket.", "label": 0},
+    {"text_a": "She loves chocolate cake.", "text_b": "Her favorite dessert is cake.", "label": 1},
+    {"text_a": "The car needs repair.", "text_b": "It is a sunny afternoon.", "label": 0},
+    {"text_a": "He plays guitar in a band.", "text_b": "He is a musician.", "label": 1},
+    {"text_a": "I finished the report.", "text_b": "The dog chased the ball.", "label": 0},
+    {"text_a": "Coffee tastes bitter.", "text_b": "This drink is not sweet.", "label": 1},
+    {"text_a": "She studies mathematics.", "text_b": "The garden is full of flowers.", "label": 0},
+]
+
+p = argparse.ArgumentParser()
+p.add_argument("--output", required=True)
+args = p.parse_args()
+Dataset.from_list(ROWS).save_to_disk(args.output)
+''',
+        encoding="utf-8",
+    )
+    return script
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _invoke(runner: CliRunner, args: list[str], *, expect_success: bool = True) -> object:
+    """Invoke ``winml eval`` with ``obj={}`` (the command uses @click.pass_context).
+
+    ``catch_exceptions=True`` so Click error-handling produces non-zero exit
+    instead of raising — required for error-path assertions.
+    """
+    result = runner.invoke(eval_cmd, args, obj={}, catch_exceptions=True)
+    if expect_success and result.exit_code != 0:
+        raise AssertionError(
+            f"winml eval exited with {result.exit_code}\n"
+            f"args: {args}\n--- output ---\n{result.output}",
+        )
+    return result
+
+
+def _assert_metrics_present(output_path: Path, required_keys: list[str]) -> dict:
+    """Load eval JSON; assert required metric keys are present + finite."""
+    assert output_path.exists(), f"output file not created: {output_path}"
+    data = json.loads(output_path.read_text())
+    assert "metrics" in data, f"missing 'metrics': {data}"
+    metrics = data["metrics"]
+    for key in required_keys:
+        assert key in metrics, f"missing metric {key!r}; got {sorted(metrics)}"
+        value = metrics[key]
+        if isinstance(value, (int, float)):
+            assert math.isfinite(value), f"metric {key} is not finite: {value}"
+    return data
+
+
+# ===========================================================================
+# A. Per-task success path
+# ===========================================================================
+
+
+class TestEvalPerTask:
+    """One end-to-end run per task in ``_EVALUATOR_REGISTRY``.
+
+    No ``--device`` / ``--ep`` — CLI auto-picks hardware.
+    """
+
+    def test_image_classification(self, runner: CliRunner, tmp_path: Path) -> None:
+        # A.1
+        out = tmp_path / "result.json"
+        _invoke(runner, [
+            "-m", "google/vit-base-patch16-224",
+            "--task", "image-classification",
+            "--samples", SAMPLES,
+            "-o", str(out),
+        ])
+        _assert_metrics_present(out, ["accuracy"])
+
+    def test_text_classification(self, runner: CliRunner, tmp_path: Path) -> None:
+        # A.2 — model aligned with CLI default dataset (nyu-mll/glue/mrpc)
+        out = tmp_path / "result.json"
+        _invoke(runner, [
+            "-m", "Intel/bert-base-uncased-mrpc",
+            "--task", "text-classification",
+            "--samples", SAMPLES,
+            "-o", str(out),
+        ])
+        _assert_metrics_present(out, ["accuracy"])
+
+    def test_token_classification(self, runner: CliRunner, tmp_path: Path) -> None:
+        # A.3
+        out = tmp_path / "result.json"
+        _invoke(runner, [
+            "-m", "dslim/bert-base-NER",
+            "--task", "token-classification",
+            "--samples", SAMPLES,
+            "-o", str(out),
+        ])
+        _assert_metrics_present(
+            out,
+            ["overall_precision", "overall_recall", "overall_f1", "overall_accuracy"],
+        )
+
+    def test_object_detection(self, runner: CliRunner, tmp_path: Path) -> None:
+        # A.4
+        out = tmp_path / "result.json"
+        _invoke(runner, [
+            "-m", "hustvl/yolos-small",
+            "--task", "object-detection",
+            "--samples", SAMPLES,
+            "-o", str(out),
+        ])
+        _assert_metrics_present(out, ["map", "map_50", "mar_100"])
+
+    def test_image_segmentation(self, runner: CliRunner, tmp_path: Path) -> None:
+        # A.5
+        out = tmp_path / "result.json"
+        _invoke(runner, [
+            "-m", "nvidia/segformer-b1-finetuned-ade-512-512",
+            "--task", "image-segmentation",
+            "--dataset", "danjacobellis/scene_parse_150",
+            "--split", "validation",
+            "--streaming",
+            "--samples", SAMPLES,
+            "-o", str(out),
+        ])
+        _assert_metrics_present(out, ["mean_iou"])
+
+    def test_question_answering(self, runner: CliRunner, tmp_path: Path) -> None:
+        # A.6
+        out = tmp_path / "result.json"
+        _invoke(runner, [
+            "-m", "distilbert/distilbert-base-cased-distilled-squad",
+            "--task", "question-answering",
+            "--samples", SAMPLES,
+            "-o", str(out),
+        ])
+        _assert_metrics_present(out, ["exact_match", "f1"])
+
+    def test_feature_extraction(self, runner: CliRunner, tmp_path: Path) -> None:
+        # A.7
+        out = tmp_path / "result.json"
+        _invoke(runner, [
+            "-m", "sentence-transformers/all-MiniLM-L6-v2",
+            "--task", "feature-extraction",
+            "--samples", SAMPLES,
+            "-o", str(out),
+        ])
+        data = json.loads(out.read_text())
+        assert data["metrics"], f"no metrics: {data}"
+
+    def test_sentence_similarity(self, runner: CliRunner, tmp_path: Path) -> None:
+        # A.8 (alias for feature-extraction)
+        out = tmp_path / "result.json"
+        _invoke(runner, [
+            "-m", "sentence-transformers/all-MiniLM-L6-v2",
+            "--task", "sentence-similarity",
+            "--samples", SAMPLES,
+            "-o", str(out),
+        ])
+        data = json.loads(out.read_text())
+        assert data["metrics"], f"no metrics: {data}"
+
+    def test_image_feature_extraction(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        # A.9
+        out = tmp_path / "result.json"
+        _invoke(runner, [
+            "-m", "facebook/dinov2-small",
+            "--task", "image-feature-extraction",
+            "--samples", SAMPLES,
+            "-o", str(out),
+        ])
+        data = json.loads(out.read_text())
+        assert data["metrics"], f"no metrics: {data}"
+
+    def test_image_to_text_fp16(self, runner: CliRunner, tmp_path: Path) -> None:
+        # A.10 — only test that exercises non-auto --precision
+        out = tmp_path / "result.json"
+        _invoke(runner, [
+            "-m", "Salesforce/blip-image-captioning-base",
+            "--task", "image-to-text",
+            "--dataset", "lmms-lab/flickr30k",
+            "--split", "test",
+            "--streaming",
+            "--samples", SAMPLES,
+            "--precision", "fp16",
+            "-o", str(out),
+        ])
+        data = json.loads(out.read_text())
+        assert data["metrics"], f"no metrics: {data}"
+
+    def test_fill_mask(self, runner: CliRunner, tmp_path: Path) -> None:
+        # A.11
+        out = tmp_path / "result.json"
+        _invoke(runner, [
+            "-m", "distilbert/distilbert-base-uncased",
+            "--task", "fill-mask",
+            "--samples", SAMPLES,
+            "-o", str(out),
+        ])
+        data = json.loads(out.read_text())
+        assert data["metrics"], f"no metrics: {data}"
+
+    def test_zero_shot_classification(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        # A.12
+        out = tmp_path / "result.json"
+        _invoke(runner, [
+            "-m", "cross-encoder/nli-deberta-v3-small",
+            "--task", "zero-shot-classification",
+            "--samples", SAMPLES,
+            "-o", str(out),
+        ])
+        _assert_metrics_present(out, ["accuracy"])
+
+    def test_zero_shot_image_classification(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        # A.13
+        out = tmp_path / "result.json"
+        _invoke(runner, [
+            "-m", "openai/clip-vit-base-patch32",
+            "--task", "zero-shot-image-classification",
+            "--samples", SAMPLES,
+            "-o", str(out),
+        ])
+        _assert_metrics_present(out, ["top1_accuracy"])
+
+
+# ===========================================================================
+# B. Alternative model-input forms
+# ===========================================================================
+
+
+class TestEvalModelInputForms:
+    """Coverage for the two non-default ``-m`` forms."""
+
+    def test_onnx_file_mode_monolithic(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        # B.1
+        hf_id = "google/vit-base-patch16-224"
+        task = "image-classification"
+
+        # Warm cache via HF id.
+        _invoke(runner, ["-m", hf_id, "--task", task, "--samples", SAMPLES])
+
+        cache_dir = find_cache_dir(hf_id, task=task)
+        assert cache_dir is not None, "expected cache after warm run"
+        onnx_files = list(cache_dir.glob("*_model.onnx"))
+        assert onnx_files, f"no *_model.onnx in {cache_dir}"
+
+        out = tmp_path / "result.json"
+        _invoke(runner, [
+            "-m", str(onnx_files[0]),
+            "--model-id", hf_id,
+            "--task", task,
+            "--samples", SAMPLES,
+            "-o", str(out),
+        ])
+        _assert_metrics_present(out, ["accuracy"])
+
+    def test_onnx_file_mode_split_encoder(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        # B.2
+        hf_id = "openai/clip-vit-base-patch32"
+        task = "zero-shot-image-classification"
+
+        _invoke(runner, ["-m", hf_id, "--task", task, "--samples", SAMPLES])
+
+        cache_dir = find_cache_dir(hf_id, task=task)
+        assert cache_dir is not None, "expected cache after warm run"
+
+        image_candidates = list(cache_dir.glob("*image*encoder*.onnx")) + list(
+            cache_dir.glob("*vision*.onnx"),
+        )
+        text_candidates = [
+            p for p in cache_dir.glob("*text*.onnx")
+            if "encoder" in p.name.lower() or "text" in p.name.lower()
+        ]
+        if not image_candidates or not text_candidates:
+            pytest.skip(
+                f"split-encoder ONNX files not found in {cache_dir}; "
+                "build may produce a monolithic ONNX for this model.",
+            )
+
+        out = tmp_path / "result.json"
+        _invoke(runner, [
+            "-m", f"image-encoder={image_candidates[0]}",
+            "-m", f"text-encoder={text_candidates[0]}",
+            "--model-id", hf_id,
+            "--task", task,
+            "--samples", SAMPLES,
+            "-o", str(out),
+        ])
+        _assert_metrics_present(out, ["accuracy"])
+
+
+# ===========================================================================
+# C. Output behavior
+# ===========================================================================
+
+
+class TestEvalOutput:
+    """``-o`` path creation + JSON validity."""
+
+    def test_creates_nested_output_dir(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        # C.1
+        out = tmp_path / "nested" / "subdir" / "result.json"
+        _invoke(runner, [
+            "-m", "Intel/bert-base-uncased-mrpc",
+            "--task", "text-classification",
+            "--samples", SAMPLES,
+            "-o", str(out),
+        ])
+        assert out.exists(), "nested output dir not auto-created"
+        data = json.loads(out.read_text())
+        assert "metrics" in data
+        assert "model_id" in data
+        assert "dataset" in data
+
+
+# ===========================================================================
+# D. --schema mode (parametrized × 13)
+# ===========================================================================
+
+
+_ALL_TASKS = [
+    "image-classification",
+    "text-classification",
+    "token-classification",
+    "object-detection",
+    "image-segmentation",
+    "question-answering",
+    "feature-extraction",
+    "sentence-similarity",
+    "image-feature-extraction",
+    "image-to-text",
+    "fill-mask",
+    "zero-shot-classification",
+    "zero-shot-image-classification",
+]
+
+
+class TestEvalSchema:
+    @pytest.mark.parametrize("task", _ALL_TASKS)
+    def test_schema_for_each_task(self, runner: CliRunner, task: str) -> None:
+        # D
+        result = _invoke(runner, ["--schema", "--task", task])
+        assert "Dataset schema" in result.output
+
+
+# ===========================================================================
+# E. --device / --ep coverage
+# ===========================================================================
+
+
+class TestEvalDeviceAndEp:
+    def test_device_cpu(self, runner: CliRunner, tmp_path: Path) -> None:
+        # E.1 — CPU works on every box
+        out = tmp_path / "result.json"
+        _invoke(runner, [
+            "-m", "distilbert/distilbert-base-uncased",
+            "--task", "fill-mask",
+            "--device", "cpu",
+            "--samples", SAMPLES,
+            "-o", str(out),
+        ])
+        data = json.loads(out.read_text())
+        assert data["metrics"], f"no metrics: {data}"
+
+    def test_device_npu_and_ep_qnn(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        # E.2 — combined --device + --ep
+        out = tmp_path / "result.json"
+        _invoke(runner, [
+            "-m", "google/vit-base-patch16-224",
+            "--task", "image-classification",
+            "--device", "npu",
+            "--ep", "qnn",
+            "--samples", SAMPLES,
+            "-o", str(out),
+        ])
+        _assert_metrics_present(out, ["accuracy"])
+
+
+# ===========================================================================
+# F. Additional options & branches
+# ===========================================================================
+
+
+class TestEvalAdditionalOptions:
+    def test_dataset_name_explicit(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        # F.1
+        out = tmp_path / "result.json"
+        _invoke(runner, [
+            "-m", "Intel/bert-base-uncased-mrpc",
+            "--task", "text-classification",
+            "--dataset", "nyu-mll/glue",
+            "--dataset-name", "mrpc",
+            "--column", "input_column=sentence1",
+            "--column", "second_input_column=sentence2",
+            "--samples", SAMPLES,
+            "-o", str(out),
+        ])
+        _assert_metrics_present(out, ["accuracy"])
+
+    def test_label_mapping_image_segmentation(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        # F.2
+        from pathlib import Path as _Path
+
+        label_map = _Path(ADE20K_LABEL_MAP)
+        if not label_map.exists():
+            pytest.skip(f"label-mapping file not in repo: {label_map}")
+
+        out = tmp_path / "result.json"
+        _invoke(runner, [
+            "-m", "nvidia/segformer-b1-finetuned-ade-512-512",
+            "--task", "image-segmentation",
+            "--dataset", "danjacobellis/scene_parse_150",
+            "--split", "validation",
+            "--streaming",
+            "--label-mapping", str(label_map),
+            "--samples", SAMPLES,
+            "-o", str(out),
+        ])
+        _assert_metrics_present(out, ["mean_iou"])
+
+    def test_config_file_basic(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        # F.3 — `eval` section provides task + samples
+        cfg = tmp_path / "cfg.json"
+        cfg.write_text(json.dumps({
+            "loader": {"task": "text-classification"},
+            "eval": {"dataset": {"samples": 5}},
+        }))
+        out = tmp_path / "result.json"
+        _invoke(runner, [
+            "-m", "Intel/bert-base-uncased-mrpc",
+            "--config", str(cfg),
+            "-o", str(out),
+        ])
+        data = _assert_metrics_present(out, ["accuracy"])
+        assert data["dataset"]["samples"] == 5, (
+            f"expected samples=5 from config, got {data['dataset']['samples']}"
+        )
+
+    def test_config_file_cli_override(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        # F.4 — CLI wins over config file
+        cfg = tmp_path / "cfg.json"
+        cfg.write_text(json.dumps({
+            "loader": {"task": "text-classification"},
+            "eval": {"dataset": {"samples": 5}},
+        }))
+        out = tmp_path / "result.json"
+        _invoke(runner, [
+            "-m", "Intel/bert-base-uncased-mrpc",
+            "--config", str(cfg),
+            "--samples", "7",
+            "-o", str(out),
+        ])
+        data = _assert_metrics_present(out, ["accuracy"])
+        assert data["dataset"]["samples"] == 7, (
+            f"expected CLI override samples=7, got {data['dataset']['samples']}"
+        )
+
+    def test_auto_task_detection(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        # F.5 — no --task flag; CLI infers from HF model
+        out = tmp_path / "result.json"
+        _invoke(runner, [
+            "-m", "Intel/bert-base-uncased-mrpc",
+            "--samples", SAMPLES,
+            "-o", str(out),
+        ])
+        data = _assert_metrics_present(out, ["accuracy"])
+        assert data.get("task") == "text-classification", (
+            f"expected auto-detected task, got {data.get('task')!r}"
+        )
+
+    def test_precision_warning_for_prebuilt_onnx(
+        self, runner: CliRunner, tmp_path: Path, caplog,
+    ) -> None:
+        # F.6 — pre-built ONNX + --precision emits warning, still succeeds
+        import logging as _logging
+
+        hf_id = "google/vit-base-patch16-224"
+        task = "image-classification"
+
+        _invoke(runner, ["-m", hf_id, "--task", task, "--samples", SAMPLES])
+
+        cache_dir = find_cache_dir(hf_id, task=task)
+        assert cache_dir is not None
+        onnx_files = list(cache_dir.glob("*_model.onnx"))
+        assert onnx_files
+
+        out = tmp_path / "result.json"
+        with caplog.at_level(_logging.WARNING, logger="winml.modelkit.commands.eval"):
+            _invoke(runner, [
+                "-m", str(onnx_files[0]),
+                "--model-id", hf_id,
+                "--task", task,
+                "--precision", "fp16",
+                "--samples", SAMPLES,
+                "-o", str(out),
+            ])
+        # Warning is emitted via ``logger.warning(...)``; capture from log records.
+        msgs = [r.getMessage().lower() for r in caplog.records]
+        assert any(
+            "precision" in m and ("ignor" in m or "pre-built" in m)
+            for m in msgs
+        ), f"expected precision-ignored warning, got:\n{msgs!r}"
+        _assert_metrics_present(out, ["accuracy"])
+
+    def test_dataset_script_with_column_remap(
+        self, runner: CliRunner, tmp_path: Path, tiny_textcls_script: Path,
+    ) -> None:
+        # F.7 — --dataset-script + --column + --trust-remote-code (good path)
+        ds_path = tmp_path / "tiny_textcls"
+        out = tmp_path / "result.json"
+        _invoke(runner, [
+            "-m", "Intel/bert-base-uncased-mrpc",
+            "--task", "text-classification",
+            "--dataset-script", str(tiny_textcls_script),
+            "--dataset", str(ds_path),
+            "--trust-remote-code",
+            "--column", "input_column=text_a",
+            "--column", "second_input_column=text_b",
+            "--samples", "10",
+            "-o", str(out),
+        ])
+        assert ds_path.exists(), "dataset script did not write to --dataset path"
+        _assert_metrics_present(out, ["accuracy"])
+
+    def test_dataset_script_without_trust_remote_code(
+        self, runner: CliRunner, tmp_path: Path, tiny_textcls_script: Path,
+    ) -> None:
+        # F.8 — error path
+        ds_path = tmp_path / "tiny_textcls"
+        result = _invoke(runner, [
+            "-m", "Intel/bert-base-uncased-mrpc",
+            "--task", "text-classification",
+            "--dataset-script", str(tiny_textcls_script),
+            "--dataset", str(ds_path),
+            "--samples", "10",
+        ], expect_success=False)
+        assert result.exit_code != 0
+        assert "trust-remote-code" in result.output.lower(), result.output
+
+
+# ===========================================================================
+# G. CLI-validation error paths (fast — no model load)
+# ===========================================================================
+
+
+class TestEvalErrorPaths:
+    def test_bad_column_format(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        # G.1
+        result = _invoke(runner, [
+            "-m", "Intel/bert-base-uncased-mrpc",
+            "--task", "text-classification",
+            "--column", "foo",  # missing '='
+            "--samples", "1",
+        ], expect_success=False)
+        assert result.exit_code != 0
+        assert "key=value" in result.output.lower() or "invalid" in result.output.lower(), (
+            result.output
+        )
+
+    def test_missing_label_mapping_file(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        # G.2
+        missing = tmp_path / "does-not-exist.json"
+        result = _invoke(runner, [
+            "-m", "Intel/bert-base-uncased-mrpc",
+            "--task", "text-classification",
+            "--label-mapping", str(missing),
+            "--samples", "1",
+        ], expect_success=False)
+        assert result.exit_code != 0
+        out_lower = result.output.lower()
+        assert ("does not exist" in out_lower
+                or "not found" in out_lower
+                or "no such file" in out_lower), result.output
+
+    def test_bogus_dataset_name(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        # G.3
+        result = _invoke(runner, [
+            "-m", "Intel/bert-base-uncased-mrpc",
+            "--task", "text-classification",
+            "--dataset", "nyu-mll/glue",
+            "--dataset-name", "not_a_real_glue_config",
+            "--samples", "1",
+        ], expect_success=False)
+        assert result.exit_code != 0
+        # Loose: exact wording depends on datasets lib version
+        assert "config" in result.output.lower() or "not_a_real_glue_config" in result.output, (
+            result.output
+        )
+
+    def test_schema_without_task(self, runner: CliRunner) -> None:
+        # G.4
+        result = _invoke(runner, ["--schema"], expect_success=False)
+        assert result.exit_code != 0
+        assert "--task" in result.output, result.output
+
+    def test_onnx_file_without_model_id(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        # G.5 — needs a real .onnx file path that exists; reuse warmed cache
+        hf_id = "google/vit-base-patch16-224"
+        task = "image-classification"
+        _invoke(runner, ["-m", hf_id, "--task", task, "--samples", SAMPLES])
+        cache_dir = find_cache_dir(hf_id, task=task)
+        assert cache_dir is not None
+        onnx_files = list(cache_dir.glob("*_model.onnx"))
+        assert onnx_files
+
+        result = _invoke(runner, [
+            "-m", str(onnx_files[0]),
+            "--task", task,
+            "--samples", "1",
+        ], expect_success=False)
+        assert result.exit_code != 0
+        assert "model-id" in result.output.lower(), result.output

--- a/tests/e2e/test_eval_e2e.py
+++ b/tests/e2e/test_eval_e2e.py
@@ -54,7 +54,7 @@ ADE20K_LABEL_MAP = "scripts/e2e_eval/datasets/ade20k_gt_to_model_label.json"
 
 
 @pytest.fixture
-def tiny_textcls_script(tmp_path: "Path") -> "Path":
+def tiny_textcls_script(tmp_path: Path) -> Path:
     """Write a minimal dataset-build script to disk and return its path.
 
     Used to exercise the ``--dataset-script`` CLI code path without
@@ -159,7 +159,7 @@ class TestEvalPerTask:
 
     def test_image_classification(self, runner: CliRunner, tmp_path: Path) -> None:
         # A.1 — HF evaluate.evaluator("image-classification") returns `accuracy`.
-        # --streaming avoids caching full mini-imagenet (~1–2 GB).
+        # --streaming avoids caching full mini-imagenet (~1-2 GB).
         out = tmp_path / "result.json"
         _invoke(runner, [
             "-m", "google/vit-base-patch16-224",
@@ -487,7 +487,7 @@ class TestEvalOutput:
 
 
 # ===========================================================================
-# D. --schema mode (parametrized × 13)
+# D. --schema mode (parametrized x 13)
 # ===========================================================================
 
 

--- a/tests/e2e/test_eval_e2e.py
+++ b/tests/e2e/test_eval_e2e.py
@@ -45,7 +45,11 @@ if TYPE_CHECKING:
 
 pytestmark = [pytest.mark.e2e]
 
-SAMPLES = "4"
+# 10 samples keeps each e2e run short while giving enough signal for
+# range-based assertions. Shuffle uses a fixed seed=42 (see
+# ``DatasetConfig.seed`` default), so the sampled subset is deterministic
+# across runs on the same dataset.
+SAMPLES = "10"
 ADE20K_LABEL_MAP = "scripts/e2e_eval/datasets/ade20k_gt_to_model_label.json"
 
 
@@ -122,6 +126,26 @@ def _assert_metrics_present(output_path: Path, required_keys: list[str]) -> dict
     return data
 
 
+def _assert_in_range(
+    metrics: dict, key: str, lo: float, hi: float,
+) -> None:
+    """Assert ``metrics[key]`` is a finite number within ``[lo, hi]``.
+
+    Use this for tasks where the metric is a bounded score (e.g. accuracy 0..1
+    or top-k accuracy 0..100). The bounds are deliberately wide — they prove
+    the value is sane, not that it matches a baseline.
+    """
+    assert key in metrics, f"missing metric {key!r}; got {sorted(metrics)}"
+    value = metrics[key]
+    assert isinstance(value, (int, float)), (
+        f"metric {key} not numeric: {value!r} ({type(value).__name__})"
+    )
+    assert math.isfinite(value), f"metric {key} is not finite: {value}"
+    assert lo <= value <= hi, (
+        f"metric {key}={value} outside expected range [{lo}, {hi}]"
+    )
+
+
 # ===========================================================================
 # A. Per-task success path
 # ===========================================================================
@@ -134,18 +158,24 @@ class TestEvalPerTask:
     """
 
     def test_image_classification(self, runner: CliRunner, tmp_path: Path) -> None:
-        # A.1
+        # A.1 — HF evaluate.evaluator("image-classification") returns `accuracy`.
+        # --streaming avoids caching full mini-imagenet (~1–2 GB).
         out = tmp_path / "result.json"
         _invoke(runner, [
             "-m", "google/vit-base-patch16-224",
             "--task", "image-classification",
+            "--streaming",
             "--samples", SAMPLES,
             "-o", str(out),
         ])
-        _assert_metrics_present(out, ["accuracy"])
+        data = _assert_metrics_present(out, ["accuracy"])
+        # ViT-base full ImageNet ≈ 0.81; floor at 0.5 still catches
+        # broken-pipeline regressions on 10 samples.
+        _assert_in_range(data["metrics"], "accuracy", 0.5, 1.0)
 
     def test_text_classification(self, runner: CliRunner, tmp_path: Path) -> None:
-        # A.2 — model aligned with CLI default dataset (nyu-mll/glue/mrpc)
+        # A.2 — model aligned with CLI default dataset (nyu-mll/glue/mrpc).
+        # HF evaluate.evaluator("text-classification") returns `accuracy`.
         out = tmp_path / "result.json"
         _invoke(runner, [
             "-m", "Intel/bert-base-uncased-mrpc",
@@ -153,7 +183,9 @@ class TestEvalPerTask:
             "--samples", SAMPLES,
             "-o", str(out),
         ])
-        _assert_metrics_present(out, ["accuracy"])
+        data = _assert_metrics_present(out, ["accuracy"])
+        # bert-mrpc full MRPC ≈ 0.86; MRPC majority baseline ≈ 0.68.
+        _assert_in_range(data["metrics"], "accuracy", 0.6, 1.0)
 
     def test_token_classification(self, runner: CliRunner, tmp_path: Path) -> None:
         # A.3
@@ -164,21 +196,32 @@ class TestEvalPerTask:
             "--samples", SAMPLES,
             "-o", str(out),
         ])
-        _assert_metrics_present(
+        data = _assert_metrics_present(
             out,
             ["overall_precision", "overall_recall", "overall_f1", "overall_accuracy"],
         )
+        # bert-base-NER full CoNLL: f1 ≈ 0.91, accuracy ≈ 0.98.
+        for k in ("overall_precision", "overall_recall", "overall_f1"):
+            _assert_in_range(data["metrics"], k, 0.5, 1.0)
+        _assert_in_range(data["metrics"], "overall_accuracy", 0.8, 1.0)
 
     def test_object_detection(self, runner: CliRunner, tmp_path: Path) -> None:
-        # A.4
+        # A.4 — COCO val is ~6 GB; --streaming keeps only the bytes needed
+        # for the sampled subset.
         out = tmp_path / "result.json"
         _invoke(runner, [
             "-m", "hustvl/yolos-small",
             "--task", "object-detection",
+            "--streaming",
             "--samples", SAMPLES,
             "-o", str(out),
         ])
-        _assert_metrics_present(out, ["map", "map_50", "mar_100"])
+        data = _assert_metrics_present(out, ["map", "map_50", "mar_100"])
+        # COCO mAP / mAR are bounded by [0, 1]; torchmetrics may report -1
+        # when no positives are sampled, which is acceptable for tiny N.
+        for k in ("map", "map_50", "mar_100"):
+            v = data["metrics"][k]
+            assert -1.0 <= v <= 1.0, f"{k}={v} outside [-1, 1]"
 
     def test_image_segmentation(self, runner: CliRunner, tmp_path: Path) -> None:
         # A.5
@@ -192,7 +235,8 @@ class TestEvalPerTask:
             "--samples", SAMPLES,
             "-o", str(out),
         ])
-        _assert_metrics_present(out, ["mean_iou"])
+        data = _assert_metrics_present(out, ["mean_iou"])
+        _assert_in_range(data["metrics"], "mean_iou", 0.0, 1.0)
 
     def test_question_answering(self, runner: CliRunner, tmp_path: Path) -> None:
         # A.6
@@ -203,7 +247,12 @@ class TestEvalPerTask:
             "--samples", SAMPLES,
             "-o", str(out),
         ])
-        _assert_metrics_present(out, ["exact_match", "f1"])
+        data = _assert_metrics_present(out, ["exact_match", "f1"])
+        # distilbert-squad full SQuAD v1: EM ≈ 77, F1 ≈ 85 (percentages).
+        # Both are harsh on N=10 (heavy per-sample variance with seed=42).
+        # Loose floors guard against degenerate output, not magnitude.
+        _assert_in_range(data["metrics"], "exact_match", 5.0, 100.0)
+        _assert_in_range(data["metrics"], "f1", 5.0, 100.0)
 
     def test_feature_extraction(self, runner: CliRunner, tmp_path: Path) -> None:
         # A.7
@@ -214,8 +263,10 @@ class TestEvalPerTask:
             "--samples", SAMPLES,
             "-o", str(out),
         ])
-        data = json.loads(out.read_text())
-        assert data["metrics"], f"no metrics: {data}"
+        # Spearman correlation reported as percentage in [-100, 100].
+        # MiniLM-L6-v2 full STSB ≈ 80; 10-sample noise can be large.
+        data = _assert_metrics_present(out, ["cosine_spearman"])
+        _assert_in_range(data["metrics"], "cosine_spearman", 40.0, 100.0)
 
     def test_sentence_similarity(self, runner: CliRunner, tmp_path: Path) -> None:
         # A.8 (alias for feature-extraction)
@@ -226,22 +277,31 @@ class TestEvalPerTask:
             "--samples", SAMPLES,
             "-o", str(out),
         ])
-        data = json.loads(out.read_text())
-        assert data["metrics"], f"no metrics: {data}"
+        data = _assert_metrics_present(out, ["cosine_spearman"])
+        _assert_in_range(data["metrics"], "cosine_spearman", 40.0, 100.0)
 
     def test_image_feature_extraction(
         self, runner: CliRunner, tmp_path: Path,
     ) -> None:
-        # A.9
+        # A.9 — kNN accuracies reported as percentages 0..100.
+        # --streaming avoids caching mini-imagenet.
         out = tmp_path / "result.json"
         _invoke(runner, [
             "-m", "facebook/dinov2-small",
             "--task", "image-feature-extraction",
+            "--streaming",
             "--samples", SAMPLES,
             "-o", str(out),
         ])
-        data = json.loads(out.read_text())
-        assert data["metrics"], f"no metrics: {data}"
+        data = _assert_metrics_present(
+            out, ["knn_top1_accuracy", "knn_top5_accuracy"],
+        )
+        # DINOv2 features cluster strongly on mini-imagenet.
+        _assert_in_range(data["metrics"], "knn_top1_accuracy", 30.0, 100.0)
+        _assert_in_range(data["metrics"], "knn_top5_accuracy", 60.0, 100.0)
+        top1 = data["metrics"]["knn_top1_accuracy"]
+        top5 = data["metrics"]["knn_top5_accuracy"]
+        assert top1 <= top5, f"top1 ({top1}) must be <= top5 ({top5})"
 
     def test_image_to_text_fp16(self, runner: CliRunner, tmp_path: Path) -> None:
         # A.10 — only test that exercises non-auto --precision
@@ -256,11 +316,25 @@ class TestEvalPerTask:
             "--precision", "fp16",
             "-o", str(out),
         ])
-        data = json.loads(out.read_text())
-        assert data["metrics"], f"no metrics: {data}"
+        # CER and CIDEr depend on optional libs (jiwer, pycocoevalcap), and
+        # the BLIP captioning model currently falls back to a generic
+        # Seq2Seq path in WinML (text2text-generation), which may produce
+        # zero valid samples on tiny N. The CLI contract here is "exit 0
+        # and produce the metric keys"; magnitude is exercised in the
+        # accuracy regression suite, not in this functional test.
+        data = _assert_metrics_present(out, ["cer", "cider", "n_samples"])
+        m = data["metrics"]
+        for k, hi in (("cer", 10.0), ("cider", 20.0)):
+            v = m[k]
+            assert v is None or (
+                isinstance(v, (int, float))
+                and math.isfinite(v)
+                and 0.0 <= v <= hi
+            ), f"metric {k}={v!r} not None or in [0,{hi}]"
+        assert isinstance(m["n_samples"], int) and m["n_samples"] >= 0
 
     def test_fill_mask(self, runner: CliRunner, tmp_path: Path) -> None:
-        # A.11
+        # A.11 — pseudo-perplexity >= 1 (perplexity is exp of non-neg NLL).
         out = tmp_path / "result.json"
         _invoke(runner, [
             "-m", "distilbert/distilbert-base-uncased",
@@ -268,13 +342,17 @@ class TestEvalPerTask:
             "--samples", SAMPLES,
             "-o", str(out),
         ])
-        data = json.loads(out.read_text())
-        assert data["metrics"], f"no metrics: {data}"
+        data = _assert_metrics_present(out, ["pseudo_perplexity", "nll"])
+        # Pseudo-perplexity over a 10-sample wikitext stream can vary
+        # widely (we observed ~3000 with seed=42). Cap is set well above
+        # observed to catch genuine numerical blowup, not normal noise.
+        _assert_in_range(data["metrics"], "pseudo_perplexity", 1.0, 1e5)
+        _assert_in_range(data["metrics"], "nll", 0.0, 15.0)
 
     def test_zero_shot_classification(
         self, runner: CliRunner, tmp_path: Path,
     ) -> None:
-        # A.12
+        # A.12 — zero-shot uses ClassificationMetric → accuracy + f1.
         out = tmp_path / "result.json"
         _invoke(runner, [
             "-m", "cross-encoder/nli-deberta-v3-small",
@@ -282,7 +360,12 @@ class TestEvalPerTask:
             "--samples", SAMPLES,
             "-o", str(out),
         ])
-        _assert_metrics_present(out, ["accuracy"])
+        data = _assert_metrics_present(out, ["accuracy", "f1"])
+        # nli-deberta-v3-small zero-shot on AG News, N=10. 4-class random
+        # baseline = 0.25; tiny-N variance can push real models below
+        # baseline. Use a very loose floor here.
+        _assert_in_range(data["metrics"], "accuracy", 0.1, 1.0)
+        _assert_in_range(data["metrics"], "f1", 0.1, 1.0)
 
     def test_zero_shot_image_classification(
         self, runner: CliRunner, tmp_path: Path,
@@ -295,7 +378,11 @@ class TestEvalPerTask:
             "--samples", SAMPLES,
             "-o", str(out),
         ])
-        _assert_metrics_present(out, ["top1_accuracy"])
+        data = _assert_metrics_present(out, ["top1_accuracy", "top5_accuracy"])
+        # CLIP-ViT-B/32 zero-shot on CIFAR-100: top1 ≈ 0.63, top5 ≈ 0.88
+        # (full set). Floors leave headroom for tiny-N variance.
+        _assert_in_range(data["metrics"], "top1_accuracy", 30.0, 100.0)
+        _assert_in_range(data["metrics"], "top5_accuracy", 60.0, 100.0)
 
 
 # ===========================================================================
@@ -313,8 +400,10 @@ class TestEvalModelInputForms:
         hf_id = "google/vit-base-patch16-224"
         task = "image-classification"
 
-        # Warm cache via HF id.
-        _invoke(runner, ["-m", hf_id, "--task", task, "--samples", SAMPLES])
+        # Warm cache via HF id (use streaming to avoid mini-imagenet cache).
+        _invoke(runner, [
+            "-m", hf_id, "--task", task, "--streaming", "--samples", SAMPLES,
+        ])
 
         cache_dir = find_cache_dir(hf_id, task=task)
         assert cache_dir is not None, "expected cache after warm run"
@@ -326,10 +415,12 @@ class TestEvalModelInputForms:
             "-m", str(onnx_files[0]),
             "--model-id", hf_id,
             "--task", task,
+            "--streaming",
             "--samples", SAMPLES,
             "-o", str(out),
         ])
-        _assert_metrics_present(out, ["accuracy"])
+        data = _assert_metrics_present(out, ["accuracy"])
+        _assert_in_range(data["metrics"], "accuracy", 0.5, 1.0)
 
     def test_onnx_file_mode_split_encoder(
         self, runner: CliRunner, tmp_path: Path,
@@ -365,7 +456,8 @@ class TestEvalModelInputForms:
             "--samples", SAMPLES,
             "-o", str(out),
         ])
-        _assert_metrics_present(out, ["accuracy"])
+        data = _assert_metrics_present(out, ["top1_accuracy"])
+        _assert_in_range(data["metrics"], "top1_accuracy", 30.0, 100.0)
 
 
 # ===========================================================================
@@ -431,17 +523,21 @@ class TestEvalSchema:
 
 class TestEvalDeviceAndEp:
     def test_device_cpu(self, runner: CliRunner, tmp_path: Path) -> None:
-        # E.1 — CPU works on every box
+        # E.1 — CPU works on every box. ResNet-50 is a small, fast image
+        # classifier well-suited to a CPU smoke test (no per-token forward
+        # passes like fill-mask).
         out = tmp_path / "result.json"
         _invoke(runner, [
-            "-m", "distilbert/distilbert-base-uncased",
-            "--task", "fill-mask",
+            "-m", "microsoft/resnet-50",
+            "--task", "image-classification",
             "--device", "cpu",
+            "--streaming",
             "--samples", SAMPLES,
             "-o", str(out),
         ])
-        data = json.loads(out.read_text())
-        assert data["metrics"], f"no metrics: {data}"
+        data = _assert_metrics_present(out, ["accuracy"])
+        # ResNet-50 full ImageNet ≈ 0.76; mini-imagenet is shifted, floor 0.4.
+        _assert_in_range(data["metrics"], "accuracy", 0.4, 1.0)
 
     def test_device_npu_and_ep_qnn(
         self, runner: CliRunner, tmp_path: Path,
@@ -453,10 +549,12 @@ class TestEvalDeviceAndEp:
             "--task", "image-classification",
             "--device", "npu",
             "--ep", "qnn",
+            "--streaming",
             "--samples", SAMPLES,
             "-o", str(out),
         ])
-        _assert_metrics_present(out, ["accuracy"])
+        data = _assert_metrics_present(out, ["accuracy"])
+        _assert_in_range(data["metrics"], "accuracy", 0.5, 1.0)
 
 
 # ===========================================================================
@@ -480,7 +578,8 @@ class TestEvalAdditionalOptions:
             "--samples", SAMPLES,
             "-o", str(out),
         ])
-        _assert_metrics_present(out, ["accuracy"])
+        data = _assert_metrics_present(out, ["accuracy"])
+        _assert_in_range(data["metrics"], "accuracy", 0.6, 1.0)
 
     def test_label_mapping_image_segmentation(
         self, runner: CliRunner, tmp_path: Path,
@@ -503,7 +602,8 @@ class TestEvalAdditionalOptions:
             "--samples", SAMPLES,
             "-o", str(out),
         ])
-        _assert_metrics_present(out, ["mean_iou"])
+        data = _assert_metrics_present(out, ["mean_iou"])
+        _assert_in_range(data["metrics"], "mean_iou", 0.0, 1.0)
 
     def test_config_file_basic(
         self, runner: CliRunner, tmp_path: Path,
@@ -521,6 +621,7 @@ class TestEvalAdditionalOptions:
             "-o", str(out),
         ])
         data = _assert_metrics_present(out, ["accuracy"])
+        _assert_in_range(data["metrics"], "accuracy", 0.6, 1.0)
         assert data["dataset"]["samples"] == 5, (
             f"expected samples=5 from config, got {data['dataset']['samples']}"
         )
@@ -542,6 +643,7 @@ class TestEvalAdditionalOptions:
             "-o", str(out),
         ])
         data = _assert_metrics_present(out, ["accuracy"])
+        _assert_in_range(data["metrics"], "accuracy", 0.6, 1.0)
         assert data["dataset"]["samples"] == 7, (
             f"expected CLI override samples=7, got {data['dataset']['samples']}"
         )
@@ -557,6 +659,7 @@ class TestEvalAdditionalOptions:
             "-o", str(out),
         ])
         data = _assert_metrics_present(out, ["accuracy"])
+        _assert_in_range(data["metrics"], "accuracy", 0.6, 1.0)
         assert data.get("task") == "text-classification", (
             f"expected auto-detected task, got {data.get('task')!r}"
         )
@@ -570,7 +673,7 @@ class TestEvalAdditionalOptions:
         hf_id = "google/vit-base-patch16-224"
         task = "image-classification"
 
-        _invoke(runner, ["-m", hf_id, "--task", task, "--samples", SAMPLES])
+        _invoke(runner, ["-m", hf_id, "--task", task, "--streaming", "--samples", SAMPLES])
 
         cache_dir = find_cache_dir(hf_id, task=task)
         assert cache_dir is not None
@@ -584,6 +687,7 @@ class TestEvalAdditionalOptions:
                 "--model-id", hf_id,
                 "--task", task,
                 "--precision", "fp16",
+                "--streaming",
                 "--samples", SAMPLES,
                 "-o", str(out),
             ])
@@ -613,7 +717,8 @@ class TestEvalAdditionalOptions:
             "-o", str(out),
         ])
         assert ds_path.exists(), "dataset script did not write to --dataset path"
-        _assert_metrics_present(out, ["accuracy"])
+        data = _assert_metrics_present(out, ["accuracy"])
+        _assert_in_range(data["metrics"], "accuracy", 0.0, 1.0)
 
     def test_dataset_script_without_trust_remote_code(
         self, runner: CliRunner, tmp_path: Path, tiny_textcls_script: Path,
@@ -692,13 +797,26 @@ class TestEvalErrorPaths:
         assert result.exit_code != 0
         assert "--task" in result.output, result.output
 
+    def test_schema_bogus_task(self, runner: CliRunner) -> None:
+        # G.6 — get_evaluator_class ValueError wrapped as UsageError
+        result = _invoke(
+            runner, ["--schema", "--task", "not-a-real-task"],
+            expect_success=False,
+        )
+        assert result.exit_code != 0
+        out_lower = result.output.lower()
+        assert ("not-a-real-task" in out_lower
+                or "unknown" in out_lower
+                or "unsupported" in out_lower
+                or "invalid" in out_lower), result.output
+
     def test_onnx_file_without_model_id(
         self, runner: CliRunner, tmp_path: Path,
     ) -> None:
         # G.5 — needs a real .onnx file path that exists; reuse warmed cache
         hf_id = "google/vit-base-patch16-224"
         task = "image-classification"
-        _invoke(runner, ["-m", hf_id, "--task", task, "--samples", SAMPLES])
+        _invoke(runner, ["-m", hf_id, "--task", task, "--streaming", "--samples", SAMPLES])
         cache_dir = find_cache_dir(hf_id, task=task)
         assert cache_dir is not None
         onnx_files = list(cache_dir.glob("*_model.onnx"))

--- a/tests/e2e/test_eval_e2e.py
+++ b/tests/e2e/test_eval_e2e.py
@@ -4,24 +4,23 @@
 # --------------------------------------------------------------------------
 """E2E functional tests for the `winml eval` CLI command.
 
-Plan: ``temp/eval_e2e_commands.md``.
-
-Each test invokes ``winml eval`` end-to-end against a real (small) model +
-~4 dataset samples and asserts exit code + expected output keys + finite
-metric values. These tests do NOT assert metric magnitudes — that's the
-accuracy regression suite under ``scripts/e2e_eval/run_eval.py``.
+Each test invokes ``winml eval`` end-to-end against a real (small) model
+with ``--samples 10`` and asserts exit code + expected metric keys +
+values within a sanity range. These tests do NOT assert metric magnitudes
+for accuracy regression — that's the suite under
+``scripts/e2e_eval/run_eval.py``.
 
 Markers:
     e2e: Auto-skipped unless ``pytest -m e2e`` is passed.
 
-Group layout (see plan for rationale):
-    A. Per-task success (13 cases)
-    B. Alternative model-input forms (2 cases)
-    C. Output behavior (1 case)
-    D. ``--schema`` parametrized (13 sub-tests)
-    E. ``--device`` / ``--ep`` (2 cases)
-    F. Additional options & branches (8 cases)
-    G. CLI-validation error paths (5 cases, fast)
+Group layout:
+    TestEvalPerTask           one success run per registered task (13)
+    TestEvalModelInputForms   ONNX-file and split-encoder ``-m`` forms (2)
+    TestEvalOutput            ``-o`` path creation (1)
+    TestEvalSchema            ``--schema --task <t>`` for every task (13)
+    TestEvalDeviceAndEp       ``--device`` / ``--ep`` (2)
+    TestEvalAdditionalOptions other options & branches (8)
+    TestEvalErrorPaths        CLI-validation error paths (6, fast)
 """
 
 from __future__ import annotations
@@ -158,7 +157,7 @@ class TestEvalPerTask:
     """
 
     def test_image_classification(self, runner: CliRunner, tmp_path: Path) -> None:
-        # A.1 — HF evaluate.evaluator("image-classification") returns `accuracy`.
+        # HF evaluate.evaluator("image-classification") returns `accuracy`.
         # --streaming avoids caching full mini-imagenet (~1-2 GB).
         out = tmp_path / "result.json"
         _invoke(runner, [
@@ -174,7 +173,7 @@ class TestEvalPerTask:
         _assert_in_range(data["metrics"], "accuracy", 0.5, 1.0)
 
     def test_text_classification(self, runner: CliRunner, tmp_path: Path) -> None:
-        # A.2 — model aligned with CLI default dataset (nyu-mll/glue/mrpc).
+        # Model aligned with CLI default dataset (nyu-mll/glue/mrpc).
         # HF evaluate.evaluator("text-classification") returns `accuracy`.
         out = tmp_path / "result.json"
         _invoke(runner, [
@@ -188,7 +187,6 @@ class TestEvalPerTask:
         _assert_in_range(data["metrics"], "accuracy", 0.6, 1.0)
 
     def test_token_classification(self, runner: CliRunner, tmp_path: Path) -> None:
-        # A.3
         out = tmp_path / "result.json"
         _invoke(runner, [
             "-m", "dslim/bert-base-NER",
@@ -206,7 +204,7 @@ class TestEvalPerTask:
         _assert_in_range(data["metrics"], "overall_accuracy", 0.8, 1.0)
 
     def test_object_detection(self, runner: CliRunner, tmp_path: Path) -> None:
-        # A.4 — COCO val is ~6 GB; --streaming keeps only the bytes needed
+        # COCO val is ~6 GB; --streaming keeps only the bytes needed
         # for the sampled subset.
         out = tmp_path / "result.json"
         _invoke(runner, [
@@ -224,7 +222,6 @@ class TestEvalPerTask:
             assert -1.0 <= v <= 1.0, f"{k}={v} outside [-1, 1]"
 
     def test_image_segmentation(self, runner: CliRunner, tmp_path: Path) -> None:
-        # A.5
         out = tmp_path / "result.json"
         _invoke(runner, [
             "-m", "nvidia/segformer-b1-finetuned-ade-512-512",
@@ -239,7 +236,6 @@ class TestEvalPerTask:
         _assert_in_range(data["metrics"], "mean_iou", 0.0, 1.0)
 
     def test_question_answering(self, runner: CliRunner, tmp_path: Path) -> None:
-        # A.6
         out = tmp_path / "result.json"
         _invoke(runner, [
             "-m", "distilbert/distilbert-base-cased-distilled-squad",
@@ -255,7 +251,6 @@ class TestEvalPerTask:
         _assert_in_range(data["metrics"], "f1", 5.0, 100.0)
 
     def test_feature_extraction(self, runner: CliRunner, tmp_path: Path) -> None:
-        # A.7
         out = tmp_path / "result.json"
         _invoke(runner, [
             "-m", "sentence-transformers/all-MiniLM-L6-v2",
@@ -269,7 +264,7 @@ class TestEvalPerTask:
         _assert_in_range(data["metrics"], "cosine_spearman", 40.0, 100.0)
 
     def test_sentence_similarity(self, runner: CliRunner, tmp_path: Path) -> None:
-        # A.8 (alias for feature-extraction)
+        # Alias for feature-extraction.
         out = tmp_path / "result.json"
         _invoke(runner, [
             "-m", "sentence-transformers/all-MiniLM-L6-v2",
@@ -283,7 +278,7 @@ class TestEvalPerTask:
     def test_image_feature_extraction(
         self, runner: CliRunner, tmp_path: Path,
     ) -> None:
-        # A.9 — kNN accuracies reported as percentages 0..100.
+        # kNN accuracies reported as percentages 0..100.
         # --streaming avoids caching mini-imagenet.
         out = tmp_path / "result.json"
         _invoke(runner, [
@@ -304,7 +299,7 @@ class TestEvalPerTask:
         assert top1 <= top5, f"top1 ({top1}) must be <= top5 ({top5})"
 
     def test_image_to_text_fp16(self, runner: CliRunner, tmp_path: Path) -> None:
-        # A.10 — only test that exercises non-auto --precision
+        # Only test that exercises non-auto --precision.
         out = tmp_path / "result.json"
         _invoke(runner, [
             "-m", "Salesforce/blip-image-captioning-base",
@@ -334,7 +329,7 @@ class TestEvalPerTask:
         assert isinstance(m["n_samples"], int) and m["n_samples"] >= 0
 
     def test_fill_mask(self, runner: CliRunner, tmp_path: Path) -> None:
-        # A.11 — pseudo-perplexity >= 1 (perplexity is exp of non-neg NLL).
+        # Pseudo-perplexity >= 1 (perplexity is exp of non-neg NLL).
         out = tmp_path / "result.json"
         _invoke(runner, [
             "-m", "distilbert/distilbert-base-uncased",
@@ -352,7 +347,7 @@ class TestEvalPerTask:
     def test_zero_shot_classification(
         self, runner: CliRunner, tmp_path: Path,
     ) -> None:
-        # A.12 — zero-shot uses ClassificationMetric → accuracy + f1.
+        # Zero-shot uses ClassificationMetric → accuracy + f1.
         out = tmp_path / "result.json"
         _invoke(runner, [
             "-m", "cross-encoder/nli-deberta-v3-small",
@@ -370,7 +365,6 @@ class TestEvalPerTask:
     def test_zero_shot_image_classification(
         self, runner: CliRunner, tmp_path: Path,
     ) -> None:
-        # A.13
         out = tmp_path / "result.json"
         _invoke(runner, [
             "-m", "openai/clip-vit-base-patch32",
@@ -396,7 +390,6 @@ class TestEvalModelInputForms:
     def test_onnx_file_mode_monolithic(
         self, runner: CliRunner, tmp_path: Path,
     ) -> None:
-        # B.1
         hf_id = "google/vit-base-patch16-224"
         task = "image-classification"
 
@@ -425,7 +418,6 @@ class TestEvalModelInputForms:
     def test_onnx_file_mode_split_encoder(
         self, runner: CliRunner, tmp_path: Path,
     ) -> None:
-        # B.2
         hf_id = "openai/clip-vit-base-patch32"
         task = "zero-shot-image-classification"
 
@@ -471,7 +463,6 @@ class TestEvalOutput:
     def test_creates_nested_output_dir(
         self, runner: CliRunner, tmp_path: Path,
     ) -> None:
-        # C.1
         out = tmp_path / "nested" / "subdir" / "result.json"
         _invoke(runner, [
             "-m", "Intel/bert-base-uncased-mrpc",
@@ -511,7 +502,6 @@ _ALL_TASKS = [
 class TestEvalSchema:
     @pytest.mark.parametrize("task", _ALL_TASKS)
     def test_schema_for_each_task(self, runner: CliRunner, task: str) -> None:
-        # D
         result = _invoke(runner, ["--schema", "--task", task])
         assert "Dataset schema" in result.output
 
@@ -523,7 +513,7 @@ class TestEvalSchema:
 
 class TestEvalDeviceAndEp:
     def test_device_cpu(self, runner: CliRunner, tmp_path: Path) -> None:
-        # E.1 — CPU works on every box. ResNet-50 is a small, fast image
+        # CPU works on every box. ResNet-50 is a small, fast image
         # classifier well-suited to a CPU smoke test (no per-token forward
         # passes like fill-mask).
         out = tmp_path / "result.json"
@@ -542,7 +532,7 @@ class TestEvalDeviceAndEp:
     def test_device_npu_and_ep_qnn(
         self, runner: CliRunner, tmp_path: Path,
     ) -> None:
-        # E.2 — combined --device + --ep
+        # Combined --device + --ep.
         out = tmp_path / "result.json"
         _invoke(runner, [
             "-m", "google/vit-base-patch16-224",
@@ -566,7 +556,6 @@ class TestEvalAdditionalOptions:
     def test_dataset_name_explicit(
         self, runner: CliRunner, tmp_path: Path,
     ) -> None:
-        # F.1
         out = tmp_path / "result.json"
         _invoke(runner, [
             "-m", "Intel/bert-base-uncased-mrpc",
@@ -584,7 +573,6 @@ class TestEvalAdditionalOptions:
     def test_label_mapping_image_segmentation(
         self, runner: CliRunner, tmp_path: Path,
     ) -> None:
-        # F.2
         from pathlib import Path as _Path
 
         label_map = _Path(ADE20K_LABEL_MAP)
@@ -608,7 +596,7 @@ class TestEvalAdditionalOptions:
     def test_config_file_basic(
         self, runner: CliRunner, tmp_path: Path,
     ) -> None:
-        # F.3 — `eval` section provides task + samples
+        # `eval` section provides task + samples.
         cfg = tmp_path / "cfg.json"
         cfg.write_text(json.dumps({
             "loader": {"task": "text-classification"},
@@ -629,7 +617,7 @@ class TestEvalAdditionalOptions:
     def test_config_file_cli_override(
         self, runner: CliRunner, tmp_path: Path,
     ) -> None:
-        # F.4 — CLI wins over config file
+        # CLI wins over config file.
         cfg = tmp_path / "cfg.json"
         cfg.write_text(json.dumps({
             "loader": {"task": "text-classification"},
@@ -651,7 +639,7 @@ class TestEvalAdditionalOptions:
     def test_auto_task_detection(
         self, runner: CliRunner, tmp_path: Path,
     ) -> None:
-        # F.5 — no --task flag; CLI infers from HF model
+        # No --task flag; CLI infers from HF model.
         out = tmp_path / "result.json"
         _invoke(runner, [
             "-m", "Intel/bert-base-uncased-mrpc",
@@ -667,7 +655,7 @@ class TestEvalAdditionalOptions:
     def test_precision_warning_for_prebuilt_onnx(
         self, runner: CliRunner, tmp_path: Path, caplog,
     ) -> None:
-        # F.6 — pre-built ONNX + --precision emits warning, still succeeds
+        # Pre-built ONNX + --precision emits warning, still succeeds.
         import logging as _logging
 
         hf_id = "google/vit-base-patch16-224"
@@ -702,7 +690,7 @@ class TestEvalAdditionalOptions:
     def test_dataset_script_with_column_remap(
         self, runner: CliRunner, tmp_path: Path, tiny_textcls_script: Path,
     ) -> None:
-        # F.7 — --dataset-script + --column + --trust-remote-code (good path)
+        # --dataset-script + --column + --trust-remote-code (happy path).
         ds_path = tmp_path / "tiny_textcls"
         out = tmp_path / "result.json"
         _invoke(runner, [
@@ -723,7 +711,6 @@ class TestEvalAdditionalOptions:
     def test_dataset_script_without_trust_remote_code(
         self, runner: CliRunner, tmp_path: Path, tiny_textcls_script: Path,
     ) -> None:
-        # F.8 — error path
         ds_path = tmp_path / "tiny_textcls"
         result = _invoke(runner, [
             "-m", "Intel/bert-base-uncased-mrpc",
@@ -745,7 +732,6 @@ class TestEvalErrorPaths:
     def test_bad_column_format(
         self, runner: CliRunner, tmp_path: Path,
     ) -> None:
-        # G.1
         result = _invoke(runner, [
             "-m", "Intel/bert-base-uncased-mrpc",
             "--task", "text-classification",
@@ -760,7 +746,6 @@ class TestEvalErrorPaths:
     def test_missing_label_mapping_file(
         self, runner: CliRunner, tmp_path: Path,
     ) -> None:
-        # G.2
         missing = tmp_path / "does-not-exist.json"
         result = _invoke(runner, [
             "-m", "Intel/bert-base-uncased-mrpc",
@@ -777,7 +762,6 @@ class TestEvalErrorPaths:
     def test_bogus_dataset_name(
         self, runner: CliRunner, tmp_path: Path,
     ) -> None:
-        # G.3
         result = _invoke(runner, [
             "-m", "Intel/bert-base-uncased-mrpc",
             "--task", "text-classification",
@@ -792,13 +776,12 @@ class TestEvalErrorPaths:
         )
 
     def test_schema_without_task(self, runner: CliRunner) -> None:
-        # G.4
         result = _invoke(runner, ["--schema"], expect_success=False)
         assert result.exit_code != 0
         assert "--task" in result.output, result.output
 
     def test_schema_bogus_task(self, runner: CliRunner) -> None:
-        # G.6 — get_evaluator_class ValueError wrapped as UsageError
+        # get_evaluator_class ValueError wrapped as UsageError.
         result = _invoke(
             runner, ["--schema", "--task", "not-a-real-task"],
             expect_success=False,
@@ -813,7 +796,7 @@ class TestEvalErrorPaths:
     def test_onnx_file_without_model_id(
         self, runner: CliRunner, tmp_path: Path,
     ) -> None:
-        # G.5 — needs a real .onnx file path that exists; reuse warmed cache
+        # Needs a real .onnx file path that exists; reuse warmed cache.
         hf_id = "google/vit-base-patch16-224"
         task = "image-classification"
         _invoke(runner, ["-m", hf_id, "--task", task, "--streaming", "--samples", SAMPLES])

--- a/tests/unit/commands/test_eval.py
+++ b/tests/unit/commands/test_eval.py
@@ -280,3 +280,276 @@ class TestEvalConfigPrecedence:
 
         # config > dataclass defaults (task default is None)
         assert cfg.task == "image-classification"
+
+    def test_cli_default_device_propagates_when_not_explicitly_passed(
+        self,
+        runner: CliRunner,
+    ):
+        """The CLI option default must win over any (stale) dataclass default.
+
+        Even when the user doesn't pass ``--device``, the CLI's default value
+        ("auto") must be the effective config — never a different dataclass
+        default. This guards against the bug where ``--device`` was sourced
+        from ``ParameterSource.DEFAULT`` and silently dropped.
+        """
+        from winml.modelkit.commands.eval import eval as eval_cmd
+
+        captured_cfg = {}
+
+        def _fake_evaluate(cfg):
+            captured_cfg["cfg"] = cfg
+
+            class _R:
+                config = cfg
+                metrics = {"accuracy": 1.0}  # noqa: RUF012
+
+                def to_dict(self):
+                    return {"metrics": self.metrics, "config": cfg.to_dict()}
+
+            return _R()
+
+        with (
+            patch("winml.modelkit.eval.evaluate", side_effect=_fake_evaluate),
+            patch("winml.modelkit.commands.eval._resolve_device", return_value=None),
+            patch("winml.modelkit.commands.eval._write_and_display", return_value=None),
+        ):
+            result = runner.invoke(
+                eval_cmd,
+                ["-m", "microsoft/resnet-50", "--task", "image-classification"],
+                obj={"debug": False},
+            )
+
+        assert result.exit_code == 0, result.output
+        cfg = captured_cfg["cfg"]
+        # Find CLI default; ``--device`` was not passed, so the resolved
+        # config must equal the CLI default (not, e.g., a stale "cpu" dataclass default).
+        cli_default = next(p.default for p in eval_cmd.params if p.name == "device")
+        assert cfg.device == cli_default
+
+    def test_config_file_device_wins_over_cli_default(
+        self,
+        runner: CliRunner,
+        eval_config_file,
+    ):
+        """Config-file values must override CLI defaults (but not CLI explicit)."""
+        from winml.modelkit.commands.eval import eval as eval_cmd
+
+        captured_cfg = {}
+
+        def _fake_evaluate(cfg):
+            captured_cfg["cfg"] = cfg
+
+            class _R:
+                config = cfg
+                metrics = {"accuracy": 1.0}  # noqa: RUF012
+
+                def to_dict(self):
+                    return {"metrics": self.metrics, "config": cfg.to_dict()}
+
+            return _R()
+
+        with (
+            patch("winml.modelkit.eval.evaluate", side_effect=_fake_evaluate),
+            patch("winml.modelkit.commands.eval._resolve_device", return_value=None),
+            patch("winml.modelkit.commands.eval._write_and_display", return_value=None),
+        ):
+            result = runner.invoke(
+                eval_cmd,
+                ["--config", str(eval_config_file), "-m", "microsoft/resnet-50"],
+                obj={"debug": False},
+            )
+
+        assert result.exit_code == 0, result.output
+        cfg = captured_cfg["cfg"]
+        # eval_config_file sets device: "gpu"; CLI --device not passed -> "gpu"
+        assert cfg.device == "gpu"
+        # And config-file dataset.samples (33) wins over CLI default
+        assert cfg.dataset.samples == 33
+
+
+# ---------------------------------------------------------------------------
+# Per-task default dataset resolution
+# ---------------------------------------------------------------------------
+
+
+class TestPerTaskDefaultDataset:
+    """When the user does not provide --dataset, the per-task default dataset
+    (path, split, columns_mapping, ...) must reach the evaluator. Only
+    ``samples`` is carried over from the user's CLI value.
+
+    Regression guard for the bug where Click's ``--split validation`` default
+    silently clobbered the per-task default split (e.g. coco→"val",
+    cifar100→"test"), making the per-task split values dead code.
+    """
+
+    @staticmethod
+    def _run_and_capture(runner: CliRunner, args: list[str]):
+        """Invoke the eval CLI, letting ``evaluate()`` run end-to-end with
+        ``_load_model`` and the evaluator class stubbed. Returns the cfg
+        observed by the evaluator (i.e. after default-injection)."""
+        import importlib
+
+        from winml.modelkit.commands.eval import eval as eval_cmd
+
+        evaluate_mod = importlib.import_module("winml.modelkit.eval.evaluate")
+
+        captured_cfg = {}
+
+        class _FakeEvaluator:
+            def __init__(self, cfg, _model):
+                captured_cfg["cfg"] = cfg
+
+            def compute(self):
+                return {"accuracy": 1.0}
+
+        with (
+            patch.object(evaluate_mod, "_load_model", return_value=object()),
+            patch.object(
+                evaluate_mod, "get_evaluator_class", return_value=_FakeEvaluator,
+            ),
+            patch("winml.modelkit.commands.eval._resolve_device", return_value=None),
+            patch("winml.modelkit.commands.eval._write_and_display", return_value=None),
+        ):
+            result = runner.invoke(eval_cmd, args, obj={"debug": False})
+
+        assert result.exit_code == 0, result.output
+        return captured_cfg["cfg"]
+
+    @pytest.mark.parametrize(
+        ("task", "expected_path", "expected_split"),
+        [
+            ("object-detection", "detection-datasets/coco", "val"),
+            ("zero-shot-classification", "fancyzhx/ag_news", "test"),
+            ("zero-shot-image-classification", "uoft-cs/cifar100", "test"),
+            ("image-classification", "timm/mini-imagenet", "test"),
+        ],
+    )
+    def test_per_task_default_split_reaches_evaluator(
+        self,
+        runner: CliRunner,
+        task: str,
+        expected_path: str,
+        expected_split: str,
+    ):
+        cfg = self._run_and_capture(
+            runner, ["-m", "some/model", "--task", task],
+        )
+        assert cfg.dataset.path == expected_path
+        assert cfg.dataset.split == expected_split
+
+    def test_user_samples_preserved_when_default_dataset_used(
+        self,
+        runner: CliRunner,
+    ):
+        """``--samples N`` must NOT be clobbered by the per-task default's samples
+        when the user didn't provide ``--dataset``.
+        """
+        cfg = self._run_and_capture(
+            runner,
+            [
+                "-m", "some/model",
+                "--task", "image-classification",
+                "--samples", "4",
+            ],
+        )
+        # Per-task default path filled in:
+        assert cfg.dataset.path == "timm/mini-imagenet"
+        # ...but user-set --samples preserved.
+        assert cfg.dataset.samples == 4
+
+    def test_user_split_ignored_when_default_dataset_used(
+        self,
+        runner: CliRunner,
+    ):
+        """When falling back to the per-task default dataset, the default owns
+        the split. ``--split`` is intentionally ignored (only ``samples`` is
+        carried over from the user). Users wanting a different split must
+        also pass ``--dataset``.
+        """
+        cfg = self._run_and_capture(
+            runner,
+            [
+                "-m", "some/model",
+                "--task", "image-classification",
+                "--split", "train",
+            ],
+        )
+        assert cfg.dataset.split == "test"  # the default's split wins
+
+    def test_user_column_ignored_when_default_dataset_used(
+        self,
+        runner: CliRunner,
+    ):
+        """``--column`` overrides are ignored when the default dataset fills
+        in. The default owns ``columns_mapping`` wholesale. To customize
+        columns, the user must also pass ``--dataset``.
+        """
+        cfg = self._run_and_capture(
+            runner,
+            [
+                "-m", "some/model",
+                "--task", "text-classification",
+                "--column", "input_column=my_text",
+            ],
+        )
+        # Default's columns_mapping wins wholesale; user's --column dropped.
+        assert cfg.dataset.columns_mapping == {
+            "input_column": "sentence1",
+            "second_input_column": "sentence2",
+        }
+
+    def test_user_streaming_ignored_when_default_dataset_used(
+        self,
+        runner: CliRunner,
+    ):
+        """``--streaming`` is ignored when the default dataset fills in;
+        the default's ``streaming`` value wins.
+        """
+        # fill-mask default has streaming=True; user passing nothing should
+        # still get streaming=True (from default), not the Click default False.
+        cfg = self._run_and_capture(
+            runner,
+            ["-m", "some/model", "--task", "fill-mask"],
+        )
+        assert cfg.dataset.streaming is True
+
+    def test_user_dataset_name_ignored_when_default_dataset_used(
+        self,
+        runner: CliRunner,
+    ):
+        """``--dataset-name`` is ignored when the default dataset fills in.
+        Only ``samples`` is carried over from the user's config.
+        """
+        cfg = self._run_and_capture(
+            runner,
+            [
+                "-m", "some/model",
+                "--task", "text-classification",
+                "--dataset-name", "sst2",
+            ],
+        )
+        # Default's name ("mrpc") wins; user's --dataset-name dropped.
+        assert cfg.dataset.name == "mrpc"
+
+    def test_default_dataset_logs_warning(
+        self,
+        runner: CliRunner,
+        caplog,
+    ):
+        """When falling back to the default dataset, a warning is emitted
+        listing the default and the ignored options.
+        """
+        import logging as _logging
+
+        with caplog.at_level(_logging.WARNING, logger="winml.modelkit.eval.evaluate"):
+            self._run_and_capture(
+                runner,
+                ["-m", "some/model", "--task", "image-classification"],
+            )
+        msgs = [r.getMessage() for r in caplog.records]
+        assert any(
+            "--dataset is not specified" in m
+            and "image-classification" in m
+            and "timm/mini-imagenet" in m
+            for m in msgs
+        ), f"expected warning not found in {msgs!r}"

--- a/tests/unit/eval/test_eval.py
+++ b/tests/unit/eval/test_eval.py
@@ -86,16 +86,14 @@ class TestGetEvaluatorClass:
     """Tests for get_evaluator_class registry lookup."""
 
     def test_registered_task_returns_class(self):
-        from winml.modelkit.eval.evaluate import (
-            _EVALUATOR_REGISTRY,
-            get_evaluator_class,
-        )
+        from winml.modelkit.eval import get_evaluator_class
+        from winml.modelkit.eval.evaluate import _EVALUATOR_REGISTRY
 
         for task, expected_cls in _EVALUATOR_REGISTRY.items():
             assert get_evaluator_class(task) is expected_cls
 
     def test_unsupported_task_raises_value_error(self):
-        from winml.modelkit.eval.evaluate import get_evaluator_class
+        from winml.modelkit.eval import get_evaluator_class
 
         with pytest.raises(ValueError, match="not supported by `winml eval`"):
             get_evaluator_class("made-up-task")

--- a/tests/unit/eval/test_eval.py
+++ b/tests/unit/eval/test_eval.py
@@ -82,6 +82,25 @@ class TestResolveTask:
             assert _resolve_task(config) == "image-classification"
 
 
+class TestGetEvaluatorClass:
+    """Tests for get_evaluator_class registry lookup."""
+
+    def test_registered_task_returns_class(self):
+        from winml.modelkit.eval.evaluate import (
+            _EVALUATOR_REGISTRY,
+            get_evaluator_class,
+        )
+
+        for task, expected_cls in _EVALUATOR_REGISTRY.items():
+            assert get_evaluator_class(task) is expected_cls
+
+    def test_unsupported_task_raises_value_error(self):
+        from winml.modelkit.eval.evaluate import get_evaluator_class
+
+        with pytest.raises(ValueError, match="not supported by `winml eval`"):
+            get_evaluator_class("made-up-task")
+
+
 class TestEvaluate:
     """Tests for evaluate() entry point."""
 
@@ -124,7 +143,7 @@ class TestEvaluate:
         config = WinMLEvaluationConfig(
             model_id="test/model",
             task=None,
-            dataset=DatasetConfig(path=None),
+            dataset=DatasetConfig(path="some/dataset"),
         )
         original = asdict(config)
 
@@ -890,58 +909,6 @@ class TestBuildEvalResultEpField:
 
 class TestDefaultDatasetImmutability:
     """Tests that module-level _DEFAULT_DATASETS are not corrupted."""
-
-    @patch("evaluate.evaluator")
-    @patch("transformers.pipeline")
-    @patch("datasets.load_dataset")
-    def test_default_dataset_not_mutated_after_evaluate(
-        self,
-        mock_load_ds,
-        mock_pipeline,
-        mock_hf_eval,
-    ):
-        """evaluate() must not corrupt _DEFAULT_DATASETS entries."""
-        import importlib
-        import sys
-        from copy import deepcopy
-
-        eval_mod = sys.modules.get(
-            "winml.modelkit.eval.evaluate",
-        ) or importlib.import_module("winml.modelkit.eval.evaluate")
-
-        # Snapshot the default datasets before evaluation
-        defaults_before = deepcopy(eval_mod._DEFAULT_DATASETS)
-
-        # Set up mocks: dataset with fewer samples than the default (100)
-        mock_ds = MagicMock()
-        mock_ds.__len__ = lambda self: 30
-        mock_ds.shuffle.return_value = mock_ds
-        mock_ds.select.return_value = mock_ds
-        mock_load_ds.return_value = mock_ds
-        mock_pipeline.return_value = MagicMock()
-
-        mock_eval_inst = MagicMock()
-        mock_eval_inst.compute.return_value = {"accuracy": 0.7}
-        mock_hf_eval.return_value = mock_eval_inst
-
-        config = WinMLEvaluationConfig(
-            model_id="test/model",
-            dataset=DatasetConfig(path=None),
-        )
-
-        with (
-            patch.object(eval_mod, "_load_model", return_value=MagicMock()),
-            patch.object(eval_mod, "_resolve_task", return_value="image-classification"),
-        ):
-            eval_mod.evaluate(config)
-
-        # Verify module-level defaults are unchanged (full dataclass state)
-        from dataclasses import asdict
-
-        for task, ds_cfg in eval_mod._DEFAULT_DATASETS.items():
-            assert asdict(ds_cfg) == asdict(defaults_before[task]), (
-                f"_DEFAULT_DATASETS['{task}'] was mutated"
-            )
 
     @patch("evaluate.evaluator")
     @patch("transformers.pipeline")

--- a/tests/unit/eval/test_image_feature_extraction_evaluator.py
+++ b/tests/unit/eval/test_image_feature_extraction_evaluator.py
@@ -209,8 +209,8 @@ class TestImageFeatureExtractionEvaluatorRegistry:
 
         assert "image-feature-extraction" in _DEFAULT_DATASETS
         ds = _DEFAULT_DATASETS["image-feature-extraction"]
-        assert ds.path == "timm/mini-imagenet"
-        assert ds.samples == 1000
+        assert ds["path"] == "timm/mini-imagenet"
+        assert ds["samples"] == 1000
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/eval/test_image_feature_extraction_evaluator.py
+++ b/tests/unit/eval/test_image_feature_extraction_evaluator.py
@@ -210,7 +210,6 @@ class TestImageFeatureExtractionEvaluatorRegistry:
         assert "image-feature-extraction" in _DEFAULT_DATASETS
         ds = _DEFAULT_DATASETS["image-feature-extraction"]
         assert ds["path"] == "timm/mini-imagenet"
-        assert ds["samples"] == 1000
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/eval/test_zero_shot_classification_evaluator.py
+++ b/tests/unit/eval/test_zero_shot_classification_evaluator.py
@@ -119,9 +119,9 @@ class TestRegistry:
         from winml.modelkit.eval.evaluate import _DEFAULT_DATASETS
 
         cfg = _DEFAULT_DATASETS["zero-shot-classification"]
-        assert cfg.path is not None
-        assert cfg.columns_mapping.get("input_column") is not None
-        assert cfg.columns_mapping.get("label_column") is not None
+        assert cfg["path"] is not None
+        assert cfg["columns_mapping"].get("input_column") is not None
+        assert cfg["columns_mapping"].get("label_column") is not None
 
     def test_exported_from_package(self) -> None:
         from winml.modelkit import eval as eval_pkg


### PR DESCRIPTION
#492 

**Fix functional correctness bugs**
1. When user specifies --samples 10 but not specify dataset. The samples for the default dataset becomes 100 but not 10
2. When user doesn't specify "device". The device used is "cpu" instead the CLI option default value "auto".

The bugs above are caused by config value merging logic. The order should be  CLI value specified > CLI option default value > Dataclass default value.

**Added below e2e test cases.**
 # `winml eval` — E2E test coverage

## Per-task forward path (13 cases, one canonical model per registered task)

- **image-classification** — `winml eval -m google/vit-base-patch16-224 --task image-classification --samples 4 -o <tmp>/r.json` → exit 0; `metrics.accuracy` finite.
- **text-classification** — `winml eval -m Intel/bert-base-uncased-mrpc --task text-classification --samples 4 -o <tmp>/r.json` → exit 0; `metrics.accuracy` finite.
- **token-classification** — `winml eval -m dslim/bert-base-NER --task token-classification --samples 4 -o <tmp>/r.json` → exit 0; `overall_precision`, `overall_recall`, `overall_f1`, `overall_accuracy` finite.
- **object-detection** — `winml eval -m hustvl/yolos-small --task object-detection --samples 4 -o <tmp>/r.json` → exit 0; `map`, `map_50`, `mar_100` finite.
- **image-segmentation** — `winml eval -m nvidia/segformer-b1-finetuned-ade-512-512 --task image-segmentation --dataset danjacobellis/scene_parse_150 --split validation --streaming --samples 4 -o <tmp>/r.json` → exit 0; `mean_iou` finite.
- **question-answering** — `winml eval -m distilbert/distilbert-base-cased-distilled-squad --task question-answering --samples 4 -o <tmp>/r.json` → exit 0; `exact_match`, `f1` finite.
- **feature-extraction** — `winml eval -m sentence-transformers/all-MiniLM-L6-v2 --task feature-extraction --samples 4 -o <tmp>/r.json` → exit 0; metrics non-empty.
- **sentence-similarity** — `winml eval -m sentence-transformers/all-MiniLM-L6-v2 --task sentence-similarity --samples 4 -o <tmp>/r.json` → exit 0; metrics non-empty.
- **image-feature-extraction** — `winml eval -m facebook/dinov2-small --task image-feature-extraction --samples 4 -o <tmp>/r.json` → exit 0; `knn_top1_accuracy` family present.
- **image-to-text (fp16)** — `winml eval -m Salesforce/blip-image-captioning-base --task image-to-text --dataset lmms-lab/flickr30k --split test --streaming --samples 4 --precision fp16 -o <tmp>/r.json` → exit 0; `cider` family present.
- **fill-mask** — `winml eval -m distilbert/distilbert-base-uncased --task fill-mask --samples 4 -o <tmp>/r.json` → exit 0; `pseudo_perplexity` family present.
- **zero-shot-classification** — `winml eval -m cross-encoder/nli-deberta-v3-small --task zero-shot-classification --samples 4 -o <tmp>/r.json` → exit 0; `accuracy` finite.
- **zero-shot-image-classification** — `winml eval -m openai/clip-vit-base-patch32 --task zero-shot-image-classification --samples 4 -o <tmp>/r.json` → exit 0; `accuracy` finite.

## Model-input forms (2 cases)

- **Pre-built monolithic ONNX file works with `--model-id`** — `winml eval -m <cache>/<hash>_model.onnx --model-id google/vit-base-patch16-224 --task image-classification --samples 4 -o <tmp>/r.json` → exit 0; `accuracy` finite.
- **Pre-built split-encoder ONNX (`-m role=path …`)** — `winml eval -m image-encoder=<enc>.onnx -m text-encoder=<txt>.onnx --model-id openai/clip-vit-base-patch32 --task zero-shot-image-classification --samples 4 -o <tmp>/r.json` → exit 0; `accuracy` finite (skip if build produces a monolithic ONNX).

## Output (1 case)

- **`-o` creates nested directories and writes valid JSON** — `winml eval -m Intel/bert-base-uncased-mrpc --task text-classification --samples 4 -o <tmp>/a/b/c/r.json` → exit 0; nested file exists; JSON has top-level keys `metrics`, `model_id`, `dataset`.

## `--schema` mode (1 parametrized case × 13 tasks)

- **`--schema --task <task>` prints schema for every registered task** — `winml eval --schema --task <task>` → exit 0; stdout contains `"Dataset schema"`.

## Device / EP (2 cases)

- **`--device cpu`** — `winml eval -m distilbert/distilbert-base-uncased --task fill-mask --device cpu --samples 4 -o <tmp>/r.json` → exit 0; metrics non-empty.
- **`--device npu --ep qnn`** (NPU box only) — `winml eval -m google/vit-base-patch16-224 --task image-classification --device npu --ep qnn --samples 4 -o <tmp>/r.json` → exit 0; `accuracy` finite.

## Additional options (8 cases)

- **`--dataset-name` selects multi-config dataset config** — `winml eval -m Intel/bert-base-uncased-mrpc --task text-classification --dataset nyu-mll/glue --dataset-name mrpc --samples 4 -o <tmp>/r.json` → exit 0; `accuracy` finite.
- **`--label-mapping` JSON is loaded and applied** — `winml eval -m nvidia/segformer-b1-finetuned-ade-512-512 --task image-segmentation --dataset danjacobellis/scene_parse_150 --split validation --streaming --label-mapping scripts/e2e_eval/datasets/ade20k_gt_to_model_label.json --samples 4 -o <tmp>/r.json` → exit 0; `mean_iou` finite.
- **`--config <file>` applies `loader.task` and `eval.dataset.samples`** — `winml eval -m Intel/bert-base-uncased-mrpc --config <tmp>/cfg.json -o <tmp>/r.json` → exit 0; result JSON shows `dataset.samples == 5`.
- **CLI `--samples` overrides value in `--config`** — `winml eval -m Intel/bert-base-uncased-mrpc --config <tmp>/cfg.json --samples 7 -o <tmp>/r.json` → exit 0; result JSON shows `dataset.samples == 7`.
- **Task auto-detected from HF model when `--task` omitted** — `winml eval -m Intel/bert-base-uncased-mrpc --samples 4 -o <tmp>/r.json` → exit 0; result JSON shows `task == "text-classification"`.
- **`--precision` on pre-built ONNX emits ignore-warning** — `winml eval -m <cache>/<hash>_model.onnx --model-id google/vit-base-patch16-224 --task image-classification --precision fp16 --samples 4 -o <tmp>/r.json` → exit 0; output contains `"precision ... ignored"`; `accuracy` finite.
- **`--dataset-script` + `--column` + `--trust-remote-code` builds and uses a local dataset** — `winml eval -m Intel/bert-base-uncased-mrpc --task text-classification --dataset-script tests/e2e/fixtures/build_tiny_textcls.py --dataset <tmp>/ds --trust-remote-code --column input_column=text_a --column second_input_column=text_b --samples 10 -o <tmp>/r.json` → exit 0; built dataset path exists; `accuracy` finite.
- **`--dataset-script` without `--trust-remote-code` errors out** — `winml eval -m Intel/bert-base-uncased-mrpc --task text-classification --dataset-script tests/e2e/fixtures/build_tiny_textcls.py --dataset <tmp>/ds --samples 10` → exit ≠ 0; stderr contains `"trust-remote-code is required"`.

## Error paths (5 cases, fast — no model load)

- **`--column` without `=` is rejected** — `winml eval -m Intel/bert-base-uncased-mrpc --task text-classification --column foo --samples 1` → exit ≠ 0; stderr contains `"key=value"`.
- **Missing `--label-mapping` file is rejected** — `winml eval -m Intel/bert-base-uncased-mrpc --task text-classification --label-mapping <tmp>/missing.json --samples 1` → exit ≠ 0; stderr indicates file not found.
- **Invalid `--dataset-name` is rejected** — `winml eval -m Intel/bert-base-uncased-mrpc --task text-classification --dataset nyu-mll/glue --dataset-name not_real --samples 1` → exit ≠ 0; stderr mentions `"config"`.
- **`--schema` without `--task` is rejected** — `winml eval --schema` → exit ≠ 0; stderr says `--task` is required.
- **ONNX `-m` without `--model-id` is rejected** — `winml eval -m <cache>/<some>.onnx --task image-classification --samples 1` → exit ≠ 0; stderr contains `"--model-id is required"`.

