### PR TITLE
Revert "Export DETR/Table Transformer ONNX with `pixel_mask` to preserve non-square detection accuracy"

### DIFF
--- a/src/winml/modelkit/models/hf/detr.py
+++ b/src/winml/modelkit/models/hf/detr.py
@@ -16,14 +16,8 @@ Note:
 
 Image size:
     DETR's preprocessor uses shortest_edge=800. The export pipeline reads
-    this from preprocessor_config.json via _populate_image_size_from_preprocessor.
-
-ONNX export:
-    Optimum's built-in DETR/Table Transformer OnnxConfig exports only
-    ``pixel_values``. For non-square images this causes large accuracy
-    regressions because padded regions cannot be masked during inference.
-    This module registers an override that adds optional ``pixel_mask``
-    input and generates matching dummy input tensors during export.
+    this from preprocessor_config.json via _populate_image_size_from_preprocessor,
+    so no custom OnnxConfig is needed. Override via --shape-config if desired.
 
 Exports:
     DETR_CONFIG: WinMLBuildConfig with conv fusion flags
@@ -31,11 +25,7 @@ Exports:
 
 from __future__ import annotations
 
-from optimum.exporters.onnx.model_configs import DetrOnnxConfig, TableTransformerOnnxConfig
-from optimum.utils.input_generators import DummyVisionInputGenerator
-
 from ...config import WinMLBuildConfig
-from ...export import register_onnx_overwrite
 from ...optim import WinMLOptimizationConfig
 
 
@@ -48,69 +38,3 @@ DETR_CONFIG = WinMLBuildConfig(
         conv_add_fusion=True,
     ),
 )
-
-
-class _DetrPixelMaskMixin:
-    """Shared pixel_mask input override for DETR-family ONNX export configs."""
-
-    @property
-    def inputs(self) -> dict[str, dict[int, str]]:
-        """Return input tensors including optional pixel_mask."""
-        return {
-            "pixel_values": {0: "batch_size", 1: "num_channels", 2: "height", 3: "width"},
-            "pixel_mask": {0: "batch_size", 1: "height", 2: "width"},
-        }
-
-
-class PixelMaskInputGenerator(DummyVisionInputGenerator):
-    """Generate all-ones pixel masks with DETR-compatible int64 dtype."""
-
-    SUPPORTED_INPUT_NAMES = ("pixel_mask",)
-
-    def generate(
-        self,
-        input_name: str,
-        framework: str = "pt",
-        int_dtype: str = "int64",
-        float_dtype: str = "fp32",
-    ):
-        """Generate an all-ones int64 pixel mask for the current image batch."""
-        del input_name, float_dtype
-        return self.random_int_tensor(
-            shape=[self.batch_size, self.height, self.width],
-            min_value=1,
-            max_value=2,
-            framework=framework,
-            dtype=int_dtype,
-        )
-
-
-@register_onnx_overwrite(
-    "detr",
-    "feature-extraction",
-    "object-detection",
-    "image-segmentation",
-    library_name="transformers",
-)
-class DetrIOConfig(_DetrPixelMaskMixin, DetrOnnxConfig):
-    """DETR ONNX config override that adds optional pixel_mask input."""
-
-    DUMMY_INPUT_GENERATOR_CLASSES = (
-        PixelMaskInputGenerator,
-        *DetrOnnxConfig.DUMMY_INPUT_GENERATOR_CLASSES,
-    )
-
-
-@register_onnx_overwrite(
-    "table-transformer",
-    "feature-extraction",
-    "object-detection",
-    library_name="transformers",
-)
-class TableTransformerIOConfig(_DetrPixelMaskMixin, TableTransformerOnnxConfig):
-    """Table Transformer ONNX config override that adds optional pixel_mask input."""
-
-    DUMMY_INPUT_GENERATOR_CLASSES = (
-        PixelMaskInputGenerator,
-        *TableTransformerOnnxConfig.DUMMY_INPUT_GENERATOR_CLASSES,
-    )

--- a/tests/unit/export/test_io_specs.py
+++ b/tests/unit/export/test_io_specs.py
@@ -240,7 +240,7 @@ class TestIOSpecsInputNames:
                 "detr",
                 "object-detection",
                 "detr_config",
-                ["pixel_values", "pixel_mask"],
+                ["pixel_values"],
             ),
         ],
         ids=["albert", "distilbert", "gpt2", "convnext", "detr"],

--- a/tests/unit/models/detr/test_onnx_config.py
+++ b/tests/unit/models/detr/test_onnx_config.py
@@ -4,21 +4,15 @@
 # --------------------------------------------------------------------------
 """Tests for DETR model configuration.
 
-Tests cover:
-- DETR_CONFIG (WinMLBuildConfig) conv fusion flags for ResNet BN folding
-- ONNX export config override registration for DETR/Table Transformer
-- pixel_mask input + dummy input generation for DETR-family exports
+Tests for DETR_CONFIG (WinMLBuildConfig) which provides conv fusion flags
+for ResNet backbone BN folding. DetrIOConfig was removed in favor of
+_populate_image_size_from_preprocessor which reads image size from
+preprocessor_config.json.
 """
 
 from __future__ import annotations
 
-import pytest
-import torch
-from transformers import DetrConfig, TableTransformerConfig
-
-from winml.modelkit.export import generate_dummy_inputs
-from winml.modelkit.export.io import _get_onnx_config  # Testing internal implementation
-from winml.modelkit.models.hf.detr import DETR_CONFIG, DetrIOConfig, TableTransformerIOConfig
+from winml.modelkit.models.hf.detr import DETR_CONFIG
 
 
 # =============================================================================
@@ -37,94 +31,3 @@ class TestDetrModelConfig:
         assert optim["conv_bn_fusion"] is True
         assert optim["conv_mul_fusion"] is True
         assert optim["conv_add_fusion"] is True
-
-
-@pytest.fixture(scope="module")
-def detr_config():
-    """Minimal DetrConfig for testing ONNX I/O config."""
-    return DetrConfig(
-        num_channels=3,
-        d_model=64,
-        encoder_layers=1,
-        decoder_layers=1,
-        encoder_attention_heads=2,
-        decoder_attention_heads=2,
-        encoder_ffn_dim=128,
-        decoder_ffn_dim=128,
-    )
-
-
-@pytest.fixture(scope="module")
-def table_transformer_config():
-    """Minimal TableTransformerConfig for testing ONNX I/O config."""
-    return TableTransformerConfig(
-        num_channels=3,
-        d_model=64,
-        encoder_layers=1,
-        decoder_layers=1,
-        encoder_attention_heads=2,
-        decoder_attention_heads=2,
-        encoder_ffn_dim=128,
-        decoder_ffn_dim=128,
-    )
-
-
-class TestDetrFamilyIOConfig:
-    """Tests for DETR-family ONNX config pixel_mask export behavior."""
-
-    @pytest.mark.parametrize(
-        "model_type,task,config_fixture,expected_class",
-        [
-            ("detr", "object-detection", "detr_config", DetrIOConfig),
-            (
-                "table-transformer",
-                "object-detection",
-                "table_transformer_config",
-                TableTransformerIOConfig,
-            ),
-        ],
-        ids=["detr", "table-transformer"],
-    )
-    def test_onnx_config_registered_with_pixel_mask(
-        self, model_type, task, config_fixture, expected_class, request
-    ):
-        """DETR-family object-detection task resolves to pixel_mask-enabled config."""
-        config = request.getfixturevalue(config_fixture)
-
-        onnx_config = _get_onnx_config(model_type, task, config)
-
-        assert isinstance(onnx_config, expected_class)
-        assert "pixel_values" in onnx_config.inputs
-        assert "pixel_mask" in onnx_config.inputs
-        assert onnx_config.inputs["pixel_mask"] == {0: "batch_size", 1: "height", 2: "width"}
-
-    @pytest.mark.parametrize(
-        "model_type,config_fixture",
-        [
-            ("detr", "detr_config"),
-            ("table-transformer", "table_transformer_config"),
-        ],
-        ids=["detr", "table-transformer"],
-    )
-    def test_generate_dummy_inputs_include_pixel_mask(self, model_type, config_fixture, request):
-        """Dummy inputs include pixel_mask aligned with pixel_values height/width."""
-        config = request.getfixturevalue(config_fixture)
-
-        inputs = generate_dummy_inputs(
-            model_type,
-            "object-detection",
-            config,
-            batch_size=2,
-            height=128,
-            width=192,
-        )
-
-        assert "pixel_values" in inputs
-        assert "pixel_mask" in inputs
-
-        pixel_values = inputs["pixel_values"]
-        pixel_mask = inputs["pixel_mask"]
-        assert pixel_values.shape == (2, 3, 128, 192)
-        assert pixel_mask.shape == (2, 128, 192)
-        assert pixel_mask.dtype == torch.int32
-        assert torch.all(pixel_mask == 1)


### PR DESCRIPTION
Reverts microsoft/winml-cli#479