### PR TITLE
run_eval: forward --device to winml build subprocess

### DIFF
--- a/scripts/e2e_eval/run_eval.py
+++ b/scripts/e2e_eval/run_eval.py
@@ -441,6 +441,8 @@ def _run_build(
             "-m",
             entry.hf_id,
             "--use-cache",
+            "--device",
+            device,
         ]
         if ep:
             build_args += ["--ep", ep]


### PR DESCRIPTION
## Summary

`winml config`, `winml perf`, and `winml eval` already receive `--device` from run_eval; `winml build` was the only step missing it. With this change, the build subprocess respects the caller's device choice instead of relying on its own auto-detection.

Companion to #667 (which forwarded `--ep` and added device-aware EP auto-select in the build CLI). With both PRs in, run_eval consistently propagates `--device`/`--ep` to every winml subprocess it spawns.

### Diff

```python
        build_args = [
            *WINML_CLI,
            "build",
            "-c",
            str(sub_cfg),
            "-m",
            entry.hf_id,
            "--use-cache",
+            \"--device\",
+            device,
        ]
        if ep:
            build_args += [\"--ep\", ep]
```

### Verification

E2E on a cold cache:

\`\`\`
python scripts/e2e_eval/run_eval.py --hf-model BAAI/bge-base-en-v1.5 --ep cpu --device cpu --eval-type perf
\`\`\`

→ exit 0, \`[PASS] 2.4s\`. Generated build config has \`\"compile\": null\` (correct for cpu — no EP-specific compile needed).