### PR TITLE
feat(analyze): disambiguate EPContext pattern_id by EP label, generalize display-name suffix stripping

### DIFF
--- a/src/winml/modelkit/analyze/__init__.py
+++ b/src/winml/modelkit/analyze/__init__.py
@@ -21,7 +21,6 @@ from .core.onnx_loader import ONNXLoader
 from .core.output_aggregator import OutputAggregator
 from .core.pattern_extractor import PatternExtractor
 from .core.runtime_checker import RuntimeChecker
-from .core.runtime_checker_query import QDQ_SUFFIX
 from .models import (
     Action,
     ActionItem,
@@ -44,7 +43,6 @@ from .utils.rule_loader import RuleLoader
 
 
 __all__ = [
-    "QDQ_SUFFIX",
     "Action",
     "ActionItem",
     "ActionLevel",

--- a/src/winml/modelkit/analyze/core/node_checkers/ep_context_node_checker.py
+++ b/src/winml/modelkit/analyze/core/node_checkers/ep_context_node_checker.py
@@ -46,9 +46,14 @@ class EPContextNodeChecker(NodeChecker):
         """Check EPContext node partition_name against the execution provider name."""
         ep_name = kwargs.get("ep_name")
         partition_name = self.get_attribute_value(node, "partition_name")
+        # Suffix every pattern_id with the EP label derived from
+        # partition_name so multi-EP analysis reports stay disambiguated
+        # (e.g. "OP/.../EPContext (QNN)").
+        ep_label = self._ep_label(partition_name)
+        scoped_pattern_id = f"{pattern_match.pattern.pattern_id} ({ep_label})"
         if partition_name is None:
             return PatternRuntime(
-                pattern_id=pattern_match.pattern.pattern_id,
+                pattern_id=scoped_pattern_id,
                 result=RuntimeTestResult(
                     run=False,
                     compile=False,
@@ -62,7 +67,7 @@ class EPContextNodeChecker(NodeChecker):
         # https://github.com/microsoft/onnxruntime/blob/7e1d818ba7923c1e44187284a6ca77bbe13aa1eb/onnxruntime/core/framework/graph_partitioner.cc#L378
         if partition_name.startswith(ep_name + "_"):
             return PatternRuntime(
-                pattern_id=pattern_match.pattern.pattern_id,
+                pattern_id=scoped_pattern_id,
                 result=RuntimeTestResult(
                     run=True,
                     compile=True,
@@ -74,7 +79,7 @@ class EPContextNodeChecker(NodeChecker):
                 pattern_match=pattern_match,
             )
         return PatternRuntime(
-            pattern_id=pattern_match.pattern.pattern_id,
+            pattern_id=scoped_pattern_id,
             result=RuntimeTestResult(
                 run=False,
                 compile=False,
@@ -84,6 +89,25 @@ class EPContextNodeChecker(NodeChecker):
             alternatives=alternatives,
             pattern_match=pattern_match,
         )
+
+    @staticmethod
+    def _ep_label(partition_name: str | None) -> str:
+        """Derive the EP label (suffix used in pattern_id) from partition_name.
+
+        Cases:
+
+        - ``None`` → ``"UNKNOWN_EP"`` (partition_name attribute missing).
+        - Canonical ORT format ``"<X>ExecutionProvider_..."`` → ``X``
+          (e.g. ``"QNNExecutionProvider_0"`` → ``"QNN"``).
+        - Anything else → ``partition_name`` itself, used directly.
+        """
+        if partition_name is None:
+            return "UNKNOWN_EP"
+        marker = "ExecutionProvider_"
+        idx = partition_name.find(marker)
+        if idx > 0:
+            return partition_name[:idx]
+        return partition_name
 
     def get_attribute_value(self, node: "onnx.NodeProto", attr_name: str) -> str | None:
         """Return the string value of a node attribute, or None if not found."""

--- a/src/winml/modelkit/commands/analyze.py
+++ b/src/winml/modelkit/commands/analyze.py
@@ -14,6 +14,7 @@ Usage:
 from __future__ import annotations
 
 import logging
+import re
 import sys
 from pathlib import Path
 
@@ -24,7 +25,6 @@ from rich.logging import RichHandler
 from rich.table import Table
 from rich.text import Text
 
-from ..analyze import QDQ_SUFFIX
 from ..utils import cli as cli_utils
 from ..utils.constants import normalize_ep_name
 from ..utils.logging import configure_logging
@@ -63,9 +63,23 @@ def _discover_runtime_rule_parquet_files() -> tuple[list[Path], list[Path]]:
     return search_dirs, parquet_files
 
 
+_TRAILING_PAREN_RE = re.compile(r" \([^()]*\)$")
+
+
 def _display_name(pattern_id: str) -> str:
-    """Extract operator display name from pattern_id ('OP/ai.onnx/Conv' -> 'Conv')."""
-    return pattern_id.split("/")[-1]
+    """Extract operator display name from pattern_id.
+
+    Examples::
+
+        'OP/ai.onnx/Conv'              -> 'Conv'
+        'OP/ai.onnx/Conv (QDQ)'        -> 'Conv'
+        'OP/com.microsoft/EPContext (QNN)' -> 'EPContext'
+
+    Strips any trailing ``" (xxx)"`` annotation (QDQ marker, EP-prefix
+    suffix produced by EPContextNodeChecker, etc.).
+    """
+    name = pattern_id.split("/")[-1]
+    return _TRAILING_PAREN_RE.sub("", name)
 
 
 _LEVEL_ICONS = [
@@ -673,7 +687,7 @@ def analyze(
 
         def on_node_result(pattern_runtime):
             """Callback invoked per-node during analysis."""
-            op = _display_name(pattern_runtime.pattern_id).removesuffix(QDQ_SUFFIX)
+            op = _display_name(pattern_runtime.pattern_id)
             level = pattern_runtime.result.classification.value
             op_counts = instance_counts.setdefault(op, {})
             op_counts[level] = op_counts.get(level, 0) + 1

--- a/tests/unit/analyze/core/test_node_checkers.py
+++ b/tests/unit/analyze/core/test_node_checkers.py
@@ -126,6 +126,51 @@ class TestEPContextNodeChecker:
         assert result.result.no_data is False
         assert "does not match ep_name" in result.result.reason
 
+    def test_pattern_id_suffixed_with_ep_label_from_partition_name(
+        self,
+        ep_context_checker,
+        sample_pattern_match,
+    ):
+        """pattern_id is suffixed with an EP label derived from
+        partition_name so multi-EP analysis reports stay disambiguated."""
+        base_id = sample_pattern_match.pattern.pattern_id
+
+        # Canonical ORT format: extract the part before "ExecutionProvider_".
+        node = helper.make_node("EPContext", [], [], partition_name="QNNExecutionProvider_0")
+        result = ep_context_checker.check(
+            node=node,
+            op_domain=ONNXDomain.COM_MICROSOFT,
+            opset_version=1,
+            pattern_match=sample_pattern_match,
+            alternatives=[],
+            ep_name="QNNExecutionProvider",
+        )
+        assert result.pattern_id == f"{base_id} (QNN)"
+
+        # Missing partition_name -> "UNKNOWN_EP".
+        node_missing = helper.make_node("EPContext", [], [])
+        result_missing = ep_context_checker.check(
+            node=node_missing,
+            op_domain=ONNXDomain.COM_MICROSOFT,
+            opset_version=1,
+            pattern_match=sample_pattern_match,
+            alternatives=[],
+            ep_name="DmlExecutionProvider",
+        )
+        assert result_missing.pattern_id == f"{base_id} (UNKNOWN_EP)"
+
+        # Non-canonical partition_name -> used directly.
+        node_short = helper.make_node("EPContext", [], [], partition_name="DML_0")
+        result_short = ep_context_checker.check(
+            node=node_short,
+            op_domain=ONNXDomain.COM_MICROSOFT,
+            opset_version=1,
+            pattern_match=sample_pattern_match,
+            alternatives=[],
+            ep_name="DML",
+        )
+        assert result_short.pattern_id == f"{base_id} (DML_0)"
+
     def test_check_with_alternatives(self, ep_context_checker, sample_pattern_match):
         """Test check preserves alternatives in result."""
         node = helper.make_node("EPContext", [], [], partition_name="DML_test")

--- a/tests/unit/analyze/test_static_analyzer_cli.py
+++ b/tests/unit/analyze/test_static_analyzer_cli.py
@@ -806,19 +806,20 @@ class TestQDQNodeDisplayMapping:
     """
 
     def test_qdq_pattern_id_maps_to_base_op_for_table_key(self) -> None:
-        """_display_name + removesuffix(QDQ_SUFFIX) maps QDQ pattern IDs to base
+        """_display_name maps QDQ-suffixed and EP-suffixed pattern IDs to base
         op types so instance_counts keys match all_op_counts keys."""
-        from winml.modelkit.analyze import QDQ_SUFFIX
         from winml.modelkit.commands.analyze import _display_name
 
-        assert _display_name("OP/ai.onnx/Conv (QDQ)").removesuffix(QDQ_SUFFIX) == "Conv"
-        assert _display_name("OP/ai.onnx/Add (QDQ)").removesuffix(QDQ_SUFFIX) == "Add"
-        assert _display_name("OP/ai.onnx/Pad (QDQ)").removesuffix(QDQ_SUFFIX) == "Pad"
-        assert (
-            _display_name("OP/ai.onnx/DequantizeLinear").removesuffix(QDQ_SUFFIX)
-            == "DequantizeLinear"
-        )
-        assert _display_name("OP/ai.onnx/Reshape").removesuffix(QDQ_SUFFIX) == "Reshape"
+        # QDQ suffix
+        assert _display_name("OP/ai.onnx/Conv (QDQ)") == "Conv"
+        assert _display_name("OP/ai.onnx/Add (QDQ)") == "Add"
+        assert _display_name("OP/ai.onnx/Pad (QDQ)") == "Pad"
+        # No suffix
+        assert _display_name("OP/ai.onnx/DequantizeLinear") == "DequantizeLinear"
+        assert _display_name("OP/ai.onnx/Reshape") == "Reshape"
+        # EP-prefix suffix from EPContextNodeChecker
+        assert _display_name("OP/com.microsoft/EPContext (QNN)") == "EPContext"
+        assert _display_name("OP/com.microsoft/EPContext (Dml)") == "EPContext"
 
     @patch("winml.modelkit.commands.analyze.Live")
     @patch("winml.modelkit.commands.analyze.Console")


### PR DESCRIPTION
## Summary

Two related changes around how `winml analyze` reports per-EP results from `EPContext` nodes.

### 1. EPContextNodeChecker: suffix pattern_id with an EP label derived from `partition_name`

Multi-EP analysis runs the same EPContext pattern under multiple providers (QNN, DML, OpenVINO, ...), so the report needs the pattern_id rows to stay disambiguated. The checker now emits `pattern_id` suffixed with the EP label derived from the node's `partition_name`:

- `partition_name = None` → label is `"UNKNOWN_EP"` (attribute missing — surfaced explicitly instead of silently producing an empty label).
- Canonical ORT format `"<X>ExecutionProvider_..."` → label is `<X>` (e.g. `"QNNExecutionProvider_0"` → `"QNN"`). See [graph_partitioner.cc#L378](https://github.com/microsoft/onnxruntime/blob/7e1d818ba7923c1e44187284a6ca77bbe13aa1eb/onnxruntime/core/framework/graph_partitioner.cc#L378) for the source format.
- Anything else → `partition_name` used directly as the label.

Helper: `EPContextNodeChecker._ep_label(partition_name)`. The existing partition-name vs `ep_name` match check is unchanged.

### 2. `_display_name` in `commands/analyze.py`: strip any trailing ` (xxx)`

To keep the live table grouping by base op type, `_display_name` now strips any trailing ` (...)` annotation via a precompiled regex. This handles QDQ markers (` (QDQ)`), the new EP-prefix suffix from change 1, and any future ` (...)` decoration uniformly.

Consequences:
- `commands/analyze.py` no longer needs to call `.removesuffix(QDQ_SUFFIX)` after `_display_name`.
- `QDQ_SUFFIX` is no longer re-exported from `winml.modelkit.analyze` (it stays an implementation detail inside `core/runtime_checker_query.py` where it's actually used).

### Tests

- `test_node_checkers.py::test_pattern_id_suffixed_with_ep_label_from_partition_name` covers all three branches (`(QNN)`, `(UNKNOWN_EP)`, `(DML_0)`).
- `test_static_analyzer_cli.py::test_qdq_pattern_id_maps_to_base_op_for_table_key` now asserts `_display_name` standalone (no separate `removesuffix` step) and adds EP-suffix coverage.
- Full analyze suite (1378 tests) passes locally.