### PR TITLE
docs: link README install table to GitHub releases page

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 | **Windows 11** (x64 or ARM64) | Windows 11 24H2+ required for NPU support |
 | **UV** | Install [UV](https://github.com/astral-sh/uv) |
 | **Windows App SDK Runtime 1.8** | [Latest Windows App SDK downloads](https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/downloads) |
-| **WinML CLI** (Python wheel) | See release instructions |
+| **WinML CLI** (Python wheel) | [Releases](https://github.com/microsoft/winml-cli/releases) |
 
 ### Required Hardware
 


### PR DESCRIPTION
## Summary

The "How to Get It" cell for the WinML CLI wheel in [README.md:48](README.md#L48) said `See release instructions` with no link. Replaced with a direct link to https://github.com/microsoft/winml-cli/releases so users can find the wheel from the Required Software table.

Used `/releases` (not `/releases/latest`) because all current releases are pre-releases, and `releases/latest` 404s when no non-prerelease exists.