### PR TITLE
feat: use resolve device in session creation

### DIFF
--- a/src/winml/modelkit/models/winml/base.py
+++ b/src/winml/modelkit/models/winml/base.py
@@ -75,7 +75,8 @@ class WinMLPreTrainedModel(PreTrainedModel, ABC):
             onnx_path: Path to ONNX model file
             config: HuggingFace PretrainedConfig (num_labels, id2label, etc.)
             device: Target device ("auto", "npu", "gpu", "cpu")
-            session_options: ORT SessionOptions (e.g., for graph_optimization_level)
+            session_options: Factory returning an ORT SessionOptions (e.g., for
+                graph_optimization_level). Called fresh per ORT session.
             ep: Explicit EP short name (e.g., "dml", "qnn"). Forwarded to WinMLSession.
         """
         self._onnx_path = Path(onnx_path)

--- a/src/winml/modelkit/session/qairt/qairt_session.py
+++ b/src/winml/modelkit/session/qairt/qairt_session.py
@@ -232,7 +232,7 @@ class WinMLQairtSession(WinMLSession):
         """Create ORT InferenceSession from EPContext model."""
         import onnxruntime as ort
 
-        sess_options = self._build_session_options(self._device)
+        sess_options, _, _ = self._build_session_options(self._device)
         self._session = ort.InferenceSession(str(self._ctx_path), sess_options=sess_options)
         self._state = SessionState.COMPILED
 

--- a/src/winml/modelkit/session/session.py
+++ b/src/winml/modelkit/session/session.py
@@ -384,10 +384,10 @@ class WinMLSession:
                     device,
                     resolved_device,
                 )
-                return opts
+                return opts, resolved_device, resolved_ep
 
         raise DeviceNotAvailableError(
-            message=f"No available device found for policy '{device}' and EP '{self._ep}'"
+            message=f"No available provider found for device '{device}' and EP '{self._ep}'"
         )
 
     def _validate_inputs(self, inputs: dict[str, Any]) -> None:

--- a/src/winml/modelkit/session/session.py
+++ b/src/winml/modelkit/session/session.py
@@ -162,7 +162,7 @@ class WinMLSession:
 
         # HF Pipeline may pass torch.device; coerce to string for downstream .lower() calls
         self._device = str(device) if not isinstance(device, str) else device
-        self._ep = ep if ep else None
+        self._ep = ep
         self._persist_jit = ep_config.enable_ep_context if ep_config else False
         self._embed_context = ep_config.embed_context if ep_config else False
         self._provider_options = ep_config.provider_options if ep_config else {}
@@ -199,6 +199,7 @@ class WinMLSession:
             return
 
         target_device = self._device
+        resolved_device = target_device
 
         logger.debug("Compiling for device: %s", target_device)
 
@@ -223,7 +224,7 @@ class WinMLSession:
                 logger.info("Model already compiled (EPContext), skipping ModelCompiler")
             else:
                 try:
-                    sess_options = self._build_session_options(target_device)
+                    sess_options, resolved_device, _ = self._build_session_options(target_device)
                     model_compiler = ort.ModelCompiler(
                         sess_options,
                         str(self._onnx_path),
@@ -245,7 +246,7 @@ class WinMLSession:
             # EP is either configured via add_provider_for_devices (WinML EP
             # registry, e.g. QNN) or left to ORT's device policy (fallback).
             # Never pass providers= — WinML-registered EPs don't support it.
-            sess_options = self._build_session_options(target_device)
+            sess_options, resolved_device, _ = self._build_session_options(target_device)
             session = ort.InferenceSession(str(model_path), sess_options=sess_options)
 
         except Exception as ep_err:
@@ -275,12 +276,8 @@ class WinMLSession:
 
         # Resolve device label from the primary provider ORT actually selected
         if self._device == "auto" and actual_providers:
-            from ..sysinfo.device import get_ep_device_map
-
-            ep_map = get_ep_device_map()
-            resolved = ep_map.get(actual_providers[0])
-            if resolved and "/" not in resolved:
-                self._device = resolved
+            self._device = resolved_device
+            logger.info("Auto-resolved device: %s", self._device)
 
     def run(
         self,
@@ -364,165 +361,34 @@ class WinMLSession:
         except Exception:
             pass  # Suppress errors during interpreter shutdown
 
-    def _build_session_options(self, device: str) -> ort.SessionOptions:
+    def _build_session_options(self, device: str) -> tuple[ort.SessionOptions, str, EPName]:
         """Build ORT SessionOptions from instance session_options and device.
 
-        When ``self._ep`` is set, uses ``add_provider_for_devices`` to
-        explicitly bind that EP — including ``"cpu"``, so the
-        CPUExecutionProvider isn't silently displaced by another CPU-capable
-        EP (e.g. OpenVINO) under PREFER_CPU policy.
-        When ``self._ep`` is not set, the path forks on device: ``"cpu"``
-        falls through to PREFER_CPU policy (skipping EP discovery so non-CPU
-        EPs aren't probed), while other devices query ``get_ep_devices()``
-        to discover an available EP. Policy-based selection is the
-        last-resort fallback.
-
-        Note: Returns a **fresh** SessionOptions when using explicit EP to
-        avoid "already registered" errors from repeated calls.
+        Returns a **fresh** SessionOptions.
         """
-        # CPU never needs EP binding — skip device discovery entirely so that
-        # non-CPU EPs (e.g. OpenVINO) are not probed via get_ep_devices(),
-        # which would trigger their native shared-library load and emit
-        # version-mismatch warnings even when the model runs on CPU.
-        # Exception: when an explicit EP is set (e.g. --ep openvino --device cpu,
-        # or --ep cpu --device cpu), fall through so the EP binding logic
-        # below can honour it.
-        if device.lower() == "cpu" and not self._ep:
-            opts = self._session_options
-            opts.set_provider_selection_policy(DEVICE_POLICY_MAP["cpu"])
-            logger.info("Using PREFER_CPU policy for device cpu")
-            return opts
+        from ..sysinfo.device import resolve_device, resolve_eps
+        from ..utils.constants import DEVICE_TO_DEVICE_TYPE, normalize_ep_name
 
-        # Explicit EP targeting: create fresh opts to avoid double-registration.
-        # When device is also specified (non-"auto"), narrow by both EP name
-        # and device type so e.g. `--ep qnn --device cpu` finds QNN-on-CPU
-        # instead of the first QNN ep_device (which may report as NPU).
-        # `--ep cpu` is honoured here too so the CPUExecutionProvider gets
-        # bound explicitly; otherwise PREFER_CPU policy lets ORT prefer
-        # OV-on-CPU (or any other registered CPU-capable EP) over the basic
-        # CPU EP, silently ignoring the user's --ep choice.
-        if self._ep:
-            from ..utils.constants import normalize_ep_name
+        resolved_device, _ = resolve_device(device, ep=self._ep)
+        resolved_ep = normalize_ep_name(self._ep) if self._ep else resolve_eps(resolved_device)[0]
+        device_type = DEVICE_TO_DEVICE_TYPE.get(resolved_device.upper())
 
-            target_name = normalize_ep_name(self._ep)
-            if target_name:
-                matched = self._find_ep_device(ep_name=target_name, device=device)
-                if matched:
-                    from ..utils.constants import DEVICE_TYPE_TO_DEVICE
-
-                    opts = ort.SessionOptions()
-                    opts.add_provider_for_devices([matched], self._provider_options)
-                    resolved = DEVICE_TYPE_TO_DEVICE.get(
-                        matched.device.type, str(matched.device.type)
-                    )
-                    logger.info(
-                        "Explicit EP: %s (%s) device=%s -> %s",
-                        self._ep,
-                        target_name,
-                        device,
-                        resolved,
-                    )
-                    return opts
-                logger.warning(
-                    "EP '%s' (%s) not found for device '%s'",
+        opts = ort.SessionOptions()
+        for ep_dev in ort.get_ep_devices():
+            if ep_dev.ep_name == resolved_ep and ep_dev.device.type == device_type:
+                opts.add_provider_for_devices([ep_dev], self._provider_options)
+                logger.info(
+                    "Create session with EP: %s (%s) device=%s -> %s",
+                    resolved_ep,
                     self._ep,
-                    target_name,
                     device,
+                    resolved_device,
                 )
-
-        # No explicit EP — discover available EP for this device type
-        if not self._ep and device.lower() != "cpu":
-            matched = self._find_ep_device(device=device)
-            if matched:
-                opts = ort.SessionOptions()
-                opts.add_provider_for_devices([matched], self._provider_options)
-                logger.info("Discovered EP for %s: %s", device, matched.ep_name)
                 return opts
 
-        # Policy-based selection (last resort)
-        opts = self._session_options
-        policy = DEVICE_POLICY_MAP.get(
-            device.lower(), ort.OrtExecutionProviderDevicePolicy.PREFER_NPU
+        raise DeviceNotAvailableError(
+            message=f"No available device found for policy '{device}' and EP '{self._ep}'"
         )
-        opts.set_provider_selection_policy(policy)
-        logger.info("Using provider selection policy %s for device %s", policy, device)
-
-        return opts
-
-    @staticmethod
-    def _find_ep_device(device: str, ep_name: EPName | None = None) -> Any:
-        """Find the first OrtEpDevice matching the given filters.
-
-        Behavior:
-            - ``ep_name`` set, ``device == "auto"`` → aggregate ep_devices
-              matching ``ep_name`` and pick the first one whose device type
-              appears earliest in that EP's preferred device list
-              (``get_ep_device_map()``).
-            - ``ep_name`` unset, ``device`` is a concrete type → aggregate
-              ep_devices matching that device type and pick the first one
-              whose EP name appears earliest in that device's EP priority
-              list (``get_device_ep_map()``).
-            - Both set (and ``device != "auto"``) → ep_device must satisfy
-              both filters (or None).
-            - ``ep_name`` unset and ``device == "auto"`` → ``None`` (no
-              effective filter — refuse to pick an arbitrary ep_device).
-
-        Note: When the ORT EP registry order disagrees with the priority
-        maps, the priority maps win — selection is deterministic and
-        independent of registry order.
-
-        Args:
-            device: Device policy ("cpu", "gpu", "npu", "auto"). ``"auto"``
-                and unknown strings act as no-op device filters.
-            ep_name: Full EP name (e.g., "DmlExecutionProvider"), or None
-                to skip EP-name filtering.
-
-        Returns:
-            The matching OrtEpDevice, or None if not found.
-        """
-        from ..sysinfo import get_device_ep_map, get_ep_device_map
-        from ..utils.constants import DEVICE_TO_DEVICE_TYPE
-
-        device_type = DEVICE_TO_DEVICE_TYPE.get(device.upper())
-
-        # No effective filter — refuse to pick an arbitrary ep_device.
-        if not ep_name and device_type is None:
-            return None
-
-        all_ep_devices = []
-        for ep_dev in ort.get_ep_devices():
-            if ep_name and ep_dev.ep_name != ep_name:
-                continue
-            if device_type is not None and ep_dev.device.type != device_type:
-                continue
-            all_ep_devices.append(ep_dev)
-
-        if not all_ep_devices:
-            return None
-
-        # Both filters set: any aggregated entry already satisfies both.
-        if ep_name and device_type is not None:
-            return all_ep_devices[0]
-
-        # ep_name set, device == "auto": pick by EP's preferred device order.
-        if ep_name:
-            preferred_devices = get_ep_device_map().get(ep_name, "").split("/")
-            for d in preferred_devices:
-                wanted = DEVICE_TO_DEVICE_TYPE.get(d.upper())
-                if wanted is None:
-                    continue
-                for ep_dev in all_ep_devices:
-                    if ep_dev.device.type == wanted:
-                        return ep_dev
-            return all_ep_devices[0]
-
-        # ep_name unset, device != "auto": pick by device's EP priority list.
-        ep_priority = get_device_ep_map().get(device.lower(), [])
-        for preferred_ep in ep_priority:
-            for ep_dev in all_ep_devices:
-                if ep_dev.ep_name == preferred_ep:
-                    return ep_dev
-        return all_ep_devices[0]
 
     def _validate_inputs(self, inputs: dict[str, Any]) -> None:
         """Validate inputs against model expectations.
@@ -816,7 +682,7 @@ class WinMLSession:
             test_model.ir_version = 8
 
             # 3. Try creating session with same device policy
-            sess_options = self._build_session_options(target_device)
+            sess_options, _, _ = self._build_session_options(target_device)
             sess_options.log_severity_level = 4  # Suppress ORT logs during probe
             ort.InferenceSession(
                 test_model.SerializeToString(),

--- a/src/winml/modelkit/session/session.py
+++ b/src/winml/modelkit/session/session.py
@@ -22,7 +22,7 @@ from .stats import PerfStats
 
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Callable, Generator
 
     import onnx
 
@@ -135,7 +135,7 @@ class WinMLSession:
         ep_config: EPConfig | None = None,
         *,
         ep: EPNameOrAlias | None = None,
-        session_options: ort.SessionOptions | None = None,
+        session_options: Callable[[], ort.SessionOptions] | None = None,
     ) -> None:
         """Initialize WinMLSession.
 
@@ -151,8 +151,11 @@ class WinMLSession:
             ep: Explicit EP short name (e.g., "migraphx", "nv_tensorrt_rtx").
                 When set, bypasses policy-based selection and uses
                 add_provider_for_devices to force the specific EP.
-            session_options: ORT SessionOptions. If None, creates default with
-                policy based on device parameter.
+            session_options: Factory returning an ``ort.SessionOptions``.
+                Called once per ``_build_session_options`` invocation so each
+                ORT session gets a fresh, un-poisoned options object
+                (``add_provider_for_devices`` mutates the options and cannot
+                be replayed). Defaults to ``ort.SessionOptions``.
         """
         WinMLSession._init_winml_eps_once()
 
@@ -167,10 +170,9 @@ class WinMLSession:
         self._embed_context = ep_config.embed_context if ep_config else False
         self._provider_options = ep_config.provider_options if ep_config else {}
 
-        # Create session_options with device policy
-        if session_options is None:
-            session_options = ort.SessionOptions()
-        self._session_options = session_options
+        self._session_options_factory: Callable[[], ort.SessionOptions] = (
+            session_options or ort.SessionOptions
+        )
 
         # State management
         self._state = SessionState.INITIALIZED
@@ -361,9 +363,11 @@ class WinMLSession:
             pass  # Suppress errors during interpreter shutdown
 
     def _build_session_options(self, device: str) -> tuple[ort.SessionOptions, str, EPName]:
-        """Build ORT SessionOptions from instance session_options and device.
+        """Build ORT SessionOptions from the session_options factory and device.
 
-        Returns a **fresh** SessionOptions.
+        Returns a **fresh** SessionOptions produced by ``self._session_options_factory``
+        on every call so each ORT session gets an un-poisoned options object —
+        ``add_provider_for_devices`` cannot be replayed on the same instance.
         """
         from ..sysinfo.device import resolve_device, resolve_eps
         from ..utils.constants import DEVICE_TO_DEVICE_TYPE, normalize_ep_name
@@ -373,7 +377,7 @@ class WinMLSession:
         resolved_ep = normalize_ep_name(self._ep) if self._ep else resolve_eps(resolved_device)[0]
         device_type = DEVICE_TO_DEVICE_TYPE.get(resolved_device.upper())
 
-        opts = ort.SessionOptions()
+        opts = self._session_options_factory()
         if add_ep_for_device(opts, resolved_ep, device_type, self._provider_options):
             logger.info(
                 "Built SessionOptions with EP: %s (%s) device=%s -> %s",

--- a/src/winml/modelkit/session/session.py
+++ b/src/winml/modelkit/session/session.py
@@ -367,24 +367,24 @@ class WinMLSession:
         """
         from ..sysinfo.device import resolve_device, resolve_eps
         from ..utils.constants import DEVICE_TO_DEVICE_TYPE, normalize_ep_name
+        from ..winml import add_ep_for_device
 
         resolved_device, _ = resolve_device(device, ep=self._ep)
         resolved_ep = normalize_ep_name(self._ep) if self._ep else resolve_eps(resolved_device)[0]
         device_type = DEVICE_TO_DEVICE_TYPE.get(resolved_device.upper())
 
         opts = ort.SessionOptions()
-        for ep_dev in ort.get_ep_devices():
-            if ep_dev.ep_name == resolved_ep and ep_dev.device.type == device_type:
-                opts.add_provider_for_devices([ep_dev], self._provider_options)
-                logger.info(
-                    "Create session with EP: %s (%s) device=%s -> %s",
-                    resolved_ep,
-                    self._ep,
-                    device,
-                    resolved_device,
-                )
-                return opts, resolved_device, resolved_ep
+        if add_ep_for_device(opts, resolved_ep, device_type, self._provider_options):
+            logger.info(
+                "Built SessionOptions with EP: %s (%s) device=%s -> %s",
+                resolved_ep,
+                self._ep,
+                device,
+                resolved_device,
+            )
+            return opts, resolved_device, resolved_ep
 
+        # Defensive: should not be reachable unless the EP enumeration races.
         raise DeviceNotAvailableError(
             message=f"No available provider found for device '{device}' and EP '{self._ep}'"
         )

--- a/src/winml/modelkit/session/session.py
+++ b/src/winml/modelkit/session/session.py
@@ -199,7 +199,6 @@ class WinMLSession:
             return
 
         target_device = self._device
-        resolved_device = target_device
 
         logger.debug("Compiling for device: %s", target_device)
 

--- a/src/winml/modelkit/winml.py
+++ b/src/winml/modelkit/winml.py
@@ -143,7 +143,7 @@ def add_ep_for_device(
     ep_name: EPName,
     device_type: Any,
     ep_options: dict | None = None,
-) -> None:
+) -> bool:
     """Ensures correct EP device selection for WinML. NEVER modify this function.
 
     ep_name is one of:
@@ -169,4 +169,5 @@ def add_ep_for_device(
             session_options.add_provider_for_devices(
                 [ep_device], {} if ep_options is None else ep_options
             )
-            break
+            return True
+    return False

--- a/tests/unit/session/test_winml_session.py
+++ b/tests/unit/session/test_winml_session.py
@@ -743,6 +743,63 @@ class TestWinMLSessionExplicitProviders:
         assert options in captured, f"provider_options not forwarded; got calls with: {captured}"
         assert "C" in outputs
 
+    def test_explicit_ep_and_device_both_required(self, simple_matmul_onnx: Path):
+        """Regression: ep=qnn + device=cpu must bind QNN-on-CPU, not QNN-on-NPU.
+
+        When both filters are set, ``add_ep_for_device`` must match ep_name
+        AND device_type. Previously the explicit-EP path ignored device, so
+        listing order in ``ort.get_ep_devices()`` decided the binding and
+        ``--ep qnn --device cpu`` could silently land on QNN-on-NPU.
+        """
+        from types import SimpleNamespace
+        from unittest.mock import patch
+
+        import onnxruntime as ort
+
+        from winml.modelkit.sysinfo.device import _get_device_ep_map_from_ort
+
+        # NPU listed first (the trap); CPU second (the correct pick).
+        npu_dev = SimpleNamespace(
+            ep_name="QNNExecutionProvider",
+            device=SimpleNamespace(type=ort.OrtHardwareDeviceType.NPU),
+        )
+        cpu_dev = SimpleNamespace(
+            ep_name="QNNExecutionProvider",
+            device=SimpleNamespace(type=ort.OrtHardwareDeviceType.CPU),
+        )
+        captured: list = []
+
+        def spy(self_so, devs, opts):
+            captured.append(devs[0].device.type)
+
+        _get_device_ep_map_from_ort.cache_clear()
+        try:
+            with (
+                patch("onnxruntime.get_ep_devices", return_value=[npu_dev, cpu_dev]),
+                patch(
+                    "winml.modelkit.sysinfo.device._get_device_ep_map_from_ort",
+                    return_value={
+                        "cpu": ("QNNExecutionProvider",),
+                        "npu": ("QNNExecutionProvider",),
+                    },
+                ),
+                patch.object(ort.SessionOptions, "add_provider_for_devices", spy),
+            ):
+                session = WinMLSession(
+                    onnx_path=simple_matmul_onnx,
+                    device="cpu",
+                    ep="qnn",
+                )
+                # Drive the binding without building a real InferenceSession,
+                # since the mock ep_devices would not load.
+                session._build_session_options("cpu")
+        finally:
+            _get_device_ep_map_from_ort.cache_clear()
+
+        assert captured == [ort.OrtHardwareDeviceType.CPU], (
+            f"binding picked the wrong device: {captured}"
+        )
+
 
 class TestWinMLSessionPerfTracking:
     """Test WinMLSession performance tracking with context manager."""

--- a/tests/unit/session/test_winml_session.py
+++ b/tests/unit/session/test_winml_session.py
@@ -176,20 +176,17 @@ class TestWinMLSessionProviders:
         """
         Test that session providers are valid and include CPU fallback.
 
-        With policy-based selection (PREFER_NPU), ORT dynamically selects
-        providers at session creation time. The key requirements are:
+        With device="auto", ``resolve_device`` walks the device priority list
+        (NPU > GPU > CPU) and picks the first one that has a compatible EP
+        available on this system. On a CPU-only runner this falls back to CPU.
+        The key requirements are:
         1. Session initializes successfully
         2. At least one provider is active
         3. CPUExecutionProvider is available as fallback
-
-        Note: WinML-registered EPs (like QNN) may be selected dynamically
-        via set_provider_selection_policy() even if not listed in
-        get_available_providers() beforehand.
         """
-        # Create session with NPU preference
         session = WinMLSession(
             onnx_path=simple_matmul_onnx,
-            device="npu",  # PREFER_NPU policy
+            device="auto",
         )
 
         # Run to trigger lazy init
@@ -526,7 +523,7 @@ class TestWinMLSessionExplicitProviders:
         session = WinMLSession(
             onnx_path=simple_matmul_onnx,
             device="cpu",
-            ep_config=EPConfig(provider="cpu", provider_options={"CPUExecutionProvider": {}}),
+            ep_config=EPConfig(provider="cpu"),
         )
 
         outputs = session.run(sample_input)
@@ -540,15 +537,28 @@ class TestWinMLSessionExplicitProviders:
         simple_matmul_onnx: Path,
         sample_input: dict[str, np.ndarray],
     ):
-        """Test ep_config.provider_options dict is passed correctly."""
-        # CPU provider doesn't need options, but we verify the parameter works
-        session = WinMLSession(
-            onnx_path=simple_matmul_onnx,
-            device="cpu",
-            ep_config=EPConfig(provider="cpu", provider_options={"CPUExecutionProvider": {}}),
-        )
+        """Verify ep_config.provider_options is forwarded to add_provider_for_devices."""
+        from unittest.mock import patch
 
-        outputs = session.run(sample_input)
+        import onnxruntime as ort
+
+        options = {"arbitrary_key": "arbitrary_value"}
+        captured: list[dict[str, str]] = []
+        real_method = ort.SessionOptions.add_provider_for_devices
+
+        def spy(self_sess, ep_devices, provider_opts):
+            captured.append(dict(provider_opts))
+            return real_method(self_sess, ep_devices, provider_opts)
+
+        with patch.object(ort.SessionOptions, "add_provider_for_devices", spy):
+            session = WinMLSession(
+                onnx_path=simple_matmul_onnx,
+                device="cpu",
+                ep_config=EPConfig(provider="cpu", provider_options=options),
+            )
+            outputs = session.run(sample_input)
+
+        assert options in captured, f"provider_options not forwarded; got calls with: {captured}"
         assert "C" in outputs
 
 
@@ -709,99 +719,6 @@ class TestWinMLSessionPerfTracking:
         assert stats.count == 3  # 5 - 2 warmup
         assert stats.mean_ms > 0
         assert stats.p99_ms > 0
-
-
-class TestFindEpDevice:
-    """Tests for WinMLSession._find_ep_device combined ep_name + device filter.
-
-    Regression guard: when both filters are set, both must match (AND logic).
-    Previously these were two separate methods and the explicit-EP path
-    ignored device, so `--ep qnn --device cpu` could return QNN-on-NPU.
-    """
-
-    @staticmethod
-    def _ep_dev(name: str, dev_type) -> object:
-        """Build a fake OrtEpDevice-like object."""
-        from types import SimpleNamespace
-
-        return SimpleNamespace(ep_name=name, device=SimpleNamespace(type=dev_type))
-
-    def _patch_devices(self, devices: list) -> object:
-        """Return a contextmanager that patches ort.get_ep_devices."""
-        from unittest.mock import patch
-
-        return patch(
-            "winml.modelkit.session.session.ort.get_ep_devices",
-            return_value=devices,
-        )
-
-    def test_ep_name_only(self) -> None:
-        """ep_name filter with device='auto' returns first matching name."""
-        import onnxruntime as ort
-
-        devs = [
-            self._ep_dev("DmlExecutionProvider", ort.OrtHardwareDeviceType.GPU),
-            self._ep_dev("QNNExecutionProvider", ort.OrtHardwareDeviceType.NPU),
-        ]
-        with self._patch_devices(devs):
-            match = WinMLSession._find_ep_device(device="auto", ep_name="QNNExecutionProvider")
-        assert match is not None
-        assert match.ep_name == "QNNExecutionProvider"
-
-    def test_device_only(self) -> None:
-        """device filter alone returns first matching device type."""
-        import onnxruntime as ort
-
-        devs = [
-            self._ep_dev("CPUExecutionProvider", ort.OrtHardwareDeviceType.CPU),
-            self._ep_dev("DmlExecutionProvider", ort.OrtHardwareDeviceType.GPU),
-        ]
-        with self._patch_devices(devs):
-            match = WinMLSession._find_ep_device(device="gpu")
-        assert match is not None
-        assert match.ep_name == "DmlExecutionProvider"
-
-    def test_ep_name_and_device_both_required(self) -> None:
-        """When both filters are set, both must match (AND logic)."""
-        import onnxruntime as ort
-
-        devs = [
-            # QNN-on-NPU comes first; user asks for QNN-on-CPU
-            self._ep_dev("QNNExecutionProvider", ort.OrtHardwareDeviceType.NPU),
-            self._ep_dev("QNNExecutionProvider", ort.OrtHardwareDeviceType.CPU),
-        ]
-        with self._patch_devices(devs):
-            match = WinMLSession._find_ep_device(ep_name="QNNExecutionProvider", device="cpu")
-        assert match is not None
-        assert match.device.type == ort.OrtHardwareDeviceType.CPU
-
-    def test_no_match_returns_none(self) -> None:
-        """Non-matching combination returns None even if individual filters would match."""
-        import onnxruntime as ort
-
-        devs = [self._ep_dev("QNNExecutionProvider", ort.OrtHardwareDeviceType.NPU)]
-        with self._patch_devices(devs):
-            match = WinMLSession._find_ep_device(ep_name="QNNExecutionProvider", device="cpu")
-        assert match is None
-
-    def test_auto_device_acts_as_no_filter(self) -> None:
-        """device='auto' falls back to ep_name-only matching."""
-        import onnxruntime as ort
-
-        devs = [self._ep_dev("QNNExecutionProvider", ort.OrtHardwareDeviceType.NPU)]
-        with self._patch_devices(devs):
-            match = WinMLSession._find_ep_device(ep_name="QNNExecutionProvider", device="auto")
-        assert match is not None
-        assert match.ep_name == "QNNExecutionProvider"
-
-    def test_ep_none_and_device_auto_returns_none(self) -> None:
-        """ep_name=None and device='auto' → None (no effective filter)."""
-        import onnxruntime as ort
-
-        devs = [self._ep_dev("QNNExecutionProvider", ort.OrtHardwareDeviceType.NPU)]
-        with self._patch_devices(devs):
-            assert WinMLSession._find_ep_device(device="auto") is None
-            assert WinMLSession._find_ep_device(device="auto", ep_name=None) is None
 
 
 @pytest.mark.ep("openvino")


### PR DESCRIPTION
Use resolve_device in session creation to align device ep resolution with other commands.

Currently we use a manual mapping in resolve_device / resolve_eps/

We could migrate to PREFER_XPU resolution with a temp model + real session later, but it is no harm to unify how we do it.

Closes https://github.com/microsoft/winml-cli/issues/700
Closes https://github.com/microsoft/winml-cli/issues/656