### PR TITLE
fix: remove ov, vitis, trtrtx alias

### DIFF
--- a/src/winml/modelkit/analyze/analyzer.py
+++ b/src/winml/modelkit/analyze/analyzer.py
@@ -514,7 +514,7 @@ class ONNXStaticAnalyzer:
             model_path: Path to ONNX model file
             ep: Target execution provider (e.g., "QNNExecutionProvider",
                 "OpenVINOExecutionProvider", "VitisAIExecutionProvider").
-                Also supports aliases: "qnn", "ov"/"openvino", "vitis"/"vitisai".
+                Also supports aliases: "qnn", "openvino", "vitisai".
                 If None, analyzes all supported EPs.
             device: Device type (e.g., "CPU", "GPU", "NPU").
                 If None, uses "NPU" as default.
@@ -549,7 +549,7 @@ class ONNXStaticAnalyzer:
             >>> # Using EP alias
             >>> result = analyzer.analyze(
             ...     "model.onnx",
-            ...     ep="ov",  # Short for OpenVINOExecutionProvider
+            ...     ep="openvino",  # Short for OpenVINOExecutionProvider
             ...     device="GPU"
             ... )
 
@@ -642,7 +642,7 @@ class ONNXStaticAnalyzer:
             model_proto: ONNX ModelProto object
             ep: Target execution provider (e.g., "QNNExecutionProvider",
                 "OpenVINOExecutionProvider", "DmlExecutionProvider").
-                Also supports aliases: "qnn", "ov"/"openvino", "vitis"/"vitisai".
+                Also supports aliases: "qnn", "openvino", "vitisai".
                 If None, analyzes all supported EPs.
             device: Target device type (e.g., "CPU", "GPU", "NPU").
                 If None, uses "NPU" as default.

--- a/src/winml/modelkit/data/hub_models.json
+++ b/src/winml/modelkit/data/hub_models.json
@@ -13,7 +13,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -33,7 +33,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -53,7 +53,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -76,7 +76,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -96,7 +96,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -116,7 +116,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -136,7 +136,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -159,7 +159,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -182,7 +182,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -204,7 +204,7 @@
         "qnn": [
           "GPU"
         ],
-        "ov": [
+        "openvino": [
           "GPU",
           "NPU"
         ],
@@ -226,7 +226,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -246,7 +246,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -266,7 +266,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -285,7 +285,7 @@
         "qnn": [
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -308,7 +308,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -331,7 +331,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -354,7 +354,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "NPU"
         ],
@@ -376,7 +376,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -399,7 +399,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -422,7 +422,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -442,7 +442,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -462,7 +462,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -485,7 +485,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "NPU"
         ]
@@ -504,7 +504,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -527,7 +527,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "NPU"
         ],
@@ -549,7 +549,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -572,7 +572,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -591,7 +591,7 @@
         "qnn": [
           "GPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -614,7 +614,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -636,7 +636,7 @@
         "qnn": [
           "GPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -659,7 +659,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -682,7 +682,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -705,7 +705,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -728,7 +728,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "NPU"
         ],
@@ -750,7 +750,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "NPU"
         ],
@@ -772,7 +772,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -795,7 +795,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -818,7 +818,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -841,7 +841,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -864,7 +864,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -884,7 +884,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -907,7 +907,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -930,7 +930,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -953,7 +953,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -976,7 +976,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -996,7 +996,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -1019,7 +1019,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -1039,7 +1039,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -1062,7 +1062,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -1085,7 +1085,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -1105,7 +1105,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -1128,7 +1128,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -1151,7 +1151,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -1174,7 +1174,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -1194,7 +1194,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -1214,7 +1214,7 @@
           "GPU",
           "NPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"
@@ -1236,7 +1236,7 @@
         "qnn": [
           "GPU"
         ],
-        "ov": [
+        "openvino": [
           "CPU",
           "GPU",
           "NPU"

--- a/src/winml/modelkit/utils/constants.py
+++ b/src/winml/modelkit/utils/constants.py
@@ -28,14 +28,12 @@ EPName = Literal[
 EPAlias = Literal[
     "qnn",
     "openvino",
-    "ov",
     "vitisai",
-    "vitis",
     "cpu",
     "cuda",
     "dml",
+    "nvtensorrtrtx",
     "nv_tensorrt_rtx",
-    "trtrtx",
     "migraphx",
 ]
 
@@ -53,14 +51,12 @@ SUPPORTED_EPS: list[EPName] = list(get_args(EPName))
 EP_ALIASES: dict[EPAlias, EPName] = {
     "qnn": "QNNExecutionProvider",
     "openvino": "OpenVINOExecutionProvider",
-    "ov": "OpenVINOExecutionProvider",
     "vitisai": "VitisAIExecutionProvider",
-    "vitis": "VitisAIExecutionProvider",
     "cpu": "CPUExecutionProvider",
     "cuda": "CUDAExecutionProvider",
     "dml": "DmlExecutionProvider",
+    "nvtensorrtrtx": "NvTensorRTRTXExecutionProvider",
     "nv_tensorrt_rtx": "NvTensorRTRTXExecutionProvider",
-    "trtrtx": "NvTensorRTRTXExecutionProvider",
     "migraphx": "MIGraphXExecutionProvider",
 }
 
@@ -102,8 +98,6 @@ def normalize_ep_name(ep: EPNameOrAlias | None) -> EPName | None:
     Examples:
         >>> normalize_ep_name("qnn")
         'QNNExecutionProvider'
-        >>> normalize_ep_name("ov")
-        'OpenVINOExecutionProvider'
         >>> normalize_ep_name("QNNExecutionProvider")
         'QNNExecutionProvider'
     """

--- a/tests/cli/test_catalog_cli.py
+++ b/tests/cli/test_catalog_cli.py
@@ -322,8 +322,8 @@ class TestCatalogFilterEp:
         vitisai = _run_json(tmp_path / "vitisai.json", "--ep", "vitisai")
         assert 0 < len(vitisai) < len(all_models)
 
-    def test_ep_alias_ov_equals_openvino(self, tmp_path: Path) -> None:
-        ov = _run_json(tmp_path / "ov.json", "--ep", "ov")
+    def test_ep_alias_openvino_equals_openvinoexecutionprovider(self, tmp_path: Path) -> None:
+        ov = _run_json(tmp_path / "ov.json", "--ep", "openvinoexecutionprovider")
         openvino = _run_json(tmp_path / "openvino.json", "--ep", "openvino")
         assert _model_ids(ov) == _model_ids(openvino)
 

--- a/tests/unit/analyze/test_static_analyzer_cli.py
+++ b/tests/unit/analyze/test_static_analyzer_cli.py
@@ -1001,7 +1001,7 @@ class TestAnalyzeEPDeviceSelectionMatrix:
                 None,
             ),
             (
-                "ov",
+                "openvino",
                 None,
                 0,
                 [
@@ -1021,7 +1021,7 @@ class TestAnalyzeEPDeviceSelectionMatrix:
                 ],
                 None,
             ),
-            ("ov", "gpu", 0, [("OpenVINOExecutionProvider", "GPU")], None),
+            ("openvino", "gpu", 0, [("OpenVINOExecutionProvider", "GPU")], None),
             (
                 "all",
                 "all",
@@ -1040,10 +1040,10 @@ class TestAnalyzeEPDeviceSelectionMatrix:
         ids=[
             "empty-empty",
             "empty-gpu",
-            "ov-empty",
+            "openvino-empty",
             "qnn-empty",
             "qnn-all",
-            "ov-gpu",
+            "openvino-gpu",
             "all-all",
         ],
     )
@@ -1136,7 +1136,7 @@ class TestAnalyzeEPDeviceSelectionMatrix:
 
     @patch("winml.modelkit.commands.analyze._render_analysis_summary")
     @patch("winml.modelkit.analyze.ONNXStaticAnalyzer")
-    def test_ov_gpu_has_local_not_supported_hint(
+    def test_openvino_gpu_has_local_not_supported_hint(
         self,
         mock_analyzer_class: MagicMock,
         mock_summary: MagicMock,
@@ -1144,7 +1144,7 @@ class TestAnalyzeEPDeviceSelectionMatrix:
         tmp_path: Path,
         mock_analyzer_result: Mock,
     ) -> None:
-        """ov + gpu should execute and carry local-not-supported hint into summary rendering."""
+        """openvino + gpu should execute and carry local-not-supported hint into summary."""
         model_file = tmp_path / "test.onnx"
         model_file.write_bytes(b"dummy")
 
@@ -1154,7 +1154,7 @@ class TestAnalyzeEPDeviceSelectionMatrix:
 
         result = runner.invoke(
             analyze,
-            ["--model", str(model_file), "--ep", "ov", "--device", "gpu"],
+            ["--model", str(model_file), "--ep", "openvino", "--device", "gpu"],
         )
         assert result.exit_code == 0
         assert mock_instance.analyze.called
@@ -1162,9 +1162,7 @@ class TestAnalyzeEPDeviceSelectionMatrix:
 
         summary_kwargs = mock_summary.call_args.kwargs
         pair_hints = summary_kwargs["pair_hints"]
-        assert pair_hints[("OpenVINOExecutionProvider", "GPU")] == [
-            "local machine not supported"
-        ]
+        assert pair_hints[("OpenVINOExecutionProvider", "GPU")] == ["local machine not supported"]
 
     @patch("winml.modelkit.commands.analyze._render_analysis_summary")
     @patch("winml.modelkit.analyze.ONNXStaticAnalyzer")
@@ -1374,9 +1372,7 @@ class TestAnalyzeSummaryRendering:
         _render_analysis_summary(
             console,
             [ep_support],
-            ep_instance_counts={
-                ("DmlExecutionProvider", "GPU"): {"Conv": {"supported": 2}}
-            },
+            ep_instance_counts={("DmlExecutionProvider", "GPU"): {"Conv": {"supported": 2}}},
             ep_patterns={},
             ep="DmlExecutionProvider",
             device="GPU",

--- a/tests/unit/commands/test_catalog.py
+++ b/tests/unit/commands/test_catalog.py
@@ -44,7 +44,7 @@ MINIMAL_CATALOG = {
                 "cpu": ["CPU"],
                 "dml": ["GPU"],
                 "qnn": ["GPU", "NPU"],
-                "ov": ["CPU", "GPU", "NPU"],
+                "openvino": ["CPU", "GPU", "NPU"],
             },
         },
         {
@@ -56,7 +56,7 @@ MINIMAL_CATALOG = {
                 "cpu": ["CPU"],
                 "dml": ["GPU"],
                 "qnn": ["GPU", "NPU"],
-                "ov": ["CPU", "GPU", "NPU"],
+                "openvino": ["CPU", "GPU", "NPU"],
             },
         },
         {
@@ -68,7 +68,7 @@ MINIMAL_CATALOG = {
             "supported_eps": {
                 "cpu": ["CPU"],
                 "dml": ["GPU"],
-                "ov": ["CPU", "GPU", "NPU"],
+                "openvino": ["CPU", "GPU", "NPU"],
             },
         },
         {
@@ -317,11 +317,11 @@ def test_filter_by_ep_qnn_alias():
     assert all("qnn" in m["supported_eps"] for m in result)
 
 
-def test_filter_by_ep_ov_alias():
+def test_filter_by_ep_openvino_alias():
     # bert (x2) and detr have OV; clip does not
-    result = _filter_by_ep(MINIMAL_CATALOG["models"], "ov")
+    result = _filter_by_ep(MINIMAL_CATALOG["models"], "openvino")
     assert len(result) == 3
-    assert all("ov" in m["supported_eps"] for m in result)
+    assert all("openvino" in m["supported_eps"] for m in result)
 
 
 def test_filter_by_ep_vitisai_alias():
@@ -447,16 +447,16 @@ def test_make_ep_col_fn_for_device_header():
 
 
 def test_make_ep_col_fn_for_device_npu_all_eps():
-    """Model with QNN+OV shows both labels in supported_eps key order."""
+    """Model with QNN+OpenVINO shows both labels in supported_eps key order."""
     _, fn = _make_ep_col_fn_for_device("NPU")
-    bert = MINIMAL_CATALOG["models"][0]  # google-bert: qnn before ov in JSON
-    assert fn(bert) == "QNN / OV"
+    bert = MINIMAL_CATALOG["models"][0]  # google-bert: qnn before openvino in JSON
+    assert fn(bert) == "QNN / OPENVINO"
 
 
-def test_make_ep_col_fn_for_device_npu_ov_only():
+def test_make_ep_col_fn_for_device_npu_openvino_only():
     _, fn = _make_ep_col_fn_for_device("NPU")
-    detr = MINIMAL_CATALOG["models"][2]  # ov only
-    assert fn(detr) == "OV"
+    detr = MINIMAL_CATALOG["models"][2]  # openvino only
+    assert fn(detr) == "OPENVINO"
 
 
 def test_make_ep_col_fn_for_device_npu_vitisai_only():
@@ -472,16 +472,16 @@ def test_make_ep_col_fn_for_device_cpu_always_present():
         assert "CPU" in fn(m)
 
 
-def test_make_ep_col_fn_for_device_cpu_ov_added_when_present():
+def test_make_ep_col_fn_for_device_cpu_openvino_added_when_present():
     _, fn = _make_ep_col_fn_for_device("CPU")
-    bert = MINIMAL_CATALOG["models"][0]  # has cpu + ov (both support CPU)
-    assert fn(bert) == "CPU / OV"
+    bert = MINIMAL_CATALOG["models"][0]  # has cpu + openvino (both support CPU)
+    assert fn(bert) == "CPU / OPENVINO"
 
 
 def test_make_ep_col_fn_for_device_gpu_shows_all_gpu_eps():
     _, fn = _make_ep_col_fn_for_device("GPU")
-    bert = MINIMAL_CATALOG["models"][0]  # dml + qnn + ov all support GPU
-    assert fn(bert) == "DML / QNN / OV"
+    bert = MINIMAL_CATALOG["models"][0]  # dml + qnn + openvino all support GPU
+    assert fn(bert) == "DML / QNN / OPENVINO"
 
 
 def test_make_ep_col_fn_for_device_gpu_dml_always_present():
@@ -577,7 +577,7 @@ def test_device_filter_shows_correct_eps():
     _, fn = _make_ep_col_fn_for_device("NPU")
     wide.print(_build_list_renderable(MINIMAL_CATALOG["models"], ep_col_header="EPs", ep_col_fn=fn))
     rendered = buf.getvalue()
-    assert "QNN / OV" in rendered  # bert models (JSON key order: qnn before ov)
+    assert "QNN / OPENVINO" in rendered  # bert models (JSON key order: qnn before openvino)
     assert "VITISAI" in rendered  # clip model
 
 

--- a/tests/unit/commands/test_run_spec.py
+++ b/tests/unit/commands/test_run_spec.py
@@ -504,9 +504,7 @@ class TestEPOption:
         [
             "qnn",
             "openvino",
-            "ov",
             "vitisai",
-            "vitis",
             "QNNExecutionProvider",
             "OpenVINOExecutionProvider",
             "VitisAIExecutionProvider",

--- a/tests/unit/compiler/test_compile_command.py
+++ b/tests/unit/compiler/test_compile_command.py
@@ -227,13 +227,13 @@ class TestCompileCommand:
         assert "(e.g. qnn, openvino)" in result.output
 
     @patch("winml.modelkit.compiler.compile_onnx")
-    def test_ep_trtrtx_propagates_gpu_device_type(
+    def test_ep_nvtensorrtrtx_propagates_gpu_device_type(
         self,
         mock_compile_onnx: MagicMock,
         runner: CliRunner,
         tmp_path: Path,
     ) -> None:
-        """Test --device gpu --ep trtrtx no longer injects provider_options[device_type]."""
+        """Test --device gpu --ep nvtensorrtrtx no longer injects provider_options[device_type]."""
         model_path = tmp_path / "model.onnx"
         self._create_simple_onnx(model_path)
 
@@ -246,7 +246,7 @@ class TestCompileCommand:
 
         result = runner.invoke(
             main,
-            ["compile", "-m", str(model_path), "--device", "gpu", "--ep", "trtrtx"],
+            ["compile", "-m", str(model_path), "--device", "gpu", "--ep", "nvtensorrtrtx"],
         )
 
         assert result.exit_code == 0, result.output

--- a/tests/unit/utils/test_ep_constants.py
+++ b/tests/unit/utils/test_ep_constants.py
@@ -139,11 +139,10 @@ class TestNormalizeEPName:
         [
             ("qnn", "QNNExecutionProvider"),
             ("openvino", "OpenVINOExecutionProvider"),
-            ("ov", "OpenVINOExecutionProvider"),
             ("vitisai", "VitisAIExecutionProvider"),
-            ("vitis", "VitisAIExecutionProvider"),
             ("cpu", "CPUExecutionProvider"),
             ("dml", "DmlExecutionProvider"),
+            ("nvtensorrtrtx", "NvTensorRTRTXExecutionProvider"),
             ("nv_tensorrt_rtx", "NvTensorRTRTXExecutionProvider"),
             ("migraphx", "MIGraphXExecutionProvider"),
         ],
@@ -185,7 +184,7 @@ class TestExtractEPOptions:
             {
                 "qnn_qairt": "/sdk",
                 "model": "m.onnx",
-                "ov_device": "GPU",
+                "openvino_device": "GPU",
                 "verbose": "1",
             }
         )


### PR DESCRIPTION
closes https://github.com/microsoft/winml-cli/issues/630

ONLY use ones from EPName unless we get confirmation from IHV