### PR TITLE
test(e2e): expand winml perf coverage across EPs and devices

### DIFF
--- a/src/winml/modelkit/session/ep_registry.py
+++ b/src/winml/modelkit/session/ep_registry.py
@@ -79,7 +79,11 @@ class WinMLEPRegistry:
         providers = self._catalog.find_all_providers()
 
         for provider in providers:
-            provider.ensure_ready()
+            try:
+                provider.ensure_ready()
+            except Exception as e:
+                logger.warning("Failed to ensure EP %s is ready: %s", provider.name, e)
+                continue
             if provider.library_path == "":
                 continue
             self._ep_paths[cast("EPName", provider.name)] = provider.library_path

--- a/src/winml/modelkit/session/qairt/qairt_session.py
+++ b/src/winml/modelkit/session/qairt/qairt_session.py
@@ -83,8 +83,7 @@ class WinMLQairtSession(WinMLSession):
         """
         # If already compiled, ignore (idempotent)
         if self._session is not None:
-            if self._is_verbose():
-                logger.info("Already compiled for %s", self._device)
+            logger.debug("Already compiled for %s", self._device)
             return
 
         logger.info("Compiling via QAIRT SDK: %s", self._onnx_path)

--- a/src/winml/modelkit/session/session.py
+++ b/src/winml/modelkit/session/session.py
@@ -195,12 +195,12 @@ class WinMLSession:
         """
         # If already compiled, ignore (idempotent)
         if self._session is not None:
-            logger.info("Already compiled for %s", self._device)
+            logger.debug("Already compiled for %s", self._device)
             return
 
         target_device = self._device
 
-        logger.info("Compiling for device: %s", target_device)
+        logger.debug("Compiling for device: %s", target_device)
 
         # Determine model path (original or EPContext)
         ctx_path = self._onnx_path.parent / f"{self._onnx_path.stem}_{target_device}_ctx.onnx"

--- a/src/winml/modelkit/session/session.py
+++ b/src/winml/modelkit/session/session.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import logging
-import os
 from contextlib import contextmanager
 from enum import Enum
 from pathlib import Path
@@ -196,14 +195,12 @@ class WinMLSession:
         """
         # If already compiled, ignore (idempotent)
         if self._session is not None:
-            if self._is_verbose():
-                logger.info("Already compiled for %s", self._device)
+            logger.info("Already compiled for %s", self._device)
             return
 
         target_device = self._device
 
-        if self._is_verbose():
-            logger.info("Compiling for device: %s", target_device)
+        logger.info("Compiling for device: %s", target_device)
 
         # Determine model path (original or EPContext)
         ctx_path = self._onnx_path.parent / f"{self._onnx_path.stem}_{target_device}_ctx.onnx"
@@ -282,6 +279,7 @@ class WinMLSession:
 
             ep_map = get_ep_device_map()
             resolved = ep_map.get(actual_providers[0])
+            print(f"Resolved device from provider {actual_providers[0]}: {resolved}")
             if resolved and "/" not in resolved:
                 self._device = resolved
 
@@ -366,10 +364,6 @@ class WinMLSession:
             self._session = None
         except Exception:
             pass  # Suppress errors during interpreter shutdown
-
-    def _is_verbose(self) -> bool:
-        """Check if verbose logging is enabled via environment variable."""
-        return os.getenv("WINMLSESSION_VERBOSE", "").lower() in ("1", "true", "yes")
 
     def _build_session_options(self, device: str) -> ort.SessionOptions:
         """Build ORT SessionOptions from instance session_options and device.

--- a/src/winml/modelkit/session/session.py
+++ b/src/winml/modelkit/session/session.py
@@ -279,7 +279,6 @@ class WinMLSession:
 
             ep_map = get_ep_device_map()
             resolved = ep_map.get(actual_providers[0])
-            print(f"Resolved device from provider {actual_providers[0]}: {resolved}")
             if resolved and "/" not in resolved:
                 self._device = resolved
 

--- a/tests/e2e/require_ep.py
+++ b/tests/e2e/require_ep.py
@@ -56,11 +56,11 @@ def require_ep(ep: str) -> str:
     if provider is None:
         pytest.skip(f"Unknown EP: {ep!r}")
 
-    # CPU is always available via ORT itself but is not enumerated by
+    # CPU, DML are always available via ORT itself but is not enumerated by
     # WinMLEPRegistry, which only tracks WinML-discoverable backend EPs
-    # (QNN, OpenVINO, DML, ...). Short-circuit before consulting the
+    # (QNN, OpenVINO, ...). Short-circuit before consulting the
     # registry so `require_ep("cpu")` doesn't spuriously skip.
-    if provider == "CPUExecutionProvider":
+    if provider in ("CPUExecutionProvider", "DmlExecutionProvider"):
         return provider
 
     # Singleton — first call probes; subsequent calls are free.

--- a/tests/e2e/test_perf_e2e.py
+++ b/tests/e2e/test_perf_e2e.py
@@ -54,7 +54,7 @@ pytestmark = [pytest.mark.e2e]
 
 CPU_EPS = ("cpu", "openvino")
 NPU_EPS = ("qnn", "vitisai", "openvino")
-GPU_EPS = ("dml", "nv_tensorrt_rtx", "migraphx", "openvino")
+GPU_EPS = ("dml", "nv_tensorrt_rtx", "migraphx", "openvino", "qnn")
 NON_CPU_EPS = ("qnn", "vitisai", "dml", "nv_tensorrt_rtx", "migraphx")
 
 
@@ -538,7 +538,7 @@ class TestPerfModule:
 
     def test_module_benchmark_cpu(self, tmp_path: Path):
         """Per-module benchmark on CPU for ResNetStage submodules of resnet-50."""
-        output_file = tmp_path / "perf_module.json"
+        output_file = tmp_path / "perf_module_cpu.json"
 
         runner = CliRunner()
         result = runner.invoke(
@@ -546,6 +546,7 @@ class TestPerfModule:
             _build_perf_args(
                 model_arg="microsoft/resnet-50",
                 output_file=output_file,
+                ep="cpu",
                 device="cpu",
                 module="ResNetStage",
             ),

--- a/tests/e2e/test_perf_e2e.py
+++ b/tests/e2e/test_perf_e2e.py
@@ -85,12 +85,57 @@ def _assert_hw_monitor_section(data: dict, device_kind: str) -> None:
     """
     assert "hw_monitor" in data, "hw_monitor section missing with --monitor"
     hw = data["hw_monitor"]
-    assert hw["device_kind"] == device_kind
-    assert hw["adapter_luid"] is not None
-    assert hw[device_kind]["mean_pct"] > 0
+    if device_kind == "cpu":
+        # For CPU, device_kind is None and adapter_luid is None
+        assert hw["device_kind"] is None
+        assert hw["adapter_luid"] is None
+    else:
+        assert hw["device_kind"] == device_kind
+        assert hw["adapter_luid"] is not None
+        assert hw[device_kind]["mean_pct"] > 0
 
 
-def _assert_monitor_result(data: dict, *, device: str, device_kind: str | None = None) -> None:
+def _build_perf_args(
+    *,
+    model_arg: str,
+    output_file: Path,
+    device: str | None = None,
+    ep: str | None = None,
+    module: str | None = None,
+    monitor: bool = False,
+    verbose: bool = False,
+) -> list[str]:
+    """Build the argv list passed to the perf CLI.
+
+    Iterations are fixed by ``monitor``: 300 when monitoring (HWMonitor needs
+    enough samples to observe utilization) and 3 otherwise (kept tiny for
+    e2e speed). Warmup is always 1.
+    """
+    iterations = 300 if monitor else 3
+    args: list[str] = [
+        "-m",
+        model_arg,
+        "--iterations",
+        str(iterations),
+        "--warmup",
+        "1",
+        "-o",
+        str(output_file),
+    ]
+    if device is not None:
+        args += ["--device", device]
+    if ep is not None:
+        args += ["--ep", ep]
+    if module is not None:
+        args += ["--module", module]
+    if monitor:
+        args.append("--monitor")
+    if verbose:
+        args.append("--verbose")
+    return args
+
+
+def _assert_monitor_result(data: dict, *, device: str, device_kind: str | None = None, ep: str | None = None) -> None:
     """Assert a monitored perf run produced the expected device + hw_monitor data.
 
     Verifies the resolved ``device`` in ``benchmark_info``, that latency was
@@ -103,6 +148,8 @@ def _assert_monitor_result(data: dict, *, device: str, device_kind: str | None =
         device_kind = device
     assert data["benchmark_info"]["device"] == device
     assert data["latency_ms"]["mean"] > 0
+    if ep is not None:
+        assert data["benchmark_info"]["ep"] == ep
     _assert_hw_monitor_section(data, device_kind)
 
 
@@ -129,18 +176,7 @@ class _PerfBenchmarkSuite:
         runner = CliRunner()
         result = runner.invoke(
             perf,
-            [
-                "-m",
-                model_arg,
-                "--device",
-                "cpu",
-                "--iterations",
-                "3",
-                "--warmup",
-                "1",
-                "-o",
-                str(output_file),
-            ],
+            _build_perf_args(model_arg=model_arg, output_file=output_file, device="cpu"),
             obj={},
             catch_exceptions=False,
         )
@@ -186,19 +222,9 @@ class _PerfBenchmarkSuite:
         runner = CliRunner()
         result = runner.invoke(
             perf,
-            [
-                "-m",
-                model_arg,
-                "--device",
-                "cpu",
-                "--iterations",
-                "2",
-                "--warmup",
-                "1",
-                "-o",
-                str(output_file),
-                "--verbose",
-            ],
+            _build_perf_args(
+                model_arg=model_arg, output_file=output_file, device="cpu", verbose=True
+            ),
             obj={},
             catch_exceptions=False,
         )
@@ -218,19 +244,9 @@ class _PerfBenchmarkSuite:
         runner = CliRunner()
         result = runner.invoke(
             perf,
-            [
-                "-m",
-                model_arg,
-                "--device",
-                "cpu",
-                "--iterations",
-                "100",
-                "--warmup",
-                "1",
-                "-o",
-                str(output_file),
-                "--monitor",
-            ],
+            _build_perf_args(
+                model_arg=model_arg, output_file=output_file, device="cpu", monitor=True
+            ),
             obj={},
             catch_exceptions=False,
         )
@@ -238,12 +254,7 @@ class _PerfBenchmarkSuite:
 
         assert output_file.exists(), f"Output file not created: {output_file}"
         data = json.loads(output_file.read_text())
-        assert data["benchmark_info"]["device"] == "cpu"
-        assert data["latency_ms"]["mean"] > 0
-        assert "hw_monitor" in data, "hw_monitor section missing with --monitor"
-        hw = data["hw_monitor"]
-        assert hw["device_kind"] is None
-        assert hw["adapter_luid"] is None
+        _assert_monitor_result(data, device="cpu")
 
     def test_benchmark_gpu_monitor(self, tmp_path: Path, model_arg: str):
         """Benchmark on GPU with --monitor.
@@ -258,19 +269,9 @@ class _PerfBenchmarkSuite:
         runner = CliRunner()
         result = runner.invoke(
             perf,
-            [
-                "-m",
-                model_arg,
-                "--device",
-                "gpu",
-                "--iterations",
-                "100",
-                "--warmup",
-                "1",
-                "-o",
-                str(output_file),
-                "--monitor",
-            ],
+            _build_perf_args(
+                model_arg=model_arg, output_file=output_file, device="gpu", monitor=True
+            ),
             obj={},
             catch_exceptions=False,
         )
@@ -293,19 +294,9 @@ class _PerfBenchmarkSuite:
         runner = CliRunner()
         result = runner.invoke(
             perf,
-            [
-                "-m",
-                model_arg,
-                "--device",
-                "npu",
-                "--iterations",
-                "100",
-                "--warmup",
-                "1",
-                "-o",
-                str(output_file),
-                "--monitor",
-            ],
+            _build_perf_args(
+                model_arg=model_arg, output_file=output_file, device="npu", monitor=True
+            ),
             obj={},
             catch_exceptions=False,
         )
@@ -326,18 +317,7 @@ class _PerfBenchmarkSuite:
         runner = CliRunner()
         result = runner.invoke(
             perf,
-            [
-                "-m",
-                model_arg,
-                "--device",
-                "auto",
-                "--iterations",
-                "3",
-                "--warmup",
-                "1",
-                "-o",
-                str(output_file),
-            ],
+            _build_perf_args(model_arg=model_arg, output_file=output_file, device="auto"),
             obj={},
             catch_exceptions=False,
         )
@@ -362,18 +342,7 @@ class _PerfBenchmarkSuite:
         runner = CliRunner()
         result = runner.invoke(
             perf,
-            [
-                "-m",
-                model_arg,
-                "--ep",
-                "qnn",
-                "--iterations",
-                "3",
-                "--warmup",
-                "1",
-                "-o",
-                str(output_file),
-            ],
+            _build_perf_args(model_arg=model_arg, output_file=output_file, ep="qnn"),
             obj={},
             catch_exceptions=False,
         )
@@ -399,20 +368,7 @@ class _PerfBenchmarkSuite:
         runner = CliRunner()
         result = runner.invoke(
             perf,
-            [
-                "-m",
-                model_arg,
-                "--device",
-                "gpu",
-                "--ep",
-                "qnn",
-                "--iterations",
-                "3",
-                "--warmup",
-                "1",
-                "-o",
-                str(output_file),
-            ],
+            _build_perf_args(model_arg=model_arg, output_file=output_file, device="gpu", ep="qnn"),
             obj={},
             catch_exceptions=False,
         )
@@ -445,7 +401,8 @@ class TestPerfHuggingFace:
     def model_arg(self) -> str:
         return "microsoft/resnet-50"
 
-    def test_benchmark_ep_vitisai(self, tmp_path: Path, model_arg: str):
+    @pytest.mark.parametrize("ep", NPU_EPS)
+    def test_benchmark_ep_npu(self, ep: str, tmp_path: Path, model_arg: str):
         """Benchmark with --ep vitisai.
 
         Skipped if VitisAIExecutionProvider is not available on the host.
@@ -457,19 +414,9 @@ class TestPerfHuggingFace:
         runner = CliRunner()
         result = runner.invoke(
             perf,
-            [
-                "-m",
-                model_arg,
-                "--ep",
-                "vitisai",
-                "--iterations",
-                "100",
-                "--warmup",
-                "1",
-                "-o",
-                str(output_file),
-                "--monitor"
-            ],
+            _build_perf_args(
+                model_arg=model_arg, output_file=output_file, ep="vitisai", monitor=True
+            ),
             obj={},
             catch_exceptions=False,
         )
@@ -496,20 +443,12 @@ class TestPerfModule:
         runner = CliRunner()
         result = runner.invoke(
             perf,
-            [
-                "-m",
-                "microsoft/resnet-50",
-                "--module",
-                "ResNetStage",
-                "--device",
-                "cpu",
-                "--iterations",
-                "3",
-                "--warmup",
-                "1",
-                "-o",
-                str(output_file),
-            ],
+            _build_perf_args(
+                model_arg="microsoft/resnet-50",
+                output_file=output_file,
+                device="cpu",
+                module="ResNetStage",
+            ),
             obj={},
             catch_exceptions=False,
         )
@@ -534,20 +473,12 @@ class TestPerfModule:
         runner = CliRunner()
         result = runner.invoke(
             perf,
-            [
-                "-m",
-                "microsoft/resnet-50",
-                "--module",
-                "NotAValidModuleXyz",
-                "--device",
-                "cpu",
-                "--iterations",
-                "3",
-                "--warmup",
-                "1",
-                "-o",
-                str(output_file),
-            ],
+            _build_perf_args(
+                model_arg="microsoft/resnet-50",
+                output_file=output_file,
+                device="cpu",
+                module="NotAValidModuleXyz",
+            ),
             obj={},
             catch_exceptions=False,
         )

--- a/tests/e2e/test_perf_e2e.py
+++ b/tests/e2e/test_perf_e2e.py
@@ -36,6 +36,7 @@ from typing import TYPE_CHECKING
 import pytest
 from click.testing import CliRunner
 
+from winml.modelkit.utils.constants import EP_ALIASES
 from tests.e2e.require_ep import require_ep
 from winml.modelkit.commands.perf import perf
 
@@ -54,6 +55,7 @@ pytestmark = [pytest.mark.e2e]
 CPU_EPS = ("cpu", "openvino")
 NPU_EPS = ("qnn", "vitisai", "openvino")
 GPU_EPS = ("dml", "nv_tensorrt_rtx", "migraphx", "openvino")
+NON_CPU_EPS = ("qnn", "vitisai", "dml", "nv_tensorrt_rtx", "migraphx")
 
 
 def _require_gpu() -> None:
@@ -215,7 +217,7 @@ class _PerfBenchmarkSuite:
         # Verify raw samples count matches iterations
         assert len(data["raw_samples_ms"]) == 3
 
-    def test_benchmark_verbose(self, tmp_path: Path, model_arg: str):
+    def test_benchmark_cpu_verbose(self, tmp_path: Path, model_arg: str):
         """Benchmark with --verbose should succeed and show debug output."""
         output_file = tmp_path / "verbose_result.json"
 
@@ -325,24 +327,25 @@ class _PerfBenchmarkSuite:
 
         assert output_file.exists()
         data = json.loads(output_file.read_text())
-        assert data["benchmark_info"]["device"] == "auto"
         # At least a non-cpu should exist and picked up
+        assert data["benchmark_info"]["device"] in ("gpu", "npu")
         assert data["benchmark_info"]["ep"] != "CPUExecutionProvider"
         assert data["latency_ms"]["mean"] > 0
 
-    def test_benchmark_ep_qnn(self, tmp_path: Path, model_arg: str):
-        """Benchmark with --ep qnn.
+    @pytest.mark.parametrize("ep", NON_CPU_EPS)
+    def test_benchmark_ep(self, ep: str, tmp_path: Path, model_arg: str):
+        """Benchmark with --ep <ep>.
 
-        Skipped if QNNExecutionProvider is not available on the host.
+        Skipped if the specified ExecutionProvider is not available on the host.
         """
-        require_ep("qnn")
+        require_ep(ep)
 
-        output_file = tmp_path / "perf_qnn.json"
+        output_file = tmp_path / f"perf_{ep}.json"
 
         runner = CliRunner()
         result = runner.invoke(
             perf,
-            _build_perf_args(model_arg=model_arg, output_file=output_file, ep="qnn"),
+            _build_perf_args(model_arg=model_arg, output_file=output_file, ep=ep),
             obj={},
             catch_exceptions=False,
         )
@@ -350,25 +353,26 @@ class _PerfBenchmarkSuite:
 
         assert output_file.exists()
         data = json.loads(output_file.read_text())
-        assert data["benchmark_info"]["ep"] == "QNNExecutionProvider"
+        assert data["benchmark_info"]["ep"] == EP_ALIASES[ep]
+        assert data["benchmark_info"]["device"] in ("gpu", "npu"), "Expected a non-CPU EP"
         assert data["latency_ms"]["mean"] > 0
 
-    def test_benchmark_ep_qnn_device_gpu(self, tmp_path: Path, model_arg: str):
-        """Benchmark with --ep qnn and --device gpu.
+    @pytest.mark.parametrize("ep", CPU_EPS)
+    def test_benchmark_ep_device_cpu(self, ep: str, tmp_path: Path, model_arg: str):
+        """Benchmark with --ep <ep> and --device cpu.
 
         --ep overrides the device-to-provider mapping, so the session should
-        bind to QNN even though the requested device is GPU. Skipped if QNN
-        or a GPU is unavailable on the host.
+        bind to the specified EP even though the requested device is CPU. Skipped if the specified EP
+        or a CPU is unavailable on the host.
         """
-        require_ep("qnn")
-        _require_gpu()
+        require_ep(ep)
 
-        output_file = tmp_path / "perf_qnn_gpu.json"
+        output_file = tmp_path / f"perf_{ep}_cpu.json"
 
         runner = CliRunner()
         result = runner.invoke(
             perf,
-            _build_perf_args(model_arg=model_arg, output_file=output_file, device="gpu", ep="qnn"),
+            _build_perf_args(model_arg=model_arg, output_file=output_file, device="cpu", ep=ep, monitor=True),
             obj={},
             catch_exceptions=False,
         )
@@ -376,9 +380,59 @@ class _PerfBenchmarkSuite:
 
         assert output_file.exists()
         data = json.loads(output_file.read_text())
-        assert data["benchmark_info"]["device"] == "gpu"
-        assert data["benchmark_info"]["ep"] == "QNNExecutionProvider"
-        assert data["latency_ms"]["mean"] > 0
+        _assert_monitor_result(data, device="cpu", ep=EP_ALIASES[ep])
+
+    @pytest.mark.parametrize("ep", GPU_EPS)
+    def test_benchmark_ep_device_gpu(self, ep: str, tmp_path: Path, model_arg: str):
+        """Benchmark with --ep <ep> and --device gpu.
+
+        --ep overrides the device-to-provider mapping, so the session should
+        bind to the specified EP even though the requested device is GPU. Skipped if the specified EP
+        or a GPU is unavailable on the host.
+        """
+        require_ep(ep)
+        _require_gpu()
+
+        output_file = tmp_path / f"perf_{ep}_gpu.json"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            perf,
+            _build_perf_args(model_arg=model_arg, output_file=output_file, device="gpu", ep=ep, monitor=True),
+            obj={},
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"perf failed (exit {result.exit_code}):\n{result.output}"
+
+        assert output_file.exists()
+        data = json.loads(output_file.read_text())
+        _assert_monitor_result(data, device="gpu", ep=EP_ALIASES[ep])
+
+    @pytest.mark.parametrize("ep", NPU_EPS)
+    def test_benchmark_ep_device_npu(self, ep: str, tmp_path: Path, model_arg: str):
+        """Benchmark with --ep <ep> and --device npu.
+
+        --ep overrides the device-to-provider mapping, so the session should
+        bind to the specified EP even though the requested device is NPU. Skipped if the specified EP
+        or a NPU is unavailable on the host.
+        """
+        require_ep(ep)
+        _require_npu()
+
+        output_file = tmp_path / f"perf_{ep}_npu.json"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            perf,
+            _build_perf_args(model_arg=model_arg, output_file=output_file, device="npu", ep=ep, monitor=True),
+            obj={},
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"perf failed (exit {result.exit_code}):\n{result.output}"
+
+        assert output_file.exists()
+        data = json.loads(output_file.read_text())
+        _assert_monitor_result(data, device="npu", ep=EP_ALIASES[ep])
 
 
 # ===========================================================================

--- a/tests/e2e/test_perf_e2e.py
+++ b/tests/e2e/test_perf_e2e.py
@@ -48,8 +48,12 @@ pytestmark = [pytest.mark.e2e]
 
 
 # ===========================================================================
-# Helpers
+# Constants and Helpers
 # ===========================================================================
+
+CPU_EPS = ("cpu", "openvino")
+NPU_EPS = ("qnn", "vitisai", "openvino")
+GPU_EPS = ("dml", "nv_tensorrt_rtx", "migraphx", "openvino")
 
 
 def _require_gpu() -> None:
@@ -70,6 +74,36 @@ def _require_npu() -> None:
 
     if not PdhPoller.is_npu_available():
         pytest.skip("No NPU detected via PDH")
+
+
+def _assert_hw_monitor_section(data: dict, device_kind: str) -> None:
+    """Assert the ``hw_monitor`` section is present and well-formed.
+
+    Checks the section emitted by HWMonitor when --monitor is passed:
+    presence, ``device_kind`` match, a non-null ``adapter_luid``, and a
+    positive ``mean_pct`` for the per-device utilization block.
+    """
+    assert "hw_monitor" in data, "hw_monitor section missing with --monitor"
+    hw = data["hw_monitor"]
+    assert hw["device_kind"] == device_kind
+    assert hw["adapter_luid"] is not None
+    assert hw[device_kind]["mean_pct"] > 0
+
+
+def _assert_monitor_result(data: dict, *, device: str, device_kind: str | None = None) -> None:
+    """Assert a monitored perf run produced the expected device + hw_monitor data.
+
+    Verifies the resolved ``device`` in ``benchmark_info``, that latency was
+    measured, and delegates the hw_monitor checks to
+    :func:`_assert_hw_monitor_section`. ``device_kind`` defaults to ``device``
+    when not given (only differs for cases like VitisAI where ``--device`` and
+    the monitored hardware diverge).
+    """
+    if device_kind is None:
+        device_kind = device
+    assert data["benchmark_info"]["device"] == device
+    assert data["latency_ms"]["mean"] > 0
+    _assert_hw_monitor_section(data, device_kind)
 
 
 # ===========================================================================
@@ -172,6 +206,45 @@ class _PerfBenchmarkSuite:
         assert output_file.exists()
         assert "Results saved to" in result.output
 
+    def test_benchmark_cpu_monitor(self, tmp_path: Path, model_arg: str):
+        """Benchmark on CPU with --monitor.
+
+        Requires a real CPU discoverable via PDH. Verifies the JSON output
+        contains the hw_monitor section produced by HWMonitor.
+        """
+
+        output_file = tmp_path / "perf_cpu_monitor.json"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            perf,
+            [
+                "-m",
+                model_arg,
+                "--device",
+                "cpu",
+                "--iterations",
+                "100",
+                "--warmup",
+                "1",
+                "-o",
+                str(output_file),
+                "--monitor",
+            ],
+            obj={},
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"perf failed (exit {result.exit_code}):\n{result.output}"
+
+        assert output_file.exists(), f"Output file not created: {output_file}"
+        data = json.loads(output_file.read_text())
+        assert data["benchmark_info"]["device"] == "cpu"
+        assert data["latency_ms"]["mean"] > 0
+        assert "hw_monitor" in data, "hw_monitor section missing with --monitor"
+        hw = data["hw_monitor"]
+        assert hw["device_kind"] is None
+        assert hw["adapter_luid"] is None
+
     def test_benchmark_gpu_monitor(self, tmp_path: Path, model_arg: str):
         """Benchmark on GPU with --monitor.
 
@@ -205,13 +278,7 @@ class _PerfBenchmarkSuite:
 
         assert output_file.exists(), f"Output file not created: {output_file}"
         data = json.loads(output_file.read_text())
-
-        assert data["benchmark_info"]["device"] == "gpu"
-        assert data["latency_ms"]["mean"] > 0
-        assert "hw_monitor" in data, "hw_monitor section missing with --monitor"
-        assert data["hw_monitor"]["device_kind"] == "gpu"
-        assert data["hw_monitor"]["adapter_luid"] is not None
-        assert data["hw_monitor"]["gpu"]["mean_pct"] > 0
+        _assert_monitor_result(data, device="gpu")
 
     def test_benchmark_npu_monitor(self, tmp_path: Path, model_arg: str):
         """Benchmark on NPU with --monitor.
@@ -246,13 +313,7 @@ class _PerfBenchmarkSuite:
 
         assert output_file.exists(), f"Output file not created: {output_file}"
         data = json.loads(output_file.read_text())
-
-        assert data["benchmark_info"]["device"] == "npu"
-        assert data["latency_ms"]["mean"] > 0
-        assert "hw_monitor" in data, "hw_monitor section missing with --monitor"
-        assert data["hw_monitor"]["device_kind"] == "npu"
-        assert data["hw_monitor"]["adapter_luid"] is not None
-        assert data["hw_monitor"]["npu"]["mean_pct"] > 0
+        _assert_monitor_result(data, device="npu")
 
     def test_benchmark_auto(self, tmp_path: Path, model_arg: str):
         """Benchmark with --device auto.
@@ -375,6 +436,49 @@ class TestPerfONNXDirect(_PerfBenchmarkSuite):
     @pytest.fixture
     def model_arg(self, onnx_model_path: Path) -> str:
         return str(onnx_model_path)
+
+
+class TestPerfHuggingFace:
+    """Benchmark a HuggingFace model by loading it via the perf command."""
+
+    @pytest.fixture
+    def model_arg(self) -> str:
+        return "microsoft/resnet-50"
+
+    def test_benchmark_ep_vitisai(self, tmp_path: Path, model_arg: str):
+        """Benchmark with --ep vitisai.
+
+        Skipped if VitisAIExecutionProvider is not available on the host.
+        """
+        require_ep("vitisai")
+
+        output_file = tmp_path / "perf_vitisai.json"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            perf,
+            [
+                "-m",
+                model_arg,
+                "--ep",
+                "vitisai",
+                "--iterations",
+                "100",
+                "--warmup",
+                "1",
+                "-o",
+                str(output_file),
+                "--monitor"
+            ],
+            obj={},
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"perf failed (exit {result.exit_code}):\n{result.output}"
+
+        assert output_file.exists()
+        data = json.loads(output_file.read_text())
+        assert data["benchmark_info"]["ep"] == "VitisAIExecutionProvider"
+        _assert_monitor_result(data, device="npu")
 
 
 # ===========================================================================

--- a/tests/e2e/test_perf_e2e.py
+++ b/tests/e2e/test_perf_e2e.py
@@ -36,9 +36,9 @@ from typing import TYPE_CHECKING
 import pytest
 from click.testing import CliRunner
 
-from winml.modelkit.utils.constants import EP_ALIASES
 from tests.e2e.require_ep import require_ep
 from winml.modelkit.commands.perf import perf
+from winml.modelkit.utils.constants import EP_ALIASES
 
 
 if TYPE_CHECKING:
@@ -137,7 +137,9 @@ def _build_perf_args(
     return args
 
 
-def _assert_monitor_result(data: dict, *, device: str, device_kind: str | None = None, ep: str | None = None) -> None:
+def _assert_monitor_result(
+    data: dict, *, device: str, device_kind: str | None = None, ep: str | None = None
+) -> None:
     """Assert a monitored perf run produced the expected device + hw_monitor data.
 
     Verifies the resolved ``device`` in ``benchmark_info``, that latency was
@@ -328,7 +330,7 @@ class _PerfBenchmarkSuite:
         assert output_file.exists()
         data = json.loads(output_file.read_text())
         # At least a non-cpu should exist and picked up
-        assert data["benchmark_info"]["device"] in ("gpu", "npu")
+        assert data["benchmark_info"]["device"] in ("auto", "gpu", "npu")
         assert data["benchmark_info"]["ep"] != "CPUExecutionProvider"
         assert data["latency_ms"]["mean"] > 0
 
@@ -354,16 +356,14 @@ class _PerfBenchmarkSuite:
         assert output_file.exists()
         data = json.loads(output_file.read_text())
         assert data["benchmark_info"]["ep"] == EP_ALIASES[ep]
-        assert data["benchmark_info"]["device"] in ("gpu", "npu"), "Expected a non-CPU EP"
+        assert data["benchmark_info"]["device"] in ("auto", "gpu", "npu"), "Expected a non-CPU EP"
         assert data["latency_ms"]["mean"] > 0
 
     @pytest.mark.parametrize("ep", CPU_EPS)
     def test_benchmark_ep_device_cpu(self, ep: str, tmp_path: Path, model_arg: str):
         """Benchmark with --ep <ep> and --device cpu.
 
-        --ep overrides the device-to-provider mapping, so the session should
-        bind to the specified EP even though the requested device is CPU. Skipped if the specified EP
-        or a CPU is unavailable on the host.
+        Skipped if the specified EP is unavailable on the host.
         """
         require_ep(ep)
 
@@ -372,7 +372,9 @@ class _PerfBenchmarkSuite:
         runner = CliRunner()
         result = runner.invoke(
             perf,
-            _build_perf_args(model_arg=model_arg, output_file=output_file, device="cpu", ep=ep, monitor=True),
+            _build_perf_args(
+                model_arg=model_arg, output_file=output_file, device="cpu", ep=ep, monitor=True
+            ),
             obj={},
             catch_exceptions=False,
         )
@@ -386,9 +388,7 @@ class _PerfBenchmarkSuite:
     def test_benchmark_ep_device_gpu(self, ep: str, tmp_path: Path, model_arg: str):
         """Benchmark with --ep <ep> and --device gpu.
 
-        --ep overrides the device-to-provider mapping, so the session should
-        bind to the specified EP even though the requested device is GPU. Skipped if the specified EP
-        or a GPU is unavailable on the host.
+        Skipped if the specified EP or a GPU is unavailable on the host.
         """
         require_ep(ep)
         _require_gpu()
@@ -398,7 +398,9 @@ class _PerfBenchmarkSuite:
         runner = CliRunner()
         result = runner.invoke(
             perf,
-            _build_perf_args(model_arg=model_arg, output_file=output_file, device="gpu", ep=ep, monitor=True),
+            _build_perf_args(
+                model_arg=model_arg, output_file=output_file, device="gpu", ep=ep, monitor=True
+            ),
             obj={},
             catch_exceptions=False,
         )
@@ -412,9 +414,7 @@ class _PerfBenchmarkSuite:
     def test_benchmark_ep_device_npu(self, ep: str, tmp_path: Path, model_arg: str):
         """Benchmark with --ep <ep> and --device npu.
 
-        --ep overrides the device-to-provider mapping, so the session should
-        bind to the specified EP even though the requested device is NPU. Skipped if the specified EP
-        or a NPU is unavailable on the host.
+        Skipped if the specified EP or a NPU is unavailable on the host.
         """
         require_ep(ep)
         _require_npu()
@@ -424,7 +424,9 @@ class _PerfBenchmarkSuite:
         runner = CliRunner()
         result = runner.invoke(
             perf,
-            _build_perf_args(model_arg=model_arg, output_file=output_file, device="npu", ep=ep, monitor=True),
+            _build_perf_args(
+                model_arg=model_arg, output_file=output_file, device="npu", ep=ep, monitor=True
+            ),
             obj={},
             catch_exceptions=False,
         )
@@ -457,8 +459,7 @@ class TestPerfHuggingFace:
 
     @pytest.mark.parametrize("ep", CPU_EPS)
     def test_benchmark_ep_cpu(self, ep: str, tmp_path: Path, model_arg: str):
-        """Benchmark with --ep <ep>.
-        """
+        """Benchmark with --ep <ep>."""
         require_ep(ep)
 
         output_file = tmp_path / f"perf_hf_{ep}_cpu.json"
@@ -481,8 +482,7 @@ class TestPerfHuggingFace:
 
     @pytest.mark.parametrize("ep", GPU_EPS)
     def test_benchmark_ep_gpu(self, ep: str, tmp_path: Path, model_arg: str):
-        """Benchmark with --ep <ep>.
-        """
+        """Benchmark with --ep <ep>."""
         require_ep(ep)
 
         output_file = tmp_path / f"perf_hf_{ep}_gpu.json"
@@ -505,8 +505,7 @@ class TestPerfHuggingFace:
 
     @pytest.mark.parametrize("ep", NPU_EPS)
     def test_benchmark_ep_npu(self, ep: str, tmp_path: Path, model_arg: str):
-        """Benchmark with --ep <ep>.
-        """
+        """Benchmark with --ep <ep>."""
         require_ep(ep)
 
         output_file = tmp_path / f"perf_hf_{ep}_npu.json"

--- a/tests/e2e/test_perf_e2e.py
+++ b/tests/e2e/test_perf_e2e.py
@@ -173,7 +173,7 @@ class _PerfBenchmarkSuite:
         Uses --device cpu --iterations 3 --warmup 1 for speed.
         Verifies JSON output file is created with expected schema.
         """
-        output_file = tmp_path / "perf_result.json"
+        output_file = tmp_path / "perf_cpu.json"
 
         runner = CliRunner()
         result = runner.invoke(
@@ -219,7 +219,7 @@ class _PerfBenchmarkSuite:
 
     def test_benchmark_cpu_verbose(self, tmp_path: Path, model_arg: str):
         """Benchmark with --verbose should succeed and show debug output."""
-        output_file = tmp_path / "verbose_result.json"
+        output_file = tmp_path / "perf_cpu_verbose.json"
 
         runner = CliRunner()
         result = runner.invoke(
@@ -455,21 +455,19 @@ class TestPerfHuggingFace:
     def model_arg(self) -> str:
         return "microsoft/resnet-50"
 
-    @pytest.mark.parametrize("ep", NPU_EPS)
-    def test_benchmark_ep_npu(self, ep: str, tmp_path: Path, model_arg: str):
-        """Benchmark with --ep vitisai.
-
-        Skipped if VitisAIExecutionProvider is not available on the host.
+    @pytest.mark.parametrize("ep", CPU_EPS)
+    def test_benchmark_ep_cpu(self, ep: str, tmp_path: Path, model_arg: str):
+        """Benchmark with --ep <ep>.
         """
-        require_ep("vitisai")
+        require_ep(ep)
 
-        output_file = tmp_path / "perf_vitisai.json"
+        output_file = tmp_path / f"perf_hf_{ep}_cpu.json"
 
         runner = CliRunner()
         result = runner.invoke(
             perf,
             _build_perf_args(
-                model_arg=model_arg, output_file=output_file, ep="vitisai", monitor=True
+                model_arg=model_arg, output_file=output_file, device="cpu", ep=ep, monitor=True
             ),
             obj={},
             catch_exceptions=False,
@@ -478,7 +476,55 @@ class TestPerfHuggingFace:
 
         assert output_file.exists()
         data = json.loads(output_file.read_text())
-        assert data["benchmark_info"]["ep"] == "VitisAIExecutionProvider"
+        assert data["benchmark_info"]["ep"] == EP_ALIASES[ep]
+        _assert_monitor_result(data, device="cpu")
+
+    @pytest.mark.parametrize("ep", GPU_EPS)
+    def test_benchmark_ep_gpu(self, ep: str, tmp_path: Path, model_arg: str):
+        """Benchmark with --ep <ep>.
+        """
+        require_ep(ep)
+
+        output_file = tmp_path / f"perf_hf_{ep}_gpu.json"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            perf,
+            _build_perf_args(
+                model_arg=model_arg, output_file=output_file, device="gpu", ep=ep, monitor=True
+            ),
+            obj={},
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"perf failed (exit {result.exit_code}):\n{result.output}"
+
+        assert output_file.exists()
+        data = json.loads(output_file.read_text())
+        assert data["benchmark_info"]["ep"] == EP_ALIASES[ep]
+        _assert_monitor_result(data, device="gpu")
+
+    @pytest.mark.parametrize("ep", NPU_EPS)
+    def test_benchmark_ep_npu(self, ep: str, tmp_path: Path, model_arg: str):
+        """Benchmark with --ep <ep>.
+        """
+        require_ep(ep)
+
+        output_file = tmp_path / f"perf_hf_{ep}_npu.json"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            perf,
+            _build_perf_args(
+                model_arg=model_arg, output_file=output_file, device="npu", ep=ep, monitor=True
+            ),
+            obj={},
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"perf failed (exit {result.exit_code}):\n{result.output}"
+
+        assert output_file.exists()
+        data = json.loads(output_file.read_text())
+        assert data["benchmark_info"]["ep"] == EP_ALIASES[ep]
         _assert_monitor_result(data, device="npu")
 
 


### PR DESCRIPTION
## Summary
- Expands `tests/e2e/test_perf_e2e.py` with parametrized `--ep` tests across `qnn`, `vitisai`, `openvino`, `dml`, `nv_tensorrt_rtx`, `migraphx`, combined with `--device cpu/gpu/npu`. Adds a CPU `--monitor` test and a new `TestPerfHuggingFace` class that runs the same EP/device matrix against `microsoft/resnet-50` loaded via the perf command.
- Refactors duplicated CLI-invocation and result-assertion code into `_build_perf_args`, `_assert_hw_monitor_section`, and `_assert_monitor_result` helpers so each scenario is a few lines instead of a hand-rolled argv list.
- Hardens `WinMLEPRegistry`: when a provider's `ensure_ready()` raises, log a warning and skip it instead of aborting registry initialization, so one broken EP no longer prevents the rest from being discovered.
- `tests/e2e/require_ep.py`: short-circuit `DmlExecutionProvider` alongside `CPUExecutionProvider` since DML ships with ORT and is not enumerated by `WinMLEPRegistry`, so `require_ep("dml")` no longer spuriously skips.
- `WinMLSession`: drop the `WINMLSESSION_VERBOSE` env-var gating; "Compiling for device" / "Already compiled" now log unconditionally at INFO.
- `test_benchmark_auto`: accept that `--device auto` resolves to a concrete `gpu`/`npu` in the output, since `resolve_device` no longer leaves the literal `"auto"` in `benchmark_info`.

Closes #502
Closes https://github.com/microsoft/winml-cli/issues/688