### PR TITLE
Improve winml eval UX: validate inputs upfront, friendlier errors, structured --schema

### DIFF
--- a/src/winml/modelkit/commands/eval.py
+++ b/src/winml/modelkit/commands/eval.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 import click
 
 from ..utils import cli as cli_utils
+from ..utils.eval_utils import TASK_SCHEMAS, TaskSchema
 
 
 if TYPE_CHECKING:
@@ -31,13 +32,7 @@ logger = logging.getLogger(__name__)
     type=str,
     multiple=True,
     default=(),
-    help=(
-        "Model to evaluate. Accepts three forms: "
-        "(1) HuggingFace model ID, e.g. `-m <hf_model_id>`. "
-        "(2) ONNX file path, e.g. `-m model.onnx` (requires --model-id). "
-        "(3) Composite / split-encoder model as repeated role=path pairs, "
-        "e.g. `-m image-encoder=vision.onnx -m text-encoder=text.onnx`."
-    ),
+    help="Model to evaluate. Accepts a HuggingFace model ID or an ONNX file path.",
 )
 @click.option(
     "--model-id",
@@ -166,25 +161,38 @@ def eval(
     show_schema: bool,
     config_file: Path | None,
 ) -> None:
-    r"""Evaluate model accuracy on a dataset.
+    r"""Evaluate a model for a task.
 
-    If --dataset is not provided, a default dataset is used based on the task.
-
-    \b
     Examples:
-        # Use default dataset (auto-detected from task)
         winml eval -m microsoft/resnet-50
-        winml eval -m model.onnx --model-id dslim/bert-base-NER
 
-        # Specify dataset explicitly
-        winml eval -m microsoft/resnet-50 --dataset imagenet-1k
-        winml eval -m model.onnx --model-id microsoft/resnet-50 --dataset imagenet-1k
+        winml eval -m model.onnx --model-id microsoft/resnet-50
 
-        # Multi-config dataset with column overrides
-        winml eval -m model.onnx --model-id Intel/bert-base-uncased-mrpc \\
-            --dataset glue --dataset-name mrpc \\
-            --column input_column=sentence1
+    Run `winml eval --schema --task <task>` to see the dataset columns
+    and options expected by each task.
     """
+    # ── 0. --schema fast path: served from a local lightweight schema table
+    #       so this branch does not import the heavy winml.modelkit.eval package.
+    if show_schema:
+        task_arg: str | None = ctx.params.get("task")
+        if task_arg is None:
+            task_list = "\n  ".join(sorted(TASK_SCHEMAS))
+            click.echo(
+                "--schema requires --task <task>.\n\n"
+                f"Supported tasks:\n  {task_list}\n\n"
+                "Example: winml eval --schema --task image-classification"
+            )
+            return
+        schema = TASK_SCHEMAS.get(task_arg)
+        if schema is None:
+            supported = ", ".join(sorted(TASK_SCHEMAS))
+            raise click.UsageError(
+                f"Task '{task_arg}' is not supported by `winml eval`. "
+                f"Supported tasks: {supported}."
+            )
+        _print_schema(task_arg, schema)
+        return
+
     if verbose or (ctx.obj and ctx.obj.get("debug")):
         logging.getLogger("winml.modelkit").setLevel(logging.DEBUG)
 
@@ -192,20 +200,6 @@ def eval(
 
     # ── 1. Build config: defaults ← config file ← CLI ──
     cfg = _build_eval_config(ctx, config_file, column, label_mapping)
-
-    if show_schema:
-        from ..eval.evaluate import get_evaluator_class
-
-        if cfg.task is None:
-            raise click.UsageError(
-                "--schema requires --task. Example: winml eval --schema --task object-detection"
-            )
-        try:
-            cls = get_evaluator_class(cfg.task)
-        except ValueError as e:
-            raise click.UsageError(str(e)) from e
-        _print_schema(cfg.task, cls.schema_info())
-        return
 
     # ── 2. Resolve in place ──
     _resolve_model(cfg, model, model_id)
@@ -227,7 +221,8 @@ def eval(
         result = evaluate(cfg)
         _write_and_display(result, cfg.output_path)
     except Exception as e:
-        logger.exception("Evaluation failed")
+        if verbose:
+            logger.exception("Evaluation failed")
         raise click.ClickException(f"Evaluation failed: {e}") from e
 
 
@@ -475,6 +470,11 @@ def _resolve_model_path(
                 "for preprocessor and config resolution."
             )
         return value, model_id
+    if model_id is not None and model_id != value:
+        raise click.UsageError(
+            "Cannot pass both `-m <hf_id>` and `--model-id`. "
+            "Use `--model-id` only together with an ONNX file path in `-m`."
+        )
     return None, model_id or value
 
 
@@ -539,24 +539,41 @@ def display_eval_report(result: object, console: object) -> None:
     console.print()
 
 
-def _print_schema(task: str, schema: list, indent: int = 0) -> None:
-    """Format and print structured schema info."""
-    prefix = "  " * indent
-    if indent == 0:
-        click.echo(f"Dataset schema ({task}):\n")
-        click.echo(f"{prefix}{'Column':<20} {'Type':<25} {'Override (--column)'}")
-        click.echo(f"{prefix}{'-' * 20} {'-' * 25} {'-' * 25}")
+def _print_schema(task: str, schema: TaskSchema) -> None:
+    """Render the human-readable input schema for *task*."""
+    width = 50
+    title = f"Input schema for {task} models"
+    click.echo(title)
+    click.echo("=" * width)
+    click.echo()
 
-    for col in schema:
-        marker = "*" if col.required else " "
-        override_str = f"--column {col.override}={col.name}" if col.override else ""
-        click.echo(f"{prefix}{marker} {col.name:<18} {col.type:<25} {override_str}")
-        if col.description:
-            click.echo(f"{prefix}  {' ' * 18} {col.description}")
-        for child in col.children:
-            co = f"--column {child.override}={child.name}" if child.override else ""
-            click.echo(f"{prefix}    .{child.name:<16} {child.type:<25} {co}")
-            if child.description:
-                click.echo(f"{prefix}    {' ' * 18} {child.description}")
+    click.echo("--column option schema")
+    click.echo()
+    click.echo("Evaluating needs a dataset with the following columns:")
+    for item in schema.columns:
+        click.echo(f"  {item.name}")
+        click.echo(f"      {item.description} (default: {item.default})")
 
-    click.echo(f"\n{prefix}* = required")
+    if schema.params:
+        click.echo()
+        click.echo("Additional configuration parameters:")
+        for p in schema.params:
+            click.echo(f"  {p.name}")
+            click.echo(f"      {p.description} (default: {p.default})")
+
+    overrides = [c for c in (*schema.columns, *schema.params) if c.remap_hint]
+    if overrides:
+        click.echo()
+        click.echo("Override any default with --column:")
+        for c in overrides:
+            click.echo(f"  --column {c.name}={c.remap_hint}")
+
+    if schema.roles:
+        click.echo()
+        click.echo("-" * width)
+        click.echo("-m option schema")
+        click.echo()
+        click.echo("Use one of the following model input forms:")
+        click.echo("  1. use huggingface id: -m <hf-id>")
+        model_args = " ".join(f"-m {r}=<{r}.onnx>" for r in schema.roles)
+        click.echo(f"  2. use onnx file: {model_args} --model-id <hf-id>")

--- a/src/winml/modelkit/commands/eval.py
+++ b/src/winml/modelkit/commands/eval.py
@@ -32,7 +32,10 @@ logger = logging.getLogger(__name__)
     type=str,
     multiple=True,
     default=(),
-    help="Model to evaluate. Accepts a HuggingFace model ID or an ONNX file path.",
+    help=(
+        "Model to evaluate. Accepts a HuggingFace model ID, an ONNX file path "
+        "(requires --model-id), or split-encoder role=path pairs (see --schema)."
+    ),
 )
 @click.option(
     "--model-id",
@@ -174,7 +177,7 @@ def eval(
     # ── 0. --schema fast path: served from a local lightweight schema table
     #       so this branch does not import the heavy winml.modelkit.eval package.
     if show_schema:
-        task_arg: str | None = ctx.params.get("task")
+        task_arg = task
         if task_arg is None:
             task_list = "\n  ".join(sorted(TASK_SCHEMAS))
             click.echo(

--- a/src/winml/modelkit/eval/base_evaluator.py
+++ b/src/winml/modelkit/eval/base_evaluator.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from ..utils.eval_utils import DatasetValidationError, validate_dataset_columns
+
 
 if TYPE_CHECKING:
     from datasets import Dataset
@@ -29,16 +31,6 @@ _PIPELINE_TASK_MAP: dict[str, str] = {
 
 class WinMLEvaluator:
     """Base evaluator. Loads dataset, creates pipeline, runs HF evaluator."""
-
-    @classmethod
-    def schema_info(cls) -> list:
-        """Return dataset schema as list of SchemaColumn."""
-        from .config import SchemaColumn
-
-        return [
-            SchemaColumn("image", "Image", "input_column", description="PIL Image"),
-            SchemaColumn("label", "ClassLabel", "label_column", description="integer class label"),
-        ]
 
     def __init__(
         self,
@@ -123,6 +115,9 @@ class WinMLEvaluator:
                 )
             dataset = dataset.select(range(actual_samples))
 
+        validate_dataset_columns(
+            dataset, self.config.task, self.config.dataset.columns_mapping,
+        )
         return self.align_labels(dataset, ds)
 
     def prepare_pipeline(self) -> Pipeline:
@@ -203,8 +198,8 @@ class WinMLEvaluator:
             logger.info("Dataset labels aligned for %s.", ds_config.path)
             return self._filter_unsupported_labels(dataset, label_column)
         except (ValueError, KeyError) as e:
-            raise RuntimeError(
-                f"Label alignment failed for dataset '{ds_config.path}': {e}",
+            raise DatasetValidationError(
+                f"label alignment failed for dataset '{ds_config.path}': {e}",
             ) from e
 
     def _get_label_mapping(self, ds_config: DatasetConfig) -> dict | None:
@@ -228,8 +223,9 @@ class WinMLEvaluator:
         dataset = dataset.filter(lambda row: row[label_column] in supported_ids)
 
         if len(dataset) == 0:
-            raise ValueError(
-                "No samples remain after label filtering. Dataset and model labels have no overlap."
+            raise DatasetValidationError(
+                "No samples remain after label filtering. "
+                "Dataset and model labels have no overlap.",
             )
 
         if len(dataset) < original_count:

--- a/src/winml/modelkit/eval/base_evaluator.py
+++ b/src/winml/modelkit/eval/base_evaluator.py
@@ -89,15 +89,21 @@ class WinMLEvaluator:
             ds.split,
             ds.samples,
         )
-        if ds.path and Path(ds.path).is_dir():
-            dataset = load_from_disk(ds.path)
-        else:
-            dataset = load_dataset(
-                ds.path,
-                name=ds.name,
-                split=ds.split,
-                streaming=ds.streaming,
-            )
+        try:
+            if ds.path and Path(ds.path).is_dir():
+                dataset = load_from_disk(ds.path)
+            else:
+                dataset = load_dataset(
+                    ds.path,
+                    name=ds.name,
+                    split=ds.split,
+                    streaming=ds.streaming,
+                )
+        except Exception as e:
+            raise DatasetValidationError(
+                f"Failed to load dataset '{ds.path}' "
+                f"(name={ds.name!r}, split='{ds.split}'): {e}",
+            ) from e
 
         if ds.streaming:
             if ds.shuffle:

--- a/src/winml/modelkit/eval/config.py
+++ b/src/winml/modelkit/eval/config.py
@@ -15,27 +15,6 @@ from ..utils.constants import EPNameOrAlias
 
 
 @dataclass
-class SchemaColumn:
-    """Describes one expected dataset column for --schema output.
-
-    Attributes:
-        name: Default column name in the dataset.
-        type: HF feature type (e.g. "Image", "ClassLabel").
-        override: CLI --column key that maps to this column (e.g. "label_column").
-        required: Whether the column is mandatory.
-        description: Short human-readable description.
-        children: Nested columns for dict-type features.
-    """
-
-    name: str
-    type: str
-    override: str | None = None
-    required: bool = True
-    description: str = ""
-    children: list[SchemaColumn] = field(default_factory=list)
-
-
-@dataclass
 class WinMLEvaluationConfig:
     """Configuration for model evaluation.
 

--- a/src/winml/modelkit/eval/evaluate.py
+++ b/src/winml/modelkit/eval/evaluate.py
@@ -12,6 +12,8 @@ from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any
 
+from rich.console import Console
+
 from .base_evaluator import WinMLEvaluator
 from .config import WinMLEvaluationConfig
 from .feature_extraction_evaluator import WinMLFeatureExtractionEvaluator
@@ -31,6 +33,7 @@ if TYPE_CHECKING:
     from ..models.winml.base import WinMLPreTrainedModel
 
 logger = logging.getLogger(__name__)
+console = Console()
 
 _EVALUATOR_REGISTRY: dict[str, type[WinMLEvaluator]] = {
     "image-classification": WinMLEvaluator,
@@ -197,19 +200,24 @@ def _load_model(config: WinMLEvaluationConfig) -> WinMLPreTrainedModel:
 
 
 def _resolve_task(config: WinMLEvaluationConfig) -> str:
-    """Resolve task from config or model's HF config."""
+    """Resolve task from config or model's HF config, and validate it is supported."""
     if config.task is not None:
-        return config.task
+        task = config.task
+    else:
+        if config.model_id is None:
+            raise ValueError("Cannot infer task without model_id. Provide --task.")
 
-    if config.model_id is None:
-        raise ValueError("Cannot infer task without model_id. Provide --task.")
+        from transformers import AutoConfig
 
-    from transformers import AutoConfig
+        from ..loader.task import _detect_task_from_config
 
-    from ..loader.task import _detect_task_from_config
+        hf_config = AutoConfig.from_pretrained(config.model_id)
+        task = _detect_task_from_config(hf_config)
 
-    hf_config = AutoConfig.from_pretrained(config.model_id)
-    return _detect_task_from_config(hf_config)
+    if task not in _EVALUATOR_REGISTRY:
+        supported = ", ".join(sorted(_EVALUATOR_REGISTRY))
+        raise ValueError(f"Task '{task}' is not supported. Supported tasks: {supported}.")
+    return task
 
 
 def evaluate(config: WinMLEvaluationConfig) -> EvalResult:
@@ -220,7 +228,13 @@ def evaluate(config: WinMLEvaluationConfig) -> EvalResult:
     config and any module-level defaults remain untouched.
     """
     config = replace(config, task=_resolve_task(config), dataset=deepcopy(config.dataset))
-    model = _load_model(config)
+    try:
+        model = _load_model(config)
+    except Exception as e:
+        raise ValueError(
+            f"Failed to load model '{config.model_id}'. "
+            f"Run 'winml eval --schema --task {config.task}' to see expected model inputs.",
+        ) from e
 
     if config.dataset.path is None:
         default = _DEFAULT_DATASETS.get(config.task)
@@ -230,19 +244,57 @@ def evaluate(config: WinMLEvaluationConfig) -> EvalResult:
             )
         for k, v in default.items():
             setattr(config.dataset, k, deepcopy(v))
-        import json as _json
-
         logger.warning(
-            "--dataset is not specified; using default dataset for task '%s'. "
-            "Any user-supplied --split / --column / --streaming / --dataset-name "
-            "(or equivalent fields in the eval config) are ignored — the keys "
-            "below take precedence:\n%s",
+            "--dataset not specified; attempting default dataset '%s' for task '%s'. "
+            "Any --split / --column / --streaming / --dataset-name options are ignored.",
+            config.dataset.path,
             config.task,
-            _json.dumps(default, indent=2),
         )
 
+    print_config(config)
+
+    from ..utils.eval_utils import DatasetValidationError
+
     cls = get_evaluator_class(config.task)
-    task_evaluator = cls(config, model)
-    metrics = task_evaluator.compute()
+    try:
+        task_evaluator = cls(config, model)
+        metrics = task_evaluator.compute()
+    except DatasetValidationError as e:
+        raise ValueError(
+            f"Dataset '{config.dataset.path}' is not compatible with task "
+            f"'{config.task}': {e}. Use --dataset to specify a different dataset, "
+            f"or run 'winml eval --schema --task {config.task}' to see the expected schema.",
+        ) from e
+    except Exception as e:
+        raise ValueError(
+            f"Failed to compute metrics for task '{config.task}' on dataset "
+            f"'{config.dataset.path}'. "
+            f"Run 'winml eval --schema --task {config.task}' to see the expected schema.",
+        ) from e
 
     return EvalResult(config=config, metrics=metrics)
+
+
+def print_config(config: WinMLEvaluationConfig) -> None:
+    """Print effective evaluation config to the console (quantize.py style)."""
+    ds = config.dataset
+    console.print(f"[bold blue]Model:[/bold blue] {config.model_id}")
+    if config.model_path is not None:
+        console.print(f"[bold blue]Model path:[/bold blue] {config.model_path}")
+    console.print(f"[bold blue]Task:[/bold blue] {config.task}")
+    console.print(f"[bold blue]Device:[/bold blue] {config.device}")
+    if config.ep is not None:
+        console.print(f"[bold blue]EP:[/bold blue] {config.ep}")
+    console.print(f"[bold blue]Precision:[/bold blue] {config.precision}")
+    console.print(f"[bold blue]Dataset:[/bold blue] {ds.path}")
+    if ds.name:
+        console.print(f"[bold blue]Dataset name:[/bold blue] {ds.name}")
+    console.print(f"[bold blue]Split:[/bold blue] {ds.split}")
+    console.print(f"[bold blue]Samples:[/bold blue] {ds.samples}")
+    console.print(f"[bold blue]Shuffle:[/bold blue] {ds.shuffle} (seed={ds.seed})")
+    console.print(f"[bold blue]Streaming:[/bold blue] {ds.streaming}")
+    if ds.columns_mapping:
+        cols = ", ".join(f"{k}={v}" for k, v in ds.columns_mapping.items())
+        console.print(f"[bold blue]Columns:[/bold blue] {cols}")
+    if config.output_path is not None:
+        console.print(f"[bold blue]Output:[/bold blue] {config.output_path}")

--- a/src/winml/modelkit/eval/evaluate.py
+++ b/src/winml/modelkit/eval/evaluate.py
@@ -33,7 +33,6 @@ if TYPE_CHECKING:
     from ..models.winml.base import WinMLPreTrainedModel
 
 logger = logging.getLogger(__name__)
-console = Console()
 
 _EVALUATOR_REGISTRY: dict[str, type[WinMLEvaluator]] = {
     "image-classification": WinMLEvaluator,
@@ -228,14 +227,6 @@ def evaluate(config: WinMLEvaluationConfig) -> EvalResult:
     config and any module-level defaults remain untouched.
     """
     config = replace(config, task=_resolve_task(config), dataset=deepcopy(config.dataset))
-    try:
-        model = _load_model(config)
-    except Exception as e:
-        raise ValueError(
-            f"Failed to load model '{config.model_id}'. "
-            f"Run 'winml eval --schema --task {config.task}' to see expected model inputs.",
-        ) from e
-
     if config.dataset.path is None:
         default = _DEFAULT_DATASETS.get(config.task)
         if default is None:
@@ -253,24 +244,34 @@ def evaluate(config: WinMLEvaluationConfig) -> EvalResult:
 
     print_config(config)
 
+    try:
+        model = _load_model(config)
+    except Exception as error:
+        raise ValueError(
+            f"Failed to load model '{config.model_id}'. "
+            "Check --model, --model-id, --task, device, and EP settings. "
+            f"For composite models, run 'winml eval --schema --task {config.task}' "
+            "to see supported role=path model options.",
+        ) from error
+
     from ..utils.eval_utils import DatasetValidationError
 
     cls = get_evaluator_class(config.task)
     try:
         task_evaluator = cls(config, model)
         metrics = task_evaluator.compute()
-    except DatasetValidationError as e:
+    except DatasetValidationError as error:
         raise ValueError(
             f"Dataset '{config.dataset.path}' is not compatible with task "
-            f"'{config.task}': {e}. Use --dataset to specify a different dataset, "
+            f"'{config.task}': {error}. Use --dataset to specify a different dataset, "
             f"or run 'winml eval --schema --task {config.task}' to see the expected schema.",
-        ) from e
-    except Exception as e:
+        ) from error
+    except (KeyError, ValueError) as error:
         raise ValueError(
             f"Failed to compute metrics for task '{config.task}' on dataset "
             f"'{config.dataset.path}'. "
             f"Run 'winml eval --schema --task {config.task}' to see the expected schema.",
-        ) from e
+        ) from error
 
     return EvalResult(config=config, metrics=metrics)
 
@@ -278,23 +279,24 @@ def evaluate(config: WinMLEvaluationConfig) -> EvalResult:
 def print_config(config: WinMLEvaluationConfig) -> None:
     """Print effective evaluation config to the console (quantize.py style)."""
     ds = config.dataset
-    console.print(f"[bold blue]Model:[/bold blue] {config.model_id}")
+    output_console = Console()
+    output_console.print(f"[bold blue]Model:[/bold blue] {config.model_id}")
     if config.model_path is not None:
-        console.print(f"[bold blue]Model path:[/bold blue] {config.model_path}")
-    console.print(f"[bold blue]Task:[/bold blue] {config.task}")
-    console.print(f"[bold blue]Device:[/bold blue] {config.device}")
+        output_console.print(f"[bold blue]Model path:[/bold blue] {config.model_path}")
+    output_console.print(f"[bold blue]Task:[/bold blue] {config.task}")
+    output_console.print(f"[bold blue]Device:[/bold blue] {config.device}")
     if config.ep is not None:
-        console.print(f"[bold blue]EP:[/bold blue] {config.ep}")
-    console.print(f"[bold blue]Precision:[/bold blue] {config.precision}")
-    console.print(f"[bold blue]Dataset:[/bold blue] {ds.path}")
+        output_console.print(f"[bold blue]EP:[/bold blue] {config.ep}")
+    output_console.print(f"[bold blue]Precision:[/bold blue] {config.precision}")
+    output_console.print(f"[bold blue]Dataset:[/bold blue] {ds.path}")
     if ds.name:
-        console.print(f"[bold blue]Dataset name:[/bold blue] {ds.name}")
-    console.print(f"[bold blue]Split:[/bold blue] {ds.split}")
-    console.print(f"[bold blue]Samples:[/bold blue] {ds.samples}")
-    console.print(f"[bold blue]Shuffle:[/bold blue] {ds.shuffle} (seed={ds.seed})")
-    console.print(f"[bold blue]Streaming:[/bold blue] {ds.streaming}")
+        output_console.print(f"[bold blue]Dataset name:[/bold blue] {ds.name}")
+    output_console.print(f"[bold blue]Split:[/bold blue] {ds.split}")
+    output_console.print(f"[bold blue]Samples:[/bold blue] {ds.samples}")
+    output_console.print(f"[bold blue]Shuffle:[/bold blue] {ds.shuffle} (seed={ds.seed})")
+    output_console.print(f"[bold blue]Streaming:[/bold blue] {ds.streaming}")
     if ds.columns_mapping:
         cols = ", ".join(f"{k}={v}" for k, v in ds.columns_mapping.items())
-        console.print(f"[bold blue]Columns:[/bold blue] {cols}")
+        output_console.print(f"[bold blue]Columns:[/bold blue] {cols}")
     if config.output_path is not None:
-        console.print(f"[bold blue]Output:[/bold blue] {config.output_path}")
+        output_console.print(f"[bold blue]Output:[/bold blue] {config.output_path}")

--- a/src/winml/modelkit/eval/feature_extraction_evaluator.py
+++ b/src/winml/modelkit/eval/feature_extraction_evaluator.py
@@ -43,41 +43,19 @@ logger = logging.getLogger(__name__)
 class WinMLFeatureExtractionEvaluator(WinMLEvaluator):
     """Evaluator for text feature extraction using Spearman correlation."""
 
-    @classmethod
-    def schema_info(cls) -> list:
-        """Return expected dataset schema for sentence similarity evaluation."""
-        from .config import SchemaColumn
-
-        return [
-            SchemaColumn(
-                "sentence1",
-                "Value(string)",
-                "input_column_1",
-                description="first sentence of the pair",
-            ),
-            SchemaColumn(
-                "sentence2",
-                "Value(string)",
-                "input_column_2",
-                description="second sentence of the pair",
-            ),
-            SchemaColumn(
-                "score",
-                "Value(float64)",
-                "score_column",
-                description="ground-truth similarity score (e.g. [0, 5] for STS-B)",
-            ),
-        ]
-
     def __init__(
         self,
         config: WinMLEvaluationConfig,
         model: WinMLPreTrainedModel,
     ) -> None:
         mapping = config.dataset.columns_mapping
-        self._input_col_1 = mapping.get("input_column_1", "sentence1")
-        self._input_col_2 = mapping.get("input_column_2", "sentence2")
-        self._score_col = mapping.get("score_column", "score")
+        from ..utils.eval_utils import get_default
+
+        mapping = config.dataset.columns_mapping
+        task = "feature-extraction"
+        self._input_col_1 = mapping.get("input_column_1", get_default(task, "input_column_1"))
+        self._input_col_2 = mapping.get("input_column_2", get_default(task, "input_column_2"))
+        self._score_col = mapping.get("score_column", get_default(task, "score_column"))
         super().__init__(config, model)
 
     def prepare_pipeline(self) -> Pipeline:

--- a/src/winml/modelkit/eval/fill_mask_evaluator.py
+++ b/src/winml/modelkit/eval/fill_mask_evaluator.py
@@ -36,18 +36,15 @@ if TYPE_CHECKING:
 class WinMLFillMaskEvaluator(WinMLEvaluator):
     """Evaluate MLMs via pseudo-perplexity."""
 
-    @classmethod
-    def schema_info(cls) -> list:
-        """Return expected dataset schema."""
-        from .config import SchemaColumn
-        return [SchemaColumn("text", "Value(string)", "input_column")]
-
     def __init__(
         self,
         config: WinMLEvaluationConfig,
         model: WinMLPreTrainedModel,
     ) -> None:
-        self._input_col = config.dataset.columns_mapping.get("input_column", "text")
+        from ..utils.eval_utils import get_default
+
+        mapping = config.dataset.columns_mapping
+        self._input_col = mapping.get("input_column", get_default("fill-mask", "input_column"))
         self._tokenizer = AutoTokenizer.from_pretrained(config.model_id)
         super().__init__(config, model)
 

--- a/src/winml/modelkit/eval/image_feature_extraction_evaluator.py
+++ b/src/winml/modelkit/eval/image_feature_extraction_evaluator.py
@@ -40,26 +40,17 @@ if TYPE_CHECKING:
 class WinMLImageFeatureExtractionEvaluator(WinMLEvaluator):
     """Evaluator for image feature extraction using kNN classification accuracy."""
 
-    @classmethod
-    def schema_info(cls) -> list:
-        """Return expected dataset schema for image feature extraction evaluation."""
-        from .config import SchemaColumn
-
-        return [
-            SchemaColumn("image", "Image", "input_column", description="PIL Image"),
-            SchemaColumn(
-                "label", "ClassLabel", "label_column",
-                description="integer class label",
-            ),
-        ]
-
     def __init__(
         self,
         config: WinMLEvaluationConfig,
         model: WinMLPreTrainedModel,
     ) -> None:
+        from ..utils.eval_utils import get_default
+
         mapping = config.dataset.columns_mapping
-        self._label_col = mapping.get("label_column", "label")
+        task = "image-feature-extraction"
+        self._image_col = mapping.get("input_column", get_default(task, "input_column"))
+        self._label_col = mapping.get("label_column", get_default(task, "label_column"))
         super().__init__(config, model)
 
     def prepare_pipeline(self) -> Pipeline:
@@ -86,7 +77,7 @@ class WinMLImageFeatureExtractionEvaluator(WinMLEvaluator):
         labels: list[int] = []
 
         for sample in tqdm(self.data, desc="Embedding images", unit="img"):
-            image = sample.get("image")
+            image = sample.get(self._image_col)
             label = sample.get(self._label_col)
 
             if image is None or label is None:

--- a/src/winml/modelkit/eval/image_segmentation_evaluator.py
+++ b/src/winml/modelkit/eval/image_segmentation_evaluator.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from ..utils.eval_utils import DatasetValidationError
 from .base_evaluator import WinMLEvaluator
 from .metrics import IGNORE_INDEX
 
@@ -42,28 +43,19 @@ logger = logging.getLogger(__name__)
 class WinMLImageSegmentationEvaluator(WinMLEvaluator):
     """Evaluator for semantic segmentation using mIoU metrics."""
 
-    @classmethod
-    def schema_info(cls) -> list:
-        """Return expected dataset schema for image segmentation."""
-        from .config import SchemaColumn
-
-        return [
-            SchemaColumn("image", "Image", "input_column", description="PIL Image"),
-            SchemaColumn(
-                "annotation",
-                "Image",
-                "annotation_column",
-                description="Single-channel annotation image (pixel value = class ID)",
-            ),
-        ]
-
     def __init__(
         self,
         config: WinMLEvaluationConfig,
         model: WinMLPreTrainedModel,
     ) -> None:
-        ds = config.dataset
-        self._annotation_col = ds.columns_mapping.get("annotation_column", "annotation")
+        from ..utils.eval_utils import get_default
+
+        mapping = config.dataset.columns_mapping
+        task = "image-segmentation"
+        self._image_col = mapping.get("input_column", get_default(task, "input_column"))
+        self._annotation_col = mapping.get(
+            "annotation_column", get_default(task, "annotation_column"),
+        )
         super().__init__(config, model)
 
     def prepare_pipeline(self) -> Pipeline:
@@ -114,7 +106,7 @@ class WinMLImageSegmentationEvaluator(WinMLEvaluator):
         )
 
         for i, sample in enumerate(self.data):
-            image = sample.get("image")
+            image = sample.get(self._image_col)
             annotation = sample.get(self._annotation_col)
 
             if image is None or annotation is None:
@@ -191,12 +183,12 @@ class WinMLImageSegmentationEvaluator(WinMLEvaluator):
     def _validate_schema(self, dataset: Dataset) -> None:
         """Check dataset has required columns."""
         if "image" not in dataset.column_names:
-            raise ValueError(
-                f"Dataset missing 'image' column. Available: {list(dataset.column_names)}."
+            raise DatasetValidationError(
+                f"Dataset missing 'image' column. Available: {list(dataset.column_names)}.",
             )
         if self._annotation_col not in dataset.column_names:
-            raise ValueError(
+            raise DatasetValidationError(
                 f"Dataset missing annotation column '{self._annotation_col}'. "
                 f"Available: {list(dataset.column_names)}. "
-                f"Set annotation_column in columns_mapping."
+                f"Set annotation_column in columns_mapping.",
             )

--- a/src/winml/modelkit/eval/image_to_text_evaluator.py
+++ b/src/winml/modelkit/eval/image_to_text_evaluator.py
@@ -38,29 +38,16 @@ logger = logging.getLogger(__name__)
 class WinMLImageToTextEvaluator(WinMLEvaluator):
     """Image-to-text evaluator. Reports CER and CIDEr."""
 
-    @classmethod
-    def schema_info(cls) -> list:
-        """Expected dataset columns: image input + reference text."""
-        from .config import SchemaColumn
-
-        return [
-            SchemaColumn("image", "Image", "input_column", description="PIL Image"),
-            SchemaColumn(
-                "text",
-                "string|list[string]",
-                "label_column",
-                description="Reference caption / transcription (string or list)",
-            ),
-        ]
-
     def __init__(
         self,
         config: WinMLEvaluationConfig,
         model: WinMLPreTrainedModel,
     ) -> None:
+        from ..utils.eval_utils import get_default
+
         cm = config.dataset.columns_mapping
-        self._image_col = cm.get("input_column", "image")
-        self._label_col = cm.get("label_column", "text")
+        self._image_col = cm.get("input_column", get_default("image-to-text", "input_column"))
+        self._label_col = cm.get("label_column", get_default("image-to-text", "label_column"))
         super().__init__(config, model)
 
     def align_labels(self, dataset, ds_config):  # type: ignore[override]

--- a/src/winml/modelkit/eval/object_detection_evaluator.py
+++ b/src/winml/modelkit/eval/object_detection_evaluator.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from ..utils.eval_utils import DatasetValidationError
 from .base_evaluator import WinMLEvaluator
 
 
@@ -35,55 +36,24 @@ logger = logging.getLogger(__name__)
 class WinMLObjectDetectionEvaluator(WinMLEvaluator):
     """Evaluator for object detection using COCO-standard mAP metrics."""
 
-    @classmethod
-    def schema_info(cls) -> list:
-        """Return expected dataset schema for object detection."""
-        from .config import SchemaColumn
-
-        return [
-            SchemaColumn("image", "Image", description="PIL Image"),
-            SchemaColumn(
-                "objects",
-                "dict",
-                "annotation_column",
-                description="annotation dict",
-                children=[
-                    SchemaColumn(
-                        "bbox", "list[list[float]]", "bbox_key", description="bounding boxes"
-                    ),
-                    SchemaColumn(
-                        "category", "list[ClassLabel]", "category_key", description="category IDs"
-                    ),
-                ],
-            ),
-            SchemaColumn(
-                "xywh",
-                "option",
-                "box_format",
-                required=False,
-                description="box format: xywh or xyxy",
-            ),
-            SchemaColumn(
-                "absolute",
-                "option",
-                "box_coords",
-                required=False,
-                description="coords: absolute or normalized",
-            ),
-        ]
-
     def __init__(
         self,
         config: WinMLEvaluationConfig,
         model: WinMLPreTrainedModel,
     ) -> None:
         # Read column config BEFORE super().__init__() since prepare_data() needs them
-        ds = config.dataset
-        self._annotation_col = ds.columns_mapping.get("annotation_column", "objects")
-        self._bbox_key = ds.columns_mapping.get("bbox_key", "bbox")
-        self._category_key = ds.columns_mapping.get("category_key", "category")
-        self._box_format = ds.columns_mapping.get("box_format", "xywh")
-        self._box_coords = ds.columns_mapping.get("box_coords", "absolute")
+        from ..utils.eval_utils import get_default
+
+        mapping = config.dataset.columns_mapping
+        task = "object-detection"
+        self._image_col = mapping.get("input_column", get_default(task, "input_column"))
+        self._annotation_col = mapping.get(
+            "annotation_column", get_default(task, "annotation_column"),
+        )
+        self._bbox_key = mapping.get("bbox_key", get_default(task, "bbox_key"))
+        self._category_key = mapping.get("category_key", get_default(task, "category_key"))
+        self._box_format = mapping.get("box_format", get_default(task, "box_format"))
+        self._box_coords = mapping.get("box_coords", get_default(task, "box_coords"))
 
         super().__init__(config, model)
 
@@ -130,9 +100,9 @@ class WinMLObjectDetectionEvaluator(WinMLEvaluator):
         id_map = {}
         for ds_id, name in enumerate(ds_class_names):
             if name not in label2id:
-                raise ValueError(
+                raise DatasetValidationError(
                     f"Dataset label '{name}' not in model's label2id. "
-                    f"Model labels: {list(label2id.keys())}"
+                    f"Model labels: {list(label2id.keys())}",
                 )
             id_map[ds_id] = int(label2id[name])
 
@@ -183,13 +153,13 @@ class WinMLObjectDetectionEvaluator(WinMLEvaluator):
                 "labels": [int(lbl) for lbl in annotations[self._category_key]],
             }
             if self._box_coords == "normalized":
-                image = sample.get("image")
+                image = sample.get(self._image_col)
                 if image is not None:
                     ref["image_size"] = image.size  # (width, height)
             references.append(ref)
 
             # --- Predictions ---
-            image = sample.get("image")
+            image = sample.get(self._image_col)
             if image is None:
                 predictions.append({"boxes": [], "scores": [], "labels": []})
                 continue
@@ -225,8 +195,9 @@ class WinMLObjectDetectionEvaluator(WinMLEvaluator):
         """Check dataset has required annotation structure."""
         ann = dataset.features.get(self._annotation_col)
         if ann is None:
-            raise ValueError(
-                f"No column '{self._annotation_col}'. Available: {list(dataset.features.keys())}."
+            raise DatasetValidationError(
+                f"No column '{self._annotation_col}'. "
+                f"Available: {list(dataset.features.keys())}.",
             )
         sub = ann
         if hasattr(ann, "feature") and isinstance(ann.feature, dict):
@@ -234,6 +205,6 @@ class WinMLObjectDetectionEvaluator(WinMLEvaluator):
         for key in (self._bbox_key, self._category_key):
             if key not in sub:
                 avail = list(sub.keys()) if isinstance(sub, dict) else []
-                raise ValueError(
-                    f"'{self._annotation_col}' has no key '{key}'. Available: {avail}."
+                raise DatasetValidationError(
+                    f"'{self._annotation_col}' has no key '{key}'. Available: {avail}.",
                 )

--- a/src/winml/modelkit/eval/question_answering_evaluator.py
+++ b/src/winml/modelkit/eval/question_answering_evaluator.py
@@ -36,29 +36,6 @@ class WinMLQuestionAnsweringEvaluator(WinMLEvaluator):
     passing a v2 dataset works transparently.
     """
 
-    @classmethod
-    def schema_info(cls) -> list:
-        """Return expected dataset schema for question answering."""
-        from .config import SchemaColumn
-
-        return [
-            SchemaColumn(
-                "question", "Value(string)", "question_column", description="question text"
-            ),
-            SchemaColumn(
-                "context", "Value(string)", "context_column", description="context passage"
-            ),
-            SchemaColumn(
-                "id", "Value(string)", "id_column", description="unique question-answer pair ID"
-            ),
-            SchemaColumn(
-                "answers",
-                "dict(text: list[str], answer_start: list[int])",
-                "label_column",
-                description="answers with text spans and start positions",
-            ),
-        ]
-
     def prepare_pipeline(self) -> Pipeline:
         """Create pipeline and set tokenizer padding for fixed-shape ONNX.
 
@@ -98,13 +75,10 @@ class WinMLQuestionAnsweringEvaluator(WinMLEvaluator):
         logger.info("Running evaluation...")
         task_evaluator = evaluator(self.config.task)
 
-        # Derive default from schema_info so the fallback isn't hardcoded.
-        schema_default = next(
-            col.name for col in self.schema_info() if col.override == "label_column"
-        )
-        label_col = self.config.dataset.columns_mapping.get(
-            "label_column", schema_default
-        )
+        from ..utils.eval_utils import get_default
+
+        mapping = self.config.dataset.columns_mapping
+        label_col = mapping.get("label_column", get_default("question-answering", "label_column"))
 
         try:
             squad_v2 = task_evaluator.is_squad_v2_format(

--- a/src/winml/modelkit/eval/text_classification_evaluator.py
+++ b/src/winml/modelkit/eval/text_classification_evaluator.py
@@ -22,23 +22,6 @@ class WinMLTextClassificationEvaluator(WinMLEvaluator):
     Configures tokenizer padding to match the ONNX model's fixed sequence length.
     """
 
-    @classmethod
-    def schema_info(cls) -> list:
-        """Return expected dataset schema for text classification."""
-        from .config import SchemaColumn
-
-        return [
-            SchemaColumn("text", "Value(string)", "input_column", description="input text"),
-            SchemaColumn("label", "ClassLabel", "label_column", description="integer class label"),
-            SchemaColumn(
-                "<pair_col>",
-                "Value(string)",
-                "second_input_column",
-                required=False,
-                description="second text for sentence pairs",
-            ),
-        ]
-
     def prepare_pipeline(self) -> Pipeline:
         """Create pipeline and set tokenizer padding for fixed-shape ONNX."""
         pipe = super().prepare_pipeline()

--- a/src/winml/modelkit/eval/token_classification_evaluator.py
+++ b/src/winml/modelkit/eval/token_classification_evaluator.py
@@ -22,21 +22,6 @@ class WinMLTokenClassificationEvaluator(WinMLEvaluator):
     Configures tokenizer padding to match the ONNX model's fixed sequence length.
     """
 
-    @classmethod
-    def schema_info(cls) -> list:
-        """Return expected dataset schema for token classification."""
-        from .config import SchemaColumn
-
-        return [
-            SchemaColumn("tokens", "list[str]", "input_column", description="tokenized words"),
-            SchemaColumn(
-                "ner_tags",
-                "Sequence(ClassLabel)",
-                "label_column",
-                description="tag IDs per token",
-            ),
-        ]
-
     def prepare_pipeline(self) -> Pipeline:
         """Create pipeline and set tokenizer padding for fixed-shape ONNX."""
         pipe = super().prepare_pipeline()

--- a/src/winml/modelkit/eval/zero_shot_classification_evaluator.py
+++ b/src/winml/modelkit/eval/zero_shot_classification_evaluator.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any
 from tqdm import tqdm
 from transformers.pipelines.zero_shot_classification import ZeroShotClassificationPipeline
 
+from ..utils.eval_utils import DatasetValidationError
 from .base_evaluator import WinMLEvaluator
 
 
@@ -58,43 +59,17 @@ class _FixedShapeZeroShotPipeline(ZeroShotClassificationPipeline):
 class WinMLZeroShotClassificationEvaluator(WinMLEvaluator):
     """Evaluator for zero-shot text classification using NLI models."""
 
-    @classmethod
-    def schema_info(cls) -> list:
-        """Return expected dataset schema for zero-shot classification."""
-        from .config import SchemaColumn
-
-        return [
-            SchemaColumn("text", "Value(string)", "input_column", description="input text"),
-            SchemaColumn(
-                "label",
-                "ClassLabel",
-                "label_column",
-                description="gold label (ClassLabel or string)",
-            ),
-            SchemaColumn(
-                "<candidate_labels>",
-                "comma-separated str",
-                "candidate_labels",
-                required=False,
-                description="override candidate labels (required for non-ClassLabel columns)",
-            ),
-            SchemaColumn(
-                "<hypothesis_template>",
-                "Value(string)",
-                "hypothesis_template",
-                required=False,
-                description='NLI hypothesis template (default: "This example is {}.")',
-            ),
-        ]
-
     def __init__(
         self,
         config: WinMLEvaluationConfig,
         model: WinMLPreTrainedModel,
     ) -> None:
+        from ..utils.eval_utils import get_default
+
         mapping = config.dataset.columns_mapping
-        self._input_col = mapping.get("input_column", "text")
-        self._label_col = mapping.get("label_column", "label")
+        task = "zero-shot-classification"
+        self._input_col = mapping.get("input_column", get_default(task, "input_column"))
+        self._label_col = mapping.get("label_column", get_default(task, "label_column"))
         self._candidate_labels_override = mapping.get("candidate_labels")
         self._hypothesis_template = mapping.get("hypothesis_template")
         super().__init__(config, model)
@@ -143,7 +118,9 @@ class WinMLZeroShotClassificationEvaluator(WinMLEvaluator):
         col_names = set(dataset.column_names)
         for col in (self._input_col, self._label_col):
             if col not in col_names:
-                raise ValueError(f"Column '{col}' not found in dataset: {sorted(col_names)}")
+                raise DatasetValidationError(
+                    f"Column '{col}' not found in dataset: {sorted(col_names)}",
+                )
         return dataset
 
     def _resolve_candidate_labels(self, dataset: Dataset) -> list[str]:
@@ -158,7 +135,7 @@ class WinMLZeroShotClassificationEvaluator(WinMLEvaluator):
         if names:
             return list(names)
 
-        raise ValueError(
+        raise DatasetValidationError(
             f"Column '{self._label_col}' is not a ClassLabel; pass "
             f'--column "candidate_labels=a,b,...".',
         )

--- a/src/winml/modelkit/eval/zero_shot_image_classification_evaluator.py
+++ b/src/winml/modelkit/eval/zero_shot_image_classification_evaluator.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from ..utils.eval_utils import DatasetValidationError
 from .base_evaluator import WinMLEvaluator
 
 
@@ -32,26 +33,17 @@ if TYPE_CHECKING:
 class WinMLZeroShotImageClassificationEvaluator(WinMLEvaluator):
     """Evaluator for zero-shot image classification using top-k accuracy."""
 
-    @classmethod
-    def schema_info(cls) -> list:
-        """Return expected dataset schema for zero-shot image classification."""
-        from .config import SchemaColumn
-
-        return [
-            SchemaColumn("image", "Image", "input_column", description="PIL Image"),
-            SchemaColumn(
-                "label", "ClassLabel", "label_column", description="integer class label"
-            ),
-        ]
-
     def __init__(
         self,
         config: WinMLEvaluationConfig,
         model: WinMLPreTrainedModel,
     ) -> None:
-        ds = config.dataset
-        self._image_col = ds.columns_mapping.get("input_column", "image")
-        self._label_col = ds.columns_mapping.get("label_column", "label")
+        from ..utils.eval_utils import get_default
+
+        mapping = config.dataset.columns_mapping
+        task = "zero-shot-image-classification"
+        self._image_col = mapping.get("input_column", get_default(task, "input_column"))
+        self._label_col = mapping.get("label_column", get_default(task, "label_column"))
         super().__init__(config, model)
         self._candidate_labels = self._resolve_class_names()
 
@@ -69,10 +61,10 @@ class WinMLZeroShotImageClassificationEvaluator(WinMLEvaluator):
         if isinstance(label_feature, ClassLabel):
             return [name.replace("_", " ") for name in label_feature.names]
 
-        raise ValueError(
+        raise DatasetValidationError(
             f"Dataset column '{self._label_col}' is not a ClassLabel feature. "
             f"Cannot resolve class names for zero-shot classification. "
-            f"Feature type: {type(label_feature)}"
+            f"Feature type: {type(label_feature)}",
         )
 
     def align_labels(self, dataset: Dataset, ds_config: DatasetConfig) -> Dataset:

--- a/src/winml/modelkit/utils/eval_utils.py
+++ b/src/winml/modelkit/utils/eval_utils.py
@@ -1,0 +1,308 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Task input-schema metadata for ``winml eval``.
+
+Shared between the CLI (``winml eval --schema``) and the individual
+evaluator classes that need default column names. Lives in ``utils`` so
+that importing it does not load the heavy ``winml.modelkit.eval`` package
+(which would otherwise drag in ``transformers``/``torch``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SchemaItem:
+    """One dataset column or one configuration parameter."""
+
+    name: str                       # the --column key (e.g. "input_column")
+    description: str                # short sentence
+    default: str | None = None      # default value; None = no default (optional entry)
+    remap_hint: str | None = None   # value placeholder; None = no --column remap
+
+
+@dataclass(frozen=True)
+class TaskSchema:
+    """Input schema description for one task."""
+
+    columns: tuple[SchemaItem, ...]
+    params: tuple[SchemaItem, ...] = ()
+    roles: tuple[str, ...] | None = None
+
+
+_IMAGE_CLASSIFICATION_SCHEMA = TaskSchema(
+    columns=(
+        SchemaItem(
+            "input_column", "input image (PIL.Image)",
+            default="image", remap_hint="<your_image_column>",
+        ),
+        SchemaItem(
+            "label_column", "integer class label",
+            default="label", remap_hint="<your_label_column>",
+        ),
+    ),
+)
+
+_TEXT_CLASSIFICATION_SCHEMA = TaskSchema(
+    columns=(
+        SchemaItem(
+            "input_column", "input text",
+            default="text", remap_hint="<your_text_column>",
+        ),
+        SchemaItem(
+            "label_column", "class label (ClassLabel or integer)",
+            default="label", remap_hint="<your_label_column>",
+        ),
+        SchemaItem(
+            "second_input_column", "second text for sentence-pair tasks (optional)",
+            remap_hint="<your_pair_column>",
+        ),
+    ),
+)
+
+_TOKEN_CLASSIFICATION_SCHEMA = TaskSchema(
+    columns=(
+        SchemaItem(
+            "input_column", "tokenized words (list of strings per sample)",
+            default="tokens", remap_hint="<your_tokens_column>",
+        ),
+        SchemaItem(
+            "label_column", "NER tag ID per token",
+            default="ner_tags", remap_hint="<your_tags_column>",
+        ),
+    ),
+)
+
+_OBJECT_DETECTION_SCHEMA = TaskSchema(
+    columns=(
+        SchemaItem(
+            "input_column", "input image (PIL.Image)",
+            default="image", remap_hint="<your_image_column>",
+        ),
+        SchemaItem(
+            "annotation_column",
+            "annotation dict containing bbox + category fields",
+            default="objects", remap_hint="<your_annotation_column>",
+        ),
+    ),
+    params=(
+        SchemaItem(
+            "bbox_key",
+            "name of the bbox field inside the annotation dict",
+            default="bbox", remap_hint="<bbox_field>",
+        ),
+        SchemaItem(
+            "category_key",
+            "name of the category field inside the annotation dict",
+            default="category", remap_hint="<category_field>",
+        ),
+        SchemaItem(
+            "box_format", "bounding box layout",
+            default="xywh", remap_hint="<xywh|xyxy>",
+        ),
+        SchemaItem(
+            "box_coords", "bounding box coordinate system",
+            default="absolute", remap_hint="<absolute|normalized>",
+        ),
+    ),
+)
+
+_IMAGE_SEGMENTATION_SCHEMA = TaskSchema(
+    columns=(
+        SchemaItem(
+            "input_column", "input image (PIL.Image)",
+            default="image", remap_hint="<your_image_column>",
+        ),
+        SchemaItem(
+            "annotation_column",
+            "single-channel mask image; pixel value = class ID",
+            default="annotation", remap_hint="<your_mask_column>",
+        ),
+    ),
+)
+
+_QUESTION_ANSWERING_SCHEMA = TaskSchema(
+    columns=(
+        SchemaItem(
+            "question_column", "question text",
+            default="question", remap_hint="<your_question_column>",
+        ),
+        SchemaItem(
+            "context_column", "context passage to read",
+            default="context", remap_hint="<your_context_column>",
+        ),
+        SchemaItem(
+            "id_column", "unique question-answer ID",
+            default="id", remap_hint="<your_id_column>",
+        ),
+        SchemaItem(
+            "label_column",
+            "answers dict with text and answer_start lists",
+            default="answers", remap_hint="<your_answers_column>",
+        ),
+    ),
+)
+
+_FEATURE_EXTRACTION_SCHEMA = TaskSchema(
+    columns=(
+        SchemaItem(
+            "input_column_1", "first sentence of the pair",
+            default="sentence1", remap_hint="<your_first_sentence_column>",
+        ),
+        SchemaItem(
+            "input_column_2", "second sentence of the pair",
+            default="sentence2", remap_hint="<your_second_sentence_column>",
+        ),
+        SchemaItem(
+            "score_column",
+            "ground-truth similarity score (e.g. [0, 5] for STS-B)",
+            default="score", remap_hint="<your_score_column>",
+        ),
+    ),
+)
+
+_IMAGE_FEATURE_EXTRACTION_SCHEMA = TaskSchema(
+    columns=(
+        SchemaItem(
+            "input_column", "input image (PIL.Image)",
+            default="image", remap_hint="<your_image_column>",
+        ),
+        SchemaItem(
+            "label_column", "integer class label (used for kNN accuracy)",
+            default="label", remap_hint="<your_label_column>",
+        ),
+    ),
+)
+
+_IMAGE_TO_TEXT_SCHEMA = TaskSchema(
+    columns=(
+        SchemaItem(
+            "input_column", "input image (PIL.Image)",
+            default="image", remap_hint="<your_image_column>",
+        ),
+        SchemaItem(
+            "label_column", "reference caption (string or list of strings)",
+            default="text", remap_hint="<your_text_column>",
+        ),
+    ),
+    roles=("encoder", "decoder"),
+)
+
+_FILL_MASK_SCHEMA = TaskSchema(
+    columns=(
+        SchemaItem(
+            "input_column", "input text scored via pseudo-perplexity",
+            default="text", remap_hint="<your_text_column>",
+        ),
+    ),
+)
+
+_ZERO_SHOT_CLASSIFICATION_SCHEMA = TaskSchema(
+    columns=(
+        SchemaItem(
+            "input_column", "input text",
+            default="text", remap_hint="<your_text_column>",
+        ),
+        SchemaItem(
+            "label_column", "gold label (ClassLabel or string)",
+            default="label", remap_hint="<your_label_column>",
+        ),
+    ),
+    params=(
+        SchemaItem(
+            "candidate_labels",
+            "candidate label vocabulary; required if label column is not a ClassLabel",
+            default="from dataset ClassLabel.names",
+            remap_hint="<comma,separated,labels>",
+        ),
+        SchemaItem(
+            "hypothesis_template",
+            "NLI prompt template; {} is replaced with each candidate label",
+            default='"This example is {}."',
+            remap_hint="<template with {} placeholder>",
+        ),
+    ),
+)
+
+_ZERO_SHOT_IMAGE_CLASSIFICATION_SCHEMA = TaskSchema(
+    columns=(
+        SchemaItem(
+            "input_column", "input image (PIL.Image)",
+            default="image", remap_hint="<your_image_column>",
+        ),
+        SchemaItem(
+            "label_column", "integer class label",
+            default="label", remap_hint="<your_label_column>",
+        ),
+    ),
+    roles=("image-encoder", "text-encoder"),
+)
+
+TASK_SCHEMAS: dict[str, TaskSchema] = {
+    "image-classification": _IMAGE_CLASSIFICATION_SCHEMA,
+    "text-classification": _TEXT_CLASSIFICATION_SCHEMA,
+    "sequence-classification": _TEXT_CLASSIFICATION_SCHEMA,
+    "next-sentence-prediction": _TEXT_CLASSIFICATION_SCHEMA,
+    "token-classification": _TOKEN_CLASSIFICATION_SCHEMA,
+    "object-detection": _OBJECT_DETECTION_SCHEMA,
+    "image-segmentation": _IMAGE_SEGMENTATION_SCHEMA,
+    "question-answering": _QUESTION_ANSWERING_SCHEMA,
+    "feature-extraction": _FEATURE_EXTRACTION_SCHEMA,
+    "sentence-similarity": _FEATURE_EXTRACTION_SCHEMA,
+    "image-feature-extraction": _IMAGE_FEATURE_EXTRACTION_SCHEMA,
+    "image-to-text": _IMAGE_TO_TEXT_SCHEMA,
+    "fill-mask": _FILL_MASK_SCHEMA,
+    "zero-shot-classification": _ZERO_SHOT_CLASSIFICATION_SCHEMA,
+    "zero-shot-image-classification": _ZERO_SHOT_IMAGE_CLASSIFICATION_SCHEMA,
+}
+
+
+def get_default(task: str, name: str) -> str | None:
+    """Return the default value for *name* in the schema of *task*.
+
+    Looks across both ``columns`` and ``params``. Returns ``None`` if the
+    task or name is unknown, or the entry has no default.
+    """
+    schema = TASK_SCHEMAS.get(task)
+    if schema is None:
+        return None
+    for item in (*schema.columns, *schema.params):
+        if item.name == name:
+            return item.default
+    return None
+
+
+class DatasetValidationError(Exception):
+    """Dataset failed schema validation against a task's expected columns."""
+
+
+def validate_dataset_columns(
+    dataset: object, task: str, columns_mapping: dict[str, str] | None = None,
+) -> None:
+    """Check required schema columns exist in *dataset*.
+
+    Resolves each required column as ``columns_mapping.get(key, schema_default)``
+    and raises :class:`DatasetValidationError` if any is missing. No-op if the
+    task is unknown or the dataset does not expose ``column_names``.
+    """
+    schema = TASK_SCHEMAS.get(task)
+    column_names = getattr(dataset, "column_names", None)
+    if schema is None or not isinstance(column_names, (list, tuple)):
+        return
+    mapping = columns_mapping or {}
+    actual = set(column_names)
+    missing = [
+        (item.name, mapping.get(item.name, item.default))
+        for item in schema.columns
+        if item.default is not None
+        and mapping.get(item.name, item.default) not in actual
+    ]
+    if missing:
+        details = ", ".join(f"{k}='{v}'" for k, v in missing)
+        raise DatasetValidationError(
+            f"missing required column(s) {details}; dataset has {sorted(actual)}",
+        )

--- a/tests/e2e/test_eval_e2e.py
+++ b/tests/e2e/test_eval_e2e.py
@@ -312,6 +312,7 @@ class TestEvalPerTask:
             "--streaming",
             "--samples", SAMPLES,
             "--precision", "fp16",
+            "--column", "label_column=caption",
             "-o", str(out),
         ])
         # CLI contract: exit 0 and produce the metric keys. Tiny N may
@@ -428,20 +429,17 @@ class TestEvalModelInputForms:
         # so cache discovery below must use the sub-task names.
         _invoke(runner, ["-m", hf_id, "--task", task, "--samples", SAMPLES])
 
-        # Locate each sub-encoder's ONNX via its sub-task. find_cache_dir /
-        # _find_build_artifacts filter by manifest["task"], so use the
-        # sub-task names rather than the composite task here.
-        from winml.modelkit.inference.engine import _find_build_artifacts
+        # Locate each sub-encoder's ONNX directly via its cache-key prefix:
+        cache_dir = find_cache_dir(hf_id, task="image-feature-extraction")
+        assert cache_dir is not None, "expected image-encoder cache after warm run"
 
-        image_sub_task = "image-feature-extraction"
-        text_sub_task = "feature-extraction"
+        def _pick_onnx(prefix: str) -> Path:
+            files = sorted(cache_dir.glob(f"{prefix}_*_model.onnx"))
+            assert files, f"no {prefix}_*_model.onnx in {cache_dir}"
+            return files[0]
 
-        cache_dir = find_cache_dir(hf_id, task=image_sub_task)
-        assert cache_dir is not None, (
-            f"expected image-encoder cache after warm run (task={image_sub_task})"
-        )
-        image_onnx, _ = _find_build_artifacts(cache_dir, task=image_sub_task)
-        text_onnx, _ = _find_build_artifacts(cache_dir, task=text_sub_task)
+        image_onnx = _pick_onnx("imgfeat")
+        text_onnx = _pick_onnx("feat")
 
         out = tmp_path / "result.json"
         _invoke(runner, [
@@ -507,7 +505,7 @@ class TestEvalSchema:
     @pytest.mark.parametrize("task", _ALL_TASKS)
     def test_schema_for_each_task(self, runner: CliRunner, task: str) -> None:
         result = _invoke(runner, ["--schema", "--task", task])
-        assert "Dataset schema" in result.output
+        assert f"Input schema for {task} models" in result.output
 
 
 # ===========================================================================
@@ -780,9 +778,10 @@ class TestEvalErrorPaths:
         )
 
     def test_schema_without_task(self, runner: CliRunner) -> None:
-        result = _invoke(runner, ["--schema"], expect_success=False)
-        assert result.exit_code != 0
+        # Informational output (exit 0) listing supported tasks; not an error.
+        result = _invoke(runner, ["--schema"])
         assert "--task" in result.output, result.output
+        assert "Supported tasks" in result.output, result.output
 
     def test_schema_bogus_task(self, runner: CliRunner) -> None:
         # get_evaluator_class ValueError wrapped as UsageError.

--- a/tests/unit/commands/test_eval.py
+++ b/tests/unit/commands/test_eval.py
@@ -72,13 +72,20 @@ class TestSinglePlain:
         assert path is None
         assert mid == "microsoft/resnet-50"
 
-    def test_plain_hf_id_explicit_model_id_wins(self):
-        """Explicit --model-id takes precedence over an HF-ID-shaped -m."""
+    def test_plain_hf_id_with_conflicting_model_id_raises(self):
+        """Passing both -m <hf_id> and --model-id is rejected as a conflict."""
+        with pytest.raises(click.UsageError, match="Cannot pass both"):
+            _resolve_model_path(
+                model=("microsoft/resnet-50",), model_id="Intel/bert-base-uncased-mrpc",
+            )
+
+    def test_plain_hf_id_with_matching_model_id_ok(self):
+        """Passing --model-id equal to -m <hf_id> is allowed (no-op duplicate)."""
         path, mid = _resolve_model_path(
-            model=("microsoft/resnet-50",), model_id="Intel/bert-base-uncased-mrpc",
+            model=("microsoft/resnet-50",), model_id="microsoft/resnet-50",
         )
         assert path is None
-        assert mid == "Intel/bert-base-uncased-mrpc"
+        assert mid == "microsoft/resnet-50"
 
     def test_plain_onnx_with_model_id(self, onnx_file):
         path, mid = _resolve_model_path(
@@ -548,7 +555,7 @@ class TestPerTaskDefaultDataset:
             )
         msgs = [r.getMessage() for r in caplog.records]
         assert any(
-            "--dataset is not specified" in m
+            "--dataset not specified" in m
             and "image-classification" in m
             and "timm/mini-imagenet" in m
             for m in msgs

--- a/tests/unit/commands/test_eval.py
+++ b/tests/unit/commands/test_eval.py
@@ -207,6 +207,17 @@ def runner() -> CliRunner:
     return CliRunner()
 
 
+class TestEvalHelp:
+    def test_model_help_mentions_onnx_model_id_and_role_path(self, runner: CliRunner):
+        from winml.modelkit.commands.eval import eval as eval_cmd
+
+        result = runner.invoke(eval_cmd, ["--help"])
+
+        assert result.exit_code == 0, result.output
+        assert "requires --model-id" in result.output
+        assert "role=path" in result.output
+
+
 @pytest.fixture
 def eval_config_file(tmp_path):
     config = {

--- a/tests/unit/eval/test_align_labels.py
+++ b/tests/unit/eval/test_align_labels.py
@@ -12,6 +12,7 @@ from datasets import ClassLabel, Dataset, Features, Sequence, Value
 
 from winml.modelkit.datasets import DatasetConfig
 from winml.modelkit.eval import WinMLEvaluator
+from winml.modelkit.utils.eval_utils import DatasetValidationError
 
 
 # ---------------------------------------------------------------------------
@@ -34,9 +35,10 @@ class MockModel:
         self.config = MockConfig(label2id, id2label)
 
 
-def make_evaluator(label2id=None, id2label=None):
+def make_evaluator(label2id=None, id2label=None, task="image-classification"):
     ev = object.__new__(WinMLEvaluator)
     ev.model = MockModel(label2id, id2label)
+    ev.config = type("Cfg", (), {"task": task})()
     return ev
 
 
@@ -155,14 +157,14 @@ class TestAlignLabelsEndToEnd:
         ev = make_evaluator(label2id={"cat": 0, "dog": 1})
         ds = make_dataset([0, 1, 2, 0, 2], names=["cat", "dog", "bird"])
         ds_config = DatasetConfig(path="test")
-        with pytest.raises(RuntimeError):
+        with pytest.raises(DatasetValidationError):
             ev.align_labels(ds, ds_config)
 
     def test_zero_overlap_raises(self):
         ev = make_evaluator(label2id={"fish": 0, "shark": 1})
         ds = make_dataset([0, 1], names=["cat", "dog"])
         ds_config = DatasetConfig(path="test")
-        with pytest.raises(RuntimeError):
+        with pytest.raises(DatasetValidationError):
             ev.align_labels(ds, ds_config)
 
     def test_different_ordering_reordered(self):
@@ -217,7 +219,7 @@ class TestFilterUnsupportedLabels:
     def test_zero_remaining_raises(self):
         ev = make_evaluator(id2label={99: "x"})
         ds = make_dataset([0, 1], names=["cat", "dog"])
-        with pytest.raises(ValueError, match="No samples remain"):
+        with pytest.raises(DatasetValidationError, match="No samples remain"):
             ev._filter_unsupported_labels(ds, "label")
 
     def test_custom_label_column(self):

--- a/tests/unit/eval/test_eval.py
+++ b/tests/unit/eval/test_eval.py
@@ -113,8 +113,8 @@ class TestEvaluate:
 
         task_without_default = next(
             t
-            for t in ["fill-mask", "summarization", "translation"]
-            if t not in eval_mod._DEFAULT_DATASETS
+            for t in ["image-segmentation", "next-sentence-prediction", "image-to-text"]
+            if t in eval_mod._EVALUATOR_REGISTRY and t not in eval_mod._DEFAULT_DATASETS
         )
 
         config = WinMLEvaluationConfig(

--- a/tests/unit/eval/test_eval.py
+++ b/tests/unit/eval/test_eval.py
@@ -98,6 +98,12 @@ class TestGetEvaluatorClass:
         with pytest.raises(ValueError, match="not supported by `winml eval`"):
             get_evaluator_class("made-up-task")
 
+    def test_evaluator_registry_matches_schema_tasks(self):
+        from winml.modelkit.eval.evaluate import _EVALUATOR_REGISTRY
+        from winml.modelkit.utils.eval_utils import TASK_SCHEMAS
+
+        assert set(_EVALUATOR_REGISTRY) == set(TASK_SCHEMAS)
+
 
 class TestEvaluate:
     """Tests for evaluate() entry point."""
@@ -161,9 +167,131 @@ class TestEvaluate:
 
         assert asdict(config) == original, "evaluate() mutated the caller's config"
 
+    def test_prints_config_before_model_load_failure(self):
+        """Users should see the effective config even when model loading fails."""
+        import importlib
+        import sys
+
+        eval_mod = sys.modules.get(
+            "winml.modelkit.eval.evaluate",
+        ) or importlib.import_module("winml.modelkit.eval.evaluate")
+
+        calls = []
+        config = WinMLEvaluationConfig(
+            model_id="test/model",
+            task="image-classification",
+            dataset=DatasetConfig(path="test-dataset"),
+        )
+
+        def fake_print_config(_config):
+            calls.append("print")
+
+        def fake_load_model(_config):
+            calls.append("load")
+            raise RuntimeError("loader failed")
+
+        with (
+            patch.object(eval_mod, "print_config", side_effect=fake_print_config),
+            patch.object(eval_mod, "_load_model", side_effect=fake_load_model),
+            pytest.raises(ValueError) as exc_info,
+        ):
+            eval_mod.evaluate(config)
+
+        assert calls == ["print", "load"]
+        assert "Failed to load model 'test/model'" in str(exc_info.value)
+        assert "expected model inputs" not in str(exc_info.value)
+
+    def test_metric_runtime_error_propagates_without_schema_hint(self):
+        """Internal evaluator failures should not be relabeled as schema issues."""
+        import importlib
+        import sys
+
+        eval_mod = sys.modules.get(
+            "winml.modelkit.eval.evaluate",
+        ) or importlib.import_module("winml.modelkit.eval.evaluate")
+
+        class FailingEvaluator:
+            def __init__(self, _config, _model):
+                pass
+
+            def compute(self):
+                raise RuntimeError("internal evaluator failure")
+
+        config = WinMLEvaluationConfig(
+            model_id="test/model",
+            task="image-classification",
+            dataset=DatasetConfig(path="test-dataset"),
+        )
+
+        with (
+            patch.object(eval_mod, "print_config", return_value=None),
+            patch.object(eval_mod, "_load_model", return_value=object()),
+            patch.object(eval_mod, "get_evaluator_class", return_value=FailingEvaluator),
+            pytest.raises(RuntimeError, match="internal evaluator failure"),
+        ):
+            eval_mod.evaluate(config)
+
+    def test_metric_data_shape_errors_keep_schema_hint(self):
+        """Known data-shape exceptions still get a concise schema hint."""
+        import importlib
+        import sys
+
+        eval_mod = sys.modules.get(
+            "winml.modelkit.eval.evaluate",
+        ) or importlib.import_module("winml.modelkit.eval.evaluate")
+
+        class FailingEvaluator:
+            def __init__(self, _config, _model):
+                pass
+
+            def compute(self):
+                raise KeyError("label")
+
+        config = WinMLEvaluationConfig(
+            model_id="test/model",
+            task="image-classification",
+            dataset=DatasetConfig(path="test-dataset"),
+        )
+
+        with (
+            patch.object(eval_mod, "print_config", return_value=None),
+            patch.object(eval_mod, "_load_model", return_value=object()),
+            patch.object(eval_mod, "get_evaluator_class", return_value=FailingEvaluator),
+            pytest.raises(ValueError, match="expected schema") as exc_info,
+        ):
+            eval_mod.evaluate(config)
+
+        assert isinstance(exc_info.value.__cause__, KeyError)
+
 
 class TestWinMLEvaluator:
     """Tests for WinMLEvaluator base class."""
+
+    @patch("datasets.load_dataset")
+    def test_load_dataset_failure_wrapped_as_validation_error(self, mock_load_ds):
+        """load_dataset failures surface as DatasetValidationError with dataset context."""
+        from winml.modelkit.eval import WinMLEvaluator
+        from winml.modelkit.utils.eval_utils import DatasetValidationError
+
+        mock_load_ds.side_effect = ValueError(
+            "Unknown split \"validation\". Should be one of ['train', 'val'].",
+        )
+
+        model = MagicMock()
+        config = WinMLEvaluationConfig(
+            model_id="test/model",
+            task="image-classification",
+            dataset=DatasetConfig(path="detection-datasets/fashionpedia", split="validation"),
+        )
+
+        with pytest.raises(DatasetValidationError) as exc_info:
+            WinMLEvaluator(config, model)
+
+        msg = str(exc_info.value)
+        assert "Failed to load dataset 'detection-datasets/fashionpedia'" in msg
+        assert "split='validation'" in msg
+        assert "Unknown split" in msg
+        assert isinstance(exc_info.value.__cause__, ValueError)
 
     @patch("evaluate.evaluator")
     @patch("transformers.pipeline")

--- a/tests/unit/eval/test_fill_mask_evaluator.py
+++ b/tests/unit/eval/test_fill_mask_evaluator.py
@@ -62,12 +62,6 @@ def _make_evaluator(model=None, max_length=None):
 
 
 class TestLifecycle:
-    def test_schema(self) -> None:
-        schema = WinMLFillMaskEvaluator.schema_info()
-        assert len(schema) == 1
-        assert schema[0].name == "text"
-        assert schema[0].type == "Value(string)"
-
     def test_prepare_pipeline_returns_none(self) -> None:
         assert _make_evaluator().pipe is None
 

--- a/tests/unit/eval/test_image_feature_extraction_evaluator.py
+++ b/tests/unit/eval/test_image_feature_extraction_evaluator.py
@@ -30,7 +30,10 @@ def make_evaluator(columns_mapping=None):
     mock_ds.__len__ = lambda self: 10
     mock_ds.shuffle.return_value = mock_ds
     mock_ds.select.return_value = mock_ds
-    mock_ds.column_names = ["image", "label"]
+    mock_ds.column_names = [
+        mapping.get("input_column", "image"),
+        mapping.get("label_column", "label"),
+    ]
 
     mock_pipe = MagicMock()
     mock_pipe.image_processor = MagicMock()
@@ -124,20 +127,6 @@ class TestKNNAccuracyMetric:
 # ---------------------------------------------------------------------------
 # WinMLImageFeatureExtractionEvaluator
 # ---------------------------------------------------------------------------
-
-class TestImageFeatureExtractionEvaluatorSchema:
-    def test_schema_has_image_and_label(self):
-        schema = WinMLImageFeatureExtractionEvaluator.schema_info()
-        names = [col.name for col in schema]
-        assert "image" in names
-        assert "label" in names
-
-    def test_schema_column_types(self):
-        schema = WinMLImageFeatureExtractionEvaluator.schema_info()
-        type_map = {col.name: col.type for col in schema}
-        assert type_map["image"] == "Image"
-        assert type_map["label"] == "ClassLabel"
-
 
 class TestImageFeatureExtractionEvaluatorInit:
     def test_default_label_column(self):

--- a/tests/unit/eval/test_image_segmentation_evaluator.py
+++ b/tests/unit/eval/test_image_segmentation_evaluator.py
@@ -12,6 +12,7 @@ from datasets import Dataset, Features, Image, Value
 from PIL import Image as PILImage
 
 from winml.modelkit.eval import IGNORE_INDEX, MeanIoUMetric, WinMLImageSegmentationEvaluator
+from winml.modelkit.utils.eval_utils import DatasetValidationError
 
 
 # ---------------------------------------------------------------------------
@@ -40,8 +41,10 @@ def make_evaluator(label2id=None, columns_mapping=None, num_labels=5):
     """Create evaluator without triggering __init__ data loading."""
     ev = object.__new__(WinMLImageSegmentationEvaluator)
     ev.model = MockModel(label2id, num_labels)
+    ev._image_col = "image"
     ev._annotation_col = "annotation"
     if columns_mapping:
+        ev._image_col = columns_mapping.get("input_column", "image")
         ev._annotation_col = columns_mapping.get("annotation_column", "annotation")
     return ev
 
@@ -89,7 +92,7 @@ class TestValidateSchema:
     def test_missing_image_column_raises(self):
         ev = make_evaluator()
         ds = Dataset.from_dict({"text": ["hello"], "annotation": ["a"]})
-        with pytest.raises(ValueError, match="missing 'image' column"):
+        with pytest.raises(DatasetValidationError, match="missing 'image' column"):
             ev._validate_schema(ds)
 
     def test_missing_annotation_column_raises(self):
@@ -97,7 +100,7 @@ class TestValidateSchema:
         features = Features({"image": Image(mode="RGB"), "label": Value("int64")})
         img = create_dummy_image(4, 3)
         ds = Dataset.from_dict({"image": [img], "label": [0]}, features=features)
-        with pytest.raises(ValueError, match="missing annotation column"):
+        with pytest.raises(DatasetValidationError, match="missing annotation column"):
             ev._validate_schema(ds)
 
     def test_custom_annotation_column(self):

--- a/tests/unit/eval/test_image_to_text_evaluator.py
+++ b/tests/unit/eval/test_image_to_text_evaluator.py
@@ -23,7 +23,10 @@ def make_evaluator(columns_mapping=None):
     mock_ds.__len__ = lambda self: 0
     mock_ds.shuffle.return_value = mock_ds
     mock_ds.select.return_value = mock_ds
-    mock_ds.column_names = ["image", "text"]
+    mock_ds.column_names = [
+        mapping.get("input_column", "image"),
+        mapping.get("label_column", "text"),
+    ]
 
     mock_pipe = MagicMock()
     model = MagicMock()
@@ -38,19 +41,6 @@ def make_evaluator(columns_mapping=None):
     with patch("datasets.load_dataset", return_value=mock_ds), \
          patch("transformers.pipeline", return_value=mock_pipe):
         return WinMLImageToTextEvaluator(config, model)
-
-
-class TestSchema:
-    def test_has_image_and_text_columns(self):
-        schema = WinMLImageToTextEvaluator.schema_info()
-        names = [col.name for col in schema]
-        assert "image" in names
-        assert "text" in names
-
-    def test_image_column_type(self):
-        schema = WinMLImageToTextEvaluator.schema_info()
-        type_map = {col.name: col.type for col in schema}
-        assert type_map["image"] == "Image"
 
 
 class TestInit:

--- a/tests/unit/eval/test_object_detection_evaluator.py
+++ b/tests/unit/eval/test_object_detection_evaluator.py
@@ -10,6 +10,7 @@ from datasets import ClassLabel, Dataset, Features, Sequence, Value
 
 from winml.modelkit.datasets import DatasetConfig
 from winml.modelkit.eval import WinMLObjectDetectionEvaluator
+from winml.modelkit.utils.eval_utils import DatasetValidationError
 
 
 # ---------------------------------------------------------------------------
@@ -33,10 +34,12 @@ def make_evaluator(label2id=None, columns_mapping=None):
     """Create evaluator without triggering __init__ data loading."""
     ev = object.__new__(WinMLObjectDetectionEvaluator)
     ev.model = MockModel(label2id)
+    ev._image_col = "image"
     ev._annotation_col = "objects"
     ev._bbox_key = "bbox"
     ev._category_key = "category"
     if columns_mapping:
+        ev._image_col = columns_mapping.get("input_column", "image")
         ev._annotation_col = columns_mapping.get("annotation_column", "objects")
         ev._bbox_key = columns_mapping.get("bbox_key", "bbox")
         ev._category_key = columns_mapping.get("category_key", "category")
@@ -79,7 +82,7 @@ class TestValidateSchema:
     def test_missing_annotation_column_raises(self):
         ev = make_evaluator()
         ds = Dataset.from_dict({"image": ["a.jpg"], "label": [0]})
-        with pytest.raises(ValueError, match="No column 'objects'"):
+        with pytest.raises(DatasetValidationError, match="No column 'objects'"):
             ev._validate_schema(ds)
 
     def test_missing_bbox_key_raises(self):
@@ -94,7 +97,7 @@ class TestValidateSchema:
             {"image": ["a.jpg"], "objects": [{"category": [0]}]},
             features=features,
         )
-        with pytest.raises(ValueError, match="has no key 'bbox'"):
+        with pytest.raises(DatasetValidationError, match="has no key 'bbox'"):
             ev._validate_schema(ds)
 
     def test_missing_category_key_raises(self):
@@ -111,7 +114,7 @@ class TestValidateSchema:
             {"image": ["a.jpg"], "objects": [{"bbox": [[0, 0, 1, 1]]}]},
             features=features,
         )
-        with pytest.raises(ValueError, match="has no key 'category'"):
+        with pytest.raises(DatasetValidationError, match="has no key 'category'"):
             ev._validate_schema(ds)
 
 
@@ -146,7 +149,7 @@ class TestAlignLabels:
         ds = make_od_dataset([[0, 1]], ["cat", "dog"])
         ds_config = DatasetConfig(path="test")
 
-        with pytest.raises(ValueError, match="Dataset label 'dog' not in"):
+        with pytest.raises(DatasetValidationError, match="Dataset label 'dog' not in"):
             ev.align_labels(ds, ds_config)
 
     def test_no_label2id_warns_and_skips(self):

--- a/tests/unit/eval/test_question_answering_evaluator.py
+++ b/tests/unit/eval/test_question_answering_evaluator.py
@@ -59,27 +59,6 @@ def make_evaluator(io_config=None, columns_mapping=None):
 
 
 # ---------------------------------------------------------------------------
-# schema_info
-# ---------------------------------------------------------------------------
-
-
-class TestSchemaInfo:
-    def test_returns_four_columns(self):
-        schema = WinMLQuestionAnsweringEvaluator.schema_info()
-        assert len(schema) == 4
-
-    def test_column_names(self):
-        schema = WinMLQuestionAnsweringEvaluator.schema_info()
-        names = [col.name for col in schema]
-        assert names == ["question", "context", "id", "answers"]
-
-    def test_column_overrides(self):
-        schema = WinMLQuestionAnsweringEvaluator.schema_info()
-        overrides = [col.override for col in schema]
-        assert overrides == ["question_column", "context_column", "id_column", "label_column"]
-
-
-# ---------------------------------------------------------------------------
 # prepare_pipeline: tokenizer padding
 # ---------------------------------------------------------------------------
 
@@ -274,7 +253,7 @@ class TestCompute:
         assert call_kwargs["label_column"] == "ans"
 
     def test_label_col_default_derived_from_schema(self):
-        """When label_column is not in columns_mapping, fallback comes from schema_info."""
+        """When label_column is not in columns_mapping, default is 'answers'."""
         ev = make_evaluator(columns_mapping={
             "question_column": "question",
             "context_column": "context",
@@ -288,7 +267,7 @@ class TestCompute:
         with patch("evaluate.evaluator", return_value=mock_task_evaluator):
             ev.compute()
 
-        # is_squad_v2_format should receive the schema default "answers"
+        # is_squad_v2_format should receive the default "answers"
         v2_call_kwargs = mock_task_evaluator.is_squad_v2_format.call_args
         assert v2_call_kwargs[1]["label_column"] == "answers"
 

--- a/tests/unit/eval/test_zero_shot_classification_evaluator.py
+++ b/tests/unit/eval/test_zero_shot_classification_evaluator.py
@@ -16,6 +16,7 @@ from winml.modelkit.eval import (
     WinMLEvaluationConfig,
     WinMLZeroShotClassificationEvaluator,
 )
+from winml.modelkit.utils.eval_utils import DatasetValidationError
 
 
 # ---------------------------------------------------------------------------
@@ -321,25 +322,6 @@ class TestPreparePipeline:
 
 
 # ---------------------------------------------------------------------------
-# schema_info
-# ---------------------------------------------------------------------------
-
-
-class TestSchemaInfo:
-    def test_schema_has_input_and_label(self) -> None:
-        cols = WinMLZeroShotClassificationEvaluator.schema_info()
-        overrides = {c.override for c in cols if c.override}
-        assert "input_column" in overrides
-        assert "label_column" in overrides
-
-    def test_schema_has_optional_overrides(self) -> None:
-        cols = WinMLZeroShotClassificationEvaluator.schema_info()
-        override_to_required = {c.override: c.required for c in cols if c.override}
-        assert override_to_required.get("candidate_labels") is False
-        assert override_to_required.get("hypothesis_template") is False
-
-
-# ---------------------------------------------------------------------------
 # align_labels / schema validation
 # ---------------------------------------------------------------------------
 
@@ -357,7 +339,7 @@ class TestAlignLabels:
             ds,
             columns_mapping={"input_column": "nope", "label_column": "label"},
         )
-        with pytest.raises(ValueError, match="Column 'nope'"):
+        with pytest.raises(DatasetValidationError, match="Column 'nope'"):
             ev.align_labels(ds, ev.config.dataset)
 
     def test_missing_label_column_raises(self) -> None:
@@ -366,7 +348,7 @@ class TestAlignLabels:
             ds,
             columns_mapping={"input_column": "text", "label_column": "missing"},
         )
-        with pytest.raises(ValueError, match="Column 'missing'"):
+        with pytest.raises(DatasetValidationError, match="Column 'missing'"):
             ev.align_labels(ds, ev.config.dataset)
 
     def test_no_alignment_against_nli_label2id(self) -> None:
@@ -407,7 +389,7 @@ class TestResolveCandidateLabels:
     def test_string_label_without_override_raises(self) -> None:
         ds = _make_string_dataset(["a"], ["World"])
         ev = make_evaluator(ds)
-        with pytest.raises(ValueError, match="not a ClassLabel"):
+        with pytest.raises(DatasetValidationError, match="not a ClassLabel"):
             ev._resolve_candidate_labels(ds)
 
     def test_empty_override_raises(self) -> None:

--- a/tests/unit/eval/test_zero_shot_image_classification_evaluator.py
+++ b/tests/unit/eval/test_zero_shot_image_classification_evaluator.py
@@ -167,12 +167,6 @@ class TestEvaluatorSetup:
         result = ev.align_labels(mock_ds, MagicMock())
         assert result is mock_ds
 
-    def test_schema_has_image_and_label(self):
-        schema = WinMLZeroShotImageClassificationEvaluator.schema_info()
-        names = [col.name for col in schema]
-        assert "image" in names
-        assert "label" in names
-
 
 class TestEvaluatorCompute:
     def test_compute_perfect_accuracy(self):


### PR DESCRIPTION
## Improve `winml eval` UX: validate inputs upfront, friendlier errors, structured `--schema`

Addresses [#216](https://github.com/microsoft/winml-cli/issues/216), [#528](https://github.com/microsoft/winml-cli/issues/528), [#529](https://github.com/microsoft/winml-cli/issues/529), [#532](https://github.com/microsoft/winml-cli/issues/532).

### What changes

**Task validation (#529)**
- `_resolve_task()` now validates the resolved task against `_EVALUATOR_REGISTRY` for both explicit `--task` and HF-inferred paths. Unsupported tasks fail immediately with `Task 'xyz' is not supported. Supported tasks: ...`, before model load and before the misleading "no default dataset" branch.
- `evaluate()` wraps `_load_model()` and `compute()` in actionable error messages pointing the user at `winml eval --schema --task <task>`.
- CLI no longer dumps a traceback at default verbosity; `-v` re-enables `logger.exception`.

**Dataset column validation (#216, #528)**
- New `utils/eval_utils.py` centralizes per-task schemas (`TaskSchema`, `SchemaItem`, `TASK_SCHEMAS`) plus `validate_dataset_columns()` and `DatasetValidationError`.
- `WinMLEvaluator.load_dataset()` validates required columns up-front; missing columns raise `DatasetValidationError` (re-raised by `evaluate()` as `Dataset '...' is not compatible with task '...': missing required column(s) ...`).
- Label-alignment failures and empty-after-filter cases now raise `DatasetValidationError` instead of `RuntimeError` / `ValueError`, so users get the same friendly wrap-up (e.g. the finbert + GLUE case in #216).
- Per-evaluator hard-coded column-default constants removed; defaults come from the shared schema table.

**`--schema` redesign (#532)**
- Fast path served from the lightweight `TASK_SCHEMAS` table — no longer imports the heavy `winml.modelkit.eval` package.
- New output format documents required dataset columns, optional config params, `--column` overrides, and (for split-encoder tasks) the `-m role=path` forms.
- `--schema --task <bad>` and `--schema` without `--task` print a clear usage hint listing supported tasks.

**Model flag cleanup (#532)**
- `-m / --model` help text simplified to one sentence; role-key syntax now documented in `--schema` output rather than the option help.
- `_resolve_model_path()` rejects `-m <hf_id> --model-id <other_id>` with `Cannot pass both ...`. The existing rule that `-m <onnx>` requires `--model-id` is unchanged.

**Misc**
- `evaluate.print_config()` lost the `used_default` flag; the dataset line now prints `ds.path` plainly.
- `commands/eval.py` example block reduced to two canonical invocations (HF id, ONNX path).

### Files
28 files changed, +601/-480. New: eval_utils.py. Bulk per-evaluator edits remove dead column constants and route through the shared schema.

### Verification
- `ruff check` clean
- `pytest tests/unit/` — 4953 passed
- `pytest test_eval_e2e.py -m e2e` — 45 passed (one e2e adjusted: `test_image_to_text_fp16` now passes `--column label_column=caption` because `lmms-lab/flickr30k` uses `caption`, which the new validator correctly flags)

### Not in this PR
- Static ONNX-input-vs-task contract check (the "expected `[input_ids, attention_mask]`" wording from #529). Existing wrapped `_load_model` / `compute()` errors already point users at `--schema`, so this is a follow-up enhancement rather than a fix.
- Dropping/aliasing `--model-id` (#532). Done conservatively: kept the flag, added the conflict check; flag-name consolidation is a separate UX decision.