### PR TITLE
fix(perf): make `winml catalog` ~10x faster by deferring heavy data-pkg imports

### DIFF
--- a/src/winml/modelkit/commands/catalog.py
+++ b/src/winml/modelkit/commands/catalog.py
@@ -19,7 +19,6 @@ Usage:
 
 from __future__ import annotations
 
-import importlib.resources
 import json
 import logging
 from pathlib import Path
@@ -54,12 +53,16 @@ _TYPE_PALETTE = ["cyan", "green", "yellow", "magenta", "blue", "red"]
 def _load_catalog() -> dict[str, Any]:
     """Load hub_models.json from package data.
 
+    Resolves the path via ``__file__`` rather than ``importlib.resources.files``
+    so that reading the catalog does not execute ``winml.modelkit.data``'s
+    package init — that init pulls in heavy optional dependencies (onnx, numpy,
+    torchvision via the dataset modules) that the catalog command never needs.
+
     Returns:
         Parsed catalog dict with ``version`` and ``models`` keys.
     """
-    pkg = importlib.resources.files("winml.modelkit.data")
-    data = (pkg / "hub_models.json").read_text(encoding="utf-8")
-    return json.loads(data)  # type: ignore[no-any-return]
+    data_path = Path(__file__).resolve().parent.parent / "data" / "hub_models.json"
+    return json.loads(data_path.read_text(encoding="utf-8"))  # type: ignore[no-any-return]
 
 
 def _filter_models(

--- a/src/winml/modelkit/data/image_classification_dataset.py
+++ b/src/winml/modelkit/data/image_classification_dataset.py
@@ -8,9 +8,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from datasets import load_dataset
-from torchvision import transforms
-
 from .registry import DataRegistry
 
 
@@ -38,6 +35,9 @@ class ImageClassificationDataset:
         split = load_dataset_config.get("split", "train")
         stream = load_dataset_config.get("stream", True)
         size = load_dataset_config.get("size", 256)
+
+        from datasets import load_dataset
+        from torchvision import transforms
 
         self.dataset = load_dataset(dataset_name, split=split, streaming=stream)
 


### PR DESCRIPTION
Fixes #538.

## Root cause

`winml catalog` was taking **5–7 s** warm to render a static curated table.

The culprit was a side effect of how `_load_catalog` located its JSON file:

```python
pkg = importlib.resources.files("winml.modelkit.data")
data = (pkg / "hub_models.json").read_text(encoding="utf-8")
```

`importlib.resources.files("winml.modelkit.data")` executes `winml/modelkit/data/__init__.py`, which eagerly imports `image_classification_dataset`, which in turn eagerly imports `torchvision` and `datasets`. That single line transitively pulls in **torch (~2.2 s), torchvision (~4.3 s), datasets / pandas / pyarrow / huggingface_hub / aiohttp / requests (~1.2 s)** every time `winml catalog` runs.

`cProfile` confirmed >5 s of the wall time was spent in those imports, not in any catalog logic.

## Fix

Two small, local changes — no architecture-specific or hard-coded model logic:

1. **`commands/catalog.py::_load_catalog`** — resolve the JSON path via `__file__` instead of `importlib.resources.files`, so reading the catalog no longer triggers `data/__init__.py`.
2. **`data/image_classification_dataset.py`** — move the `torchvision` and `datasets.load_dataset` imports into the constructor body so they fire only when the dataset is actually instantiated.

## Measured impact

`winml catalog --task image-classification` end-to-end (5 warm runs):

| State | Wall time |
|---|---|
| Before | 5 000 – 6 000 ms |
| After this PR | **490 – 630 ms** |

Roughly **10× faster** at the CLI level. Remaining time is dominated by `import onnxruntime` via `utils/constants.py` (~210 ms) — out of scope for this PR; can be addressed in a follow-up if needed.

## Verification

- Existing pytest suite: 263 passed, 0 regressions (`pytest -k "constants or catalog or device"`).
- `winml catalog --task image-classification` output identical to pre-PR (5 image-classification models rendered correctly).