### PR TITLE
Fix image-to-text model build

### DIFF
--- a/src/winml/modelkit/datasets/__init__.py
+++ b/src/winml/modelkit/datasets/__init__.py
@@ -45,7 +45,6 @@ TASK_DATASET_MAPPING = {
     "sentence-similarity": TextDataset,
     "next-sentence-prediction": TextDataset,
     "fill-mask": TextDataset,
-    "text2text-generation": TextDataset,
     "zero-shot-classification": TextDataset,
     "image-segmentation": ImageSegmentationDataset,
     "random": RandomDataset,


### PR DESCRIPTION
### Fix: remove `text2text-generation → TextDataset` calibration mapping

## Root cause

Seq2seq decoder ONNX (trocr/blip/bart/marian) expects `decoder_input_ids`, `encoder_hidden_states`, KV-cache, etc. `TextDataset` only produces `input_ids` / `attention_mask` from `glue/mrpc`. During calibration, `format_data` filters keys against the model's `io_config`, so every sample becomes `{}` and ORT raises `ValueError: No data is collected.` → decoder quantization fails → `COMPILE_FAIL`.

## Why the mapping is not needed

- Without it, `universal_calib_dataset` falls back to `RandomDataset`, which synthesizes tensors from `io_config` with the correct shapes/dtypes for all decoder inputs (including KV-cache). This is the pre-#408 behavior.
- Production eval is unaffected: all image-to-text entries in models_with_acc.json use `"precision": "fp16"`, which sets `quant=None` and skips quantization entirely. The bug only surfaces when seq2seq decoders are actually quantized (e.g., NPU runs against models_all.json, or manual `--precision w8a16`).

## Change

```diff
     "fill-mask": TextDataset,
-    "text2text-generation": TextDataset,
     "zero-shot-classification": TextDataset,
```

## Verification

- `uv run pytest tests/ -k dataset` → 102 passed.
- `run_eval.py --eval-type perf --device npu --hf-model microsoft/trocr-base-printed` → PASS (was `COMPILE_FAIL`).