### PR TITLE
fix(export): restore monolithic BlipCaptioningIOConfig

### DIFF
--- a/src/winml/modelkit/models/hf/__init__.py
+++ b/src/winml/modelkit/models/hf/__init__.py
@@ -35,6 +35,7 @@ from .bart import BartEncoderIOConfig as _BartEncoderIOConfig  # triggers regist
 from .bert import BERT_CONFIG
 from .blip import BLIP_CONFIG
 from .blip import MODEL_CLASS_MAPPING as _BLIP_CLASS_MAPPING
+from .blip import BlipCaptioningIOConfig as _BlipCaptioningIOConfig  # triggers registration
 from .blip import BlipDecoderIOConfig as _BlipDecoderIOConfig  # triggers registration
 from .blip import BlipVisionEncoderIOConfig as _BlipVisionEncoderIOConfig  # triggers registration
 from .clip import CLIP_CONFIG

--- a/src/winml/modelkit/models/hf/blip.py
+++ b/src/winml/modelkit/models/hf/blip.py
@@ -46,7 +46,7 @@ from transformers import BlipForConditionalGeneration
 from transformers.cache_utils import DynamicCache, EncoderDecoderCache
 
 from ...config import WinMLBuildConfig
-from ...export import register_onnx_overwrite
+from ...export import MaxLengthTextInputGenerator, register_onnx_overwrite
 from ...optim import WinMLOptimizationConfig
 from ..winml.composite_model import register_composite_model
 from ..winml.encoder_decoder import EncoderDecoderInputGenerator, WinMLEncoderDecoderModel
@@ -69,6 +69,56 @@ BLIP_CONFIG = WinMLBuildConfig(
         matmul_add_fusion=True,
     ),
 )
+
+
+# =============================================================================
+# Monolithic ONNX Export Config (single-file image-to-text export)
+# =============================================================================
+#
+# TODO: remove once ``winml export`` supports composite models. This monolithic
+# config is a temporary fallback so ``winml export`` can produce a single ONNX
+# for BLIP at ``image-to-text`` / ``image-text-to-text``. The split encoder +
+# decoder configs above are the production path used by the composite pipeline
+# (``winml config`` / ``winml build``); when ``winml export`` learns to emit
+# multiple ONNX files for composite models, delete this class. See issue #636.
+
+
+@register_onnx_overwrite("blip", "image-to-text", library_name="transformers")
+@register_onnx_overwrite("blip", "image-text-to-text", library_name="transformers")
+class BlipCaptioningIOConfig(OnnxConfig):
+    """Monolithic ONNX config for BLIP captioning — single-graph fallback.
+
+    Traces ``BlipForConditionalGeneration.forward`` with pixel_values +
+    decoder input_ids/attention_mask -> logits. Only used by ``winml export``
+    (single-file path); the composite encoder + decoder split below is the
+    production export route used by ``winml config`` / ``winml build``.
+    """
+
+    NORMALIZED_CONFIG_CLASS = NormalizedConfig.with_args(
+        num_channels="vision_config.num_channels",
+        image_size="vision_config.image_size",
+        vocab_size="text_config.vocab_size",
+        sequence_length="text_config.max_position_embeddings",
+        allow_new=True,
+    )
+    DUMMY_INPUT_GENERATOR_CLASSES = (
+        DummyVisionInputGenerator,
+        MaxLengthTextInputGenerator,
+    )
+
+    @property
+    def inputs(self) -> dict[str, dict[int, str]]:
+        return {
+            "pixel_values": {0: "batch_size", 1: "num_channels", 2: "height", 3: "width"},
+            "input_ids": {0: "batch_size", 1: "sequence_length"},
+            "attention_mask": {0: "batch_size", 1: "sequence_length"},
+        }
+
+    @property
+    def outputs(self) -> dict[str, dict[int, str]]:
+        return {
+            "logits": {0: "batch_size", 1: "sequence_length"},
+        }
 
 
 # =============================================================================
@@ -281,8 +331,8 @@ class WinMLBlipImageToText(WinMLEncoderDecoderModel):
                 "pad_token_id": tc.pad_token_id,
             }
             kw.setdefault("max_new_tokens", self._max_dec - 1)
-            kw.setdefault("num_beams", 1)        # static batch=1 ONNX → no beams
-            kw.setdefault("do_sample", False)    # deterministic greedy
+            kw.setdefault("num_beams", 1)  # static batch=1 ONNX → no beams
+            kw.setdefault("do_sample", False)  # deterministic greedy
             self._generation_config = GenerationConfig(**kw)
         return self._generation_config
 


### PR DESCRIPTION
## Summary

- Re-register a single-graph `BlipCaptioningIOConfig` for `("blip", "image-to-text")` and `("blip", "image-text-to-text")` so `winml export` can produce a single ONNX for `BlipForConditionalGeneration` again.
- The split encoder + decoder configs introduced by #408 are intentional for the composite pipeline (`winml config` / `winml build`) but left `winml export` with no OnnxConfig for the auto-detected task; `resolve_export_config` raised `ONNXConfigNotFoundError`, `commands/export.py:285` swallowed it at DEBUG level, and the export later died on the cryptic `input_tensors must be populated to generate dummy inputs`.
- The new class is tagged with a `TODO` to delete once `winml export` learns to emit multiple ONNX files for composite models. Composite production path (`BlipVisionEncoderIOConfig`, `BlipDecoderIOConfig`, `WinMLBlipImageToText`) is unchanged.

Fixes https://github.com/microsoft/winml-cli/issues/636

## Verification

**1. `winml export` single-file path works** for the model in the issue:

```
$ winml export -m Salesforce/blip-image-captioning-base -o temp/blip-image-captioning-base.onnx --no-hierarchy
Auto-resolved input specs: ['pixel_values', 'input_ids', 'attention_mask']
Auto-resolved output specs: ['logits']
Detected task: image-text-to-text
Success! Model exported to: temp/blip-image-captioning-base.onnx
```

Inspected ONNX I/O:
- Inputs: `pixel_values [1,3,384,384]`, `input_ids [1,512]`, `attention_mask [1,512]`
- Output: `logits [1,512,30524]`
- 1325 nodes

**2. Composite pipeline still produces two sub-model ONNXs** (no regression):

```
$ python scripts/e2e_eval/run_eval.py --hf-model Salesforce/blip-image-captioning-base \
      --eval-type perf --device cpu --timeout 1200
[1/1] Salesforce/blip-image-captioning-base / image-to-text  (P0, Benchmark)
    building component: decoder
    building component: encoder
    perf: decoder
    perf: encoder
  [PASS] 5.2s
Perf pass rate: 1/1 (100.0%)
```

`~/.cache/winml/artifacts/Salesforce_blip-image-captioning-base/` confirms two distinct sub-models:

| Component | Cache prefix | Model file |
|---|---|---|
| Vision encoder (`image-feature-extraction`) | `imgfeat_88fbdc24...` | `imgfeat_*_model.onnx` (~344 MB) |
| Text decoder (`text2text-generation`) | `txt2txt_dc71a2a1...` | `txt2txt_*_model.onnx` (~645 MB) |