### PR TITLE
fix(analyze): create parent dirs for -o and --optim-config before writing

### DIFF
--- a/src/winml/modelkit/commands/analyze.py
+++ b/src/winml/modelkit/commands/analyze.py
@@ -808,6 +808,7 @@ def analyze(
         # Save JSON if requested
         if output:
             try:
+                output.parent.mkdir(parents=True, exist_ok=True)
                 output.write_text(result.to_json(), encoding="utf-8")
                 logger.info("JSON results saved to: %s", output)
             except OSError as e:
@@ -822,6 +823,7 @@ def analyze(
 
             try:
                 config = result.get_optimization_config(ep=ep_normalized)
+                optim_config.parent.mkdir(parents=True, exist_ok=True)
                 optim_config.write_text(json.dumps(config.to_dict(), indent=2), encoding="utf-8")
                 logger.info("Optimization config saved to: %s", optim_config)
             except OSError as e:

--- a/tests/unit/analyze/test_static_analyzer_cli.py
+++ b/tests/unit/analyze/test_static_analyzer_cli.py
@@ -550,6 +550,120 @@ class TestAnalyzeCommandOutput:
         assert result.exit_code == 2
         assert not output_file.exists()
 
+    @patch("winml.modelkit.analyze.ONNXStaticAnalyzer")
+    def test_output_creates_parent_dirs(
+        self,
+        mock_analyzer_class: MagicMock,
+        runner: CliRunner,
+        tmp_path: Path,
+        mock_analyzer_result: Mock,
+    ) -> None:
+        """Test that --output creates missing parent directories."""
+        model_file = tmp_path / "test.onnx"
+        model_file.write_bytes(b"dummy")
+        output_file = tmp_path / "nested" / "dir" / "results.json"
+
+        mock_instance = Mock()
+        mock_instance.analyze.return_value = mock_analyzer_result
+        mock_analyzer_class.return_value = mock_instance
+
+        assert not output_file.parent.exists()
+
+        result = runner.invoke(
+            analyze,
+            [
+                "--model",
+                str(model_file),
+                "--ep",
+                "QNNExecutionProvider",
+                "--device",
+                "NPU",
+                "--output",
+                str(output_file),
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert output_file.exists()
+
+    @patch("winml.modelkit.analyze.ONNXStaticAnalyzer")
+    def test_optim_config_to_file(
+        self,
+        mock_analyzer_class: MagicMock,
+        runner: CliRunner,
+        tmp_path: Path,
+        mock_analyzer_result: Mock,
+    ) -> None:
+        """Test that --optim-config saves optimization config to file."""
+        model_file = tmp_path / "test.onnx"
+        model_file.write_bytes(b"dummy")
+        config_file = tmp_path / "optim.json"
+
+        mock_analyzer_result.get_optimization_config.return_value.to_dict.return_value = {
+            "ep": "QNNExecutionProvider"
+        }
+        mock_instance = Mock()
+        mock_instance.analyze.return_value = mock_analyzer_result
+        mock_analyzer_class.return_value = mock_instance
+
+        result = runner.invoke(
+            analyze,
+            [
+                "--model",
+                str(model_file),
+                "--ep",
+                "QNNExecutionProvider",
+                "--device",
+                "NPU",
+                "--optim-config",
+                str(config_file),
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert config_file.exists()
+        content = json.loads(config_file.read_text())
+        assert "ep" in content
+
+    @patch("winml.modelkit.analyze.ONNXStaticAnalyzer")
+    def test_optim_config_creates_parent_dirs(
+        self,
+        mock_analyzer_class: MagicMock,
+        runner: CliRunner,
+        tmp_path: Path,
+        mock_analyzer_result: Mock,
+    ) -> None:
+        """Test that --optim-config creates missing parent directories."""
+        model_file = tmp_path / "test.onnx"
+        model_file.write_bytes(b"dummy")
+        config_file = tmp_path / "nested" / "dir" / "optim.json"
+
+        mock_analyzer_result.get_optimization_config.return_value.to_dict.return_value = {
+            "ep": "QNNExecutionProvider"
+        }
+        mock_instance = Mock()
+        mock_instance.analyze.return_value = mock_analyzer_result
+        mock_analyzer_class.return_value = mock_instance
+
+        assert not config_file.parent.exists()
+
+        result = runner.invoke(
+            analyze,
+            [
+                "--model",
+                str(model_file),
+                "--ep",
+                "QNNExecutionProvider",
+                "--device",
+                "NPU",
+                "--optim-config",
+                str(config_file),
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert config_file.exists()
+
 
 class TestAnalyzeCommandIntegration:
     """Integration tests for analyze command."""


### PR DESCRIPTION
## Summary

- Adds `output.parent.mkdir(parents=True, exist_ok=True)` before the `-o`/`--output` write in `analyze.py`
- Adds `optim_config.parent.mkdir(parents=True, exist_ok=True)` before the `--optim-config` write in `analyze.py`

## Context

`winml analyze --optim-config convnext/optim_config.json` raised `[Errno 2] No such file or directory` when the parent directory (`convnext/`) didn't exist. All other commands (`export`, `perf`, `quantize`, `config`) already call `parent.mkdir(parents=True, exist_ok=True)` before writing output — `analyze` was the only exception.

Closes #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)