### PR TITLE
feat: Estimate model precision in WinMLSession; show in perf output

### DIFF
--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -897,7 +897,7 @@ def _print_model_info(
 
     precision = io_config.get("precision")
     if precision:
-        console.print(f"[dim]Precision:[/dim]   {precision}")
+        console.print(f"[dim]Model Precision:[/dim]   {precision}")
 
     names = io_config.get("input_names", [])
     shapes = io_config.get("input_shapes", [])

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -892,10 +892,12 @@ def _print_model_info(
     console.print()
     device_line = f"{device} / {ep_name}" if ep_name else device
     console.print(f"[dim]Device:[/dim]      {device_line}")
-    # TODO: show resolved precision once WinMLPreTrainedModel.precision
-    # is implemented (derive from _build_config.quant.weight_type)
     if task:
         console.print(f"[dim]Task:[/dim]        {task}")
+
+    precision = io_config.get("precision")
+    if precision:
+        console.print(f"[dim]Precision:[/dim]   {precision}")
 
     names = io_config.get("input_names", [])
     shapes = io_config.get("input_shapes", [])

--- a/src/winml/modelkit/session/session.py
+++ b/src/winml/modelkit/session/session.py
@@ -680,7 +680,8 @@ class WinMLSession:
                 - output_shapes: list of output shapes
                 - output_types: list of numpy dtypes for outputs
                 - precision: best-effort precision label (e.g. "fp16",
-                  "int8", "w8a16", "unknown")
+                  "int8", "w8a16"), or ``None`` when no signal could be
+                  derived from the graph
         """
         if self._io_config is None:
             from ..onnx import load_onnx
@@ -734,11 +735,12 @@ class WinMLSession:
         return value_ranges
 
     @staticmethod
-    def _get_precision(model_proto: onnx.ModelProto) -> str:
+    def _get_precision(model_proto: onnx.ModelProto) -> str | None:
         """Best-effort estimate of a model's numeric precision.
 
         Returns one of: ``"fp32"``, ``"fp16"``, ``"bf16"``, ``"int4"``,
-        ``"int8"``, ``"int16"``, ``"w{w}a{a}"`` (mixed), or ``"unknown"``.
+        ``"int8"``, ``"int16"``, ``"w{w}a{a}"`` (mixed), or ``None`` when
+        no signal can be derived.
 
         Detection is purely operator-schema-based (no model-architecture
         or naming assumptions). The ladder, first match wins:
@@ -751,7 +753,7 @@ class WinMLSession:
            schema ``bits`` attribute + dominant float bit width for
            activations → ``w{w}a{a}``.
         3. No quant markers → dominant float dtype among initializers.
-        4. No signal → ``"unknown"``.
+        4. No signal → ``None``.
         """
         from onnx import TensorProto
 
@@ -825,7 +827,7 @@ class WinMLSession:
             return "fp16"
 
         # (4) No signal.
-        return "unknown"
+        return None
 
     @staticmethod
     def _dominant_float_bits(graph: onnx.GraphProto) -> int | None:

--- a/src/winml/modelkit/session/session.py
+++ b/src/winml/modelkit/session/session.py
@@ -679,6 +679,8 @@ class WinMLSession:
                 - output_names: list of output tensor names
                 - output_shapes: list of output shapes
                 - output_types: list of numpy dtypes for outputs
+                - precision: best-effort precision label (e.g. "fp16",
+                  "int8", "w8a16", "unknown")
         """
         if self._io_config is None:
             from ..onnx import load_onnx
@@ -687,6 +689,7 @@ class WinMLSession:
             self._io_config = get_io_config(model)
             # Enrich with value_range from build config if available
             self._io_config["input_value_ranges"] = self._load_input_value_ranges()
+            self._io_config["precision"] = self._get_precision(model)
         return self._io_config
 
     def _load_input_value_ranges(self) -> dict[str, list[int]]:
@@ -729,6 +732,121 @@ class WinMLSession:
                     logger.debug("Could not read build config %s: %s", cfg_path, exc)
 
         return value_ranges
+
+    @staticmethod
+    def _get_precision(model_proto: onnx.ModelProto) -> str:
+        """Best-effort estimate of a model's numeric precision.
+
+        Returns one of: ``"fp32"``, ``"fp16"``, ``"bf16"``, ``"int4"``,
+        ``"int8"``, ``"int16"``, ``"w{w}a{a}"`` (mixed), or ``"unknown"``.
+
+        Detection is purely operator-schema-based (no model-architecture
+        or naming assumptions). The ladder, first match wins:
+
+        1. QDQ (``QuantizeLinear`` / ``DequantizeLinear``): dominant
+           ``zero_point`` initializer bit width per side. A pair is
+           weight-side when its source tensor is an initializer,
+           activation-side otherwise.
+        2. Block-wise quant (``MatMulNBits`` / ``GatherBlockQuantized``):
+           schema ``bits`` attribute + dominant float bit width for
+           activations → ``w{w}a{a}``.
+        3. No quant markers → dominant float dtype among initializers.
+        4. No signal → ``"unknown"``.
+        """
+        from onnx import TensorProto
+
+        graph = model_proto.graph
+        init_dtypes: dict[str, int] = {init.name: init.data_type for init in graph.initializer}
+        init_names = set(init_dtypes)
+        op_types = {n.op_type for n in graph.node}
+
+        int_bits: dict[int, int] = {
+            int(TensorProto.UINT4): 4,
+            int(TensorProto.INT4): 4,
+            int(TensorProto.UINT8): 8,
+            int(TensorProto.INT8): 8,
+            int(TensorProto.UINT16): 16,
+            int(TensorProto.INT16): 16,
+            int(TensorProto.UINT32): 32,
+            int(TensorProto.INT32): 32,
+        }
+
+        def _label(w_bits: int, a_bits: int) -> str:
+            return f"int{w_bits}" if w_bits == a_bits else f"w{w_bits}a{a_bits}"
+
+        # (1) QDQ — dominant zero_point bit width per side.
+        if op_types & {"QuantizeLinear", "DequantizeLinear"}:
+            weight_counts: dict[int, int] = {}
+            act_counts: dict[int, int] = {}
+            for node in graph.node:
+                if node.op_type not in ("QuantizeLinear", "DequantizeLinear"):
+                    continue
+                if len(node.input) < 3:
+                    continue
+                zp_dtype = init_dtypes.get(node.input[2])
+                if zp_dtype is None:
+                    continue
+                bits = int_bits.get(zp_dtype)
+                if bits is None:
+                    continue
+                target = weight_counts if node.input[0] in init_names else act_counts
+                target[bits] = target.get(bits, 0) + 1
+
+            if weight_counts or act_counts:
+                w = (
+                    max(weight_counts, key=lambda k: weight_counts[k])
+                    if weight_counts
+                    else max(act_counts, key=lambda k: act_counts[k])
+                )
+                a = max(act_counts, key=lambda k: act_counts[k]) if act_counts else w
+                return _label(w, a)
+
+        # (2) Block-wise quantization carries a schema-defined `bits` attr.
+        nbits: set[int] = set()
+        for node in graph.node:
+            if node.op_type in ("MatMulNBits", "GatherBlockQuantized"):
+                for attr in node.attribute:
+                    if attr.name == "bits":
+                        nbits.add(attr.i)
+        if nbits:
+            w_bits = min(nbits)
+            a_bits = WinMLSession._dominant_float_bits(graph) or 16
+            return _label(w_bits, a_bits)
+
+        # (3) Float-only model — dominant initializer dtype.
+        dom = WinMLSession._dominant_float_bits(graph)
+        if dom == 32:
+            return "fp32"
+        if dom == 16:
+            has_bf16 = any(init.data_type == TensorProto.BFLOAT16 for init in graph.initializer)
+            has_fp16 = any(init.data_type == TensorProto.FLOAT16 for init in graph.initializer)
+            if has_bf16 and not has_fp16:
+                return "bf16"
+            return "fp16"
+
+        # (4) No signal.
+        return "unknown"
+
+    @staticmethod
+    def _dominant_float_bits(graph: onnx.GraphProto) -> int | None:
+        """Return 32 or 16 — whichever float dtype dominates initializer count.
+
+        ``None`` if no float initializers are present.
+        """
+        from onnx import TensorProto
+
+        counts: dict[int, int] = {}
+        for init in graph.initializer:
+            if init.data_type in (
+                TensorProto.FLOAT,
+                TensorProto.FLOAT16,
+                TensorProto.BFLOAT16,
+            ):
+                counts[init.data_type] = counts.get(init.data_type, 0) + 1
+        if not counts:
+            return None
+        dominant = max(counts, key=lambda k: counts[k])
+        return 32 if dominant == TensorProto.FLOAT else 16
 
     def is_compatible(
         self,

--- a/tests/unit/session/test_winml_session.py
+++ b/tests/unit/session/test_winml_session.py
@@ -366,6 +366,188 @@ class TestWinMLSessionMetadata:
         assert io_cfg["input_shapes"] == [[1, 4]]
 
 
+class TestWinMLSessionPrecisionDetection:
+    """Test `_get_precision` estimation across the detection ladder."""
+
+    @staticmethod
+    def _save(model, path: Path) -> Path:
+        import onnx
+
+        onnx.save(model, str(path))
+        return path
+
+    def test_precision_fp32_from_initializers(self, simple_matmul_onnx: Path):
+        """Float initializers (fp32) → 'fp32'."""
+        session = WinMLSession(onnx_path=simple_matmul_onnx, device="auto")
+        assert session.io_config["precision"] == "fp32"
+
+    def test_precision_fp16_from_initializers(self, tmp_path: Path):
+        """Float initializers (fp16) → 'fp16'."""
+        import numpy as np
+        from onnx import TensorProto, helper
+
+        a = helper.make_tensor_value_info("A", TensorProto.FLOAT16, [1, 4])
+        c = helper.make_tensor_value_info("C", TensorProto.FLOAT16, [1, 4])
+        b_vals = np.random.randn(4, 4).astype(np.float16)
+        b = helper.make_tensor("B", TensorProto.FLOAT16, [4, 4], b_vals.tobytes(), raw=True)
+        node = helper.make_node("MatMul", ["A", "B"], ["C"])
+        graph = helper.make_graph([node], "fp16", [a], [c], [b])
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+        model.ir_version = 7
+        path = self._save(model, tmp_path / "fp16.onnx")
+
+        session = WinMLSession(onnx_path=path, device="auto")
+        assert session.io_config["precision"] == "fp16"
+
+    def test_precision_int8_from_qdq(self, tmp_path: Path):
+        """QDQ pair with int8 zero_point on a weight initializer → 'int8'."""
+        import numpy as np
+        from onnx import TensorProto, helper
+
+        a = helper.make_tensor_value_info("A", TensorProto.FLOAT, [1, 4])
+        c = helper.make_tensor_value_info("C", TensorProto.FLOAT, [1, 4])
+
+        w_q = helper.make_tensor(
+            "W_q",
+            TensorProto.INT8,
+            [4, 4],
+            np.zeros((4, 4), dtype=np.int8).tobytes(),
+            raw=True,
+        )
+        w_scale = helper.make_tensor("W_scale", TensorProto.FLOAT, [], [0.1])
+        w_zp = helper.make_tensor(
+            "W_zp", TensorProto.INT8, [], np.array([0], dtype=np.int8).tobytes(), raw=True
+        )
+
+        dq = helper.make_node("DequantizeLinear", ["W_q", "W_scale", "W_zp"], ["W"], name="dq")
+        matmul = helper.make_node("MatMul", ["A", "W"], ["C"], name="mm")
+
+        graph = helper.make_graph([dq, matmul], "qdq_int8", [a], [c], [w_q, w_scale, w_zp])
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+        model.ir_version = 7
+        path = self._save(model, tmp_path / "qdq_int8.onnx")
+
+        session = WinMLSession(onnx_path=path, device="auto")
+        assert session.io_config["precision"] == "int8"
+
+    def test_precision_w8a16_mixed_qdq(self, tmp_path: Path):
+        """Activation quantized to uint16 + weight to int8 → 'w8a16'."""
+        import numpy as np
+        from onnx import TensorProto, helper
+
+        a = helper.make_tensor_value_info("A", TensorProto.FLOAT, [1, 4])
+        c = helper.make_tensor_value_info("C", TensorProto.FLOAT, [1, 4])
+
+        # Activation Q→DQ with uint16 zero_point (dynamic input → activation side)
+        a_scale = helper.make_tensor("A_scale", TensorProto.FLOAT, [], [0.05])
+        a_zp = helper.make_tensor(
+            "A_zp",
+            TensorProto.UINT16,
+            [],
+            np.array([0], dtype=np.uint16).tobytes(),
+            raw=True,
+        )
+        q_act = helper.make_node("QuantizeLinear", ["A", "A_scale", "A_zp"], ["A_q"], name="q_act")
+        dq_act = helper.make_node(
+            "DequantizeLinear", ["A_q", "A_scale", "A_zp"], ["A_d"], name="dq_act"
+        )
+
+        # Weight DQ with int8 zero_point (initializer → weight side)
+        w_q = helper.make_tensor(
+            "W_q",
+            TensorProto.INT8,
+            [4, 4],
+            np.zeros((4, 4), dtype=np.int8).tobytes(),
+            raw=True,
+        )
+        w_scale = helper.make_tensor("W_scale", TensorProto.FLOAT, [], [0.1])
+        w_zp = helper.make_tensor(
+            "W_zp", TensorProto.INT8, [], np.array([0], dtype=np.int8).tobytes(), raw=True
+        )
+        dq_w = helper.make_node("DequantizeLinear", ["W_q", "W_scale", "W_zp"], ["W"], name="dq_w")
+
+        matmul = helper.make_node("MatMul", ["A_d", "W"], ["C"], name="mm")
+
+        graph = helper.make_graph(
+            [q_act, dq_act, dq_w, matmul],
+            "qdq_w8a16",
+            [a],
+            [c],
+            [a_scale, a_zp, w_q, w_scale, w_zp],
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+        model.ir_version = 7
+        path = self._save(model, tmp_path / "qdq_w8a16.onnx")
+
+        session = WinMLSession(onnx_path=path, device="auto")
+        assert session.io_config["precision"] == "w8a16"
+
+    def test_precision_matmulnbits_w4a16(self, tmp_path: Path):
+        """MatMulNBits with bits=4 + fp16 initializers → 'w4a16'."""
+        import numpy as np
+        from onnx import TensorProto, helper
+
+        a = helper.make_tensor_value_info("A", TensorProto.FLOAT16, [1, 32])
+        c = helper.make_tensor_value_info("C", TensorProto.FLOAT16, [1, 16])
+
+        # MatMulNBits packed-weight + scales (dummy shapes — schema doesn't validate)
+        w_packed = helper.make_tensor(
+            "W",
+            TensorProto.UINT8,
+            [16, 1, 16],
+            np.zeros((16, 1, 16), dtype=np.uint8).tobytes(),
+            raw=True,
+        )
+        scales = helper.make_tensor(
+            "scales",
+            TensorProto.FLOAT16,
+            [16],
+            np.ones(16, dtype=np.float16).tobytes(),
+            raw=True,
+        )
+
+        node = helper.make_node(
+            "MatMulNBits",
+            ["A", "W", "scales"],
+            ["C"],
+            domain="com.microsoft",
+            K=32,
+            N=16,
+            bits=4,
+            block_size=32,
+        )
+
+        graph = helper.make_graph([node], "mmnbits_w4", [a], [c], [w_packed, scales])
+        model = helper.make_model(
+            graph,
+            opset_imports=[
+                helper.make_opsetid("", 13),
+                helper.make_opsetid("com.microsoft", 1),
+            ],
+        )
+        model.ir_version = 7
+        path = self._save(model, tmp_path / "mmnbits_w4.onnx")
+
+        session = WinMLSession(onnx_path=path, device="auto")
+        assert session.io_config["precision"] == "w4a16"
+
+    def test_precision_no_signal_unknown(self, tmp_path: Path):
+        """No QDQ ops, no MatMulNBits, no float initializers → 'unknown'."""
+        from onnx import TensorProto, helper
+
+        a = helper.make_tensor_value_info("A", TensorProto.INT64, [1, 4])
+        c = helper.make_tensor_value_info("C", TensorProto.INT64, [1, 4])
+
+        identity = helper.make_node("Identity", ["A"], ["C"])
+        graph = helper.make_graph([identity], "no_signal", [a], [c])
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+        model.ir_version = 7
+        path = self._save(model, tmp_path / "no_signal.onnx")
+
+        session = WinMLSession(onnx_path=path, device="auto")
+        assert session.io_config["precision"] == "unknown"
+
+
 @pytest.mark.skip(reason="Re-batching not yet implemented")
 class TestWinMLSessionReBatching:
     """Test re-batching for static batch size models."""

--- a/tests/unit/session/test_winml_session.py
+++ b/tests/unit/session/test_winml_session.py
@@ -531,8 +531,8 @@ class TestWinMLSessionPrecisionDetection:
         session = WinMLSession(onnx_path=path, device="auto")
         assert session.io_config["precision"] == "w4a16"
 
-    def test_precision_no_signal_unknown(self, tmp_path: Path):
-        """No QDQ ops, no MatMulNBits, no float initializers → 'unknown'."""
+    def test_precision_no_signal_returns_none(self, tmp_path: Path):
+        """No QDQ ops, no MatMulNBits, no float initializers → None."""
         from onnx import TensorProto, helper
 
         a = helper.make_tensor_value_info("A", TensorProto.INT64, [1, 4])
@@ -545,7 +545,7 @@ class TestWinMLSessionPrecisionDetection:
         path = self._save(model, tmp_path / "no_signal.onnx")
 
         session = WinMLSession(onnx_path=path, device="auto")
-        assert session.io_config["precision"] == "unknown"
+        assert session.io_config["precision"] is None
 
 
 @pytest.mark.skip(reason="Re-batching not yet implemented")

--- a/tests/unit/session/test_winml_session.py
+++ b/tests/unit/session/test_winml_session.py
@@ -371,9 +371,9 @@ class TestWinMLSessionPrecisionDetection:
 
     @staticmethod
     def _save(model, path: Path) -> Path:
-        import onnx
+        from onnx import save
 
-        onnx.save(model, str(path))
+        save(model, str(path))
         return path
 
     def test_precision_fp32_from_initializers(self, simple_matmul_onnx: Path):


### PR DESCRIPTION
## Summary

- Added `WinMLSession._get_precision()` — a best-effort, operator-schema-based precision estimator that runs over the already-loaded `ModelProto` (no extra I/O, no model-name hardcoding). Exposed through `io_config["precision"]`.
- Detection ladder, first match wins:
  1. **QDQ** (`QuantizeLinear` / `DequantizeLinear`) — dominant `zero_point` initializer bit width per side; weight-side when the source tensor is an initializer. Returns `int{n}` or `w{w}a{a}`.
  2. **Block-wise quant** (`MatMulNBits` / `GatherBlockQuantized`) — schema `bits` attribute + dominant float bit width for activations → `w{w}a{a}`.
  3. **Dominant float dtype** among initializers → `fp32` / `fp16` / `bf16`.
  4. No signal → `None`.
- `_print_model_info` in `commands/perf.py` now shows `Precision:` between `Task:` and `Inputs:`; the line is suppressed when precision is `None` so unknown cases produce no noise.
- 6 new unit tests in `tests/unit/session/test_winml_session.py` cover fp32, fp16, int8 QDQ, mixed `w8a16` QDQ, `MatMulNBits` `w4a16`, and the no-signal-returns-`None` path.