### PR TITLE
fix: HWMonitor uses session ep to align with session; _find_ep_device uses fixed order instead of ort.get_ep_devices

### DIFF
--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -409,11 +409,10 @@ class PerfBenchmark:
         from ..utils.constants import normalize_ep_name
 
         monitor_device = self._model.device or self.config.device or "auto"
-        ep_name = normalize_ep_name(self.config.ep) if self.config.ep else None
         hw_monitor = HWMonitor(
             poll_interval_ms=_HW_POLL_INTERVAL_MS,
             device=monitor_device,
-            ep_name=ep_name,
+            ep_name=session.ep_name,
         )
 
         # EP-specific proof-of-execution monitor.
@@ -663,7 +662,7 @@ def _perf_modules(
                         hw_ctx = HWMonitor(
                             poll_interval_ms=_HW_POLL_INTERVAL_MS,
                             device=resolved_device,
-                            ep_name=normalize_ep_name(ep) if ep else None,
+                            ep_name=session.ep_name,
                         )
 
                 if hw_ctx:
@@ -1025,7 +1024,7 @@ def _run_onnx_benchmark(
             hw_ctx = HWMonitor(
                 poll_interval_ms=_HW_POLL_INTERVAL_MS,
                 device=session.device or device,
-                ep_name=normalize_ep_name(config.ep) if config.ep else None,
+                ep_name=session.ep_name,
             )
         else:
             Console(stderr=True).print(

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -627,7 +627,7 @@ def _perf_modules(
             cfg.quant = None
             cfg.compile = None
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             try:
                 build_result = build_hf_model(
                     config=cfg,
@@ -647,6 +647,9 @@ def _perf_modules(
                 )
                 io_cfg = session.io_config
                 inputs = generate_random_inputs(io_cfg, batch_size=batch_size)
+
+                # Compile session early so session.device is resolved for display
+                session.compile()
 
                 total_iters = warmup + iterations
                 hw_ctx = None

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -406,8 +406,6 @@ class PerfBenchmark:
         # GPU when --device gpu is specified, NPU when --device npu, etc.
         # ep_name lets the monitor resolve the exact LUID via ORT's autoEP
         # metadata so we follow the adapter the session actually binds to.
-        from ..utils.constants import normalize_ep_name
-
         monitor_device = self._model.device or self.config.device or "auto"
         hw_monitor = HWMonitor(
             poll_interval_ms=_HW_POLL_INTERVAL_MS,
@@ -656,7 +654,6 @@ def _perf_modules(
 
                 if monitor:
                     from ..session.monitor.hw_monitor import HWMonitor
-                    from ..utils.constants import normalize_ep_name
 
                     if HWMonitor.is_available():
                         hw_ctx = HWMonitor(
@@ -1018,7 +1015,6 @@ def _run_onnx_benchmark(
     # Determine if hardware monitoring is available
     if config.monitor:
         from ..session.monitor.hw_monitor import HWMonitor
-        from ..utils.constants import normalize_ep_name
 
         if HWMonitor.is_available():
             hw_ctx = HWMonitor(

--- a/src/winml/modelkit/session/session.py
+++ b/src/winml/modelkit/session/session.py
@@ -487,7 +487,7 @@ class WinMLSession:
         Returns:
             The matching OrtEpDevice, or None if not found.
         """
-        from ..sysinfo.device import get_device_ep_map, get_ep_device_map
+        from ..sysinfo import get_device_ep_map, get_ep_device_map
         from ..utils.constants import DEVICE_TO_DEVICE_TYPE
 
         device_type = DEVICE_TO_DEVICE_TYPE.get(device.upper())

--- a/src/winml/modelkit/session/session.py
+++ b/src/winml/modelkit/session/session.py
@@ -202,11 +202,6 @@ class WinMLSession:
 
         target_device = self._device
 
-        # Resolve auto device
-        if target_device == "auto":
-            target_device = self._detect_best_device()
-            self._device = target_device  # Update instance device
-
         if self._is_verbose():
             logger.info("Compiling for device: %s", target_device)
 
@@ -466,19 +461,22 @@ class WinMLSession:
         """Find the first OrtEpDevice matching the given filters.
 
         Behavior:
-            - ``ep_name`` set, ``device == "auto"`` → first ep_device
-              matching ``ep_name`` (or None).
-            - ``ep_name`` unset, ``device == "auto"`` → ``None`` (no
+            - ``ep_name`` set, ``device == "auto"`` → aggregate ep_devices
+              matching ``ep_name`` and pick the first one whose device type
+              appears earliest in that EP's preferred device list
+              (``get_ep_device_map()``).
+            - ``ep_name`` unset, ``device`` is a concrete type → aggregate
+              ep_devices matching that device type and pick the first one
+              whose EP name appears earliest in that device's EP priority
+              list (``get_device_ep_map()``).
+            - Both set (and ``device != "auto"``) → ep_device must satisfy
+              both filters (or None).
+            - ``ep_name`` unset and ``device == "auto"`` → ``None`` (no
               effective filter — refuse to pick an arbitrary ep_device).
-            - ``ep_name`` unset, ``device`` is a concrete type → first
-              ep_device matching that device type (or None).
-            - Both set → ep_device must satisfy both (or None).
 
-        Note: Selection order is determined by the ORT EP registry, which is
-        not part of any documented contract. On systems where multiple EPs
-        match the same device type (e.g., QNN and DML both appear as GPU),
-        a device-only query returns the first one in registry order. Pass
-        ``ep_name`` to disambiguate.
+        Note: When the ORT EP registry order disagrees with the priority
+        maps, the priority maps win — selection is deterministic and
+        independent of registry order.
 
         Args:
             device: Device policy ("cpu", "gpu", "npu", "auto"). ``"auto"``
@@ -489,6 +487,7 @@ class WinMLSession:
         Returns:
             The matching OrtEpDevice, or None if not found.
         """
+        from ..sysinfo.device import get_device_ep_map, get_ep_device_map
         from ..utils.constants import DEVICE_TO_DEVICE_TYPE
 
         device_type = DEVICE_TO_DEVICE_TYPE.get(device.upper())
@@ -497,13 +496,40 @@ class WinMLSession:
         if not ep_name and device_type is None:
             return None
 
+        all_ep_devices = []
         for ep_dev in ort.get_ep_devices():
             if ep_name and ep_dev.ep_name != ep_name:
                 continue
             if device_type is not None and ep_dev.device.type != device_type:
                 continue
-            return ep_dev
-        return None
+            all_ep_devices.append(ep_dev)
+
+        if not all_ep_devices:
+            return None
+
+        # Both filters set: any aggregated entry already satisfies both.
+        if ep_name and device_type is not None:
+            return all_ep_devices[0]
+
+        # ep_name set, device == "auto": pick by EP's preferred device order.
+        if ep_name:
+            preferred_devices = get_ep_device_map().get(ep_name, "").split("/")
+            for d in preferred_devices:
+                wanted = DEVICE_TO_DEVICE_TYPE.get(d.upper())
+                if wanted is None:
+                    continue
+                for ep_dev in all_ep_devices:
+                    if ep_dev.device.type == wanted:
+                        return ep_dev
+            return all_ep_devices[0]
+
+        # ep_name unset, device != "auto": pick by device's EP priority list.
+        ep_priority = get_device_ep_map().get(device.lower(), [])
+        for preferred_ep in ep_priority:
+            for ep_dev in all_ep_devices:
+                if ep_dev.ep_name == preferred_ep:
+                    return ep_dev
+        return all_ep_devices[0]
 
     def _validate_inputs(self, inputs: dict[str, Any]) -> None:
         """Validate inputs against model expectations.
@@ -562,19 +588,6 @@ class WinMLSession:
             ort_inputs[name] = arr
 
         return ort_inputs
-
-    def _detect_best_device(self) -> str:
-        """Auto-detect best available device.
-
-        Returns "auto" to let ORT select the best provider based on PREFER_NPU policy.
-        This avoids using any explicit EP provider names.
-        """
-        # With PREFER_NPU policy, ORT will automatically select:
-        # 1. NPU (QNN) if available
-        # 2. GPU (CUDA/DML) if no NPU
-        # 3. CPU as fallback
-        logger.info("Auto-detecting device (using PREFER_NPU policy)")
-        return "auto"
 
     def _get_compile_suggestion(self, device: str, error: Exception) -> str:
         """Get compile error suggestion based on device policy."""

--- a/src/winml/modelkit/sysinfo/__init__.py
+++ b/src/winml/modelkit/sysinfo/__init__.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-from .device import get_ep_device_map, resolve_device, resolve_eps
+from .device import get_device_ep_map, get_ep_device_map, resolve_device, resolve_eps
 from .hardware import CPU, GPU, NPU
 from .software import OS
 from .sysinfo import SysInfo
@@ -14,6 +14,7 @@ __all__ = [
     "NPU",
     "OS",
     "SysInfo",
+    "get_device_ep_map",
     "get_ep_device_map",
     "resolve_device",
     "resolve_eps",

--- a/src/winml/modelkit/sysinfo/device.py
+++ b/src/winml/modelkit/sysinfo/device.py
@@ -82,6 +82,20 @@ def get_ep_device_map() -> dict[EPName, str]:
     return dict(_EP_DEVICE_MAP)
 
 
+def get_device_ep_map() -> dict[str, list[EPName]]:
+    """Return a copy of the device-to-EP mapping.
+
+    Public accessor for the internal ``_DEVICE_EP_MAP``. Each device key
+    maps to the EPs that target it, in priority order (most powerful EP
+    first), derived from ``_EP_DEVICE_MAP``'s declaration order.
+
+    Returns:
+        Dict mapping device types to ordered EP-name lists (e.g.
+        ``{"gpu": ["NvTensorRTRTXExecutionProvider", ...], ...}``).
+    """
+    return {device: list(eps) for device, eps in _DEVICE_EP_MAP.items()}
+
+
 @functools.lru_cache(maxsize=1)
 def _get_available_devices() -> tuple[str, ...]:
     """Return prioritized tuple of available devices (cached).

--- a/src/winml/modelkit/sysinfo/pdh_adapters.py
+++ b/src/winml/modelkit/sysinfo/pdh_adapters.py
@@ -336,9 +336,10 @@ def _resolve_via_ort(kind: str, ep_name: EPName | None) -> str | None:
             )
             continue
         logger.debug(
-            "Resolved %s LUID via ORT (ep=%s): %s",
+            "Resolved %s LUID via ORT (ep=%s, ep_name=%s): %s",
             kind.upper(),
             ep_dev.ep_name,
+            ep_name,
             formatted,
         )
         return formatted


### PR DESCRIPTION
Before the fix
- `winml perf -m microsoft/resnet-50 --device gpu --iterations 1000 --monitor` session and monitor could use different ones (session openvino, monitor dml)
-  `winml perf -m model.onnx --device gpu --iterations 1000 --monitor` could use random ones depend on registering order like dml instead of openvino