### PR TITLE
fix(sysinfo): raise on explicit device with no compatible EP (#431)

### DIFF
--- a/src/winml/modelkit/sysinfo/device.py
+++ b/src/winml/modelkit/sysinfo/device.py
@@ -195,7 +195,9 @@ def resolve_device(
         (chosen_device, available_devices_list)
 
     Raises:
-        ValueError: If device or ep is not recognized.
+        ValueError: If ``device`` or ``ep`` is not recognized, or if an
+            explicit ``device`` (non-``auto``) is requested but no EP
+            compatible with it is currently available.
     """
     device = device.lower()
 
@@ -235,15 +237,15 @@ def resolve_device(
         # Fallback: CPU is always valid
         return "cpu", available_devices
 
-    # Explicit device requested -- warn if no compatible EP
+    # Explicit device requested -- raise if no compatible EP is available.
+    # Falling through with a warning would write an unusable config that fails
+    # later at compile/inference time. (issue #431)
     compatible_eps = _DEVICE_EP_MAP.get(device, [])
     if not any(ep_name in available_eps for ep_name in compatible_eps):
-        logger.warning(
-            "Device '%s' requested but no compatible EP found. "
-            "Compatible EPs: %s. Available EPs: %s",
-            device,
-            compatible_eps,
-            sorted(available_eps),
+        raise ValueError(
+            f"Device '{device}' requested but no compatible EP is available. "
+            f"Compatible EPs: {compatible_eps}. "
+            f"Available EPs: {sorted(available_eps)}."
         )
     return device, available_devices
 
@@ -261,8 +263,4 @@ def resolve_eps(resolved_device: str) -> list[EPName]:
         advertised by ORT/WinML, in ``_DEVICE_EP_MAP`` priority order.
     """
     available_eps = _get_available_eps()
-    return [
-        ep
-        for ep in _DEVICE_EP_MAP.get(resolved_device.lower(), [])
-        if ep in available_eps
-    ]
+    return [ep for ep in _DEVICE_EP_MAP.get(resolved_device.lower(), []) if ep in available_eps]

--- a/tests/unit/commands/test_compile_quantize_flags.py
+++ b/tests/unit/commands/test_compile_quantize_flags.py
@@ -23,8 +23,7 @@ _DEVICE_TO_EPS = {
 
 @pytest.fixture(autouse=True)
 def mock_functions():
-    """Mock resolve_eps to avoid hardware detection.
-    """
+    """Mock resolve_eps to avoid hardware detection."""
     with (
         patch(
             "winml.modelkit.commands.compile.resolve_eps",
@@ -219,6 +218,12 @@ class TestCompileDeviceDisplayLabel:
             patch("winml.modelkit.commands.compile.is_compiled_onnx", return_value=False),
             patch("winml.modelkit.compiler.compile_onnx", return_value=mock_result),
             patch("winml.modelkit.compiler.WinMLCompileConfig"),
+            # Make resolve_device succeed under the test runner's empty EP env
+            # (it's the display label we're testing here, not EP resolution).
+            patch(
+                "winml.modelkit.sysinfo.device._get_available_eps",
+                return_value=frozenset({"QNNExecutionProvider"}),
+            ),
         ):
             result = CliRunner().invoke(
                 compile, ["-m", str(model_file), "--device", "gpu", "--ep", "qnn"]

--- a/tests/unit/sysinfo/test_device.py
+++ b/tests/unit/sysinfo/test_device.py
@@ -300,8 +300,12 @@ class TestResolveDevice:
         with pytest.raises(ValueError, match="Unknown device 'tpu'"):
             resolve_device("tpu")
 
-    def test_resolve_device_explicit_no_ep_warns(self, caplog) -> None:
-        """Explicit "npu" but no QNN EP -> returns "npu" with warning."""
+    def test_resolve_device_explicit_no_ep_raises(self) -> None:
+        """Explicit "npu" but no NPU EP installed -> raises ValueError (issue #431).
+
+        A warning + success here writes an unusable config; we'd rather fail
+        fast at config time than at compile/inference time.
+        """
         with (
             patch(
                 "winml.modelkit.sysinfo.device._get_available_devices",
@@ -311,13 +315,28 @@ class TestResolveDevice:
                 "winml.modelkit.sysinfo.device._get_available_eps",
                 return_value=frozenset({"CPUExecutionProvider"}),
             ),
-            caplog.at_level(logging.WARNING, logger="winml.modelkit.sysinfo.device"),
+            pytest.raises(ValueError, match="no compatible EP"),
         ):
-            device, available = resolve_device("npu")
+            resolve_device("npu")
 
-        assert device == "npu"
-        assert available == ["npu", "gpu", "cpu"]
-        assert any("no compatible EP found" in record.message for record in caplog.records)
+    def test_resolve_device_explicit_no_ep_error_names_missing_eps(self) -> None:
+        """Error message must name the compatible EPs so users know what to install."""
+        with (
+            patch(
+                "winml.modelkit.sysinfo.device._get_available_devices",
+                return_value=["npu", "gpu", "cpu"],
+            ),
+            patch(
+                "winml.modelkit.sysinfo.device._get_available_eps",
+                return_value=frozenset({"CPUExecutionProvider"}),
+            ),
+            pytest.raises(ValueError) as exc_info,
+        ):
+            resolve_device("npu")
+
+        message = str(exc_info.value)
+        # Names at least one NPU-compatible EP so the user can act on it
+        assert "QNNExecutionProvider" in message or "VitisAIExecutionProvider" in message
 
     def test_resolve_device_case_insensitive(self) -> None:
         """Device argument should be case-insensitive."""
@@ -479,8 +498,8 @@ class TestResolveDeviceWithEp:
         assert device == "npu"
         assert available == ["npu", "gpu"]
 
-    def test_ep_explicit_device_filtered_out(self, caplog) -> None:
-        """ep='qnn' + device='cpu' returns 'cpu' but available_devices excludes cpu."""
+    def test_ep_explicit_device_filtered_out_raises(self) -> None:
+        """ep='qnn' + device='cpu' raises: cpu has no compatible EP within {QNN}."""
         with (
             patch(
                 "winml.modelkit.sysinfo.device._get_available_devices",
@@ -492,13 +511,9 @@ class TestResolveDeviceWithEp:
                     {"QNNExecutionProvider", "CPUExecutionProvider"},
                 ),
             ),
-            caplog.at_level(logging.WARNING, logger="winml.modelkit.sysinfo.device"),
+            pytest.raises(ValueError, match="no compatible EP"),
         ):
-            device, available = resolve_device("cpu", ep="qnn")
-
-        assert device == "cpu"
-        assert available == ["npu", "gpu"]
-        assert any("no compatible EP found" in record.message for record in caplog.records)
+            resolve_device("cpu", ep="qnn")
 
 
 class TestResolveEps:
@@ -555,9 +570,7 @@ class TestResolveEps:
         """OpenVINO declares ``npu/gpu/cpu`` so it shows up for cpu too."""
         with patch(
             "winml.modelkit.sysinfo.device._get_available_eps",
-            return_value=frozenset(
-                {"OpenVINOExecutionProvider", "CPUExecutionProvider"}
-            ),
+            return_value=frozenset({"OpenVINOExecutionProvider", "CPUExecutionProvider"}),
         ):
             assert resolve_eps("cpu") == [
                 "OpenVINOExecutionProvider",


### PR DESCRIPTION
Closes #431.

## Summary

- ``winml config --device npu`` previously logged a warning and exited 0 with an unusable config when no NPU EP (QNN / VitisAI / OpenVINO) was advertised. The failure surfaced later at compile/inference time, far from the misconfiguration.
- ``resolve_device()`` now raises ``ValueError`` for explicit device requests with no compatible EP. ``commands/config.py`` and ``commands/build.py`` already route ``ValueError`` to ``click.UsageError`` → non-zero exit with a clean message naming the missing EPs.
- ``--device auto`` is unchanged: it still walks the priority list and falls through to GPU/CPU when an NPU EP is missing (acceptance criterion 3).

## Before / after

Before (on a box with NPU silicon but no QNN/VitisAI/OpenVINO):

```
$ winml config -m microsoft/resnet-50 --device npu --precision int8 -o out.json
WARNING - Device 'npu' requested but no compatible EP found. ...
✅ Config saved to: out.json       ← exit 0, but the config is unusable
```

After:

```
$ winml config -m microsoft/resnet-50 --device npu --precision int8 -o out.json
Error: Device 'npu' requested but no compatible EP is available.
Compatible EPs: ['VitisAIExecutionProvider', 'QNNExecutionProvider', 'OpenVINOExecutionProvider'].
Available EPs: ['CPUExecutionProvider', 'DmlExecutionProvider'].
$ echo $?
2
```