### PR TITLE
fix(inspect): distinguish local-path-not-found from network errors

### DIFF
--- a/src/winml/modelkit/commands/inspect.py
+++ b/src/winml/modelkit/commands/inspect.py
@@ -138,14 +138,25 @@ def inspect(
             "Use --list-tasks to see available tasks."
         )
 
-    # Handle ONNX file input
+    # Classify the input before hitting HF Hub: local paths must exist.
+    # HF IDs (org/model) have no file extension and no path separators other
+    # than a single forward slash, so the heuristics below have no false-positives
+    # for normal HF model identifiers.
     from pathlib import Path
 
-    if model_id and model_id.endswith(".onnx") and Path(model_id).is_file():
-        raise click.ClickException(
-            "ONNX file inspection is not yet supported. "
-            "Use 'winml config -m model.onnx' for ONNX build config."
+    if model_id:
+        _p = Path(model_id)
+        _is_local = (
+            _p.is_absolute() or "\\" in model_id or model_id.startswith(".") or bool(_p.suffix)
         )
+        if _is_local:
+            if _p.suffix == ".onnx" and _p.is_file():
+                raise click.ClickException(
+                    "ONNX file inspection is not yet supported. "
+                    "Use 'winml config -m model.onnx' for ONNX build config."
+                )
+            if not _p.exists():
+                raise click.ClickException(f"Local path '{model_id}' does not exist.")
 
     from ..inspect import InspectError, ModelNotFoundError, NetworkError
     from ..inspect.formatter import output_json, output_table
@@ -246,6 +257,8 @@ def _inspect_model_v2(
     # =========================================================================
     # STEP 2: Shared loader resolution (same call as config command)
     # =========================================================================
+    from huggingface_hub.utils import RepositoryNotFoundError
+
     try:
         loader_config, hf_config, _resolved_class = resolve_loader_config(
             model_id,
@@ -253,6 +266,8 @@ def _inspect_model_v2(
             model_type=model_type_override,
             model_class=model_class_override,
         )
+    except RepositoryNotFoundError as e:
+        raise ModelNotFoundError(f"Model '{model_id}' not found on Hugging Face Hub.") from e
     except ValueError as e:
         err_str = str(e).lower()
         if "not found" in err_str or "404" in err_str:

--- a/src/winml/modelkit/commands/inspect.py
+++ b/src/winml/modelkit/commands/inspect.py
@@ -31,6 +31,14 @@ logger = logging.getLogger(__name__)
 console = Console()
 
 
+def _looks_like_local_path(model_id: str) -> bool:
+    """Return True when model_id is explicitly a local path."""
+    from pathlib import Path
+
+    _p = Path(model_id).expanduser()
+    return _p.exists() or _p.is_absolute() or "\\" in model_id or model_id.startswith((".", "~"))
+
+
 @click.command("inspect")
 @click.option(
     "-m",
@@ -138,17 +146,13 @@ def inspect(
             "Use --list-tasks to see available tasks."
         )
 
-    # Classify the input before hitting HF Hub: local paths must exist.
-    # HF IDs (org/model) have no file extension and no path separators other
-    # than a single forward slash, so the heuristics below have no false-positives
-    # for normal HF model identifiers.
-    from pathlib import Path
-
+    # Classify the input before hitting HF Hub: explicitly-local paths must exist.
+    # Keep this conservative to avoid misclassifying valid HF IDs as local paths.
     if model_id:
-        _p = Path(model_id)
-        _is_local = (
-            _p.is_absolute() or "\\" in model_id or model_id.startswith(".") or bool(_p.suffix)
-        )
+        from pathlib import Path
+
+        _p = Path(model_id).expanduser()
+        _is_local = _looks_like_local_path(model_id)
         if _is_local:
             if _p.suffix == ".onnx" and _p.is_file():
                 raise click.ClickException(

--- a/src/winml/modelkit/commands/inspect.py
+++ b/src/winml/modelkit/commands/inspect.py
@@ -285,14 +285,21 @@ def _inspect_model_v2(
             model_class=model_class_override,
         )
     except RepositoryNotFoundError as e:
-        raise ModelNotFoundError(f"Model '{model_id}' not found on Hugging Face Hub.") from e
+        # Direct HF Hub 404 — keep full message (includes private-repo hint).
+        raise ModelNotFoundError(str(e)) from e
     except ValueError as e:
         err_str = str(e).lower()
         if "not found" in err_str or "404" in err_str:
             raise ModelNotFoundError(str(e)) from e
         raise InspectError(str(e)) from e
     except OSError as e:
-        raise NetworkError(str(e)) from e
+        # transformers wraps RepositoryNotFoundError as a plain OSError with a
+        # recognizable message.  Detect that pattern so users see "Model not found"
+        # (with the original hint text) rather than the misleading "Network error".
+        err_msg = str(e)
+        if "is not a valid model identifier" in err_msg or "is not a local folder" in err_msg:
+            raise ModelNotFoundError(err_msg) from e
+        raise NetworkError(err_msg) from e
 
     if parent_hf_config is None:
         parent_hf_config = hf_config

--- a/src/winml/modelkit/commands/inspect.py
+++ b/src/winml/modelkit/commands/inspect.py
@@ -30,13 +30,28 @@ from rich.console import Console
 logger = logging.getLogger(__name__)
 console = Console()
 
+# File extensions that unambiguously indicate a local file path.
+# HF model IDs routinely contain dots in version numbers (Phi-3.5, Qwen2.5, …)
+# so matching on any suffix would cause false-positives; restrict to known extensions.
+_LOCAL_FILE_EXTS = frozenset({".onnx", ".pt", ".pth", ".safetensors", ".bin"})
+
 
 def _looks_like_local_path(model_id: str) -> bool:
-    """Return True when model_id is explicitly a local path."""
+    """Return True when model_id is explicitly a local path.
+
+    Conservative heuristic — only returns True for unambiguous local indicators:
+    path separators, absolute paths, dot/tilde prefixes, or known model file extensions.
+    """
     from pathlib import Path
 
     _p = Path(model_id).expanduser()
-    return _p.exists() or _p.is_absolute() or "\\" in model_id or model_id.startswith((".", "~"))
+    return (
+        _p.exists()
+        or _p.is_absolute()
+        or "\\" in model_id
+        or model_id.startswith(("./", "../", "~/"))
+        or _p.suffix.lower() in _LOCAL_FILE_EXTS
+    )
 
 
 @click.command("inspect")
@@ -146,21 +161,20 @@ def inspect(
             "Use --list-tasks to see available tasks."
         )
 
-    # Classify the input before hitting HF Hub: explicitly-local paths must exist.
-    # Keep this conservative to avoid misclassifying valid HF IDs as local paths.
-    if model_id:
+    # Classify the input before hitting HF Hub: local paths must exist.
+    # _looks_like_local_path uses a conservative allowlist to avoid misclassifying
+    # HF IDs with version dots (Phi-3.5, Qwen2.5, …) as local paths.
+    if model_id and _looks_like_local_path(model_id):
         from pathlib import Path
 
         _p = Path(model_id).expanduser()
-        _is_local = _looks_like_local_path(model_id)
-        if _is_local:
-            if _p.suffix == ".onnx" and _p.is_file():
-                raise click.ClickException(
-                    "ONNX file inspection is not yet supported. "
-                    "Use 'winml config -m model.onnx' for ONNX build config."
-                )
-            if not _p.exists():
-                raise click.ClickException(f"Local path '{model_id}' does not exist.")
+        if _p.suffix == ".onnx" and _p.is_file():
+            raise click.ClickException(
+                "ONNX file inspection is not yet supported. "
+                "Use 'winml config -m model.onnx' for ONNX build config."
+            )
+        if not _p.exists():
+            raise click.ClickException(f"Local path '{model_id}' does not exist.")
 
     from ..inspect import InspectError, ModelNotFoundError, NetworkError
     from ..inspect.formatter import output_json, output_table

--- a/tests/unit/commands/test_inspect_cli.py
+++ b/tests/unit/commands/test_inspect_cli.py
@@ -299,3 +299,9 @@ class TestInspectErrors:
             assert result.exit_code != 0
             assert "Model not found" in result.output
             assert "Network error" not in result.output
+
+    def test_hf_id_with_dot_not_treated_as_missing_local_path(self) -> None:
+        """A valid-looking HF ID with '.' should not be pre-classified as local."""
+        from winml.modelkit.commands.inspect import _looks_like_local_path
+
+        assert _looks_like_local_path("org/model.onnx") is False

--- a/tests/unit/commands/test_inspect_cli.py
+++ b/tests/unit/commands/test_inspect_cli.py
@@ -289,7 +289,31 @@ class TestInspectErrors:
         assert "Network error" not in result.output
 
     def test_bogus_hf_id_shows_model_not_found(self, runner: CliRunner) -> None:
-        """RepositoryNotFoundError from HF Hub maps to 'Model not found', not 'Network error'."""
+        """transformers wraps HF Hub 404 as a plain OSError; must show 'Model not found'."""
+        from winml.modelkit.commands.inspect import inspect
+
+        # Reproduce what AutoConfig.from_pretrained actually raises for a missing repo:
+        # transformers catches RepositoryNotFoundError internally and re-raises as OSError.
+        hf_oserror = OSError(
+            "totally-bogus/does-not-exist is not a local folder and is not a valid model "
+            "identifier listed on 'https://huggingface.co/models'\n"
+            "If this is a private repository, make sure to pass a token having permission "
+            "to this repo either by logging in with `hf auth login` or by passing "
+            "`token=<your_token>`"
+        )
+        with patch(
+            "transformers.AutoConfig.from_pretrained",
+            side_effect=hf_oserror,
+        ):
+            result = runner.invoke(inspect, ["-m", "totally-bogus/does-not-exist"], obj={})
+            assert result.exit_code != 0
+            assert "Model not found" in result.output
+            assert "Network error" not in result.output
+            # Private-repo hint must be preserved in the error output.
+            assert "private repository" in result.output
+
+    def test_bogus_hf_id_repository_not_found_error(self, runner: CliRunner) -> None:
+        """RepositoryNotFoundError surfaced directly also maps to 'Model not found'."""
         from huggingface_hub.utils import RepositoryNotFoundError
 
         from winml.modelkit.commands.inspect import inspect

--- a/tests/unit/commands/test_inspect_cli.py
+++ b/tests/unit/commands/test_inspect_cli.py
@@ -263,3 +263,39 @@ class TestInspectErrors:
             result = runner.invoke(inspect, ["-m", "test"], obj={})
             assert result.exit_code != 0
             assert "Inspection error" in result.output
+
+    def test_missing_local_file_shows_path_error(
+        self, runner: CliRunner, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        """Absolute path to a missing file shows a clear local error, not 'Network error'."""
+        from winml.modelkit.commands.inspect import inspect
+
+        missing = str(tmp_path / "missing.onnx")
+        result = runner.invoke(inspect, ["-m", missing], obj={})
+        assert result.exit_code != 0
+        assert "does not exist" in result.output
+        assert "Network error" not in result.output
+
+    def test_missing_local_relative_path_shows_path_error(self, runner: CliRunner) -> None:
+        """Relative path starting with '.' shows a clear local error, not 'Network error'."""
+        from winml.modelkit.commands.inspect import inspect
+
+        result = runner.invoke(inspect, ["-m", "./does-not-exist.onnx"], obj={})
+        assert result.exit_code != 0
+        assert "does not exist" in result.output
+        assert "Network error" not in result.output
+
+    def test_bogus_hf_id_shows_model_not_found(self, runner: CliRunner) -> None:
+        """RepositoryNotFoundError from HF Hub maps to 'Model not found', not 'Network error'."""
+        from huggingface_hub.utils import RepositoryNotFoundError
+
+        from winml.modelkit.commands.inspect import inspect
+
+        with patch(
+            "transformers.AutoConfig.from_pretrained",
+            side_effect=RepositoryNotFoundError("totally-bogus/does-not-exist"),
+        ):
+            result = runner.invoke(inspect, ["-m", "totally-bogus/does-not-exist"], obj={})
+            assert result.exit_code != 0
+            assert "Model not found" in result.output
+            assert "Network error" not in result.output

--- a/tests/unit/commands/test_inspect_cli.py
+++ b/tests/unit/commands/test_inspect_cli.py
@@ -10,10 +10,15 @@ NO actual HuggingFace downloads or model loading.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 @pytest.fixture
@@ -264,10 +269,8 @@ class TestInspectErrors:
             assert result.exit_code != 0
             assert "Inspection error" in result.output
 
-    def test_missing_local_file_shows_path_error(
-        self, runner: CliRunner, tmp_path: pytest.TempPathFactory
-    ) -> None:
-        """Absolute path to a missing file shows a clear local error, not 'Network error'."""
+    def test_missing_local_file_shows_path_error(self, runner: CliRunner, tmp_path: Path) -> None:
+        """Absolute path to a missing .onnx file shows a clear local error, not 'Network error'."""
         from winml.modelkit.commands.inspect import inspect
 
         missing = str(tmp_path / "missing.onnx")
@@ -300,8 +303,15 @@ class TestInspectErrors:
             assert "Model not found" in result.output
             assert "Network error" not in result.output
 
-    def test_hf_id_with_dot_not_treated_as_missing_local_path(self) -> None:
-        """A valid-looking HF ID with '.' should not be pre-classified as local."""
-        from winml.modelkit.commands.inspect import _looks_like_local_path
+    def test_dotted_hf_id_reaches_hub_path(self, runner: CliRunner) -> None:
+        """HF IDs with version dots (e.g. Phi-3.5) must not be classified as local paths."""
+        from winml.modelkit.commands.inspect import inspect
 
-        assert _looks_like_local_path("org/model.onnx") is False
+        with patch(
+            "transformers.AutoConfig.from_pretrained",
+            side_effect=RuntimeError("intentional — proves we reached the Hub path"),
+        ):
+            result = runner.invoke(inspect, ["-m", "microsoft/Phi-3.5-mini-instruct"], obj={})
+        assert "does not exist" not in result.output, (
+            "dotted HF ID was misclassified as a local path"
+        )


### PR DESCRIPTION
## Summary

Fixes microsoft/winml-cli#542. Two distinct failure modes were both surfacing as `"Network error"`:

- A bogus HF ID (`totally-bogus/does-not-exist`) → `RepositoryNotFoundError` is an `OSError` subclass, so the broad `except OSError → NetworkError` handler caught it
- A missing local file (`.\does-not-exist.onnx`) → `AutoConfig.from_pretrained` raised a plain `OSError` with a confusing HF Hub message including "Network error"

**Fix 1 — local path pre-check in `inspect()`** ([inspect.py](src/winml/modelkit/commands/inspect.py))

Before touching HF Hub, classify the input. If it looks like a local path (absolute, backslash, dot-prefix, or has a file extension — none of which appear in normal `org/model` HF IDs) and does not exist, fail early with:
```
Error: Local path '.\does-not-exist.onnx' does not exist.
```

**Fix 2 — explicit `RepositoryNotFoundError` catch in `_inspect_model_v2()`** ([inspect.py](src/winml/modelkit/commands/inspect.py))

Catch `RepositoryNotFoundError` before the broad `OSError` handler so HF 404s map to `ModelNotFoundError` and surface as:
```
Error: Model not found: Model 'totally-bogus/does-not-exist' not found on Hugging Face Hub.
```

**Tests** ([test_inspect_cli.py](tests/unit/commands/test_inspect_cli.py))
- `test_missing_local_file_shows_path_error` — absolute tmp path without `.onnx`
- `test_missing_local_relative_path_shows_path_error` — `./does-not-exist.onnx`
- `test_bogus_hf_id_shows_model_not_found` — patches `AutoConfig.from_pretrained` to raise `RepositoryNotFoundError`