### PR TITLE
ci(release): publish rules zip with version-qualified filename

### DIFF
--- a/.pipelines/modelkit-release-github.yml
+++ b/.pipelines/modelkit-release-github.yml
@@ -49,7 +49,7 @@ extends:
             targetPath: '$(Build.SourcesDirectory)/official_build'
 
         - task: PowerShell@2
-          displayName: 'Stage wheels + rules.zip'
+          displayName: 'Stage wheels + rules zip'
           inputs:
             targetType: 'inline'
             script: |
@@ -63,6 +63,15 @@ extends:
               }
               $wheels | Copy-Item -Destination $dst -Force
 
+              # Wheel filename is <normalized_name>-<version>-<python tag>-<abi tag>-<platform tag>.whl
+              # PEP 503 normalizes "winml-cli" -> "winml_cli" in filenames.
+              $firstWheel = $wheels | Select-Object -First 1
+              if ($firstWheel.Name -notmatch '^winml_cli-([^-]+)-') {
+                  throw "wheel filename '$($firstWheel.Name)' does not match expected pattern 'winml_cli-<version>-...'"
+              }
+              $version = $matches[1]
+              Write-Host "Version: $version"
+
               $rulesZipCandidates = Get-ChildItem $src -Filter "rules.zip" -Recurse
               if (-not $rulesZipCandidates) {
                 throw "No rules.zip found under $src. Release requires the official build to publish rules.zip."
@@ -71,10 +80,11 @@ extends:
                 Write-Warning "Found $($rulesZipCandidates.Count) rules.zip files; using the first one"
               }
               $selectedRulesZip = $rulesZipCandidates | Select-Object -First 1
-              Copy-Item $selectedRulesZip.FullName -Destination (Join-Path $dst "rules.zip") -Force
+              $rulesZipName = "rules-v$version.zip"
+              Copy-Item $selectedRulesZip.FullName -Destination (Join-Path $dst $rulesZipName) -Force
 
               Write-Host "Found $($wheels.Count) wheel(s)"
-              Write-Host "Using build-produced rules.zip from $($selectedRulesZip.FullName)"
+              Write-Host "Using build-produced rules.zip from $($selectedRulesZip.FullName) -> $rulesZipName"
               Write-Host "Staged GitHub release assets:"
               Get-ChildItem $dst | ForEach-Object { Write-Host (" - {0} ({1:N0} bytes)" -f $_.Name, $_.Length) }
 
@@ -121,7 +131,7 @@ extends:
             title: 'WinML CLI $(ReleaseTag)'
             assets: |
               $(Build.SourcesDirectory)/release_assets/*.whl
-              $(Build.SourcesDirectory)/release_assets/rules.zip
+              $(Build.SourcesDirectory)/release_assets/rules-v$(ReleaseVersion).zip
             isDraft: false
             isPreRelease: true
             addChangeLog: false

--- a/src/winml/modelkit/analyze/rules/runtime_check_rules/README.md
+++ b/src/winml/modelkit/analyze/rules/runtime_check_rules/README.md
@@ -7,26 +7,27 @@ also be fetched from release assets or `ModelKitArtifacts` for source builds.
 
 ## Setup
 
-### Option 1: Download from the latest GitHub release (for source builds)
+### Option 1: Download from a GitHub release (for source builds)
 
 If you are building from source code (for example, cloning this repo), download
-the `rules.zip` asset from the latest winml-cli release.
+the `rules-v<version>.zip` asset from a winml-cli release. Replace `<version>`
+with the release version you want (e.g. `0.0.3`) and `<tag>` with the matching
+release tag (e.g. `v0.0.3`); all current releases are pre-releases, so an
+explicit tag is required (`gh release download` without a tag skips
+pre-releases).
 
 ```bash
-gh release download --repo microsoft/winml-cli --pattern 'rules.zip' --dir .
+gh release download <tag> --repo microsoft/winml-cli --pattern 'rules-v<version>.zip' --dir .
 ```
 
-`gh release download` defaults to the latest release. Use `--tag <version>`
-to pin a specific release if you need a reproducible snapshot.
-
-Then extract `rules.zip` into this directory:
+Then extract the archive into this directory:
 
 ```powershell
-Expand-Archive -Path .\rules.zip -DestinationPath src\winml\modelkit\analyze\rules\runtime_check_rules -Force
+Expand-Archive -Path .\rules-v<version>.zip -DestinationPath src\winml\modelkit\analyze\rules\runtime_check_rules -Force
 ```
 
 ```bash
-unzip -o rules.zip -d src/winml/modelkit/analyze/rules/runtime_check_rules
+unzip -o rules-v<version>.zip -d src/winml/modelkit/analyze/rules/runtime_check_rules
 ```
 
 The zip preserves file paths relative to `runtime_check_rules/`.


### PR DESCRIPTION
## Summary
- Release pipeline now publishes the analyzer rules archive as `rules-v<version>.zip` (matching the wheel's version-qualified naming) instead of `rules.zip`. Version is parsed from the staged wheel filename inside the Prepare job's stage step.
- Updated the `runtime_check_rules` README to use `<tag>` / `<version>` placeholders in the `gh release download` and extract commands, and to call out that all current releases are pre-releases (so an explicit tag is required — `gh release download` without `--tag` skips pre-releases).

No prior release has published `rules.zip` as an asset (v0.0.1 and v0.0.2 did not include it), so there is no backward-compatibility concern with the rename.