### PR TITLE
rename: winml-modelkit -> winml-cli

### DIFF
--- a/.pipelines/modelkit-release-github.yml
+++ b/.pipelines/modelkit-release-github.yml
@@ -98,9 +98,9 @@ extends:
               $wheel = Get-ChildItem "$(Build.SourcesDirectory)/release_assets/*.whl" | Select-Object -First 1
               if (-not $wheel) { throw "no wheel found in staged assets" }
               # Wheel filename is <normalized_name>-<version>-<python tag>-<abi tag>-<platform tag>.whl
-              # PEP 503 normalizes "winml-modelkit" -> "winml_modelkit" in filenames.
-              if ($wheel.Name -notmatch '^winml_modelkit-([^-]+)-') {
-                  throw "wheel filename '$($wheel.Name)' does not match expected pattern 'winml_modelkit-<version>-...'"
+              # PEP 503 normalizes "winml-cli" -> "winml_cli" in filenames.
+              if ($wheel.Name -notmatch '^winml_cli-([^-]+)-') {
+                  throw "wheel filename '$($wheel.Name)' does not match expected pattern 'winml_cli-<version>-...'"
               }
               $version = $matches[1]
               $tag = "v$version"
@@ -113,7 +113,7 @@ extends:
           displayName: 'Create GitHub Release'
           inputs:
             gitHubConnection: 'ModelKit'
-            repositoryName: 'microsoft/WinML-ModelKit'
+            repositoryName: 'microsoft/winml-cli'
             action: create
             target: '$(Build.SourceVersion)'
             tagSource: userSpecifiedTag

--- a/.pipelines/modelkit-release-github.yml
+++ b/.pipelines/modelkit-release-github.yml
@@ -118,7 +118,7 @@ extends:
             target: '$(Build.SourceVersion)'
             tagSource: userSpecifiedTag
             tag: '$(ReleaseTag)'
-            title: 'ModelKit $(ReleaseTag)'
+            title: 'WinML CLI $(ReleaseTag)'
             assets: |
               $(Build.SourcesDirectory)/release_assets/*.whl
               $(Build.SourcesDirectory)/release_assets/rules.zip

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ We're always looking for your help to improve the product (bug fixes, new featur
 ## Contribute a code change
 
 * Start by reading the project [README](./README.md) to understand the scope and goals of WinML CLI.
-* If your change is non-trivial or introduces new public facing APIs, please use the [feature request issue template](https://github.com/microsoft/WinML-ModelKit/issues/new) to discuss it with the team first.
+* If your change is non-trivial or introduces new public facing APIs, please use the [feature request issue template](https://github.com/microsoft/winml-cli/issues/new) to discuss it with the team first.
 * For all other changes, you can directly create a pull request (PR) and we'll be happy to take a look.
 * Make sure your PR adheres to the coding conventions and standards below.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WinML CLI
 
-[![ModelKit CI](https://github.com/microsoft/WinML-ModelKit/actions/workflows/modelkit-ci.yml/badge.svg)](https://github.com/microsoft/WinML-ModelKit/actions/workflows/modelkit-ci.yml)
+[![ModelKit CI](https://github.com/microsoft/winml-cli/actions/workflows/modelkit-ci.yml/badge.svg)](https://github.com/microsoft/winml-cli/actions/workflows/modelkit-ci.yml)
 ![Status](https://img.shields.io/badge/status-early%20access-blue)
 ![Python](https://img.shields.io/badge/python-3.10%2B-blue?logo=python&logoColor=white)
 ![License](https://img.shields.io/badge/license-MIT-green)
@@ -99,7 +99,7 @@ source .venv/Scripts/activate
 **2. Install from wheel**
 
 ```bash
-uv pip install winml_modelkit-<version>-py3-none-any.whl
+uv pip install winml_cli-<version>-py3-none-any.whl
 ```
 
 **3. Verify your environment**
@@ -459,7 +459,7 @@ locations.
 
 We welcome contributions! Please see the [contribution guidelines](CONTRIBUTING.md).
 
-For feature requests or bug reports, please file a [GitHub Issue](https://github.com/microsoft/WinML-ModelKit/issues).
+For feature requests or bug reports, please file a [GitHub Issue](https://github.com/microsoft/winml-cli/issues).
 
 ---
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -2,7 +2,7 @@
 
 ## How to file issues and get help
 
-This project uses [GitHub Issues](https://github.com/microsoft/WinML-ModelKit/issues) to track bugs and feature requests. Please search the existing
+This project uses [GitHub Issues](https://github.com/microsoft/winml-cli/issues) to track bugs and feature requests. Please search the existing
 issues before filing new issues to avoid duplicates. For new issues, file your bug or
 feature request as a new Issue.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ build-backend = "setuptools.build_meta"
 requires = [ "setuptools>=61", "wheel" ]
 
 [project]
-name = "winml-modelkit"
+name = "winml-cli"
 version = "0.0.2"
 description = "Accelerate Model Deployment on WinML"
 readme = "README.md"
@@ -90,10 +90,10 @@ optional-dependencies.openvino = [ "openvino>=2023" ]
 optional-dependencies.qnn = [
   "onnxruntime-qnn>=1.24.1; python_version>='3.11'",
 ]
-urls."Bug Tracker" = "https://github.com/microsoft/WinML-ModelKit/issues"
-urls.Documentation = "https://github.com/microsoft/WinML-ModelKit/blob/main/README.md"
-urls.Homepage = "https://github.com/microsoft/WinML-ModelKit"
-urls.Repository = "https://github.com/microsoft/WinML-ModelKit.git"
+urls."Bug Tracker" = "https://github.com/microsoft/winml-cli/issues"
+urls.Documentation = "https://github.com/microsoft/winml-cli/blob/main/README.md"
+urls.Homepage = "https://github.com/microsoft/winml-cli"
+urls.Repository = "https://github.com/microsoft/winml-cli.git"
 # =============================================================================
 # SETUPTOOLS - Package Configuration (Flat Layout with Namespace Prefix)
 # =============================================================================

--- a/scripts/download_rules.py
+++ b/scripts/download_rules.py
@@ -8,7 +8,7 @@ For Microsoft internal use only. Requires gh CLI authenticated with an account
 that has access to the gim-home org.
 
 External contributors should instead download rule parquet files from the latest
-WinML-ModelKit GitHub release; see
+winml-cli GitHub release; see
 src/winml/modelkit/analyze/rules/runtime_check_rules/README.md.
 
 This script does not download release assets. It pulls parquet files directly

--- a/src/winml/modelkit/__init__.py
+++ b/src/winml/modelkit/__init__.py
@@ -46,7 +46,7 @@ from . import _warnings  # Configure warning filters before importing subpackage
 
 
 try:
-    __version__ = version("winml-modelkit")
+    __version__ = version("winml-cli")
 except PackageNotFoundError:
     __version__ = "0.0.1.dev0"
 

--- a/src/winml/modelkit/analyze/rules/runtime_check_rules/README.md
+++ b/src/winml/modelkit/analyze/rules/runtime_check_rules/README.md
@@ -10,10 +10,10 @@ also be fetched from release assets or `ModelKitArtifacts` for source builds.
 ### Option 1: Download from the latest GitHub release (for source builds)
 
 If you are building from source code (for example, cloning this repo), download
-the `rules.zip` asset from the latest WinML-ModelKit release.
+the `rules.zip` asset from the latest winml-cli release.
 
 ```bash
-gh release download --repo microsoft/WinML-ModelKit --pattern 'rules.zip' --dir .
+gh release download --repo microsoft/winml-cli --pattern 'rules.zip' --dir .
 ```
 
 `gh release download` defaults to the latest release. Use `--tag <version>`
@@ -43,7 +43,7 @@ The script sparse-checkouts `gim-home/ModelKitArtifacts/rules` and copies all `*
 files here (preserving subdirectories).
 
 This script downloads from the internal `ModelKitArtifacts` repo, not from
-WinML-ModelKit release assets.
+winml-cli release assets.
 
 Use `--force` to re-download all files even if they already exist locally.
 

--- a/src/winml/modelkit/commands/analyze.py
+++ b/src/winml/modelkit/commands/analyze.py
@@ -534,9 +534,7 @@ def analyze(
         if not parquet_files:
             searched = ", ".join(str(p) for p in search_dirs) if search_dirs else "(none)"
             logger.error("No runtime rule parquet files were found.")
-            logger.error(
-                "Please reinstall winml-modelkit, or manually download rule parquet files."
-            )
+            logger.error("Please reinstall winml-cli, or manually download rule parquet files.")
             logger.error("Searched directories: %s", searched)
             sys.exit(2)
 

--- a/tests/README_PIPE_TESTS.md
+++ b/tests/README_PIPE_TESTS.md
@@ -227,7 +227,7 @@ def test_end_to_end_workflow(sample_model):
 
 ### Run all pipe tests
 ```bash
-cd D:\BYOM\WinML-ModelKit
+cd D:\BYOM\winml-cli
 uv run pytest tests/test_pipe_*.py tests/test_optimizer.py -v
 ```
 


### PR DESCRIPTION
## Summary

- Rename PyPI distribution from `winml-modelkit` to `winml-cli` so `pip install winml-cli` resolves the package
- Update GitHub repo URL references from `microsoft/WinML-ModelKit` to `microsoft/winml-cli` to match the renamed repository
- Update the wheel filename validation in `.pipelines/modelkit-release-github.yml` to check the new normalized name `winml_cli-`

The Python module path `winml.modelkit` is unchanged — only the PyPI distribution and repo URLs were renamed.

## Notes

- Local verification: `uv pip show winml-cli` → `Name: winml-cli, Version: 0.0.2`; `winml.modelkit.__version__` resolves to `0.0.2` via the new `version("winml-cli")` lookup.
- The PyPI release pipeline (`.pipelines/modelkit-release-pypi.yml`) still lives on the `zhiwang/release-pypi-pipeline` branch and will receive the same wheel-filename-pattern update when that branch is rebased.
- Test fixtures under `tests/integration/analyze/runtime_checker/*_results*.json` still contain the old name string inside `sys_info.pipPackages`, but that field is in the `ignored_keys` list in `tests/integration/analyze/runtime_checker/test_helper.py`, so comparisons still pass. Those fixtures will refresh naturally next time someone re-records them.