### PR TITLE
Register BART for table-question-answering task (TAPEX)

### DIFF
--- a/src/winml/modelkit/models/hf/bart.py
+++ b/src/winml/modelkit/models/hf/bart.py
@@ -481,13 +481,21 @@ BART_CONFIG = WinMLBuildConfig(
 
 
 @register_composite_model("bart", "summarization")
+@register_composite_model("bart", "table-question-answering")
 class WinMLBartModel(WinMLEncoderDecoderModel):
-    """BART encoder-decoder model for summarization.
+    """BART encoder-decoder model for summarization and table-question-answering.
 
     Declares BART sub-component tasks and generation-config defaults.
     All encoder-decoder forward/cache logic lives in
     ``WinMLEncoderDecoderModel``.  Uses ``WinMLSlidingWindowCache`` — see
     module docstring for the rationale.
+
+    The ``table-question-answering`` registration covers TAPEX-style models
+    (e.g., ``microsoft/tapex-base-finetuned-wikisql``).  TAPEX is plain BART
+    fine-tuned for table QA — the table+query are serialized to text by the
+    tokenizer (``TapexTokenizer``), then the encoder-decoder generates the
+    answer.  The export and inference paths are identical to summarization
+    (encoder=feature-extraction, decoder=text2text-generation sub-tasks).
     """
 
     _SUB_MODEL_CONFIG: ClassVar[dict[str, str]] = {


### PR DESCRIPTION
## Summary

Adds `@register_composite_model("bart", "table-question-answering")` to `WinMLBartModel` so TAPEX-style models (plain BART fine-tuned for table QA via `TapexTokenizer`) work end-to-end through `winml config`, `winml build`, and `winml perf`. Export and inference paths reuse the existing summarization implementation unchanged (encoder=feature-extraction, decoder=text2text-generation sub-tasks).

## Goal: enable e2e perf for these models in `scripts/e2e_eval/testsets/models_all.json`

The `(task=table-question-answering, model_type=bart)` registry entries this PR unblocks:

| # | Model ID | Priority |
|---|---|---|
| 1 | microsoft/tapex-base | P2 |
| 2 | microsoft/tapex-base-finetuned-wikisql | P2 |
| 3 | microsoft/tapex-base-finetuned-wtq | P2 |
| 4 | microsoft/tapex-large | P2 |
| 5 | microsoft/tapex-large-finetuned-tabfact | P2 |
| 6 | microsoft/tapex-large-finetuned-wikisql | P2 |
| 7 | microsoft/tapex-large-finetuned-wtq | P2 |
| 8 | microsoft/tapex-large-sql-execution | P2 |

(The remaining two `table-question-answering` entries in the registry — `sudipto-ducs/InLegalLLaMA-Instruct` (llama) and `vahrush/NTB_probe_sec` (t5) — are not covered by this PR; they need separate model_type registrations.)

## Verified

`python scripts/e2e_eval/run_eval.py --hf-model <id> --task table-question-answering --device cpu` runs end-to-end (config → build encoder+decoder → perf both components):

| Model | Result | Elapsed |
|---|---|---|
| microsoft/tapex-base-finetuned-wikisql | PASS | 4.1s |
| microsoft/tapex-base | PASS | 4.5s |

Inference parity with the PyTorch reference was also confirmed on `microsoft/tapex-base-finetuned-wikisql` (3 WikiSQL queries, bit-identical decoded answers between WinML ONNX and HF `BartForConditionalGeneration.generate`).