### PR TITLE
Clean up winml analyze: EP/device selection, op-check skipped UI, merged optim config

### DIFF
--- a/src/winml/modelkit/commands/analyze.py
+++ b/src/winml/modelkit/commands/analyze.py
@@ -183,10 +183,6 @@ def _build_analysis_table(
 
     if op_check_skipped:
         title += "  Skipped - no rule data"
-    elif complete:
-        title += "  [bold green]✅ Complete[/bold green]"
-
-    if op_check_skipped:
         table = Table(
             title=title,
             show_header=False,
@@ -196,8 +192,12 @@ def _build_analysis_table(
             expand=False,
             width=80,
         )
+        # add_column is required even though no rows are added — without it the
+        # empty table doesn't render the centered title.
         table.add_column("")
         return table
+    if complete:
+        title += "  [bold green]✅ Complete[/bold green]"
 
     # Build display order: all_ops sorted by count, or just data if no all_ops
     if all_ops:
@@ -770,6 +770,7 @@ def analyze(
             for candidate_device in devices
             if candidate_device.lower() in EP_SUPPORTED_DEVICES[candidate_ep]
         ]
+        execution_pairs = _sort_ep_device_pairs(execution_pairs)
 
         local_pairs = set(_get_local_ep_device_pairs())
 
@@ -779,18 +780,16 @@ def analyze(
             unsupported_pairs = [pair for pair in execution_pairs if pair not in local_pairs]
             if unsupported_pairs:
                 logger.warning(
-                    "device is set to auto (inferred from local availability) but ep is "
-                    "not; some (ep, device) pairs to "
-                    "analyze are not supported in local environment: %s",
+                    "--device auto resolves from local availability, but --ep is pinned;"
+                    " the following pairs are not available on this machine: %s",
                     ", ".join(_ep_name_device_display_name(e, d) for e, d in unsupported_pairs),
                 )
         elif ep == "auto":
             unsupported_pairs = [pair for pair in execution_pairs if pair not in local_pairs]
             if unsupported_pairs:
                 logger.warning(
-                    "ep is set to auto (inferred from local availability) but device is "
-                    "not; some (ep, device) pairs to "
-                    "analyze are not supported in local environment: %s",
+                    "--ep auto resolves from local availability, but --device is pinned;"
+                    " the following pairs are not available on this machine: %s",
                     ", ".join(_ep_name_device_display_name(e, d) for e, d in unsupported_pairs),
                 )
 
@@ -1171,9 +1170,9 @@ def analyze(
 
                 per_pair_values: dict[str, list[tuple[tuple[str, str], object]]] = {}
                 for (target_ep, target_device), run_result in zip(
-                    execution_pairs, analysis_results, strict=False
+                    execution_pairs, analysis_results, strict=True
                 ):
-                    pair_config = run_result.get_optimization_config(ep=target_ep)
+                    pair_config = run_result.get_optimization_config(ep=target_ep).to_dict()
                     for key, value in pair_config.items():
                         per_pair_values.setdefault(key, []).append(
                             ((target_ep, target_device), value)

--- a/src/winml/modelkit/commands/analyze.py
+++ b/src/winml/modelkit/commands/analyze.py
@@ -473,13 +473,13 @@ def _render_analysis_summary(
 
         # List ops by non-white support level (skip when op check was skipped \u2014
         # the classification would be all-unknown with no useful detail).
+        _issue_sections = [
+            (SupportLevel.UNSUPPORTED, "red", "\u26d4 Unsupported"),
+            (SupportLevel.PARTIAL, "yellow", "\u26a0\ufe0f  Partial"),
+            (SupportLevel.UNKNOWN, "bright_black", "\u2753 Unknown"),
+        ]
+        classification = ep_support.classification
         if not op_check_skipped:
-            classification = ep_support.classification
-            _issue_sections = [
-                (SupportLevel.UNSUPPORTED, "red", "\u26d4 Unsupported"),
-                (SupportLevel.PARTIAL, "yellow", "\u26a0\ufe0f  Partial"),
-                (SupportLevel.UNKNOWN, "bright_black", "\u2753 Unknown"),
-            ]
             for level, color, heading in _issue_sections:
                 ops = classification.get(level, [])
                 if ops:
@@ -500,9 +500,13 @@ def _render_analysis_summary(
                     f"         {icon_p} [dim]{pid}[/dim] ({p['count']} instances, {label})"
                 )
 
-        has_issues = any(classification.get(lvl) for lvl, _, _ in _issue_sections) or bad_patterns
-        if not has_issues:
-            console.print("      [green]Ready to deploy[/green]")
+        # "Ready to deploy" requires actual op-check data; suppress when skipped.
+        if not op_check_skipped:
+            has_issues = (
+                any(classification.get(lvl) for lvl, _, _ in _issue_sections) or bad_patterns
+            )
+            if not has_issues:
+                console.print("      [green]Ready to deploy[/green]")
 
         console.print()
 

--- a/src/winml/modelkit/commands/analyze.py
+++ b/src/winml/modelkit/commands/analyze.py
@@ -372,6 +372,7 @@ def _render_analysis_summary(
     ep: EPNameOrAlias | Literal["all", "auto"] | None = None,
     device: str | None = None,
     no_data_eps: set[tuple[str, str]] | None = None,
+    op_check_skipped: bool = False,
 ) -> None:
     """Render the Analysis Summary section after pattern detection.
 
@@ -383,6 +384,10 @@ def _render_analysis_summary(
         ep_patterns: Per-EP subgraph pattern support extracted from results.
         ep: Requested EP name (for display when no results).
         device: Requested device (for display when no results).
+        op_check_skipped: True when op check was skipped (no rule data, no
+            unknown-op probing). When True, the per-op classification list is
+            suppressed — every op would land in "unknown" with no actionable
+            information.
     """
     from ..analyze.models.support_level import SupportLevel
 
@@ -466,19 +471,21 @@ def _render_analysis_summary(
         console.print(f"   {icon} [{ep_style}]{ep_label}[/{ep_style}]: ", end="")
         console.print(analyzed)
 
-        # List ops by non-white support level
-        classification = ep_support.classification
-        _issue_sections = [
-            (SupportLevel.UNSUPPORTED, "red", "\u26d4 Unsupported"),
-            (SupportLevel.PARTIAL, "yellow", "\u26a0\ufe0f  Partial"),
-            (SupportLevel.UNKNOWN, "bright_black", "\u2753 Unknown"),
-        ]
-        for level, color, heading in _issue_sections:
-            ops = classification.get(level, [])
-            if ops:
-                console.print(f"      [{color}]{heading}:[/{color}]")
-                for op in sorted(ops):
-                    console.print(f"         \u2022 [dim]{op}[/dim]")
+        # List ops by non-white support level (skip when op check was skipped \u2014
+        # the classification would be all-unknown with no useful detail).
+        if not op_check_skipped:
+            classification = ep_support.classification
+            _issue_sections = [
+                (SupportLevel.UNSUPPORTED, "red", "\u26d4 Unsupported"),
+                (SupportLevel.PARTIAL, "yellow", "\u26a0\ufe0f  Partial"),
+                (SupportLevel.UNKNOWN, "bright_black", "\u2753 Unknown"),
+            ]
+            for level, color, heading in _issue_sections:
+                ops = classification.get(level, [])
+                if ops:
+                    console.print(f"      [{color}]{heading}:[/{color}]")
+                    for op in sorted(ops):
+                        console.print(f"         \u2022 [dim]{op}[/dim]")
 
         # List non-supported patterns for this EP
         patterns = (ep_patterns or {}).get(ep_name, {})
@@ -500,24 +507,39 @@ def _render_analysis_summary(
         console.print()
 
 
-def _resolve_run_unknown_op(ep: str, run_unknown_op: bool) -> bool:
-    """Resolve whether to run unknown operators for a given EP.
+def _resolve_run_unknown_op(
+    ep: str,
+    device: str,
+    run_unknown_op: bool,
+    local_pairs: set[tuple[str, str]],
+) -> bool:
+    """Resolve whether to run unknown operators for a given (EP, device) pair.
 
     Some execution providers (e.g., VitisAI) do not have sufficient runtime
     data to support unknown operator checks, so --run-unknown-op is disabled
-    for them regardless of the user's flag.
+    for them regardless of the user's flag. Unknown-op probing also requires
+    the pair to be available locally — probing a non-local pair would just
+    fail at session creation.
 
     Args:
         ep: Execution provider name (e.g., "VitisAIExecutionProvider")
+        device: Device name (e.g., "NPU")
         run_unknown_op: User-requested flag value
+        local_pairs: Set of (ep, device) pairs available on the local machine
 
     Returns:
-        Effective run_unknown_op value for this EP
+        Effective run_unknown_op value for this (ep, device) pair
     """
     if run_unknown_op and ep == "VitisAIExecutionProvider":
         logger.info(
             "Disabling --run-unknown-op for VitisAIExecutionProvider: "
             "AMD op runtime results are not available yet"
+        )
+        return False
+    if run_unknown_op and (ep, device) not in local_pairs:
+        logger.warning(
+            "Disabling --run-unknown-op for %s: pair is not available on the local machine",
+            _ep_name_device_display_name(ep, device),
         )
         return False
     return run_unknown_op
@@ -1036,7 +1058,9 @@ def analyze(
                     current_device = target_device
                     current_ep_device_pair = None
 
-                    run_unknown_op_for_ep = _resolve_run_unknown_op(target_ep, run_unknown_op)
+                    run_unknown_op_for_ep = _resolve_run_unknown_op(
+                        target_ep, target_device, run_unknown_op, local_pairs
+                    )
 
                     current_run_unknown_op = run_unknown_op_for_ep
 
@@ -1074,6 +1098,7 @@ def analyze(
                         ep=target_ep,
                         device=target_device,
                         no_data_eps=_no_data_eps,
+                        op_check_skipped=current_op_check_skipped,
                     )
 
                     # Legend (at the very bottom, only when there are EP results)
@@ -1094,7 +1119,9 @@ def analyze(
         else:
             # Quiet mode — no live display
             for target_ep, target_device in execution_pairs:
-                run_unknown_op_for_ep = _resolve_run_unknown_op(target_ep, run_unknown_op)
+                run_unknown_op_for_ep = _resolve_run_unknown_op(
+                    target_ep, target_device, run_unknown_op, local_pairs
+                )
 
                 result = analyzer.analyze(
                     model_path=str(model),

--- a/src/winml/modelkit/commands/analyze.py
+++ b/src/winml/modelkit/commands/analyze.py
@@ -142,7 +142,7 @@ def _build_stacked_bar(counts: dict[str, int], max_count: int) -> Text:
 
 
 def _build_analyzed_text(counts: dict[str, int]) -> Text:
-    """Build 'W/G/B' format like '53/0/0' or '12/5/1' with colors."""
+    """Build 'S/P/U/Unk' format like '53/0/0/0' or '12/5/1/3' with colors."""
     w = counts.get("supported", 0)
     g = counts.get("partial", 0)
     b = counts.get("unsupported", 0)
@@ -154,9 +154,8 @@ def _build_analyzed_text(counts: dict[str, int]) -> Text:
     text.append(str(g), style="bold yellow" if g > 0 else "dim")
     text.append("/", style="dim")
     text.append(str(b), style="bold red" if b > 0 else "dim")
-    if u > 0:
-        text.append("/", style="dim")
-        text.append(str(u), style="bold bright_black")
+    text.append("/", style="dim")
+    text.append(str(u), style="bold bright_black" if u > 0 else "dim")
     return text
 
 
@@ -222,7 +221,7 @@ def _build_analysis_table(
     )
 
     table.add_column("Op Type", width=28, no_wrap=True)
-    table.add_column("S/P/U", width=14, no_wrap=True)
+    table.add_column("S/P/U/Unk", width=16, no_wrap=True)
     table.add_column("", no_wrap=True)
 
     agg: dict[str, int] = {"supported": 0, "partial": 0, "unsupported": 0, "unknown": 0}
@@ -1049,14 +1048,10 @@ def analyze(
                     _render_pattern_matching(console, ep_patterns)
 
                     # Analysis Summary section
-                    summary_ep_instance_counts = {
-                        f"{ep_name}@{device}": counts
-                        for (ep_name, device), counts in ep_instance_counts.items()
-                    }
                     _render_analysis_summary(
                         console,
                         result.output.results,
-                        summary_ep_instance_counts,
+                        ep_instance_counts,
                         ep_patterns=ep_patterns,
                         ep=target_ep,
                         device=target_device,
@@ -1066,7 +1061,7 @@ def analyze(
                     # Legend (at the very bottom, only when there are EP results)
                     if result.output.results:
                         console.print(
-                            "  [dim]S/P/U = Supported/Partial/Unsupported[/dim]"
+                            "  [dim]S/P/U/Unk = Supported/Partial/Unsupported/Unknown[/dim]"
                             "  [green]██[/green] supported"
                             "  [yellow]██[/yellow] partial"
                             "  [red]██[/red] unsupported"

--- a/src/winml/modelkit/commands/analyze.py
+++ b/src/winml/modelkit/commands/analyze.py
@@ -165,6 +165,7 @@ def _build_analysis_table(
     ep_device_pair_display_name: str | None = None,
     complete: bool = False,
     all_ops: dict[str, int] | None = None,
+    op_check_skipped: bool = False,
 ) -> Table:
     """Build the analysis table with variable-width stacked bars.
 
@@ -175,7 +176,30 @@ def _build_analysis_table(
           ep_device_pair_display_name: EP/device display label for title
         complete: Show complete marker
         all_ops: All op types with total counts (for showing pending rows)
+        op_check_skipped: If True, render a title-only table (no rows/columns)
     """
+    title = "📊 OP CHECK"
+    if ep_device_pair_display_name:
+        title += f" — [bold cyan]{ep_device_pair_display_name}[/bold cyan]"
+
+    if op_check_skipped:
+        title += "  Skipped - no rule data"
+    elif complete:
+        title += "  [bold green]✅ Complete[/bold green]"
+
+    if op_check_skipped:
+        table = Table(
+            title=title,
+            show_header=False,
+            header_style="bold",
+            box=None,
+            padding=(0, 1),
+            expand=False,
+            width=80,
+        )
+        table.add_column("")
+        return table
+
     # Build display order: all_ops sorted by count, or just data if no all_ops
     if all_ops:
         display_order = sorted(all_ops, key=lambda x: all_ops[x], reverse=True)
@@ -187,12 +211,6 @@ def _build_analysis_table(
         max_count = max(all_ops.values(), default=1)
     else:
         max_count = max((sum(v.values()) for v in data.values()), default=1)
-
-    title = "📊 OP CHECK"
-    if ep_device_pair_display_name:
-        title += f" — [bold cyan]{ep_device_pair_display_name}[/bold cyan]"
-    if complete:
-        title += "  [bold green]✅ Complete[/bold green]"
 
     table = Table(
         title=title,
@@ -284,9 +302,6 @@ _SUPPORT_LEVEL_TO_SHORT = {
 
 _PAT_COLORS = {"s": "green", "p": "yellow", "u": "red", "uk": "bright_black"}
 
-_HINT_LOCAL_MACHINE_NOT_SUPPORTED = "local machine not supported"
-_HINT_NO_RULE_DATA = "no rule data"
-
 
 def _render_pattern_matching(
     console: Console,
@@ -358,7 +373,6 @@ def _render_analysis_summary(
     ep: EPNameOrAlias | Literal["all", "auto"] | None = None,
     device: str | None = None,
     no_data_eps: set[tuple[str, str]] | None = None,
-    pair_hints: dict[tuple[str, str], list[str]] | None = None,
 ) -> None:
     """Render the Analysis Summary section after pattern detection.
 
@@ -398,11 +412,8 @@ def _render_analysis_summary(
         device_name = (ep_support.device_type or device or "").upper()
         ep_device_pair = (ep_name, device_name)
         ep_label = (
-            ep_name
-            if not device_name
-            else _ep_name_device_display_name(ep_name, device_name)
+            ep_name if not device_name else _ep_name_device_display_name(ep_name, device_name)
         )
-        hints_for_ep = (pair_hints or {}).get(ep_device_pair, [])
 
         # Aggregate instance counts for this EP.
         ep_data = ep_instance_counts.get(ep_device_pair)
@@ -410,8 +421,7 @@ def _render_analysis_summary(
             ep_data = {}
         has_instance_data = any(
             sum(
-                counts.get(level, 0)
-                for level in ("supported", "partial", "unsupported", "unknown")
+                counts.get(level, 0) for level in ("supported", "partial", "unsupported", "unknown")
             )
             > 0
             for counts in ep_data.values()
@@ -422,11 +432,6 @@ def _render_analysis_summary(
         if no_data_eps and ep_device_pair in no_data_eps and not has_instance_data:
             patterns = (ep_patterns or {}).get(ep_name, {})
             console.print(f"   🔵 [bold bright_black]{ep_label}[/bold bright_black]:")
-            for hint in hints_for_ep:
-                hint_style = (
-                    "yellow" if hint == _HINT_LOCAL_MACHINE_NOT_SUPPORTED else "dim"
-                )
-                console.print(f"      [{hint_style}]Hint: {hint}[/{hint_style}]")
             if patterns:
                 console.print("      [dim]Op check skipped — no rule data[/dim]")
                 for pid, p in sorted(patterns.items(), key=lambda x: x[1]["count"], reverse=True):
@@ -461,9 +466,6 @@ def _render_analysis_summary(
         analyzed = _build_analyzed_text(agg)
         console.print(f"   {icon} [{ep_style}]{ep_label}[/{ep_style}]: ", end="")
         console.print(analyzed)
-        for hint in hints_for_ep:
-            hint_style = "yellow" if hint == _HINT_LOCAL_MACHINE_NOT_SUPPORTED else "dim"
-            console.print(f"      [{hint_style}]Hint: {hint}[/{hint_style}]")
 
         # List ops by non-white support level
         classification = ep_support.classification
@@ -717,196 +719,50 @@ def analyze(
             has_rule_data_for_ep,
         )
 
-        ep_raw = (ep or "auto").strip()
-        device_raw = (device or "auto").strip()
+        if device == "auto":
+            from ..sysinfo.device import _get_available_devices
 
-        ep_mode_key = ep_raw.lower()
-        device_mode_key = device_raw.lower()
+            devices = _get_available_devices()
+        elif device == "all":
+            devices = SUPPORTED_DEVICES
+        else:
+            devices = [device]
+        devices = sorted(d.upper() for d in devices)
 
-        ep_mode = "auto"
-        ep_filter: EPName | None = None
-        if ep_mode_key == "all":
-            ep_mode = "all"
-        elif ep_mode_key != "auto":
-            ep_mode = "specific"
-            ep_filter = normalize_ep_name(ep_raw)
+        if ep == "auto":
+            from ..sysinfo.device import _get_available_eps
 
-        device_mode = "auto"
-        device_filter: str | None = None
-        if device_mode_key == "all":
-            device_mode = "all"
-        elif device_mode_key != "auto":
-            device_mode = "specific"
-            device_filter = device_raw.upper()
+            eps = _get_available_eps()
+        elif ep == "all":
+            eps = SUPPORTED_EPS
+        else:
+            # ep is a specific EP or alias
+            eps = [normalize_ep_name(ep)]
 
-        local_pairs = _sort_ep_device_pairs(_get_local_ep_device_pairs())
-        local_pair_set = set(local_pairs)
-        rule_pairs: set[tuple[EPName, str]] = {
+        execution_pairs = [
             (candidate_ep, candidate_device)
-            for candidate_ep in SUPPORTED_EPS
-            for candidate_device in SUPPORTED_DEVICES
-            if has_rule_data_for_ep(candidate_ep, candidate_device)
-        }
-        local_rule_pairs = _sort_ep_device_pairs(set(local_pairs) & rule_pairs)
-        if not local_rule_pairs and not local_pairs:
-            # Fallback when local capability probing is unavailable.
-            local_rule_pairs = _sort_ep_device_pairs(rule_pairs)
+            for candidate_ep in eps
+            for candidate_device in devices
+            if candidate_device.lower() in EP_SUPPORTED_DEVICES[candidate_ep]
+        ]
 
-        execution_pairs: list[tuple[EPName, str]] = []
+        print(
+            f"Candidate EPs: {eps}"
+            f"\nCandidate devices: {devices}"
+            f"\nCandidate EP/device pairs before local filtering: {execution_pairs}"
+        )
 
-        def _rule_pairs_for_ep(target_ep: EPName) -> list[tuple[EPName, str]]:
-            return _sort_ep_device_pairs(
-                {
-                    (target_ep, candidate_device)
-                    for candidate_device in SUPPORTED_DEVICES
-                    if (target_ep, candidate_device) in rule_pairs
-                }
-            )
+        local_pairs = set(_get_local_ep_device_pairs())
+        print(f"Locally available EP/device pairs: {local_pairs}")
 
-        if ep_mode == "auto" and device_mode == "auto":
-            execution_pairs = list(local_rule_pairs)
-        elif ep_mode == "specific" and device_mode == "auto":
-            assert ep_filter is not None
-            local_for_ep: list[tuple[EPName, str]] = [
-                (candidate_ep, candidate_device)
-                for candidate_ep, candidate_device in local_pairs
-                if candidate_ep == ep_filter
-            ]
-            if not local_for_ep:
-                logger.error("Local machine does not support %s with --device auto.", ep_filter)
-                logger.error(
-                    "Try --device all to analyze all rule-data-backed targets for %s.",
-                    ep_filter,
-                )
-                sys.exit(2)
-
-            execution_pairs = _sort_ep_device_pairs(
-                {
-                    (candidate_ep, candidate_device)
-                    for candidate_ep, candidate_device in local_for_ep
-                    if (candidate_ep, candidate_device) in rule_pairs
-                }
-            )
-            if not execution_pairs:
-                if run_unknown_op:
-                    execution_pairs = _sort_ep_device_pairs(set(local_for_ep))
-                else:
-                    logger.error("No rule data found for %s on local available devices.", ep_filter)
-                    logger.error(
-                        "Try --run-unknown-op to probe unsupported/unknown operators "
-                        "on local runtime."
-                    )
-                    sys.exit(2)
-        elif ep_mode == "specific" and device_mode == "all":
-            assert ep_filter is not None
-            execution_pairs = _rule_pairs_for_ep(ep_filter)
-            if not execution_pairs:
-                logger.error("No rule data found for %s.", ep_filter)
-                logger.error(
-                    "Try --run-unknown-op to probe unsupported/unknown operators on local runtime."
-                )
-                sys.exit(2)
-        elif ep_mode == "specific" and device_mode == "specific":
-            assert ep_filter is not None
-            assert device_filter is not None
-            requested_pair = (ep_filter, device_filter)
-            if requested_pair in rule_pairs or run_unknown_op:
-                execution_pairs = [requested_pair]
-            else:
-                logger.error("No rule data found for %s on %s.", ep_filter, device_filter)
-                logger.error(
-                    "Try --run-unknown-op to probe unsupported/unknown operators on local runtime."
-                )
-                sys.exit(2)
-        elif ep_mode == "all" and device_mode == "all":
-            execution_pairs = _sort_ep_device_pairs(rule_pairs)
-        elif ep_mode == "all" and device_mode == "specific":
-            assert device_filter is not None
-            execution_pairs = _sort_ep_device_pairs(
-                {
-                    (candidate_ep, device_filter)
-                    for candidate_ep in SUPPORTED_EPS
-                    if (candidate_ep, device_filter) in rule_pairs
-                }
-            )
-        elif ep_mode == "all" and device_mode == "auto":
-            execution_pairs = list(local_rule_pairs)
-        elif ep_mode == "auto" and device_mode == "specific":
-            assert device_filter is not None
-            execution_pairs = _sort_ep_device_pairs(
-                {
-                    (candidate_ep, candidate_device)
-                    for candidate_ep, candidate_device in local_rule_pairs
-                    if candidate_device == device_filter
-                }
-            )
-            if not execution_pairs:
-                local_for_device: list[tuple[EPName, str]] = [
-                    (candidate_ep, candidate_device)
-                    for candidate_ep, candidate_device in local_pairs
-                    if candidate_device == device_filter
-                ]
-                if local_for_device:
-                    if run_unknown_op:
-                        execution_pairs = _sort_ep_device_pairs(set(local_for_device))
-                    else:
-                        logger.error(
-                            "No rule data found for any EP on %s in local available targets.",
-                            device_filter,
-                        )
-                        logger.error(
-                            "Try --run-unknown-op to probe unsupported/unknown operators "
-                            "on local runtime."
-                        )
-                        sys.exit(2)
-
-                if not execution_pairs:
-                    rule_for_device = _sort_ep_device_pairs(
-                        {
-                            (candidate_ep, candidate_device)
-                            for candidate_ep, candidate_device in rule_pairs
-                            if candidate_device == device_filter
-                        }
-                    )
-                    if rule_for_device:
-                        logger.error(
-                            "Local machine does not support --device %s with --ep auto.",
-                            device_filter,
-                        )
-                        logger.error(
-                            "Try --device all to analyze all rule-data-backed targets "
-                            "on local runtime."
-                        )
-                        sys.exit(2)
-        elif ep_mode == "auto" and device_mode == "all":
-            execution_pairs = list(local_rule_pairs)
+        if device == "auto" or ep == "auto":
+            execution_pairs = [pair for pair in execution_pairs if pair in local_pairs]
 
         if not execution_pairs:
             logger.error("No EP/device combination matched the current selection.")
-            logger.error(
-                "Try --run-unknown-op to probe unsupported/unknown operators on local runtime."
-            )
             sys.exit(2)
 
-        pair_hints: dict[tuple[str, str], list[str]] = {}
-        for target_ep, target_device in execution_pairs:
-            hints: list[str] = []
-            if (target_ep, target_device) not in local_pair_set:
-                hints.append(_HINT_LOCAL_MACHINE_NOT_SUPPORTED)
-            if (target_ep, target_device) not in rule_pairs:
-                hints.append(_HINT_NO_RULE_DATA)
-            if hints:
-                pair_hints[(target_ep, target_device)] = hints
-
-        if len(execution_pairs) == 1:
-            ep_label = execution_pairs[0][0]
-            device_label = execution_pairs[0][1]
-        else:
-            ep_label = "all"
-            device_label = "all"
-
         logger.info("Analyzing model: %s", model)
-        logger.info("Target: %s on %s", ep_label, device_label)
         logger.info(
             "Local targets: %s",
             ", ".join(
@@ -953,17 +809,12 @@ def analyze(
                     f"   📋 Operators: [cyan]{_total_ops}[/cyan] total, "
                     f"[cyan]{_unique_ops}[/cyan] unique types"
                 )
-                console.print(
-                    f"   🎯 Target: [bold]{ep_label}[/bold] on [bold]{device_label}[/bold]"
-                )
                 if len(execution_pairs) > 1:
                     execution_labels = ", ".join(
                         _ep_name_device_display_name(target_ep, target_device)
                         for target_ep, target_device in execution_pairs
                     )
-                    console.print(
-                        f"   🎯 Execution targets: [cyan]{execution_labels}[/cyan]"
-                    )
+                    console.print(f"   🎯 Analysis targets: [cyan]{execution_labels}[/cyan]")
                 console.print()
                 del _proto  # free memory
             except Exception:
@@ -983,6 +834,7 @@ def analyze(
         _no_data_eps: set[tuple[str, str]] = set()  # EP/device pairs with no op rule data
         analysis_results: list = []
         current_run_unknown_op = False
+        current_op_check_skipped = False
 
         def _current_ep_device_pair_display_name() -> str:
             """Return current EP/device display label, or empty when unset."""
@@ -1018,6 +870,7 @@ def analyze(
                                 ep_device_pair_display_name=_current_ep_device_pair_display_name(),
                                 complete=True,
                                 all_ops=all_op_counts,
+                                op_check_skipped=current_op_check_skipped,
                             )
                         )
                     except Exception:
@@ -1043,6 +896,7 @@ def analyze(
                             ep_device_pair_display_name=_current_ep_device_pair_display_name(),
                             complete=True,
                             all_ops=all_op_counts,
+                            op_check_skipped=current_op_check_skipped,
                         )
                     )
             except Exception:
@@ -1056,7 +910,7 @@ def analyze(
             nonlocal current_ep_device_pair
             nonlocal instance_counts, all_op_counts, ep_counter, live
             nonlocal unknown_op_progress, unknown_op_task_id, unknown_op_total_nodes
-            nonlocal current_run_unknown_op
+            nonlocal current_run_unknown_op, current_op_check_skipped
 
             # Finalize previous EP's Live display
             if current_ep_device_pair is not None:
@@ -1069,10 +923,13 @@ def analyze(
             all_op_counts = {_display_name(k): v for k, v in operator_counts.items()}
             instance_counts = {}
 
+            has_rule_data = has_rule_data_for_ep(ep_name, current_device)
+            current_op_check_skipped = not has_rule_data and not current_run_unknown_op
+
             # Skip OP CHECK display for EPs with no rule data —
             # op results would all be 0/0/0 (unknown). Pattern detection
             # still runs; results appear in the ANALYSIS SUMMARY.
-            if not has_rule_data_for_ep(ep_name, current_device):
+            if not has_rule_data:
                 _no_data_eps.add((ep_name, current_device))
 
                 if current_run_unknown_op:
@@ -1103,7 +960,7 @@ def analyze(
                         "unknown-op",
                         total=max(1, unknown_op_total_nodes),
                     )
-                return
+                    return
 
             ep_counter += 1
 
@@ -1121,6 +978,7 @@ def analyze(
                     instance_counts,
                     ep_device_pair_display_name=_current_ep_device_pair_display_name(),
                     all_ops=all_op_counts,
+                    op_check_skipped=current_op_check_skipped,
                 ),
                 console=console,
                 refresh_per_second=30,
@@ -1140,6 +998,7 @@ def analyze(
                         instance_counts,
                         ep_device_pair_display_name=_current_ep_device_pair_display_name(),
                         all_ops=all_op_counts,
+                        op_check_skipped=current_op_check_skipped,
                     )
                 )
 
@@ -1209,7 +1068,6 @@ def analyze(
                         ep=target_ep,
                         device=target_device,
                         no_data_eps=_no_data_eps,
-                        pair_hints=pair_hints,
                     )
 
                     # Legend (at the very bottom, only when there are EP results)

--- a/src/winml/modelkit/commands/analyze.py
+++ b/src/winml/modelkit/commands/analyze.py
@@ -747,8 +747,24 @@ def analyze(
 
         local_pairs = set(_get_local_ep_device_pairs())
 
-        if device == "auto" or ep == "auto":
+        if device == "auto" and ep == "auto":
             execution_pairs = [pair for pair in execution_pairs if pair in local_pairs]
+        elif device == "auto":
+            unsupported_pairs = [pair for pair in execution_pairs if pair not in local_pairs]
+            if unsupported_pairs:
+                logger.warning(
+                    "device is set to auto but ep is not; some (ep, device) pairs to "
+                    "analyze are not supported in local environment: %s",
+                    ", ".join(_ep_name_device_display_name(e, d) for e, d in unsupported_pairs),
+                )
+        elif ep == "auto":
+            unsupported_pairs = [pair for pair in execution_pairs if pair not in local_pairs]
+            if unsupported_pairs:
+                logger.warning(
+                    "ep is set to auto but device is not; some (ep, device) pairs to "
+                    "analyze are not supported in local environment: %s",
+                    ", ".join(_ep_name_device_display_name(e, d) for e, d in unsupported_pairs),
+                )
 
         if not execution_pairs:
             logger.error("No EP/device combination matched the current selection.")

--- a/src/winml/modelkit/commands/analyze.py
+++ b/src/winml/modelkit/commands/analyze.py
@@ -753,7 +753,8 @@ def analyze(
             unsupported_pairs = [pair for pair in execution_pairs if pair not in local_pairs]
             if unsupported_pairs:
                 logger.warning(
-                    "device is set to auto but ep is not; some (ep, device) pairs to "
+                    "device is set to auto (inferred from local availability) but ep is "
+                    "not; some (ep, device) pairs to "
                     "analyze are not supported in local environment: %s",
                     ", ".join(_ep_name_device_display_name(e, d) for e, d in unsupported_pairs),
                 )
@@ -761,7 +762,8 @@ def analyze(
             unsupported_pairs = [pair for pair in execution_pairs if pair not in local_pairs]
             if unsupported_pairs:
                 logger.warning(
-                    "ep is set to auto but device is not; some (ep, device) pairs to "
+                    "ep is set to auto (inferred from local availability) but device is "
+                    "not; some (ep, device) pairs to "
                     "analyze are not supported in local environment: %s",
                     ", ".join(_ep_name_device_display_name(e, d) for e, d in unsupported_pairs),
                 )

--- a/src/winml/modelkit/commands/analyze.py
+++ b/src/winml/modelkit/commands/analyze.py
@@ -746,14 +746,7 @@ def analyze(
             if candidate_device.lower() in EP_SUPPORTED_DEVICES[candidate_ep]
         ]
 
-        print(
-            f"Candidate EPs: {eps}"
-            f"\nCandidate devices: {devices}"
-            f"\nCandidate EP/device pairs before local filtering: {execution_pairs}"
-        )
-
         local_pairs = set(_get_local_ep_device_pairs())
-        print(f"Locally available EP/device pairs: {local_pairs}")
 
         if device == "auto" or ep == "auto":
             execution_pairs = [pair for pair in execution_pairs if pair in local_pairs]
@@ -1130,19 +1123,41 @@ def analyze(
             import json
 
             try:
-                config_ep = execution_pairs[0][0]
-                if len(execution_pairs) > 1:
-                    logger.warning(
-                        "Multiple EP/device targets selected; writing optimization config "
-                        "for the first target: %s",
-                        _ep_name_device_display_name(
-                            execution_pairs[0][0],
-                            execution_pairs[0][1],
-                        ),
+                # Merge optimization configs from all execution pairs; warn on conflicts.
+
+                per_pair_values: dict[str, list[tuple[tuple[str, str], object]]] = {}
+                for (target_ep, target_device), run_result in zip(
+                    execution_pairs, analysis_results, strict=False
+                ):
+                    pair_config = run_result.get_optimization_config(ep=target_ep)
+                    for key, value in pair_config.items():
+                        per_pair_values.setdefault(key, []).append(
+                            ((target_ep, target_device), value)
+                        )
+
+                per_pair_values["gelu_fusion"][0] = (per_pair_values["gelu_fusion"][0][0], False)
+
+                merged: dict[str, object] = {}
+                for key, entries in per_pair_values.items():
+                    merged[key] = entries[0][1]
+                    distinct = {value for _, value in entries}
+                    if len(distinct) == 1:
+                        continue
+                    detail = ", ".join(
+                        f"{_ep_name_device_display_name(pair[0], pair[1])}={value!r}"
+                        for pair, value in entries
                     )
-                config = analysis_results[0].get_optimization_config(ep=config_ep)
+                    logger.warning(
+                        "Conflicting optimization setting %r across analysis pairs: %s "
+                        "(using %r from first pair in merged config)",
+                        key,
+                        detail,
+                        merged[key],
+                    )
+
+                merged = dict(sorted(merged.items()))
                 optim_config.parent.mkdir(parents=True, exist_ok=True)
-                optim_config.write_text(json.dumps(config.to_dict(), indent=2), encoding="utf-8")
+                optim_config.write_text(json.dumps(merged, indent=2), encoding="utf-8")
                 logger.info("Optimization config saved to: %s", optim_config)
             except OSError as e:
                 logger.error("Failed to write config to %s: %s", optim_config, e)

--- a/src/winml/modelkit/commands/analyze.py
+++ b/src/winml/modelkit/commands/analyze.py
@@ -1135,8 +1135,6 @@ def analyze(
                             ((target_ep, target_device), value)
                         )
 
-                per_pair_values["gelu_fusion"][0] = (per_pair_values["gelu_fusion"][0][0], False)
-
                 merged: dict[str, object] = {}
                 for key, entries in per_pair_values.items():
                     merged[key] = entries[0][1]

--- a/tests/unit/analyze/test_static_analyzer_cli.py
+++ b/tests/unit/analyze/test_static_analyzer_cli.py
@@ -657,7 +657,7 @@ class TestAnalyzeCommandOutput:
         model_file.write_bytes(b"dummy")
         config_file = tmp_path / "optim.json"
 
-        mock_analyzer_result.get_optimization_config.return_value = {
+        mock_analyzer_result.get_optimization_config.return_value.to_dict.return_value = {
             "gelu_fusion": True,
         }
         mock_instance = Mock()
@@ -696,7 +696,7 @@ class TestAnalyzeCommandOutput:
         model_file.write_bytes(b"dummy")
         config_file = tmp_path / "nested" / "dir" / "optim.json"
 
-        mock_analyzer_result.get_optimization_config.return_value = {
+        mock_analyzer_result.get_optimization_config.return_value.to_dict.return_value = {
             "gelu_fusion": True,
         }
         mock_instance = Mock()
@@ -990,17 +990,17 @@ class TestAnalyzeEPDeviceSelectionMatrix:
     @pytest.mark.parametrize(
         ("ep_arg", "device_arg", "expect_exit", "expect_calls", "expect_error"),
         [
-            # Both auto: filter pre-EP_SUPPORTED_DEVICES list to local_pairs.
+            # Both auto: filter to local_pairs. Output sorted by EP_SUPPORTED_DEVICES.
             (
                 None,
                 None,
                 0,
                 [
-                    ("CPUExecutionProvider", "CPU"),
-                    ("DmlExecutionProvider", "GPU"),
                     ("NvTensorRTRTXExecutionProvider", "GPU"),
-                    ("OpenVINOExecutionProvider", "CPU"),
                     ("OpenVINOExecutionProvider", "NPU"),
+                    ("OpenVINOExecutionProvider", "CPU"),
+                    ("DmlExecutionProvider", "GPU"),
+                    ("CPUExecutionProvider", "CPU"),
                 ],
                 None,
             ),
@@ -1010,9 +1010,9 @@ class TestAnalyzeEPDeviceSelectionMatrix:
                 "gpu",
                 0,
                 [
-                    ("DmlExecutionProvider", "GPU"),
                     ("NvTensorRTRTXExecutionProvider", "GPU"),
                     ("OpenVINOExecutionProvider", "GPU"),
+                    ("DmlExecutionProvider", "GPU"),
                 ],
                 None,
             ),
@@ -1022,9 +1022,9 @@ class TestAnalyzeEPDeviceSelectionMatrix:
                 None,
                 0,
                 [
-                    ("OpenVINOExecutionProvider", "CPU"),
-                    ("OpenVINOExecutionProvider", "GPU"),
                     ("OpenVINOExecutionProvider", "NPU"),
+                    ("OpenVINOExecutionProvider", "GPU"),
+                    ("OpenVINOExecutionProvider", "CPU"),
                 ],
                 None,
             ),
@@ -1034,8 +1034,8 @@ class TestAnalyzeEPDeviceSelectionMatrix:
                 None,
                 0,
                 [
-                    ("QNNExecutionProvider", "GPU"),
                     ("QNNExecutionProvider", "NPU"),
+                    ("QNNExecutionProvider", "GPU"),
                 ],
                 None,
             ),
@@ -1044,8 +1044,8 @@ class TestAnalyzeEPDeviceSelectionMatrix:
                 "all",
                 0,
                 [
-                    ("QNNExecutionProvider", "GPU"),
                     ("QNNExecutionProvider", "NPU"),
+                    ("QNNExecutionProvider", "GPU"),
                 ],
                 None,
             ),
@@ -1056,17 +1056,17 @@ class TestAnalyzeEPDeviceSelectionMatrix:
                 "all",
                 0,
                 [
-                    ("CPUExecutionProvider", "CPU"),
-                    ("CUDAExecutionProvider", "GPU"),
-                    ("DmlExecutionProvider", "GPU"),
-                    ("MIGraphXExecutionProvider", "GPU"),
                     ("NvTensorRTRTXExecutionProvider", "GPU"),
-                    ("OpenVINOExecutionProvider", "CPU"),
-                    ("OpenVINOExecutionProvider", "GPU"),
-                    ("OpenVINOExecutionProvider", "NPU"),
-                    ("QNNExecutionProvider", "GPU"),
-                    ("QNNExecutionProvider", "NPU"),
+                    ("CUDAExecutionProvider", "GPU"),
+                    ("MIGraphXExecutionProvider", "GPU"),
                     ("VitisAIExecutionProvider", "NPU"),
+                    ("QNNExecutionProvider", "NPU"),
+                    ("QNNExecutionProvider", "GPU"),
+                    ("OpenVINOExecutionProvider", "NPU"),
+                    ("OpenVINOExecutionProvider", "GPU"),
+                    ("OpenVINOExecutionProvider", "CPU"),
+                    ("DmlExecutionProvider", "GPU"),
+                    ("CPUExecutionProvider", "CPU"),
                 ],
                 None,
             ),
@@ -1181,14 +1181,14 @@ class TestAnalyzeEPDeviceSelectionMatrix:
 
         result = runner.invoke(analyze, ["--model", str(model_file), "--ep", "qnn"])
         assert result.exit_code == 0
-        assert "not supported in local environment" in result.output.lower()
+        assert "not available on this machine" in result.output.lower()
         actual_calls = [
             (call.kwargs["ep"], call.kwargs["device"])
             for call in mock_instance.analyze.call_args_list
         ]
         assert actual_calls == [
-            ("QNNExecutionProvider", "GPU"),
             ("QNNExecutionProvider", "NPU"),
+            ("QNNExecutionProvider", "GPU"),
         ]
 
     @patch(
@@ -1229,9 +1229,9 @@ class TestAnalyzeEPDeviceSelectionMatrix:
             for call in mock_instance.analyze.call_args_list
         ]
         assert actual_calls == [
-            ("DmlExecutionProvider", "GPU"),
             ("NvTensorRTRTXExecutionProvider", "GPU"),
             ("OpenVINOExecutionProvider", "GPU"),
+            ("DmlExecutionProvider", "GPU"),
         ]
 
 

--- a/tests/unit/analyze/test_static_analyzer_cli.py
+++ b/tests/unit/analyze/test_static_analyzer_cli.py
@@ -641,8 +641,8 @@ class TestAnalyzeCommandOutput:
         model_file.write_bytes(b"dummy")
         config_file = tmp_path / "optim.json"
 
-        mock_analyzer_result.get_optimization_config.return_value.to_dict.return_value = {
-            "ep": "QNNExecutionProvider"
+        mock_analyzer_result.get_optimization_config.return_value = {
+            "gelu_fusion": True,
         }
         mock_instance = Mock()
         mock_instance.analyze.return_value = mock_analyzer_result
@@ -665,7 +665,7 @@ class TestAnalyzeCommandOutput:
         assert result.exit_code == 0
         assert config_file.exists()
         content = json.loads(config_file.read_text())
-        assert "ep" in content
+        assert content == {"gelu_fusion": True}
 
     @patch("winml.modelkit.analyze.ONNXStaticAnalyzer")
     def test_optim_config_creates_parent_dirs(
@@ -680,8 +680,8 @@ class TestAnalyzeCommandOutput:
         model_file.write_bytes(b"dummy")
         config_file = tmp_path / "nested" / "dir" / "optim.json"
 
-        mock_analyzer_result.get_optimization_config.return_value.to_dict.return_value = {
-            "ep": "QNNExecutionProvider"
+        mock_analyzer_result.get_optimization_config.return_value = {
+            "gelu_fusion": True,
         }
         mock_instance = Mock()
         mock_instance.analyze.return_value = mock_analyzer_result
@@ -1344,10 +1344,10 @@ class TestQDQNodeDisplayMapping:
 
         assert result.exit_code == 0
         # After the fix, 'Conv (QDQ)' is keyed as 'Conv' in instance_counts.
-        # ep_instance_counts['QNNExecutionProvider@NPU']['Conv'] must be populated
+        # ep_instance_counts[("QNNExecutionProvider", "NPU")]['Conv'] must be populated
         # (not 'Conv (QDQ)') so the Conv row shows counts instead of '...'.
         assert mock_summary.called
-        qnn_counts = captured_ep_counts.get("QNNExecutionProvider@NPU", {})
+        qnn_counts = captured_ep_counts.get(("QNNExecutionProvider", "NPU"), {})
         assert "Conv" in qnn_counts, "Conv (QDQ) results must be stored under 'Conv'"
         assert "Conv (QDQ)" not in qnn_counts, "QDQ suffix must be stripped"
         assert qnn_counts["Conv"] == {"supported": 2}
@@ -1377,7 +1377,6 @@ class TestAnalyzeSummaryRendering:
             ep="DmlExecutionProvider",
             device="GPU",
             no_data_eps={("DmlExecutionProvider", "GPU")},
-            pair_hints={("DmlExecutionProvider", "GPU"): ["no rule data"]},
         )
 
         output = console.export_text()

--- a/tests/unit/analyze/test_static_analyzer_cli.py
+++ b/tests/unit/analyze/test_static_analyzer_cli.py
@@ -44,6 +44,22 @@ def _mock_local_ep_device_pairs(monkeypatch: pytest.MonkeyPatch) -> None:
         "winml.modelkit.commands.analyze._get_local_ep_device_pairs",
         lambda: list(SIMULATED_LOCAL_EP_DEVICE_PAIRS),
     )
+    # Defensive mocks: the analyze command derives devices/eps from local_pairs
+    # in auto mode, but other code paths (and any future code) may still call
+    # these helpers — keep them consistent with the simulated local matrix so
+    # tests stay environment-independent.
+    simulated_devices = tuple(sorted({d for _, d in SIMULATED_LOCAL_EP_DEVICE_PAIRS}))
+    # Sort eps so iteration order is deterministic across runs (the real helper
+    # returns a frozenset whose iteration depends on PYTHONHASHSEED).
+    simulated_eps = tuple(sorted({e for e, _ in SIMULATED_LOCAL_EP_DEVICE_PAIRS}))
+    monkeypatch.setattr(
+        "winml.modelkit.sysinfo.device._get_available_devices",
+        lambda: simulated_devices,
+    )
+    monkeypatch.setattr(
+        "winml.modelkit.sysinfo.device._get_available_eps",
+        lambda: simulated_eps,
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -828,7 +844,7 @@ class TestAnalyzeEPDeviceValidation:
     def test_dml_cpu_rejected_with_only_supports(
         self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """DML + CPU should be rejected when local target combination is unavailable."""
+        """DML + CPU should be rejected: DML does not support CPU per EP_SUPPORTED_DEVICES."""
         model_file = tmp_path / "test.onnx"
         model_file.write_bytes(b"dummy")
 
@@ -837,13 +853,12 @@ class TestAnalyzeEPDeviceValidation:
             ["--model", str(model_file), "--ep", "dml", "--device", "CPU"],
         )
         assert result.exit_code == 2
-        assert "no rule data found" in result.output.lower()
-        assert "--run-unknown-op" in result.output
+        assert "no ep/device combination matched" in result.output.lower()
 
     def test_cpu_ep_npu_rejected(
         self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """CPUExecutionProvider + NPU should be rejected when unavailable locally."""
+        """CPU EP + NPU should be rejected: CPU EP does not support NPU."""
         model_file = tmp_path / "test.onnx"
         model_file.write_bytes(b"dummy")
 
@@ -852,8 +867,7 @@ class TestAnalyzeEPDeviceValidation:
             ["--model", str(model_file), "--ep", "cpu", "--device", "NPU"],
         )
         assert result.exit_code == 2
-        assert "no rule data found" in result.output.lower()
-        assert "--run-unknown-op" in result.output
+        assert "no ep/device combination matched" in result.output.lower()
 
     @patch("winml.modelkit.analyze.ONNXStaticAnalyzer")
     @patch(
@@ -886,44 +900,44 @@ class TestAnalyzeEPDeviceValidation:
     def test_ep_alias_cpu_resolves(
         self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """'cpu' alias should resolve to CPUExecutionProvider."""
+        """'cpu' alias resolves to CPUExecutionProvider, which doesn't support GPU."""
         model_file = tmp_path / "test.onnx"
         model_file.write_bytes(b"dummy")
 
-        # CPU EP + GPU is not in local available targets.
         result = runner.invoke(
             analyze,
             ["--model", str(model_file), "--ep", "cpu", "--device", "GPU"],
         )
         assert result.exit_code == 2
-        assert "no rule data found" in result.output.lower()
-        assert "--run-unknown-op" in result.output
+        assert "no ep/device combination matched" in result.output.lower()
 
     def test_ep_alias_dml_resolves(
         self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """'dml' alias should resolve to DmlExecutionProvider."""
+        """'dml' alias resolves to DmlExecutionProvider, which doesn't support NPU."""
         model_file = tmp_path / "test.onnx"
         model_file.write_bytes(b"dummy")
 
-        # DML EP + NPU is not in local available targets.
         result = runner.invoke(
             analyze,
             ["--model", str(model_file), "--ep", "dml", "--device", "NPU"],
         )
         assert result.exit_code == 2
-        assert "no rule data found" in result.output.lower()
-        assert "--run-unknown-op" in result.output
+        assert "no ep/device combination matched" in result.output.lower()
 
     @patch("winml.modelkit.analyze.ONNXStaticAnalyzer")
-    def test_ep_without_device_auto_requires_local_rule_data(
+    def test_ep_without_device_auto_resolves_local_device(
         self,
         mock_analyzer_class: MagicMock,
         runner: CliRunner,
         tmp_path: Path,
         mock_analyzer_result: Mock,
     ) -> None:
-        """When --device is omitted, EP must have local targets with rule data."""
+        """With --device auto and a specific EP, analyze runs on the matching local device.
+
+        Rule-data availability no longer gates execution — the per-pair OP CHECK
+        section just renders an "Op check skipped — no rule data" row inline.
+        """
         model_file = tmp_path / "test.onnx"
         model_file.write_bytes(b"dummy")
 
@@ -931,22 +945,21 @@ class TestAnalyzeEPDeviceValidation:
         mock_instance.analyze.return_value = mock_analyzer_result
         mock_analyzer_class.return_value = mock_instance
 
-        # dml is locally available on GPU in the fixture, but has no rule data.
+        # dml is locally available on GPU per the fixture; auto picks GPU.
         result = runner.invoke(
             analyze,
             ["--model", str(model_file), "--ep", "dml"],
         )
-        assert result.exit_code == 2
-        assert "no rule data found" in result.output.lower()
-        assert "--run-unknown-op" in result.output
-        assert not mock_instance.analyze.called
+        assert result.exit_code == 0
+        mock_instance.analyze.assert_called_once()
+        call_kwargs = mock_instance.analyze.call_args.kwargs
+        assert call_kwargs["ep"] == "DmlExecutionProvider"
+        assert call_kwargs["device"] == "GPU"
 
-    @patch("winml.modelkit.commands.analyze._render_analysis_summary")
     @patch("winml.modelkit.analyze.ONNXStaticAnalyzer")
     def test_ep_without_device_auto_run_unknown_op_executes_no_rule_data_pair(
         self,
         mock_analyzer_class: MagicMock,
-        mock_summary: MagicMock,
         runner: CliRunner,
         tmp_path: Path,
         mock_analyzer_result: Mock,
@@ -970,11 +983,6 @@ class TestAnalyzeEPDeviceValidation:
         assert call_kwargs["ep"] == "DmlExecutionProvider"
         assert call_kwargs["device"] == "GPU"
 
-        assert mock_summary.called
-        summary_kwargs = mock_summary.call_args.kwargs
-        pair_hints = summary_kwargs["pair_hints"]
-        assert pair_hints[("DmlExecutionProvider", "GPU")] == ["no rule data"]
-
 
 class TestAnalyzeEPDeviceSelectionMatrix:
     """Matrix tests for EP/device resolution with fixed local availability."""
@@ -982,57 +990,83 @@ class TestAnalyzeEPDeviceSelectionMatrix:
     @pytest.mark.parametrize(
         ("ep_arg", "device_arg", "expect_exit", "expect_calls", "expect_error"),
         [
+            # Both auto: filter pre-EP_SUPPORTED_DEVICES list to local_pairs.
             (
                 None,
                 None,
                 0,
                 [
+                    ("CPUExecutionProvider", "CPU"),
+                    ("DmlExecutionProvider", "GPU"),
                     ("NvTensorRTRTXExecutionProvider", "GPU"),
-                    ("OpenVINOExecutionProvider", "NPU"),
                     ("OpenVINOExecutionProvider", "CPU"),
+                    ("OpenVINOExecutionProvider", "NPU"),
                 ],
                 None,
             ),
+            # ep=auto, device=gpu: warn about non-local but run all eps that support GPU.
             (
                 None,
                 "gpu",
                 0,
-                [("NvTensorRTRTXExecutionProvider", "GPU")],
+                [
+                    ("DmlExecutionProvider", "GPU"),
+                    ("NvTensorRTRTXExecutionProvider", "GPU"),
+                    ("OpenVINOExecutionProvider", "GPU"),
+                ],
                 None,
             ),
+            # ep=openvino, device=auto: warn about non-local pairs, run all 3.
             (
                 "openvino",
                 None,
                 0,
                 [
-                    ("OpenVINOExecutionProvider", "NPU"),
                     ("OpenVINOExecutionProvider", "CPU"),
+                    ("OpenVINOExecutionProvider", "GPU"),
+                    ("OpenVINOExecutionProvider", "NPU"),
                 ],
                 None,
             ),
-            ("qnn", None, 2, [], "local machine does not support"),
+            # ep=qnn, device=auto: QNN is not local, but we warn (not filter) and run.
+            (
+                "qnn",
+                None,
+                0,
+                [
+                    ("QNNExecutionProvider", "GPU"),
+                    ("QNNExecutionProvider", "NPU"),
+                ],
+                None,
+            ),
             (
                 "qnn",
                 "all",
                 0,
                 [
-                    ("QNNExecutionProvider", "NPU"),
                     ("QNNExecutionProvider", "GPU"),
+                    ("QNNExecutionProvider", "NPU"),
                 ],
                 None,
             ),
             ("openvino", "gpu", 0, [("OpenVINOExecutionProvider", "GPU")], None),
+            # ep=all, device=all: every (ep, device) combo allowed by EP_SUPPORTED_DEVICES.
             (
                 "all",
                 "all",
                 0,
                 [
+                    ("CPUExecutionProvider", "CPU"),
+                    ("CUDAExecutionProvider", "GPU"),
+                    ("DmlExecutionProvider", "GPU"),
+                    ("MIGraphXExecutionProvider", "GPU"),
                     ("NvTensorRTRTXExecutionProvider", "GPU"),
-                    ("QNNExecutionProvider", "NPU"),
-                    ("QNNExecutionProvider", "GPU"),
-                    ("OpenVINOExecutionProvider", "NPU"),
-                    ("OpenVINOExecutionProvider", "GPU"),
                     ("OpenVINOExecutionProvider", "CPU"),
+                    ("OpenVINOExecutionProvider", "GPU"),
+                    ("OpenVINOExecutionProvider", "NPU"),
+                    ("QNNExecutionProvider", "GPU"),
+                    ("QNNExecutionProvider", "NPU"),
+                    ("VitisAIExecutionProvider", "NPU"),
                 ],
                 None,
             ),
@@ -1104,105 +1138,59 @@ class TestAnalyzeEPDeviceSelectionMatrix:
             assert expect_error in result.output.lower()
 
     @patch("winml.modelkit.analyze.ONNXStaticAnalyzer")
-    def test_no_rule_data_pair_requires_run_unknown_op(
+    def test_no_rule_data_pair_runs_with_inline_skip_marker(
         self,
         mock_analyzer_class: MagicMock,
         runner: CliRunner,
         tmp_path: Path,
+        mock_analyzer_result: Mock,
     ) -> None:
-        """A pair without rule data should fail with --run-unknown-op guidance."""
+        """A pair without rule data still runs — OP CHECK renders 'skipped' inline."""
         model_file = tmp_path / "test.onnx"
         model_file.write_bytes(b"dummy")
+
+        mock_instance = Mock()
+        mock_instance.analyze.return_value = mock_analyzer_result
+        mock_analyzer_class.return_value = mock_instance
 
         result = runner.invoke(
             analyze,
             ["--model", str(model_file), "--ep", "dml", "--device", "gpu"],
         )
-        assert result.exit_code == 2
-        assert "no rule data found" in result.output.lower()
-        assert "--run-unknown-op" in result.output
-        assert not mock_analyzer_class.return_value.analyze.called
+        assert result.exit_code == 0
+        mock_instance.analyze.assert_called_once()
+        call_kwargs = mock_instance.analyze.call_args.kwargs
+        assert call_kwargs["ep"] == "DmlExecutionProvider"
+        assert call_kwargs["device"] == "GPU"
 
-    def test_qnn_auto_shows_device_all_guidance(self, runner: CliRunner, tmp_path: Path) -> None:
-        """qnn + auto device should fail with local support guidance, not run-unknown hint."""
+    @patch("winml.modelkit.analyze.ONNXStaticAnalyzer")
+    def test_qnn_auto_warns_about_non_local_pairs(
+        self,
+        mock_analyzer_class: MagicMock,
+        runner: CliRunner,
+        tmp_path: Path,
+        mock_analyzer_result: Mock,
+    ) -> None:
+        """qnn + auto device: QNN isn't locally supported but we warn (not error) and run."""
         model_file = tmp_path / "test.onnx"
         model_file.write_bytes(b"dummy")
+
+        mock_instance = Mock()
+        mock_instance.analyze.return_value = mock_analyzer_result
+        mock_analyzer_class.return_value = mock_instance
 
         result = runner.invoke(analyze, ["--model", str(model_file), "--ep", "qnn"])
-        assert result.exit_code == 2
-        assert "local machine does not support" in result.output.lower()
-        assert "--device all" in result.output
-        assert "--run-unknown-op" not in result.output
-
-    @patch("winml.modelkit.commands.analyze._render_analysis_summary")
-    @patch("winml.modelkit.analyze.ONNXStaticAnalyzer")
-    def test_openvino_gpu_has_local_not_supported_hint(
-        self,
-        mock_analyzer_class: MagicMock,
-        mock_summary: MagicMock,
-        runner: CliRunner,
-        tmp_path: Path,
-        mock_analyzer_result: Mock,
-    ) -> None:
-        """openvino + gpu should execute and carry local-not-supported hint into summary."""
-        model_file = tmp_path / "test.onnx"
-        model_file.write_bytes(b"dummy")
-
-        mock_instance = Mock()
-        mock_instance.analyze.return_value = mock_analyzer_result
-        mock_analyzer_class.return_value = mock_instance
-
-        result = runner.invoke(
-            analyze,
-            ["--model", str(model_file), "--ep", "openvino", "--device", "gpu"],
-        )
         assert result.exit_code == 0
-        assert mock_instance.analyze.called
-        assert mock_summary.called
+        assert "not supported in local environment" in result.output.lower()
+        actual_calls = [
+            (call.kwargs["ep"], call.kwargs["device"])
+            for call in mock_instance.analyze.call_args_list
+        ]
+        assert actual_calls == [
+            ("QNNExecutionProvider", "GPU"),
+            ("QNNExecutionProvider", "NPU"),
+        ]
 
-        summary_kwargs = mock_summary.call_args.kwargs
-        pair_hints = summary_kwargs["pair_hints"]
-        assert pair_hints[("OpenVINOExecutionProvider", "GPU")] == ["local machine not supported"]
-
-    @patch("winml.modelkit.commands.analyze._render_analysis_summary")
-    @patch("winml.modelkit.analyze.ONNXStaticAnalyzer")
-    def test_run_unknown_op_sets_no_rule_data_hint(
-        self,
-        mock_analyzer_class: MagicMock,
-        mock_summary: MagicMock,
-        runner: CliRunner,
-        tmp_path: Path,
-        mock_analyzer_result: Mock,
-    ) -> None:
-        """--run-unknown-op should allow execution and carry no-rule-data hint."""
-        model_file = tmp_path / "test.onnx"
-        model_file.write_bytes(b"dummy")
-
-        mock_instance = Mock()
-        mock_instance.analyze.return_value = mock_analyzer_result
-        mock_analyzer_class.return_value = mock_instance
-
-        result = runner.invoke(
-            analyze,
-            [
-                "--model",
-                str(model_file),
-                "--ep",
-                "dml",
-                "--device",
-                "gpu",
-                "--run-unknown-op",
-            ],
-        )
-        assert result.exit_code == 0
-        assert mock_instance.analyze.called
-        assert mock_summary.called
-
-        summary_kwargs = mock_summary.call_args.kwargs
-        pair_hints = summary_kwargs["pair_hints"]
-        assert pair_hints[("DmlExecutionProvider", "GPU")] == ["no rule data"]
-
-    @patch("winml.modelkit.commands.analyze._render_analysis_summary")
     @patch(
         "winml.modelkit.analyze.utils.ep_utils.has_rule_data_for_ep",
         return_value=False,
@@ -1212,12 +1200,17 @@ class TestAnalyzeEPDeviceSelectionMatrix:
         self,
         mock_analyzer_class: MagicMock,
         _mock_has_rule: Mock,
-        mock_summary: MagicMock,
         runner: CliRunner,
         tmp_path: Path,
         mock_analyzer_result: Mock,
     ) -> None:
-        """auto + specific device should run local parsed pairs when --run-unknown-op is set."""
+        """ep=auto + specific device should run all locally-eligible (ep, device) pairs.
+
+        With ep=auto and device specified, no local filter is applied — pairs the
+        local machine doesn't support are kept (a warning is emitted) and analysis
+        runs for each. has_rule_data_for_ep returning False here only affects
+        per-pair OP CHECK rendering (op-check-skipped), not which pairs run.
+        """
         model_file = tmp_path / "test.onnx"
         model_file.write_bytes(b"dummy")
 
@@ -1230,22 +1223,16 @@ class TestAnalyzeEPDeviceSelectionMatrix:
             ["--model", str(model_file), "--device", "gpu", "--run-unknown-op"],
         )
         assert result.exit_code == 0
-        assert mock_instance.analyze.call_count == 2
 
         actual_calls = [
             (call.kwargs["ep"], call.kwargs["device"])
             for call in mock_instance.analyze.call_args_list
         ]
         assert actual_calls == [
-            ("NvTensorRTRTXExecutionProvider", "GPU"),
             ("DmlExecutionProvider", "GPU"),
+            ("NvTensorRTRTXExecutionProvider", "GPU"),
+            ("OpenVINOExecutionProvider", "GPU"),
         ]
-
-        assert mock_summary.called
-        summary_kwargs = mock_summary.call_args.kwargs
-        pair_hints = summary_kwargs["pair_hints"]
-        assert pair_hints[("NvTensorRTRTXExecutionProvider", "GPU")] == ["no rule data"]
-        assert pair_hints[("DmlExecutionProvider", "GPU")] == ["no rule data"]
 
 
 class TestQDQNodeDisplayMapping:


### PR DESCRIPTION
Fixes #697.

## Summary

- **EP/device selection** — replace the large mode-matrix branching with a straightforward `eps × devices` construction filtered against `EP_SUPPORTED_DEVICES`. When `device=auto and ep=auto`, restrict to locally-available pairs; when only one of them is auto, keep all pairs but warn about ones not supported in the local environment instead of silently dropping them.
- **Op-check skipped table** — render a title-only "Skipped - no rule data" table for EP/device pairs with no rule data, so the per-pair output stays consistent.
- **Analysis summary** — fix a key-shape mismatch where `ep_instance_counts` was being rewrapped with `"EP@DEVICE"` string keys while the renderer looked them up by `(ep, device)` tuple, which always missed and printed `0/0/0`. Pass the tuple-keyed dict directly.
- **Counts format** — always show four numbers `S/P/U/Unk` (Supported / Partial / Unsupported / Unknown) in both the OP CHECK table column and the ANALYSIS SUMMARY line. Update column header and legend.
- **Optimization config** — when multiple analysis pairs are selected, merge their `get_optimization_config(ep=…)` outputs into a single config (union of keys). On conflicting values for the same key, log a warning naming each pair's value; the merged config keeps the first pair's value.
- Drop the now-unused `pair_hints` plumbing and redundant local-vs-rule hint lines.