### PR TITLE
fix(ep): demote per-provider ensure_ready failure to debug

### DIFF
--- a/src/winml/modelkit/session/ep_registry.py
+++ b/src/winml/modelkit/session/ep_registry.py
@@ -82,7 +82,7 @@ class WinMLEPRegistry:
             try:
                 provider.ensure_ready()
             except Exception as e:
-                logger.warning("Failed to ensure EP %s is ready: %s", provider.name, e)
+                logger.debug("Failed to ensure EP %s is ready: %s", provider.name, e)
                 continue
             if provider.library_path == "":
                 continue


### PR DESCRIPTION
## Summary

- Per [#688](https://github.com/microsoft/winml-cli/issues/688), `WinMLEPRegistry._load_ep_catalog` already isolates per-provider `ensure_ready()` failures, but logs them at `warning` level.
- Duplicate/legacy `EpCatalog` entries (e.g. a stale legacy-framework `NvTensorRTRTXExecutionProvider`) are an expected transient state during the publisher migration, so the noisy `Failed to ensure EP ... Package dependency criteria could not be resolved` warning surfaces on every `winml sys` invocation on affected machines.
- Demote that single per-provider line to `debug`. The outer `_discover_eps` `warning` for catalog-creation/enumeration failures is unchanged.

Closes #688