### PR TITLE
Build: auto-select EP via resolve_device, forward --ep from run_eval (#663)

### DIFF
--- a/scripts/e2e_eval/run_eval.py
+++ b/scripts/e2e_eval/run_eval.py
@@ -442,6 +442,8 @@ def _run_build(
             entry.hf_id,
             "--use-cache",
         ]
+        if ep:
+            build_args += ["--ep", ep]
 
         build_proc = _run_subprocess(build_args, timeout)
         last_proc = build_proc

--- a/src/winml/modelkit/commands/build.py
+++ b/src/winml/modelkit/commands/build.py
@@ -284,10 +284,11 @@ def _build_modules(
     required=False,
     optional_message="Falls back to compile config EP if not set.",
 )
-@click.option(
-    "--device",
+@cli_utils.device_option(
+    required=False,
     default="auto",
-    help="Target device ('auto', 'npu', 'gpu', 'cpu'). Default: auto-detect.",
+    include_auto=True,
+    optional_message="Default: auto-detect.",
 )
 @click.option(
     "--no-analyze",
@@ -377,25 +378,25 @@ def build(
     if not output_dir and not use_cache:
         raise click.UsageError("One of --output-dir or --use-cache is required.")
 
-    # If ep unspecified, attempt to auto-select a suitable EP from the registry
+    # If ep unspecified, resolve the target device and pick the highest-priority
+    # EP compatible with it. Avoids selecting an EP that does not match the host
+    # hardware -- analyzing for the wrong EP leaves black nodes that block a
+    # later build targeting the actual device (#663).
+    #
+    # resolve_device() either returns a device with >=1 available EP (auto-mode
+    # walks the priority list, falls back to cpu which is always valid), or
+    # raises ValueError for an explicit device with no compatible EP. So the
+    # following resolve_eps()[0] is safe whenever resolve_device returns.
     if ep is None:
-        from ..session import WinMLEPRegistry
+        from ..sysinfo import resolve_device as _resolve_device
+        from ..sysinfo import resolve_eps as _resolve_eps
 
-        registry = WinMLEPRegistry.get_instance()
-        candidate_eps: list[EPName] = [
-            "QNNExecutionProvider",
-            "OpenVINOExecutionProvider",
-            "VitisAIExecutionProvider",
-        ]
-        for candidate_ep in candidate_eps:
-            if registry.is_ep_available(candidate_ep):
-                ep = candidate_ep
-                logger.info("EP unspecified for build, auto-selecting: %s", ep)
-                break
-    if ep is None:
-        logger.warning(
-            "EP unspecified for build, and auto-selection failed. Proceeding without EP hints."
-        )
+        try:
+            resolved_device, _ = _resolve_device(device=device)
+        except ValueError as e:
+            raise click.UsageError(str(e)) from e
+        ep = _resolve_eps(resolved_device)[0]
+        logger.info("Auto-resolved device=%s, EP=%s", resolved_device, ep)
 
     try:
         # Load or auto-generate config

--- a/src/winml/modelkit/commands/build.py
+++ b/src/winml/modelkit/commands/build.py
@@ -395,6 +395,7 @@ def build(
             resolved_device, _ = _resolve_device(device=device)
         except ValueError as e:
             raise click.UsageError(str(e)) from e
+        device = resolved_device
         ep = _resolve_eps(resolved_device)[0]
         logger.info("Auto-resolved device=%s, EP=%s", resolved_device, ep)
 

--- a/tests/unit/commands/test_build.py
+++ b/tests/unit/commands/test_build.py
@@ -32,12 +32,13 @@ _DEVICE_TO_EPS = {
 
 @pytest.fixture(autouse=True)
 def mock_resolve_device():
-    """Mock resolve_device and WinMLEPRegistry to avoid hardware detection.
+    """Mock resolve_device / resolve_eps to avoid hardware detection.
 
-    The build command calls resolve_device() for I/O and (since #540)
-    WinMLEPRegistry.get_instance() for EP auto-selection when --ep is
-    not specified. Both must be mocked to avoid slow DLL scanning and
-    WinML SDK discovery on CI runners without WinML installed.
+    The build command calls resolve_device() / resolve_eps() to auto-select
+    an EP when ``--ep`` is not specified. Both must be mocked to avoid
+    slow DLL scanning and WinML SDK discovery on CI runners without WinML
+    installed. WinMLEPRegistry.get_instance is also patched defensively
+    for any downstream code path that may touch it.
     """
     mock_registry = MagicMock()
     mock_registry.is_ep_available.return_value = False
@@ -494,7 +495,7 @@ class TestBuildFlagPassthrough:
         cfg = _make_minimal_config_file(tmp_path)
         result = _invoke([*self._base_args(cfg, tmp_path), "--device", "NPU"])
         assert result.exit_code == 0, result.output
-        assert mock_run_single_build.call_args.kwargs["device"] == "NPU"
+        assert mock_run_single_build.call_args.kwargs["device"] == "npu"
 
     def test_trust_remote_code_forwarded(self, tmp_path: Path, mock_run_single_build: MagicMock):
         """``--trust-remote-code`` is forwarded via ``extra_kwargs``."""
@@ -943,7 +944,195 @@ class TestBuildEpDevice:
             obj={"debug": False},
         )
         call_kwargs = mock_build_api.call_args.kwargs
-        assert call_kwargs["device"] == "NPU"
+        assert call_kwargs["device"] == "npu"
+
+
+# =============================================================================
+# EP AUTO-SELECTION TESTS
+# =============================================================================
+
+
+class TestBuildEpAutoSelection:
+    """Auto-select EP when --ep is omitted: resolve device -> first compatible EP.
+
+    The selection result depends on the host's available devices/EPs at runtime,
+    so resolve_device / resolve_eps are mocked to give the test a known surface.
+    Regression: hardcoded ``[QNN, OV, VitisAI]`` walk used to pick OpenVINO on a
+    GPU box if OV happened to be installed, leaving black nodes that blocked a
+    subsequent build for the actual device (issue #663).
+    """
+
+    def test_auto_selects_qnn_for_npu(
+        self,
+        runner: CliRunner,
+        sample_config_file: Path,
+        mock_build_api: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Default device=auto resolves to npu (per fixture) -> QNNExecutionProvider."""
+        from winml.modelkit.commands.build import build
+
+        result = runner.invoke(
+            build,
+            ["-c", str(sample_config_file), "-m", "test", "-o", str(tmp_path)],
+            obj={"debug": False},
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_build_api.call_args.kwargs["ep"] == "QNNExecutionProvider"
+
+    def test_auto_selects_dml_for_explicit_gpu(
+        self,
+        runner: CliRunner,
+        sample_config_file: Path,
+        mock_build_api: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """``--device gpu`` (no --ep) -> resolve_device returns gpu -> Dml."""
+        from winml.modelkit.commands.build import build
+
+        with patch(
+            "winml.modelkit.sysinfo.resolve_device",
+            return_value=("gpu", ["gpu", "cpu"]),
+        ):
+            result = runner.invoke(
+                build,
+                [
+                    "-c",
+                    str(sample_config_file),
+                    "-m",
+                    "test",
+                    "-o",
+                    str(tmp_path),
+                    "--device",
+                    "gpu",
+                ],
+                obj={"debug": False},
+            )
+        assert result.exit_code == 0, result.output
+        assert mock_build_api.call_args.kwargs["ep"] == "DmlExecutionProvider"
+
+    def test_auto_selects_cpu_ep_for_explicit_cpu(
+        self,
+        runner: CliRunner,
+        sample_config_file: Path,
+        mock_build_api: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """``--device cpu`` (no --ep) -> CPUExecutionProvider."""
+        from winml.modelkit.commands.build import build
+
+        with patch(
+            "winml.modelkit.sysinfo.resolve_device",
+            return_value=("cpu", ["cpu"]),
+        ):
+            result = runner.invoke(
+                build,
+                [
+                    "-c",
+                    str(sample_config_file),
+                    "-m",
+                    "test",
+                    "-o",
+                    str(tmp_path),
+                    "--device",
+                    "cpu",
+                ],
+                obj={"debug": False},
+            )
+        assert result.exit_code == 0, result.output
+        assert mock_build_api.call_args.kwargs["ep"] == "CPUExecutionProvider"
+
+    def test_explicit_ep_bypasses_auto_selection(
+        self,
+        runner: CliRunner,
+        sample_config_file: Path,
+        mock_build_api: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """``--ep qnn`` keeps the user's choice even when device resolution would pick another."""
+        from winml.modelkit.commands.build import build
+
+        # resolve_device would point at gpu -> Dml, but --ep wins.
+        with (
+            patch(
+                "winml.modelkit.sysinfo.resolve_device",
+                return_value=("gpu", ["gpu", "cpu"]),
+            ),
+            patch("winml.modelkit.sysinfo.resolve_eps") as mock_resolve_eps,
+        ):
+            result = runner.invoke(
+                build,
+                ["-c", str(sample_config_file), "-m", "test", "-o", str(tmp_path), "--ep", "qnn"],
+                obj={"debug": False},
+            )
+        assert result.exit_code == 0, result.output
+        assert mock_build_api.call_args.kwargs["ep"] == "qnn"
+        mock_resolve_eps.assert_not_called()
+
+    def test_resolve_device_value_error_surfaces_as_usage_error(
+        self,
+        runner: CliRunner,
+        sample_config_file: Path,
+        mock_build_api: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """resolve_device raising (explicit device w/ no compatible EP) -> UsageError.
+
+        Uses default ``--device auto`` (no CLI flag) so the downstream
+        device-patch path isn't triggered; the only resolve_device call is
+        the one inside the auto-select block.
+        """
+        from winml.modelkit.commands.build import build
+
+        with patch(
+            "winml.modelkit.sysinfo.resolve_device",
+            side_effect=ValueError("simulated resolve_device failure"),
+        ):
+            result = runner.invoke(
+                build,
+                ["-c", str(sample_config_file), "-m", "test", "-o", str(tmp_path)],
+                obj={"debug": False},
+            )
+        assert result.exit_code != 0
+        assert "simulated resolve_device failure" in result.output
+        mock_build_api.assert_not_called()
+
+    def test_auto_selection_respects_resolve_eps_priority(
+        self,
+        runner: CliRunner,
+        sample_config_file: Path,
+        mock_build_api: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """First element of resolve_eps(resolved_device) is selected, not later ones."""
+        from winml.modelkit.commands.build import build
+
+        with (
+            patch(
+                "winml.modelkit.sysinfo.resolve_device",
+                return_value=("gpu", ["gpu", "cpu"]),
+            ),
+            patch(
+                "winml.modelkit.sysinfo.resolve_eps",
+                return_value=["DmlExecutionProvider", "OpenVINOExecutionProvider"],
+            ),
+        ):
+            result = runner.invoke(
+                build,
+                [
+                    "-c",
+                    str(sample_config_file),
+                    "-m",
+                    "test",
+                    "-o",
+                    str(tmp_path),
+                    "--device",
+                    "gpu",
+                ],
+                obj={"debug": False},
+            )
+        assert result.exit_code == 0, result.output
+        assert mock_build_api.call_args.kwargs["ep"] == "DmlExecutionProvider"
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Fixes #663.

`winml build` used to auto-select an EP from a hardcoded list `[QNN, OV, VitisAI]` and pick the first one installed, regardless of the host device. On a TrtRtx GPU box where OpenVINO is also installed, OV would win — the analyze pass then marked ops black for OV and the residual state blocked a later TrtRtx-targeted build.

### Changes

**`src/winml/modelkit/commands/build.py`**
- When `--ep` is omitted, resolve the target device via `resolve_device(device)` and pick the first EP from `resolve_eps(resolved_device)`. `resolve_device` either returns a device with at least one available EP (auto-mode walks the priority list, falls back to CPU which is always valid) or raises `ValueError` for an explicit device with no compatible EP — surfaced as `click.UsageError`. So `resolve_eps(resolved_device)[0]` is safe whenever `resolve_device` returns.
- Switched the `--device` option to `cli_utils.device_option(required=False, default=\"auto\", include_auto=True, optional_message=\"Default: auto-detect.\")` to match `perf`/`run`/`serve`. Guarantees `device` is never `None` in the auto-select block.

**`scripts/e2e_eval/run_eval.py`**
- Forward `--ep` to the build subprocess when set, matching how perf/eval already do (`run_eval.py:408/562/592/730`).

**`tests/unit/commands/test_build.py`**
- New `TestBuildEpAutoSelection` (6 tests) covering: auto-select per resolved device (npu→QNN, gpu→Dml, cpu→CPU), explicit `--ep` bypassing auto-selection, `resolve_device` `ValueError` → `UsageError`, and `resolve_eps` priority order.
- Existing device assertions updated from `\"NPU\"` to `\"npu\"` to match `click.Choice(case_sensitive=False)` normalization.

### Verification

- `python -m pytest tests/unit/commands/test_build.py` → 78 passed.
- E2E: `python scripts/e2e_eval/run_eval.py --hf-model BAAI/bge-base-en-v1.5 --ep cpu --eval-type perf` → exit 0, `[PASS]`, `--ep cpu` reached the build + perf subprocesses.