### PR TITLE
fix(winml): null EpCatalog handle after enumeration to prevent QNN NPU crash on exit

### DIFF
--- a/src/winml/modelkit/session/ep_registry.py
+++ b/src/winml/modelkit/session/ep_registry.py
@@ -85,15 +85,17 @@ class WinMLEPRegistry:
             self._ep_paths[cast("EPName", provider.name)] = provider.library_path
             logger.debug("Found EP: %s at %s", provider.name, provider.library_path)
 
-        # WinMLEpCatalogRelease (called by EpCatalog.close() / EpCatalog.__del__)
-        # crashes with ACCESS_VIOLATION (0xC0000005) on some QNN NPU driver
-        # configurations — a Windows SEH exception that Python try/except cannot
-        # catch.  All provider paths have been extracted above, so the catalog
-        # handle is no longer needed.  Null it out immediately so that
-        # EpCatalog.close() becomes a no-op for the remainder of the process
-        # lifetime, whether invoked from a background thread or interpreter
-        # shutdown.  Native resources are reclaimed by the OS when the process
-        # exits.
+        # Workaround: WinMLEpCatalogRelease (called by EpCatalog.close() /
+        # EpCatalog.__del__) crashes with ACCESS_VIOLATION (0xC0000005) on some
+        # QNN NPU driver configurations — a Windows SEH exception that Python
+        # try/except cannot catch.  All provider paths have been extracted
+        # above, so the catalog handle is no longer needed.  Null it out
+        # immediately so that EpCatalog.close() becomes a no-op for the
+        # remainder of the process lifetime, whether invoked from a background
+        # thread or interpreter shutdown.  Native resources are reclaimed by
+        # the OS when the process exits.
+        # TODO: Remove once windowsml fixes WinMLEpCatalogRelease to be safe
+        # during process teardown on all QNN NPU driver configurations.
         if hasattr(self._catalog, "_handle"):
             self._catalog._handle = None
 

--- a/src/winml/modelkit/session/ep_registry.py
+++ b/src/winml/modelkit/session/ep_registry.py
@@ -85,6 +85,18 @@ class WinMLEPRegistry:
             self._ep_paths[cast("EPName", provider.name)] = provider.library_path
             logger.debug("Found EP: %s at %s", provider.name, provider.library_path)
 
+        # WinMLEpCatalogRelease (called by EpCatalog.close() / EpCatalog.__del__)
+        # crashes with ACCESS_VIOLATION (0xC0000005) on some QNN NPU driver
+        # configurations — a Windows SEH exception that Python try/except cannot
+        # catch.  All provider paths have been extracted above, so the catalog
+        # handle is no longer needed.  Null it out immediately so that
+        # EpCatalog.close() becomes a no-op for the remainder of the process
+        # lifetime, whether invoked from a background thread or interpreter
+        # shutdown.  Native resources are reclaimed by the OS when the process
+        # exits.
+        if hasattr(self._catalog, "_handle"):
+            self._catalog._handle = None
+
     def register_to_ort(self) -> list[EPName]:
         """Register discovered EPs to ONNX Runtime.
 

--- a/src/winml/modelkit/winml.py
+++ b/src/winml/modelkit/winml.py
@@ -50,15 +50,17 @@ class WinML:
             "onnxruntime_genai": [],
         }
 
-        # WinMLEpCatalogRelease (called by EpCatalog.close() / EpCatalog.__del__)
-        # crashes with ACCESS_VIOLATION (0xC0000005) on some QNN NPU driver
-        # configurations — a Windows SEH exception that Python try/except cannot
-        # catch.  All provider paths have been extracted above, so the catalog
-        # handle is no longer needed.  Null it out immediately so that
-        # EpCatalog.close() becomes a no-op for the remainder of the process
-        # lifetime, whether invoked from a background thread or interpreter
-        # shutdown.  Native resources are reclaimed by the OS when the process
-        # exits.
+        # Workaround: WinMLEpCatalogRelease (called by EpCatalog.close() /
+        # EpCatalog.__del__) crashes with ACCESS_VIOLATION (0xC0000005) on some
+        # QNN NPU driver configurations — a Windows SEH exception that Python
+        # try/except cannot catch.  All provider paths have been extracted
+        # above, so the catalog handle is no longer needed.  Null it out
+        # immediately so that EpCatalog.close() becomes a no-op for the
+        # remainder of the process lifetime, whether invoked from a background
+        # thread or interpreter shutdown.  Native resources are reclaimed by
+        # the OS when the process exits.
+        # TODO: Remove once windowsml fixes WinMLEpCatalogRelease to be safe
+        # during process teardown on all QNN NPU driver configurations.
         if hasattr(self._catalog, "_handle"):
             self._catalog._handle = None
 

--- a/src/winml/modelkit/winml.py
+++ b/src/winml/modelkit/winml.py
@@ -50,13 +50,22 @@ class WinML:
             "onnxruntime_genai": [],
         }
 
+        # WinMLEpCatalogRelease (called by EpCatalog.close() / EpCatalog.__del__)
+        # crashes with ACCESS_VIOLATION (0xC0000005) on some QNN NPU driver
+        # configurations — a Windows SEH exception that Python try/except cannot
+        # catch.  All provider paths have been extracted above, so the catalog
+        # handle is no longer needed.  Null it out immediately so that
+        # EpCatalog.close() becomes a no-op for the remainder of the process
+        # lifetime, whether invoked from a background thread or interpreter
+        # shutdown.  Native resources are reclaimed by the OS when the process
+        # exits.
+        if hasattr(self._catalog, "_handle"):
+            self._catalog._handle = None
+
     def __del__(self) -> None:
         """Clean up WinML resources."""
         self._providers = None
-        catalog = getattr(self, "_catalog", None)
-        if catalog is not None:
-            catalog.close()
-            self._catalog = None
+        self._catalog = None
 
     def register_execution_providers(
         self, ort: bool = True, ort_genai: bool = False


### PR DESCRIPTION
## Summary

`WinMLEpCatalogRelease` crashes with `ACCESS_VIOLATION` (0xC0000005) on some QNN NPU driver configurations during Python interpreter shutdown, causing every non-cached `winml build` to exit with `STATUS_ACCESS_VIOLATION` instead of 0.

## Root Cause

Two independent singletons — `WinML` (in `winml.py`) and `WinMLEPRegistry` (in `session/ep_registry.py`) — each create a `windowsml.EpCatalog` instance to enumerate EP library paths. After use, Python's garbage collector eventually calls `EpCatalog.__del__` → `close()` → `WinMLEpCatalogRelease(self._handle)`. On affected QNN NPU driver configurations this native call raises a Windows SEH exception (`STATUS_ACCESS_VIOLATION`), which Python's `try/except Exception` cannot catch.

The crash fires on a background thread during interpreter shutdown — after all build stages complete successfully — so exit code 3221225477 (0xC0000005) is observed even though `quantized.onnx` was written correctly. This explains why 19/22 non-cached models failed in the eval run (cache hits never initialize `EpCatalog`).

Stack trace captured by `faulthandler`:
```
Thread 0x0000bc98:
  File "windowsml/__init__.py", line 428 in close       # WinMLEpCatalogRelease(self._handle)
  File "windowsml/__init__.py", line 439 in __del__
```

## Fix

After `find_all_providers()` returns, all EP library paths have been extracted into a plain Python dict. The `EpCatalog` handle is no longer needed for the rest of the process lifetime. Setting `self._catalog._handle = None` makes `EpCatalog.close()` a no-op (it guards on `if self._handle:`), preventing the crash regardless of when or which thread triggers `__del__`. OS reclaims native resources on process exit.

Applied to both `EpCatalog`-holding singletons:
- `WinML.__init__` in `winml.py`
- `WinMLEPRegistry._load_ep_catalog` in `session/ep_registry.py`

## Verification

Ran `Intel/dpt-hybrid-midas` NPU build (the model that crashed most reliably):
- **Before fix**: 2/2 runs exit with code 3221225477 (0xC0000005)
- **After fix**: 2/2 runs exit with code 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)