### PR TITLE
feat(build): output analyze_result.json; fix --device npu config validation

### DIFF
--- a/src/winml/modelkit/analyze/analyzer.py
+++ b/src/winml/modelkit/analyze/analyzer.py
@@ -854,6 +854,7 @@ def analyze_onnx(
     run_unknown_op: bool = False,
     on_ep_start: Callable | None = None,
     on_node_result: Callable | None = None,
+    output_path: Path | None = None,
 ) -> AnalyzeResult:
     """Analyze an ONNX model and return lint + autoconf results.
 
@@ -873,6 +874,9 @@ def analyze_onnx(
             detected patterns. Default ``True``. When ``False``, skips the
             information engine entirely for faster lint-only analysis
             (``optimization_config`` will be ``None``).
+        output_path: Optional file path to write the full :class:`AnalysisResult`
+            as JSON. The file is written (or overwritten) after each call, so
+            repeated calls with the same path keep the most recent result.
 
     Returns:
         AnalyzeResult with lint diagnostics and optional optimization config.
@@ -888,6 +892,11 @@ def analyze_onnx(
         ...     print(f"Errors: {result.lint.error_patterns}")
         >>> if result.autoconf:
         ...     print(f"Autoconf: {result.optimization_config.to_dict()}")
+
+        >>> # Save full analysis JSON alongside the model
+        >>> result = analyze_onnx(
+        ...     "model.onnx", ep="qnn", output_path=Path("analyze_result.json")
+        ... )
 
         >>> # Lint-only (skip autoconf — faster, no information engine)
         >>> result = analyze_onnx("model.onnx", ep="qnn", autoconf=False)
@@ -913,6 +922,12 @@ def analyze_onnx(
         on_ep_start=on_ep_start,
         on_node_result=on_node_result,
     )
+
+    if output_path is not None:
+        output_path = Path(output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(analysis.to_json(), encoding="utf-8")
+        logger.debug("Analysis result written: %s", output_path)
 
     # Extract lint result (always computed — uses RuntimeChecker classification)
     lint = analysis.get_lint_result(ep=ep)

--- a/src/winml/modelkit/build/common.py
+++ b/src/winml/modelkit/build/common.py
@@ -41,6 +41,7 @@ def run_optimize_analyze_loop(
     on_iteration_start: Any = None,
     on_patterns_discovered: Any = None,
     on_reoptimize: Any = None,
+    analyze_output_path: Path | None = None,
     **onnx_kwargs: Any,
 ) -> tuple[Path, float, int, int, dict]:
     """Optimize an ONNX model, analyze, and optionally re-optimize via autoconf.
@@ -61,6 +62,9 @@ def run_optimize_analyze_loop(
         device: Target device for the analyzer.
         max_optim_iterations: Maximum autoconf re-optimization rounds.
             0 means optimize+analyze only (no autoconf re-optimization).
+        analyze_output_path: Optional path to write the full analysis result as
+            JSON. Written after every analyze pass; each pass overwrites the
+            previous one so the file always reflects the most recent analysis.
         **onnx_kwargs: Additional ONNX-level kwargs.
 
     Returns:
@@ -97,6 +101,7 @@ def run_optimize_analyze_loop(
             on_iteration_start=on_iteration_start,
             on_patterns_discovered=on_patterns_discovered,
             on_reoptimize=on_reoptimize,
+            analyze_output_path=analyze_output_path,
             **onnx_kwargs,
         )
     else:
@@ -119,6 +124,7 @@ def _run_analyze_loop(
     on_iteration_start: Any = None,
     on_patterns_discovered: Any = None,
     on_reoptimize: Any = None,
+    analyze_output_path: Path | None = None,
     **kwargs: Any,
 ) -> tuple[int, int, dict]:
     """Run iterative analyzer autoconf loop in a temp folder.
@@ -152,6 +158,7 @@ def _run_analyze_loop(
                 run_unknown_op=False,
                 on_ep_start=on_ep_start,
                 on_node_result=on_node_result,
+                output_path=analyze_output_path,
             )
             analyze_iterations += 1
 
@@ -197,6 +204,7 @@ def _run_analyze_loop(
             device=device,
             run_unknown_op=False,
             on_node_result=lambda _: None,
+            output_path=analyze_output_path,
         )
 
         copy_onnx_model(iter_model, optimized_path)

--- a/src/winml/modelkit/build/hf.py
+++ b/src/winml/modelkit/build/hf.py
@@ -171,6 +171,7 @@ def build_hf_model(
     final_path = output_dir / _name("model.onnx")
     config_path = output_dir / _name("winml_build_config.json")
     manifest_path = output_dir / _name("build_manifest.json")
+    analyze_result_path = output_dir / _name("analyze_result.json")
 
     # Check for existing artifact (skip build if present and not rebuilding)
     if final_path.exists() and not rebuild:
@@ -274,6 +275,7 @@ def build_hf_model(
             ep=ep,
             device=device,
             max_optim_iterations=hack_max_optim_iterations,
+            analyze_output_path=analyze_result_path,
             **onnx_kwargs,
         )
         stage_timings["optimize"] = opt_elapsed

--- a/src/winml/modelkit/build/onnx.py
+++ b/src/winml/modelkit/build/onnx.py
@@ -106,6 +106,7 @@ def build_onnx_model(
     final_path = output_dir / "model.onnx"
     config_path = output_dir / "winml_build_config.json"
     manifest_path = output_dir / "build_manifest.json"
+    analyze_result_path = output_dir / "analyze_result.json"
 
     # Check for existing artifact (skip build if present and not rebuilding)
     if final_path.exists() and not rebuild:
@@ -177,6 +178,7 @@ def build_onnx_model(
                 ep=ep,
                 device=device,
                 max_optim_iterations=hack_max_optim_iterations,
+                analyze_output_path=analyze_result_path,
                 **onnx_kwargs,
             )
         )

--- a/src/winml/modelkit/commands/build.py
+++ b/src/winml/modelkit/commands/build.py
@@ -435,7 +435,15 @@ def build(
                 from ..config import resolve_quant_compile_config
 
                 resolved_quant, _ = resolve_quant_compile_config(device=device)
-                cfg.quant = resolved_quant
+                if resolved_quant is None:
+                    cfg.quant = None
+                elif cfg.quant is None:
+                    cfg.quant = resolved_quant
+                else:
+                    # Only update precision fields; preserve task/model_name
+                    # and other calibration settings from the existing config.
+                    cfg.quant.weight_type = resolved_quant.weight_type
+                    cfg.quant.activation_type = resolved_quant.activation_type
                 if cfg.compile is not None and cfg.compile.ep_config is not None:
                     provider = cfg.compile.ep_config.provider
                     patched = WinMLCompileConfig.for_provider(provider, device=device)
@@ -756,6 +764,7 @@ def _run_optimize_stage(
     max_iters: int,
     stage_timings: list[tuple[str, float | None]],
     show_io_first: bool = False,
+    analyze_output_path: Path | None = None,
 ) -> tuple[Path, float]:
     """Run the optimize stage inside a StageLive context.
 
@@ -867,6 +876,7 @@ def _run_optimize_stage(
             on_patterns_discovered=_on_patterns,
             on_reoptimize=_on_reoptimize,
             use_external_data=True,
+            analyze_output_path=analyze_output_path,
         )
         # Mark config as resolved so CI/CD reruns skip the analyzer.
         config.auto = False
@@ -1099,6 +1109,7 @@ def _build_hf_pipeline(
     compiled_path = output_dir / _name("compiled.onnx")
     final_path = output_dir / _name("model.onnx")
     config_path = output_dir / _name("winml_build_config.json")
+    analyze_result_path = output_dir / _name("analyze_result.json")
 
     # Reuse check
     if final_path.exists() and not rebuild:
@@ -1154,6 +1165,7 @@ def _build_hf_pipeline(
         max_iters=max_iters,
         stage_timings=stage_timings,
         show_io_first=False,
+        analyze_output_path=analyze_result_path,
     )
 
     # Persist config after autoconf
@@ -1217,6 +1229,7 @@ def _build_onnx_pipeline(
     compiled_path = output_dir / f"{stem}_compiled.onnx"
     final_path = output_dir / "model.onnx"
     config_path = output_dir / "winml_build_config.json"
+    analyze_result_path = output_dir / "analyze_result.json"
 
     # Reuse check
     if final_path.exists() and not rebuild:
@@ -1246,6 +1259,7 @@ def _build_onnx_pipeline(
         max_iters=max_iters,
         stage_timings=stage_timings,
         show_io_first=True,
+        analyze_output_path=analyze_result_path,
     )
 
     config_path.write_text(json.dumps(config.to_dict(), indent=2))

--- a/tests/unit/build/test_hf.py
+++ b/tests/unit/build/test_hf.py
@@ -875,3 +875,101 @@ class TestBuildHfPreQuantized:
         assert "quantize" in result.stages_skipped
         mock_pipeline["optimize"].assert_called_once()
         mock_pipeline["quantize"].assert_not_called()
+
+
+# =============================================================================
+# ANALYZE JSON OUTPUT TESTS
+# =============================================================================
+
+
+class TestAnalyzeJsonOutput:
+    """Test that analyze_result.json is written to the build folder."""
+
+    def test_analyze_onnx_called_with_output_path(
+        self, tmp_path: Path, sample_config_no_quant_compile, mock_pipeline
+    ) -> None:
+        """analyze_onnx is called with output_path pointing to analyze_result.json."""
+        build_hf_model(
+            config=sample_config_no_quant_compile,
+            output_dir=tmp_path,
+            model_id="test",
+            ep="qnn",
+        )
+        # Both loop call and final call pass output_path
+        for call in mock_pipeline["analyze"].call_args_list:
+            assert call.kwargs["output_path"] == tmp_path / "analyze_result.json"
+
+    def test_analyze_output_path_respects_cache_key(
+        self, tmp_path: Path, sample_config_no_quant_compile, mock_pipeline
+    ) -> None:
+        """analyze_result.json is prefixed when cache_key is set."""
+        build_hf_model(
+            config=sample_config_no_quant_compile,
+            output_dir=tmp_path,
+            model_id="test",
+            cache_key="imgcls_abc123",
+        )
+        expected = tmp_path / "imgcls_abc123_analyze_result.json"
+        for call in mock_pipeline["analyze"].call_args_list:
+            assert call.kwargs["output_path"] == expected
+
+    def test_no_output_path_for_prequantized(
+        self, tmp_path: Path, sample_config, mock_pipeline
+    ) -> None:
+        """Pre-quantized path never calls analyze_onnx (no JSON written)."""
+        mock_pipeline["is_quantized_onnx"].return_value = True
+        build_hf_model(
+            config=sample_config,
+            output_dir=tmp_path / "output",
+            pytorch_model=mock_pipeline["model"],
+        )
+        mock_pipeline["analyze"].assert_not_called()
+
+    def test_analyze_onnx_writes_json_to_disk(self, tmp_path: Path) -> None:
+        """analyze_onnx with output_path writes a valid JSON file."""
+        import onnx
+        from onnx import TensorProto, helper
+
+        from winml.modelkit.analyze import analyze_onnx
+
+        # Build a trivial ONNX model (single Relu node)
+        node = helper.make_node("Relu", inputs=["x"], outputs=["y"])
+        graph = helper.make_graph(
+            [node],
+            "test",
+            [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1])],
+            [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1])],
+        )
+        model_proto = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+        model_path = tmp_path / "tiny.onnx"
+        onnx.save(model_proto, str(model_path))
+
+        output_path = tmp_path / "analyze_result.json"
+        analyze_onnx(model_path, ep="qnn", output_path=output_path)
+
+        assert output_path.exists()
+        data = json.loads(output_path.read_text())
+        assert "metadata" in data
+        assert "results" in data
+
+    def test_analyze_onnx_no_output_path_writes_nothing(self, tmp_path: Path) -> None:
+        """analyze_onnx without output_path writes no file (backward compat)."""
+        import onnx
+        from onnx import TensorProto, helper
+
+        from winml.modelkit.analyze import analyze_onnx
+
+        node = helper.make_node("Relu", inputs=["x"], outputs=["y"])
+        graph = helper.make_graph(
+            [node],
+            "test",
+            [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1])],
+            [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1])],
+        )
+        model_proto = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+        model_path = tmp_path / "tiny.onnx"
+        onnx.save(model_proto, str(model_path))
+
+        analyze_onnx(model_path, ep="qnn")  # no output_path
+
+        assert not any(tmp_path.glob("*.json"))

--- a/tests/unit/build/test_hf.py
+++ b/tests/unit/build/test_hf.py
@@ -928,19 +928,20 @@ class TestAnalyzeJsonOutput:
     def test_analyze_onnx_writes_json_to_disk(self, tmp_path: Path) -> None:
         """analyze_onnx with output_path writes a valid JSON file."""
         import onnx
-        from onnx import TensorProto, helper
 
         from winml.modelkit.analyze import analyze_onnx
 
         # Build a trivial ONNX model (single Relu node)
-        node = helper.make_node("Relu", inputs=["x"], outputs=["y"])
-        graph = helper.make_graph(
+        node = onnx.helper.make_node("Relu", inputs=["x"], outputs=["y"])
+        graph = onnx.helper.make_graph(
             [node],
             "test",
-            [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1])],
-            [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1])],
+            [onnx.helper.make_tensor_value_info("x", onnx.TensorProto.FLOAT, [1])],
+            [onnx.helper.make_tensor_value_info("y", onnx.TensorProto.FLOAT, [1])],
         )
-        model_proto = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+        model_proto = onnx.helper.make_model(
+            graph, opset_imports=[onnx.helper.make_opsetid("", 17)]
+        )
         model_path = tmp_path / "tiny.onnx"
         onnx.save(model_proto, str(model_path))
 
@@ -955,18 +956,19 @@ class TestAnalyzeJsonOutput:
     def test_analyze_onnx_no_output_path_writes_nothing(self, tmp_path: Path) -> None:
         """analyze_onnx without output_path writes no file (backward compat)."""
         import onnx
-        from onnx import TensorProto, helper
 
         from winml.modelkit.analyze import analyze_onnx
 
-        node = helper.make_node("Relu", inputs=["x"], outputs=["y"])
-        graph = helper.make_graph(
+        node = onnx.helper.make_node("Relu", inputs=["x"], outputs=["y"])
+        graph = onnx.helper.make_graph(
             [node],
             "test",
-            [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1])],
-            [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1])],
+            [onnx.helper.make_tensor_value_info("x", onnx.TensorProto.FLOAT, [1])],
+            [onnx.helper.make_tensor_value_info("y", onnx.TensorProto.FLOAT, [1])],
         )
-        model_proto = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+        model_proto = onnx.helper.make_model(
+            graph, opset_imports=[onnx.helper.make_opsetid("", 17)]
+        )
         model_path = tmp_path / "tiny.onnx"
         onnx.save(model_proto, str(model_path))
 

--- a/tests/unit/build/test_onnx.py
+++ b/tests/unit/build/test_onnx.py
@@ -554,3 +554,30 @@ class TestBuildOnnxManifest:
         assert result.reused is True
         assert result.manifest_path is None
         assert not (output_dir / "build_manifest.json").exists()
+
+
+# =============================================================================
+# ANALYZE JSON OUTPUT TESTS
+# =============================================================================
+
+
+class TestOnnxAnalyzeJsonOutput:
+    """Test that analyze_result.json is written to the build folder."""
+
+    def test_analyze_onnx_called_with_output_path(
+        self, tmp_path: Path, fake_onnx: Path, sample_onnx_config_minimal, mock_onnx_pipeline
+    ) -> None:
+        """analyze_onnx is called with output_path = output_dir/analyze_result.json."""
+        output_dir = tmp_path / "output"
+        build_onnx_model(fake_onnx, config=sample_onnx_config_minimal, output_dir=output_dir)
+
+        for call in mock_onnx_pipeline["analyze"].call_args_list:
+            assert call.kwargs["output_path"] == output_dir / "analyze_result.json"
+
+    def test_no_output_path_for_prequantized(
+        self, tmp_path: Path, fake_onnx: Path, sample_onnx_config, mock_onnx_pipeline
+    ) -> None:
+        """Pre-quantized path never calls analyze_onnx (no JSON written)."""
+        mock_onnx_pipeline["is_quantized_onnx"].return_value = True
+        build_onnx_model(fake_onnx, config=sample_onnx_config, output_dir=tmp_path / "output")
+        mock_onnx_pipeline["analyze"].assert_not_called()


### PR DESCRIPTION
## Summary

- **`analyze_result.json`**: The full static analysis result is now written to the build output folder after every analyze pass (each pass overwrites the previous), so users can inspect node-level compatibility after a build.
- **`--device npu` fix**: `winml build -m <model> --device npu` previously always failed with _"quant.task is required"_. This was a regression introduced in ed7dbfda (#477).

## Details

### analyze_result.json
- `analyze_onnx()` gains an `output_path` parameter; when set, it writes `AnalysisResult.to_json()` to disk after each call
- `run_optimize_analyze_loop` / `_run_analyze_loop` thread `analyze_output_path` through to every `analyze_onnx()` call
- `build/hf.py`, `build/onnx.py`, and the CLI's `_run_optimize_stage` all supply `analyze_result_path`

### _patch_device regression fix
`_patch_device` was replacing the entire `cfg.quant` object with the result of `resolve_quant_compile_config()`, which only carries `weight_type`/`activation_type`. This silently dropped `task` and `model_name` that `generate_build_config()` had already set, causing validation to fail for any device that requires quantization (i.e. NPU).

Fix: when an existing quant config is present, only update the precision fields instead of replacing the whole object.

```python
# Before
cfg.quant = resolved_quant  # drops task, model_name

# After
if resolved_quant is None:
    cfg.quant = None
elif cfg.quant is None:
    cfg.quant = resolved_quant
else:
    cfg.quant.weight_type = resolved_quant.weight_type
    cfg.quant.activation_type = resolved_quant.activation_type
```