### PR TITLE
Fix onnxruntime search dll path.

### DIFF
--- a/src/winml/modelkit/__init__.py
+++ b/src/winml/modelkit/__init__.py
@@ -42,6 +42,37 @@ for _stream in (sys.stdout, sys.stderr):
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
+
+def _preload_bundled_onnxruntime_dll() -> None:
+    # Windows ships C:\Windows\System32\onnxruntime.dll (older API version)
+    # as part of the system WindowsML component. When WinML EP plugin DLLs
+    # are loaded (via EpCatalog), they import "onnxruntime.dll" by base name
+    # and the loader binds them to the system copy, producing
+    # "The requested API version [N] is not available" errors.
+    # Loading the wheel-bundled DLL by full path first makes later base-name
+    # imports resolve to the already-loaded module.
+    if sys.platform != "win32":
+        return
+    try:
+        import ctypes
+        import os
+        from importlib.util import find_spec
+        from pathlib import Path
+
+        spec = find_spec("onnxruntime")
+        if spec is None or spec.origin is None:
+            return
+        dll = Path(spec.origin).parent / "capi" / "onnxruntime.dll"
+        if not dll.is_file():
+            return
+        os.add_dll_directory(str(dll.parent))
+        ctypes.WinDLL(str(dll))
+    except Exception as _e:  # pragma: no cover - best-effort preload
+        print(f"Warning: failed to preload bundled onnxruntime.dll: {_e}", file=sys.stderr)
+
+
+_preload_bundled_onnxruntime_dll()
+
 from . import _warnings  # Configure warning filters before importing subpackages
 
 

--- a/tests/unit/test_modelkit_init.py
+++ b/tests/unit/test_modelkit_init.py
@@ -1,0 +1,67 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Regression tests for ``_preload_bundled_onnxruntime_dll``.
+
+The preload is the load-order fix for the System32 vs. wheel-bundled
+``onnxruntime.dll`` collision on Windows. It must run before any subpackage
+import that transitively touches onnxruntime, otherwise the System32 copy
+wins and produces "requested API version [N] is not available" errors on
+end-user machines. These tests pin the contract without needing a real
+Windows host or a real wheel.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest import mock
+
+
+def _reimport_modelkit():
+    # Drop the cached package so its __init__.py (and the preload call at
+    # module scope) executes again under the active mocks.
+    for name in [
+        m for m in sys.modules if m == "winml.modelkit" or m.startswith("winml.modelkit.")
+    ]:
+        sys.modules.pop(name, None)
+    import importlib
+
+    return importlib.import_module("winml.modelkit")
+
+
+def test_preload_is_noop_on_non_windows(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    with mock.patch("ctypes.WinDLL", create=True) as windll:
+        _reimport_modelkit()
+        windll.assert_not_called()
+
+
+def test_preload_skips_when_bundled_dll_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "platform", "win32")
+    fake_spec = types.SimpleNamespace(origin=str(tmp_path / "onnxruntime" / "__init__.py"))
+    with (
+        mock.patch("importlib.util.find_spec", return_value=fake_spec),
+        mock.patch("ctypes.WinDLL", create=True) as windll,
+        mock.patch("os.add_dll_directory", create=True) as add_dir,
+    ):
+        _reimport_modelkit()
+        windll.assert_not_called()
+        add_dir.assert_not_called()
+
+
+def test_preload_loads_dll_on_windows_when_present(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "platform", "win32")
+    capi = tmp_path / "onnxruntime" / "capi"
+    capi.mkdir(parents=True)
+    (capi / "onnxruntime.dll").write_bytes(b"")
+    fake_spec = types.SimpleNamespace(origin=str(tmp_path / "onnxruntime" / "__init__.py"))
+    with (
+        mock.patch("importlib.util.find_spec", return_value=fake_spec),
+        mock.patch("ctypes.WinDLL", create=True) as windll,
+        mock.patch("os.add_dll_directory", create=True) as add_dir,
+    ):
+        _reimport_modelkit()
+        add_dir.assert_called_once_with(str(capi))
+        windll.assert_called_once_with(str(capi / "onnxruntime.dll"))


### PR DESCRIPTION
Windows ships C:\Windows\System32\onnxruntime.dll (older API version) as part of the system WindowsML component.
When WinML EP plugin DLLs are loaded (via EpCatalog), they import "onnxruntime.dll" by base name and the loader binds them to the system copy, producing  "The requested API version [N] is not available" errors.
Loading the wheel-bundled DLL by full path first makes later base-name imports resolve to the already-loaded module.