### PR TITLE
fix: resolve_device/resolve_eps uses get_registered_ep_devices

### DIFF
--- a/src/winml/modelkit/sysinfo/device.py
+++ b/src/winml/modelkit/sysinfo/device.py
@@ -10,7 +10,7 @@ import functools
 import logging
 from typing import TYPE_CHECKING
 
-from ..utils.constants import EP_SUPPORTED_DEVICES, EPName, normalize_ep_name
+from ..utils.constants import DEVICE_TYPE_TO_DEVICE, EP_SUPPORTED_DEVICES, EPName, normalize_ep_name
 from ..winml import get_registered_ep_devices
 
 
@@ -173,58 +173,44 @@ def resolve_device(
     if device != "auto" and device not in _VALID_DEVICES:
         raise ValueError(f"Unknown device '{device}'. Expected 'auto', 'npu', 'gpu', or 'cpu'.")
 
-    # Materialize cached tuple as a fresh list per call so that any
-    # caller mutation (e.g. `available.append(...)`) cannot poison the cache.
-    available_devices = list(_get_available_devices())
-    available_eps = _get_available_eps()
+    device_ep_map: dict[str, list[EPName]] = {}
+    for ep_device in get_registered_ep_devices():
+        device_name = DEVICE_TYPE_TO_DEVICE.get(ep_device.device.type)
+        if device_name is not None:
+            device_ep_map.setdefault(device_name.lower(), []).append(ep_device.ep_name)
 
     if ep is not None:
         ep_full = normalize_ep_name(ep)
         if ep_full not in EP_SUPPORTED_DEVICES:
             raise ValueError(f"Unknown EP '{ep}'. Expected one of: {sorted(EP_SUPPORTED_DEVICES)}")
-        available_eps = available_eps & {ep_full}
-        if not available_eps:
+        device_ep_map = {dev: [ep_full] for dev, eps in device_ep_map.items() if ep_full in eps}
+        if not device_ep_map:
             raise ValueError(
                 f"Requested EP '{ep}' is not available on this system. "
                 f"Available EPs: {sorted(_get_available_eps())}."
             )
 
-        ep_compatible_devices = set(EP_SUPPORTED_DEVICES[ep_full])
-        available_devices = [d for d in available_devices if d in ep_compatible_devices]
-
-    if not available_eps:
-        logger.warning(
-            "No execution providers detected. Falling back to CPU. "
-            "Install onnxruntime or Windows App SDK for EP discovery."
-        )
-
     if device == "auto":
         # Walk priority list, pick first device with a matching EP
-        for dev in available_devices:
-            compatible_eps = _DEVICE_EP_MAP.get(dev, [])
-            if any(ep_name in available_eps for ep_name in compatible_eps):
+        for dev in _VALID_DEVICES:
+            if dev in device_ep_map:
                 logger.info(
                     "Auto-selected device '%s' with compatible EPs: %s for auto device",
                     dev,
-                    sorted(ep_name for ep_name in compatible_eps if ep_name in available_eps),
+                    sorted(device_ep_map[dev]),
                 )
-                return dev, available_devices
-        # Fallback: CPU is always valid
-        return "cpu", available_devices
+                return dev, [dev for dev in _VALID_DEVICES if dev in device_ep_map]
 
     # Explicit device requested -- raise if no compatible EP is available.
-    # Falling through with a warning would write an unusable config that fails
-    # later at compile/inference time. (issue #431)
-    compatible_eps = _DEVICE_EP_MAP.get(device, [])
-    if not any(ep_name in available_eps for ep_name in compatible_eps):
+    if device not in device_ep_map:
         raise ValueError(
-            f"Device '{device}' requested but no compatible EP is available. "
-            f"Compatible EPs: {compatible_eps}. "
-            f"Available EPs: {sorted(available_eps)}."
+            f"Device '{device}' requested but no EP is available. "
+            f"Available EPs: {sorted(_get_available_eps())}."
         )
-    return device, available_devices
+    return device, [dev for dev in _VALID_DEVICES if dev in device_ep_map]
 
 
+@functools.lru_cache(maxsize=3)
 def resolve_eps(resolved_device: str) -> list[EPName]:
     """Return list of available EPs compatible with the given device.
 
@@ -237,5 +223,9 @@ def resolve_eps(resolved_device: str) -> list[EPName]:
         EPs from ``_DEVICE_EP_MAP[device]`` that are also currently
         advertised by ORT/WinML, in ``_DEVICE_EP_MAP`` priority order.
     """
-    available_eps = _get_available_eps()
+    available_eps = set()
+    for ep_device in get_registered_ep_devices():
+        device_name = DEVICE_TYPE_TO_DEVICE.get(ep_device.device.type)
+        if device_name is not None and device_name.lower() == resolved_device.lower():
+            available_eps.add(ep_device.ep_name)
     return [ep for ep in _DEVICE_EP_MAP.get(resolved_device.lower(), []) if ep in available_eps]

--- a/src/winml/modelkit/sysinfo/device.py
+++ b/src/winml/modelkit/sysinfo/device.py
@@ -11,6 +11,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from ..utils.constants import EP_SUPPORTED_DEVICES, EPName, normalize_ep_name
+from ..winml import get_registered_ep_devices
 
 
 if TYPE_CHECKING:
@@ -90,47 +91,25 @@ def get_device_ep_map() -> dict[str, list[EPName]]:
 def _get_available_devices() -> tuple[str, ...]:
     """Return prioritized tuple of available devices (cached).
 
-    Priority: NPU > GPU > CPU.
-    Always includes "cpu" as fallback.
-    Uses SysInfo hardware classes for detection.
-
-    Hardware does not change during a process lifetime, so this result is
-    cached via lru_cache (mirrors ``_get_available_eps``). Without this
-    cache, ``resolve_device`` calls within a single CLI invocation each
-    re-run Windows WMI/PowerShell subprocesses (~1.2s/call locally,
-    5-10x slower on cold CI), which on Windows CI runners has caused
-    user-facing commands like ``winml config -m <model> --device npu``
-    to balloon past 280s.
-
-    Returns a ``tuple`` (not ``list``) so the cached value is immutable
-    by construction — callers can't accidentally poison the cache.
-
-    This is an internal helper for :func:`resolve_device` and should not
-    be called directly by external code.
+    Aggregates device types advertised by registered ORT EP devices and
+    filters against the supported set in priority order: NPU > GPU > CPU.
 
     Returns:
         Tuple like ("npu", "gpu", "cpu") with only available devices.
     """
-    devices: list[str] = []
+    from ..utils.constants import DEVICE_TYPE_TO_DEVICE
+
+    available: set[str] = {}
 
     try:
-        from .hardware import NPU
-
-        if NPU.get_all():
-            devices.append("npu")
+        for ep_device in get_registered_ep_devices():
+            device_name = DEVICE_TYPE_TO_DEVICE.get(ep_device.device.type)
+            if device_name is not None:
+                available.add(device_name.lower())
     except Exception:
-        logger.debug("NPU detection failed or unavailable")
+        logger.debug("Failed to enumerate registered EP devices", exc_info=True)
 
-    try:
-        from .hardware import GPU
-
-        if GPU.get_all():
-            devices.append("gpu")
-    except Exception:
-        logger.debug("GPU detection failed or unavailable")
-
-    devices.append("cpu")  # CPU always available
-    return tuple(devices)
+    return tuple(d for d in ("npu", "gpu", "cpu") if d in available)
 
 
 @functools.lru_cache(maxsize=1)

--- a/src/winml/modelkit/sysinfo/device.py
+++ b/src/winml/modelkit/sysinfo/device.py
@@ -108,7 +108,11 @@ def _get_device_ep_map_from_ort() -> dict[str, tuple[EPName, ...]]:
             if device_name is not None:
                 result.setdefault(device_name.lower(), []).append(ep_device.ep_name)
     except Exception:
-        logger.debug("Failed to enumerate registered EP devices", exc_info=True)
+        # WARNING (not DEBUG): if ORT is installed but enumeration fails
+        # (driver bug, version mismatch, etc.) downstream code sees an empty
+        # map and raises "No execution providers detected" — the user needs
+        # the root cause visible at default verbosity to act on it.
+        logger.warning("Failed to enumerate registered EP devices", exc_info=True)
     return {dev: tuple(eps) for dev, eps in result.items()}
 
 
@@ -128,36 +132,16 @@ def _get_available_devices() -> tuple[str, ...]:
 
 @functools.lru_cache(maxsize=1)
 def _get_available_eps() -> frozenset[EPName]:
-    """Collect available EP names from WinML and ORT (cached).
+    """Return all EPs registered with ORT EP devices (cached).
 
-    Hardware and EPs do not change during a process lifetime,
-    so this result is cached via lru_cache.
-
-    Returns:
-        Frozenset of available EP name strings.
+    Derived from :func:`_get_device_ep_map_from_ort` so EP-availability checks
+    and error messages stay consistent — see the comment block at the top of
+    this module. Earlier implementations also queried WinMLEPRegistry and
+    ``ort.get_available_providers()``, but those can disagree with
+    ``ort.get_ep_devices()`` and produced contradictory diagnostics
+    ("EP X not available" while X appeared in the listed set).
     """
-    available_eps: set[EPName] = set()
-
-    try:
-        from ..session.ep_registry import WinMLEPRegistry
-
-        registry = WinMLEPRegistry.get_instance()
-        available_eps.update(registry.get_available_eps().keys())
-    except (ImportError, RuntimeError):
-        pass  # WinML not available
-    except Exception:
-        logger.warning("Unexpected error during WinML EP discovery", exc_info=True)
-
-    try:
-        import onnxruntime as ort
-
-        available_eps.update(ort.get_available_providers())
-    except (ImportError, RuntimeError):
-        pass  # ORT not installed
-    except Exception:
-        logger.warning("Unexpected error during ORT EP discovery", exc_info=True)
-
-    return frozenset(available_eps)
+    return frozenset(ep for eps in _get_device_ep_map_from_ort().values() for ep in eps)
 
 
 def resolve_device(

--- a/src/winml/modelkit/sysinfo/device.py
+++ b/src/winml/modelkit/sysinfo/device.py
@@ -55,8 +55,12 @@ for _ep, _devices in EP_SUPPORTED_DEVICES.items():
     for _d in _devices:
         _DEVICE_EP_MAP.setdefault(_d, []).append(_ep)
 
-# Valid explicit device values - sort by preference
-_VALID_DEVICES = frozenset({"npu", "gpu", "cpu"})
+# Device priority for auto-selection. Order is significant — NPU is the
+# preferred accelerator, CPU is the safe fallback. Use this whenever an
+# ordered device list is needed; ``_VALID_DEVICES`` (below) is only for
+# fast membership checks.
+_DEVICE_PRIORITY: tuple[str, ...] = ("npu", "gpu", "cpu")
+_VALID_DEVICES = frozenset(_DEVICE_PRIORITY)
 
 
 def get_ep_device_map() -> dict[EPName, str]:
@@ -88,28 +92,38 @@ def get_device_ep_map() -> dict[str, list[EPName]]:
 
 
 @functools.lru_cache(maxsize=1)
-def _get_available_devices() -> tuple[str, ...]:
-    """Return prioritized tuple of available devices (cached).
+def _get_device_ep_map_from_ort() -> dict[str, tuple[EPName, ...]]:
+    """Return device -> EPs targeting it, derived from registered ORT EP devices.
 
-    Aggregates device types advertised by registered ORT EP devices and
-    filters against the supported set in priority order: NPU > GPU > CPU.
-
-    Returns:
-        Tuple like ("npu", "gpu", "cpu") with only available devices.
+    Built from :func:`get_registered_ep_devices` (the authoritative ORT API
+    available in the Windows ML build). Single source of truth consumed by
+    :func:`_get_available_devices`, :func:`resolve_device`, and
+    :func:`resolve_eps`. Cached for the process lifetime since hardware/EPs
+    do not change at runtime.
     """
-    from ..utils.constants import DEVICE_TYPE_TO_DEVICE
-
-    available: set[str] = {}
-
+    result: dict[str, list[EPName]] = {}
     try:
         for ep_device in get_registered_ep_devices():
             device_name = DEVICE_TYPE_TO_DEVICE.get(ep_device.device.type)
             if device_name is not None:
-                available.add(device_name.lower())
+                result.setdefault(device_name.lower(), []).append(ep_device.ep_name)
     except Exception:
         logger.debug("Failed to enumerate registered EP devices", exc_info=True)
+    return {dev: tuple(eps) for dev, eps in result.items()}
 
-    return tuple(d for d in ("npu", "gpu", "cpu") if d in available)
+
+@functools.lru_cache(maxsize=1)
+def _get_available_devices() -> tuple[str, ...]:
+    """Return prioritized tuple of available devices (cached).
+
+    Derived from :func:`_get_device_ep_map`; only device types with at least
+    one registered EP appear. Priority order: NPU > GPU > CPU.
+
+    Returns:
+        Tuple like ("npu", "gpu", "cpu") with only available devices.
+    """
+    device_ep_map = _get_device_ep_map_from_ort()
+    return tuple(d for d in _DEVICE_PRIORITY if d in device_ep_map)
 
 
 @functools.lru_cache(maxsize=1)
@@ -173,33 +187,32 @@ def resolve_device(
     if device != "auto" and device not in _VALID_DEVICES:
         raise ValueError(f"Unknown device '{device}'. Expected 'auto', 'npu', 'gpu', or 'cpu'.")
 
-    device_ep_map: dict[str, list[EPName]] = {}
-    for ep_device in get_registered_ep_devices():
-        device_name = DEVICE_TYPE_TO_DEVICE.get(ep_device.device.type)
-        if device_name is not None:
-            device_ep_map.setdefault(device_name.lower(), []).append(ep_device.ep_name)
+    device_ep_map = dict(_get_device_ep_map_from_ort())
 
     if ep is not None:
         ep_full = normalize_ep_name(ep)
         if ep_full not in EP_SUPPORTED_DEVICES:
             raise ValueError(f"Unknown EP '{ep}'. Expected one of: {sorted(EP_SUPPORTED_DEVICES)}")
-        device_ep_map = {dev: [ep_full] for dev, eps in device_ep_map.items() if ep_full in eps}
+        device_ep_map = {dev: (ep_full,) for dev, eps in device_ep_map.items() if ep_full in eps}
         if not device_ep_map:
             raise ValueError(
                 f"Requested EP '{ep}' is not available on this system. "
                 f"Available EPs: {sorted(_get_available_eps())}."
             )
 
+    if not device_ep_map:
+        raise RuntimeError("No execution providers detected.")
+
+    available_devices = [d for d in _DEVICE_PRIORITY if d in device_ep_map]
+
     if device == "auto":
-        # Walk priority list, pick first device with a matching EP
-        for dev in _VALID_DEVICES:
-            if dev in device_ep_map:
-                logger.info(
-                    "Auto-selected device '%s' with compatible EPs: %s for auto device",
-                    dev,
-                    sorted(device_ep_map[dev]),
-                )
-                return dev, [dev for dev in _VALID_DEVICES if dev in device_ep_map]
+        chosen = available_devices[0]
+        logger.info(
+            "Auto-selected device '%s' with compatible EPs: %s for auto device",
+            chosen,
+            sorted(device_ep_map[chosen]),
+        )
+        return chosen, available_devices
 
     # Explicit device requested -- raise if no compatible EP is available.
     if device not in device_ep_map:
@@ -207,7 +220,7 @@ def resolve_device(
             f"Device '{device}' requested but no EP is available. "
             f"Available EPs: {sorted(_get_available_eps())}."
         )
-    return device, [dev for dev in _VALID_DEVICES if dev in device_ep_map]
+    return device, available_devices
 
 
 def resolve_eps(resolved_device: str) -> list[EPName]:
@@ -222,9 +235,6 @@ def resolve_eps(resolved_device: str) -> list[EPName]:
         EPs from ``_DEVICE_EP_MAP[device]`` that are also currently
         advertised by ORT/WinML, in ``_DEVICE_EP_MAP`` priority order.
     """
-    available_eps = set()
-    for ep_device in get_registered_ep_devices():
-        device_name = DEVICE_TYPE_TO_DEVICE.get(ep_device.device.type)
-        if device_name is not None and device_name.lower() == resolved_device.lower():
-            available_eps.add(ep_device.ep_name)
-    return [ep for ep in _DEVICE_EP_MAP.get(resolved_device.lower(), []) if ep in available_eps]
+    device = resolved_device.lower()
+    available_eps = set(_get_device_ep_map_from_ort().get(device, ()))
+    return [ep for ep in _DEVICE_EP_MAP.get(device, []) if ep in available_eps]

--- a/src/winml/modelkit/sysinfo/device.py
+++ b/src/winml/modelkit/sysinfo/device.py
@@ -55,7 +55,7 @@ for _ep, _devices in EP_SUPPORTED_DEVICES.items():
     for _d in _devices:
         _DEVICE_EP_MAP.setdefault(_d, []).append(_ep)
 
-# Valid explicit device values
+# Valid explicit device values - sort by preference
 _VALID_DEVICES = frozenset({"npu", "gpu", "cpu"})
 
 
@@ -210,7 +210,6 @@ def resolve_device(
     return device, [dev for dev in _VALID_DEVICES if dev in device_ep_map]
 
 
-@functools.lru_cache(maxsize=3)
 def resolve_eps(resolved_device: str) -> list[EPName]:
     """Return list of available EPs compatible with the given device.
 

--- a/src/winml/modelkit/sysinfo/device.py
+++ b/src/winml/modelkit/sysinfo/device.py
@@ -217,7 +217,8 @@ def resolve_device(
     # Explicit device requested -- raise if no compatible EP is available.
     if device not in device_ep_map:
         raise ValueError(
-            f"Device '{device}' requested but no EP is available. "
+            f"Device '{device}' requested but no compatible EP is available. "
+            f"Compatible EPs: {_DEVICE_EP_MAP[device]}. "
             f"Available EPs: {sorted(_get_available_eps())}."
         )
     return device, available_devices

--- a/src/winml/modelkit/winml.py
+++ b/src/winml/modelkit/winml.py
@@ -122,16 +122,20 @@ def register_execution_providers(ort: bool = True, ort_genai: bool = False) -> d
 
 
 @functools.lru_cache(maxsize=1)
-def get_registered_ep_devices() -> list[Any]:
+def get_registered_ep_devices() -> tuple[Any, ...]:
     """Return ORT EP devices after ensuring WinML EPs are registered.
 
     This helper centralizes the common sequence used by callers that need the
     authoritative autoEP device list from ``onnxruntime.get_ep_devices()``.
+
+    Returns a tuple (not a list) because the result is cached via lru_cache —
+    a mutable container would let callers silently poison the cache for
+    every subsequent caller in the process.
     """
     import onnxruntime as ort
 
     register_execution_providers(ort=True)
-    return list(ort.get_ep_devices())
+    return tuple(ort.get_ep_devices())
 
 
 def add_ep_for_device(
@@ -161,7 +165,7 @@ def add_ep_for_device(
     ep_devices = ort.get_ep_devices()
     for ep_device in ep_devices:
         if ep_device.ep_name == ep_name and ep_device.device.type == device_type:
-            logger.info(f"Adding {ep_name} for {device_type}")
+            logger.info("Adding %s for %s", ep_name, device_type)
             session_options.add_provider_for_devices(
                 [ep_device], {} if ep_options is None else ep_options
             )

--- a/src/winml/modelkit/winml.py
+++ b/src/winml/modelkit/winml.py
@@ -4,14 +4,16 @@
 # --------------------------------------------------------------------------
 from __future__ import annotations
 
-import sys
-import traceback
+import functools
+import logging
 from typing import TYPE_CHECKING, Any
 
 
 if TYPE_CHECKING:
     from .utils.constants import EPName
 
+
+logger = logging.getLogger(__name__)
 
 _winml_instance: WinML | None = None
 
@@ -96,12 +98,12 @@ class WinML:
                     try:
                         module.register_execution_provider_library(name, path)
                         self._registered_eps[module.__name__].append(name)
-                    except Exception as e:
-                        print(
-                            f"Failed to register execution provider {name}: {e}",
-                            file=sys.stderr,
+                    except Exception:
+                        logger.exception(
+                            "Failed to register %s for module %s",
+                            name,
+                            module.__name__,
                         )
-                        traceback.print_exc()
         return self._registered_eps
 
 
@@ -119,6 +121,7 @@ def register_execution_providers(ort: bool = True, ort_genai: bool = False) -> d
     return WinML().register_execution_providers(ort=ort, ort_genai=ort_genai)
 
 
+@functools.lru_cache(maxsize=1)
 def get_registered_ep_devices() -> list[Any]:
     """Return ORT EP devices after ensuring WinML EPs are registered.
 
@@ -158,7 +161,7 @@ def add_ep_for_device(
     ep_devices = ort.get_ep_devices()
     for ep_device in ep_devices:
         if ep_device.ep_name == ep_name and ep_device.device.type == device_type:
-            print(f"Adding {ep_name} for {device_type}")
+            logger.info(f"Adding {ep_name} for {device_type}")
             session_options.add_provider_for_devices(
                 [ep_device], {} if ep_options is None else ep_options
             )

--- a/tests/unit/commands/test_compile_quantize_flags.py
+++ b/tests/unit/commands/test_compile_quantize_flags.py
@@ -275,10 +275,10 @@ class TestCompileDeviceDisplayLabel:
             patch("winml.modelkit.compiler.WinMLCompileConfig"),
             # Make resolve_device succeed under the test runner's empty EP env
             # (it's the display label we're testing here, not EP resolution).
-            # resolve_device now reads _get_device_ep_map; populate both NPU
+            # resolve_device now reads _get_device_ep_map_from_ort; populate both NPU
             # and GPU with QNN since --device gpu --ep qnn must be satisfiable.
             patch(
-                "winml.modelkit.sysinfo.device._get_device_ep_map",
+                "winml.modelkit.sysinfo.device._get_device_ep_map_from_ort",
                 return_value={
                     "gpu": ("QNNExecutionProvider",),
                 },

--- a/tests/unit/commands/test_compile_quantize_flags.py
+++ b/tests/unit/commands/test_compile_quantize_flags.py
@@ -275,6 +275,14 @@ class TestCompileDeviceDisplayLabel:
             patch("winml.modelkit.compiler.WinMLCompileConfig"),
             # Make resolve_device succeed under the test runner's empty EP env
             # (it's the display label we're testing here, not EP resolution).
+            # resolve_device now reads _get_device_ep_map; populate both NPU
+            # and GPU with QNN since --device gpu --ep qnn must be satisfiable.
+            patch(
+                "winml.modelkit.sysinfo.device._get_device_ep_map",
+                return_value={
+                    "gpu": ("QNNExecutionProvider",),
+                },
+            ),
             patch(
                 "winml.modelkit.sysinfo.device._get_available_eps",
                 return_value=frozenset({"QNNExecutionProvider"}),
@@ -553,4 +561,3 @@ class TestQuantizePrecisionValidation:
         assert r.exit_code != 0, r.output
         assert "not a supported quantization precision" in r.output
         assert ran["called"] is False
-

--- a/tests/unit/sysinfo/conftest.py
+++ b/tests/unit/sysinfo/conftest.py
@@ -23,9 +23,9 @@ def _clear_device_caches() -> None:
     from winml.modelkit.sysinfo.device import (
         _get_available_devices,
         _get_available_eps,
-        _get_device_ep_map,
+        _get_device_ep_map_from_ort,
     )
 
     _get_available_devices.cache_clear()
     _get_available_eps.cache_clear()
-    _get_device_ep_map.cache_clear()
+    _get_device_ep_map_from_ort.cache_clear()

--- a/tests/unit/sysinfo/conftest.py
+++ b/tests/unit/sysinfo/conftest.py
@@ -16,9 +16,9 @@ def _clear_device_caches() -> None:
     ``_get_available_devices`` and ``_get_available_eps`` are cached at
     module level (``@functools.lru_cache(maxsize=1)``) because hardware
     doesn't change during a process lifetime — but tests in this module
-    mock the underlying probes (``NPU.get_all``, ``GPU.get_all``, etc.)
-    and need each test to see fresh probe results, not cached output
-    from whichever test ran first.
+    mock the underlying probes (``get_registered_ep_devices``, etc.) and
+    need each test to see fresh probe results, not cached output from
+    whichever test ran first.
     """
     from winml.modelkit.sysinfo.device import (
         _get_available_devices,

--- a/tests/unit/sysinfo/conftest.py
+++ b/tests/unit/sysinfo/conftest.py
@@ -23,7 +23,9 @@ def _clear_device_caches() -> None:
     from winml.modelkit.sysinfo.device import (
         _get_available_devices,
         _get_available_eps,
+        _get_device_ep_map,
     )
 
     _get_available_devices.cache_clear()
     _get_available_eps.cache_clear()
+    _get_device_ep_map.cache_clear()

--- a/tests/unit/sysinfo/test_device.py
+++ b/tests/unit/sysinfo/test_device.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -185,13 +184,13 @@ class TestMappingConstants:
 
 
 def _patch_device_ep_map(mapping: dict[str, tuple[str, ...]]):
-    """Patch the central _get_device_ep_map probe with ``mapping``.
+    """Patch the central _get_device_ep_map_from_ort probe with ``mapping``.
 
     Single mock point for resolve_device/resolve_eps tests. Each value is the
     tuple of EPs registered for that device, in the order ORT would return.
     """
     return patch(
-        "winml.modelkit.sysinfo.device._get_device_ep_map",
+        "winml.modelkit.sysinfo.device._get_device_ep_map_from_ort",
         return_value=mapping,
     )
 
@@ -233,13 +232,6 @@ class TestResolveDevice:
 
         assert device == "cpu"
         assert available == ["cpu"]
-
-    def test_resolve_device_auto_no_eps(self) -> None:
-        """Auto mode: no EPs at all -> falls back to CPU."""
-        with _patch_device_ep_map({}):
-            device, _available = resolve_device("auto")
-
-        assert device == "cpu"
 
     def test_resolve_device_explicit_valid(self) -> None:
         """Explicit device "gpu" -> returns "gpu"."""
@@ -283,15 +275,18 @@ class TestResolveDevice:
 
         assert device == "cpu"
 
-    def test_resolve_device_empty_eps_warns(self, caplog) -> None:
-        """When no EPs are detected, a warning is logged."""
+    def test_resolve_device_no_eps_raises(self) -> None:
+        """Auto mode with no registered EPs raises RuntimeError.
+
+        Hit when ORT/WinML isn't installed (or hasn't enumerated any device).
+        Failing fast is more helpful than silently writing a config that
+        targets a CPU with no compatible EP.
+        """
         with (
             _patch_device_ep_map({}),
-            caplog.at_level(logging.WARNING, logger="winml.modelkit.sysinfo.device"),
+            pytest.raises(RuntimeError, match="No execution providers detected"),
         ):
             resolve_device("auto")
-
-        assert any("No execution providers detected" in record.message for record in caplog.records)
 
 
 class TestResolveDeviceWithEp:

--- a/tests/unit/sysinfo/test_device.py
+++ b/tests/unit/sysinfo/test_device.py
@@ -74,15 +74,20 @@ class TestGetAvailableDevices:
 
         assert devices == ("cpu",)
 
-    def test_cpu_always_present(self) -> None:
-        """CPU is always in the result, even if EP enumeration fails."""
+    def test_returns_empty_when_enumeration_fails(self) -> None:
+        """If EP enumeration raises, return empty tuple (no devices visible).
+
+        ``resolve_device("auto")`` is responsible for the CPU fallback when no
+        devices are reachable; ``_get_available_devices`` only reports what is
+        actually registered.
+        """
         with patch(
             "winml.modelkit.sysinfo.device.get_registered_ep_devices",
             side_effect=RuntimeError("ORT not available"),
         ):
             devices = _get_available_devices()
 
-        assert devices == ("cpu",)
+        assert devices == ()
 
     def test_priority_order_independent_of_input(self) -> None:
         """Result is always NPU > GPU > CPU regardless of enumeration order."""
@@ -179,42 +184,29 @@ class TestMappingConstants:
         assert "NvTensorRTRTXExecutionProvider" in _DEVICE_EP_MAP["gpu"]
 
 
+def _patch_device_ep_map(mapping: dict[str, tuple[str, ...]]):
+    """Patch the central _get_device_ep_map probe with ``mapping``.
+
+    Single mock point for resolve_device/resolve_eps tests. Each value is the
+    tuple of EPs registered for that device, in the order ORT would return.
+    """
+    return patch(
+        "winml.modelkit.sysinfo.device._get_device_ep_map",
+        return_value=mapping,
+    )
+
+
 class TestResolveDevice:
     """Tests for resolve_device()."""
 
-    def setup_method(self) -> None:
-        """Mock _get_available_eps so the real function never runs.
-
-        Tests stack their own ``with patch(...)`` on top of this default mock
-        to set test-specific return values; the inner patch shadows ours for
-        the duration of the with-block and restores back on exit.
-        """
-        self._eps_patcher = patch(
-            "winml.modelkit.sysinfo.device._get_available_eps",
-            return_value=frozenset(),
-        )
-        self._eps_patcher.start()
-
-    def teardown_method(self) -> None:
-        self._eps_patcher.stop()
-
     def test_resolve_device_auto_npu_with_ep(self) -> None:
-        """Auto mode: NPU hardware + QNN EP -> returns "npu"."""
-        with (
-            patch(
-                "winml.modelkit.sysinfo.device._get_available_devices",
-                return_value=["npu", "gpu", "cpu"],
-            ),
-            patch(
-                "winml.modelkit.sysinfo.device._get_available_eps",
-                return_value=frozenset(
-                    {
-                        "QNNExecutionProvider",
-                        "DmlExecutionProvider",
-                        "CPUExecutionProvider",
-                    }
-                ),
-            ),
+        """Auto mode: NPU EP registered -> returns "npu"."""
+        with _patch_device_ep_map(
+            {
+                "npu": ("QNNExecutionProvider",),
+                "gpu": ("QNNExecutionProvider", "DmlExecutionProvider"),
+                "cpu": ("CPUExecutionProvider",),
+            }
         ):
             device, available = resolve_device("auto")
 
@@ -222,113 +214,55 @@ class TestResolveDevice:
         assert available == ["npu", "gpu", "cpu"]
 
     def test_resolve_device_auto_npu_without_ep(self) -> None:
-        """Auto mode: NPU hardware + no QNN EP -> falls through to GPU or CPU."""
-        with (
-            patch(
-                "winml.modelkit.sysinfo.device._get_available_devices",
-                return_value=["npu", "gpu", "cpu"],
-            ),
-            patch(
-                "winml.modelkit.sysinfo.device._get_available_eps",
-                return_value=frozenset(
-                    {
-                        "DmlExecutionProvider",
-                        "CPUExecutionProvider",
-                    }
-                ),
-            ),
+        """Auto mode: no NPU EP registered -> falls through to GPU."""
+        with _patch_device_ep_map(
+            {
+                "gpu": ("DmlExecutionProvider",),
+                "cpu": ("CPUExecutionProvider",),
+            }
         ):
             device, available = resolve_device("auto")
 
         assert device == "gpu"
-        assert available == ["npu", "gpu", "cpu"]
+        assert available == ["gpu", "cpu"]
 
     def test_resolve_device_auto_cpu_fallback(self) -> None:
-        """Auto mode: GPU hardware but no GPU EP -> falls through to CPU."""
-        with (
-            patch(
-                "winml.modelkit.sysinfo.device._get_available_devices",
-                return_value=["gpu", "cpu"],
-            ),
-            patch(
-                "winml.modelkit.sysinfo.device._get_available_eps",
-                return_value=frozenset({"CPUExecutionProvider"}),
-            ),
-        ):
+        """Auto mode: only CPU EP registered -> returns "cpu"."""
+        with _patch_device_ep_map({"cpu": ("CPUExecutionProvider",)}):
             device, available = resolve_device("auto")
 
         assert device == "cpu"
-        assert available == ["gpu", "cpu"]
+        assert available == ["cpu"]
 
     def test_resolve_device_auto_no_eps(self) -> None:
         """Auto mode: no EPs at all -> falls back to CPU."""
-        with (
-            patch(
-                "winml.modelkit.sysinfo.device._get_available_devices",
-                return_value=["npu", "gpu", "cpu"],
-            ),
-            patch(
-                "winml.modelkit.sysinfo.device._get_available_eps",
-                return_value=frozenset(),
-            ),
-        ):
+        with _patch_device_ep_map({}):
             device, _available = resolve_device("auto")
 
         assert device == "cpu"
 
     def test_resolve_device_explicit_valid(self) -> None:
         """Explicit device "gpu" -> returns "gpu"."""
-        with (
-            patch(
-                "winml.modelkit.sysinfo.device._get_available_devices",
-                return_value=["npu", "gpu", "cpu"],
-            ),
-            patch(
-                "winml.modelkit.sysinfo.device._get_available_eps",
-                return_value=frozenset(
-                    {
-                        "DmlExecutionProvider",
-                        "CPUExecutionProvider",
-                    }
-                ),
-            ),
+        with _patch_device_ep_map(
+            {
+                "gpu": ("DmlExecutionProvider",),
+                "cpu": ("CPUExecutionProvider",),
+            }
         ):
             device, available = resolve_device("gpu")
 
         assert device == "gpu"
-        assert available == ["npu", "gpu", "cpu"]
+        assert available == ["gpu", "cpu"]
 
     def test_resolve_device_explicit_invalid(self) -> None:
         """Unrecognized device "tpu" -> raises ValueError."""
         with pytest.raises(ValueError, match="Unknown device 'tpu'"):
             resolve_device("tpu")
 
-    def test_resolve_device_explicit_no_ep_raises(self) -> None:
-        """Explicit "npu" but no NPU EP installed -> raises ValueError (issue #431).
-
-        A warning + success here writes an unusable config; we'd rather fail
-        fast at config time than at compile/inference time.
-        """
-        with (
-            patch(
-                "winml.modelkit.sysinfo.device._get_available_devices",
-                return_value=["npu", "gpu", "cpu"],
-            ),
-            patch(
-                "winml.modelkit.sysinfo.device._get_available_eps",
-                return_value=frozenset({"CPUExecutionProvider"}),
-            ),
-            pytest.raises(ValueError, match="no compatible EP"),
-        ):
-            resolve_device("npu")
-
     def test_resolve_device_explicit_no_ep_error_names_missing_eps(self) -> None:
         """Error message must name the compatible EPs so users know what to install."""
         with (
-            patch(
-                "winml.modelkit.sysinfo.device._get_available_devices",
-                return_value=["npu", "gpu", "cpu"],
-            ),
+            _patch_device_ep_map({"cpu": ("CPUExecutionProvider",)}),
             patch(
                 "winml.modelkit.sysinfo.device._get_available_eps",
                 return_value=frozenset({"CPUExecutionProvider"}),
@@ -338,21 +272,13 @@ class TestResolveDevice:
             resolve_device("npu")
 
         message = str(exc_info.value)
+        assert "no compatible EP" in message
         # Names at least one NPU-compatible EP so the user can act on it
         assert "QNNExecutionProvider" in message or "VitisAIExecutionProvider" in message
 
     def test_resolve_device_case_insensitive(self) -> None:
         """Device argument should be case-insensitive."""
-        with (
-            patch(
-                "winml.modelkit.sysinfo.device._get_available_devices",
-                return_value=["cpu"],
-            ),
-            patch(
-                "winml.modelkit.sysinfo.device._get_available_eps",
-                return_value=frozenset({"CPUExecutionProvider"}),
-            ),
-        ):
+        with _patch_device_ep_map({"cpu": ("CPUExecutionProvider",)}):
             device, _ = resolve_device("CPU")
 
         assert device == "cpu"
@@ -360,14 +286,7 @@ class TestResolveDevice:
     def test_resolve_device_empty_eps_warns(self, caplog) -> None:
         """When no EPs are detected, a warning is logged."""
         with (
-            patch(
-                "winml.modelkit.sysinfo.device._get_available_devices",
-                return_value=["cpu"],
-            ),
-            patch(
-                "winml.modelkit.sysinfo.device._get_available_eps",
-                return_value=frozenset(),
-            ),
+            _patch_device_ep_map({}),
             caplog.at_level(logging.WARNING, logger="winml.modelkit.sysinfo.device"),
         ):
             resolve_device("auto")
@@ -378,34 +297,14 @@ class TestResolveDevice:
 class TestResolveDeviceWithEp:
     """Tests for resolve_device(ep=...) — EP-aware filtering of available_devices/eps."""
 
-    def setup_method(self) -> None:
-        """Mock _get_available_eps so the real function never runs."""
-        self._eps_patcher = patch(
-            "winml.modelkit.sysinfo.device._get_available_eps",
-            return_value=frozenset(),
-        )
-        self._eps_patcher.start()
-
-    def teardown_method(self) -> None:
-        self._eps_patcher.stop()
-
     def test_ep_qnn_filters_devices_to_npu_and_gpu(self) -> None:
         """ep='qnn' narrows available_devices to QNN's compatible devices (npu/gpu)."""
-        with (
-            patch(
-                "winml.modelkit.sysinfo.device._get_available_devices",
-                return_value=("npu", "gpu", "cpu"),
-            ),
-            patch(
-                "winml.modelkit.sysinfo.device._get_available_eps",
-                return_value=frozenset(
-                    {
-                        "QNNExecutionProvider",
-                        "DmlExecutionProvider",
-                        "CPUExecutionProvider",
-                    }
-                ),
-            ),
+        with _patch_device_ep_map(
+            {
+                "npu": ("QNNExecutionProvider",),
+                "gpu": ("QNNExecutionProvider", "DmlExecutionProvider"),
+                "cpu": ("CPUExecutionProvider",),
+            }
         ):
             device, available = resolve_device("auto", ep="qnn")
 
@@ -414,17 +313,11 @@ class TestResolveDeviceWithEp:
 
     def test_ep_qnn_auto_picks_gpu_when_no_npu(self) -> None:
         """ep='qnn' on a GPU-only system auto-selects gpu."""
-        with (
-            patch(
-                "winml.modelkit.sysinfo.device._get_available_devices",
-                return_value=("gpu", "cpu"),
-            ),
-            patch(
-                "winml.modelkit.sysinfo.device._get_available_eps",
-                return_value=frozenset(
-                    {"QNNExecutionProvider", "CPUExecutionProvider"},
-                ),
-            ),
+        with _patch_device_ep_map(
+            {
+                "gpu": ("QNNExecutionProvider",),
+                "cpu": ("CPUExecutionProvider",),
+            }
         ):
             device, available = resolve_device("auto", ep="qnn")
 
@@ -433,17 +326,11 @@ class TestResolveDeviceWithEp:
 
     def test_ep_dml_filters_to_gpu_only(self) -> None:
         """ep='dml' narrows available_devices to gpu (DML is gpu-only)."""
-        with (
-            patch(
-                "winml.modelkit.sysinfo.device._get_available_devices",
-                return_value=("npu", "gpu", "cpu"),
-            ),
-            patch(
-                "winml.modelkit.sysinfo.device._get_available_eps",
-                return_value=frozenset(
-                    {"DmlExecutionProvider", "CPUExecutionProvider"},
-                ),
-            ),
+        with _patch_device_ep_map(
+            {
+                "gpu": ("DmlExecutionProvider",),
+                "cpu": ("CPUExecutionProvider",),
+            }
         ):
             device, available = resolve_device("auto", ep="dml")
 
@@ -453,9 +340,12 @@ class TestResolveDeviceWithEp:
     def test_ep_requested_but_not_available_raises(self) -> None:
         """If the requested EP is known but not present on the system, raise."""
         with (
-            patch(
-                "winml.modelkit.sysinfo.device._get_available_devices",
-                return_value=("npu", "gpu", "cpu"),
+            _patch_device_ep_map(
+                {
+                    "npu": ("QNNExecutionProvider",),
+                    "gpu": ("QNNExecutionProvider", "DmlExecutionProvider"),
+                    "cpu": ("CPUExecutionProvider",),
+                }
             ),
             patch(
                 "winml.modelkit.sysinfo.device._get_available_eps",
@@ -481,17 +371,12 @@ class TestResolveDeviceWithEp:
 
     def test_ep_case_insensitive(self) -> None:
         """ep argument is case-insensitive."""
-        with (
-            patch(
-                "winml.modelkit.sysinfo.device._get_available_devices",
-                return_value=("npu", "gpu", "cpu"),
-            ),
-            patch(
-                "winml.modelkit.sysinfo.device._get_available_eps",
-                return_value=frozenset(
-                    {"QNNExecutionProvider", "CPUExecutionProvider"},
-                ),
-            ),
+        with _patch_device_ep_map(
+            {
+                "npu": ("QNNExecutionProvider",),
+                "gpu": ("QNNExecutionProvider",),
+                "cpu": ("CPUExecutionProvider",),
+            }
         ):
             device, available = resolve_device("auto", ep="QNN")
 
@@ -501,9 +386,12 @@ class TestResolveDeviceWithEp:
     def test_ep_explicit_device_filtered_out_raises(self) -> None:
         """ep='qnn' + device='cpu' raises: cpu has no compatible EP within {QNN}."""
         with (
-            patch(
-                "winml.modelkit.sysinfo.device._get_available_devices",
-                return_value=("npu", "gpu", "cpu"),
+            _patch_device_ep_map(
+                {
+                    "npu": ("QNNExecutionProvider",),
+                    "gpu": ("QNNExecutionProvider",),
+                    "cpu": ("CPUExecutionProvider",),
+                }
             ),
             patch(
                 "winml.modelkit.sysinfo.device._get_available_eps",
@@ -524,20 +412,19 @@ class TestResolveEps:
 
         For ``gpu``, the priority is NV → CUDA → MIGraphX → QNN → OpenVINO →
         DML (IHV-first, native-last). When all are advertised, all are
-        returned in that order.
+        returned in that order regardless of the order ORT reports them.
         """
-        with patch(
-            "winml.modelkit.sysinfo.device._get_available_eps",
-            return_value=frozenset(
-                {
-                    "NvTensorRTRTXExecutionProvider",
-                    "CUDAExecutionProvider",
+        with _patch_device_ep_map(
+            {
+                "gpu": (
+                    "DmlExecutionProvider",  # intentionally first to prove
+                    "QNNExecutionProvider",  # output order comes from
+                    "NvTensorRTRTXExecutionProvider",  # _DEVICE_EP_MAP, not
+                    "CUDAExecutionProvider",  # from the input ordering.
                     "MIGraphXExecutionProvider",
-                    "QNNExecutionProvider",
                     "OpenVINOExecutionProvider",
-                    "DmlExecutionProvider",
-                }
-            ),
+                ),
+            }
         ):
             assert resolve_eps("gpu") == [
                 "NvTensorRTRTXExecutionProvider",
@@ -550,17 +437,21 @@ class TestResolveEps:
 
     def test_gpu_with_only_dml_available(self) -> None:
         """Common Windows case: DML is the only GPU EP advertised."""
-        with patch(
-            "winml.modelkit.sysinfo.device._get_available_eps",
-            return_value=frozenset({"DmlExecutionProvider", "CPUExecutionProvider"}),
+        with _patch_device_ep_map(
+            {
+                "gpu": ("DmlExecutionProvider",),
+                "cpu": ("CPUExecutionProvider",),
+            }
         ):
             assert resolve_eps("gpu") == ["DmlExecutionProvider"]
 
     def test_npu_filters_to_installed_eps(self) -> None:
         """Only EPs that ORT/WinML actually advertises are returned."""
-        with patch(
-            "winml.modelkit.sysinfo.device._get_available_eps",
-            return_value=frozenset({"QNNExecutionProvider", "CPUExecutionProvider"}),
+        with _patch_device_ep_map(
+            {
+                "npu": ("QNNExecutionProvider",),
+                "cpu": ("CPUExecutionProvider",),
+            }
         ):
             # _DEVICE_EP_MAP["npu"] includes Vitis and OpenVINO too, but only
             # QNN is in the available set.
@@ -568,9 +459,10 @@ class TestResolveEps:
 
     def test_cpu_includes_multi_device_eps(self) -> None:
         """OpenVINO declares ``npu/gpu/cpu`` so it shows up for cpu too."""
-        with patch(
-            "winml.modelkit.sysinfo.device._get_available_eps",
-            return_value=frozenset({"OpenVINOExecutionProvider", "CPUExecutionProvider"}),
+        with _patch_device_ep_map(
+            {
+                "cpu": ("OpenVINOExecutionProvider", "CPUExecutionProvider"),
+            }
         ):
             assert resolve_eps("cpu") == [
                 "OpenVINOExecutionProvider",
@@ -579,28 +471,24 @@ class TestResolveEps:
 
     def test_case_insensitive(self) -> None:
         """Upper-case input is normalized before lookup."""
-        with patch(
-            "winml.modelkit.sysinfo.device._get_available_eps",
-            return_value=frozenset({"QNNExecutionProvider"}),
-        ):
+        with _patch_device_ep_map({"npu": ("QNNExecutionProvider",)}):
             assert resolve_eps("NPU") == ["QNNExecutionProvider"]
             assert resolve_eps("Npu") == ["QNNExecutionProvider"]
 
     def test_unknown_device_returns_empty(self) -> None:
         """Unknown device name returns ``[]``, not a KeyError."""
-        with patch(
-            "winml.modelkit.sysinfo.device._get_available_eps",
-            return_value=frozenset({"QNNExecutionProvider", "CPUExecutionProvider"}),
+        with _patch_device_ep_map(
+            {
+                "npu": ("QNNExecutionProvider",),
+                "cpu": ("CPUExecutionProvider",),
+            }
         ):
             assert resolve_eps("tpu") == []
             assert resolve_eps("") == []
 
     def test_no_eps_available_returns_empty(self) -> None:
         """When ORT/WinML advertises nothing, every device resolves to []."""
-        with patch(
-            "winml.modelkit.sysinfo.device._get_available_eps",
-            return_value=frozenset(),
-        ):
+        with _patch_device_ep_map({}):
             assert resolve_eps("npu") == []
             assert resolve_eps("gpu") == []
             assert resolve_eps("cpu") == []

--- a/tests/unit/sysinfo/test_device.py
+++ b/tests/unit/sysinfo/test_device.py
@@ -20,10 +20,16 @@ from winml.modelkit.sysinfo.device import (
 from winml.modelkit.utils.constants import EP_NAMES
 
 
-def _make_ep_device(device_type) -> MagicMock:
-    """Build a mock OrtEpDevice whose ``.device.type`` is ``device_type``."""
+def _make_ep_device(device_type, ep_name: str = "TestEP") -> MagicMock:
+    """Build a mock OrtEpDevice with ``.device.type`` and ``.ep_name`` set.
+
+    Both attributes matter to ``_get_device_ep_map_from_ort``: ``device.type``
+    keys the result map, and ``ep_name`` populates each value tuple. Tests
+    that don't care about the EP name can rely on the default.
+    """
     mock = MagicMock()
     mock.device.type = device_type
+    mock.ep_name = ep_name
     return mock
 
 

--- a/tests/unit/sysinfo/test_device.py
+++ b/tests/unit/sysinfo/test_device.py
@@ -21,97 +21,100 @@ from winml.modelkit.sysinfo.device import (
 from winml.modelkit.utils.constants import EP_NAMES
 
 
+def _make_ep_device(device_type) -> MagicMock:
+    """Build a mock OrtEpDevice whose ``.device.type`` is ``device_type``."""
+    mock = MagicMock()
+    mock.device.type = device_type
+    return mock
+
+
 class TestGetAvailableDevices:
     """Tests for _get_available_devices()."""
 
     def test_with_npu_and_gpu(self) -> None:
-        """When NPU and GPU are present, returns ("npu", "gpu", "cpu")."""
-        mock_npu = MagicMock()
-        mock_gpu = MagicMock()
+        """When NPU and GPU EP devices are registered, returns ("npu", "gpu", "cpu")."""
+        import onnxruntime as ort
 
-        with (
-            patch(
-                "winml.modelkit.sysinfo.hardware.NPU.get_all",
-                return_value=[mock_npu],
-            ),
-            patch(
-                "winml.modelkit.sysinfo.hardware.GPU.get_all",
-                return_value=[mock_gpu],
-            ),
+        with patch(
+            "winml.modelkit.sysinfo.device.get_registered_ep_devices",
+            return_value=[
+                _make_ep_device(ort.OrtHardwareDeviceType.NPU),
+                _make_ep_device(ort.OrtHardwareDeviceType.GPU),
+                _make_ep_device(ort.OrtHardwareDeviceType.CPU),
+            ],
         ):
             devices = _get_available_devices()
 
         assert devices == ("npu", "gpu", "cpu")
 
     def test_no_npu_with_gpu(self) -> None:
-        """When no NPU but GPU present, returns ("gpu", "cpu")."""
-        mock_gpu = MagicMock()
+        """When no NPU but GPU registered, returns ("gpu", "cpu")."""
+        import onnxruntime as ort
 
-        with (
-            patch(
-                "winml.modelkit.sysinfo.hardware.NPU.get_all",
-                return_value=[],
-            ),
-            patch(
-                "winml.modelkit.sysinfo.hardware.GPU.get_all",
-                return_value=[mock_gpu],
-            ),
+        with patch(
+            "winml.modelkit.sysinfo.device.get_registered_ep_devices",
+            return_value=[
+                _make_ep_device(ort.OrtHardwareDeviceType.GPU),
+                _make_ep_device(ort.OrtHardwareDeviceType.CPU),
+            ],
         ):
             devices = _get_available_devices()
 
         assert devices == ("gpu", "cpu")
 
     def test_no_npu_no_gpu(self) -> None:
-        """When no NPU and no GPU, returns ("cpu",)."""
-        with (
-            patch(
-                "winml.modelkit.sysinfo.hardware.NPU.get_all",
-                return_value=[],
-            ),
-            patch(
-                "winml.modelkit.sysinfo.hardware.GPU.get_all",
-                return_value=[],
-            ),
+        """When only CPU EP devices are registered, returns ("cpu",)."""
+        import onnxruntime as ort
+
+        with patch(
+            "winml.modelkit.sysinfo.device.get_registered_ep_devices",
+            return_value=[_make_ep_device(ort.OrtHardwareDeviceType.CPU)],
         ):
             devices = _get_available_devices()
 
         assert devices == ("cpu",)
 
     def test_cpu_always_present(self) -> None:
-        """CPU is always in the result, even if detection fails."""
-        with (
-            patch(
-                "winml.modelkit.sysinfo.hardware.NPU.get_all",
-                side_effect=RuntimeError("WMI failed"),
-            ),
-            patch(
-                "winml.modelkit.sysinfo.hardware.GPU.get_all",
-                side_effect=RuntimeError("WMI failed"),
-            ),
+        """CPU is always in the result, even if EP enumeration fails."""
+        with patch(
+            "winml.modelkit.sysinfo.device.get_registered_ep_devices",
+            side_effect=RuntimeError("ORT not available"),
         ):
             devices = _get_available_devices()
 
-        assert "cpu" in devices
         assert devices == ("cpu",)
 
-    def test_npu_detection_failure_falls_through(self) -> None:
-        """If NPU detection raises, GPU and CPU still appear."""
-        mock_gpu = MagicMock()
+    def test_priority_order_independent_of_input(self) -> None:
+        """Result is always NPU > GPU > CPU regardless of enumeration order."""
+        import onnxruntime as ort
 
-        with (
-            patch(
-                "winml.modelkit.sysinfo.hardware.NPU.get_all",
-                side_effect=RuntimeError("WMI failed"),
-            ),
-            patch(
-                "winml.modelkit.sysinfo.hardware.GPU.get_all",
-                return_value=[mock_gpu],
-            ),
+        with patch(
+            "winml.modelkit.sysinfo.device.get_registered_ep_devices",
+            return_value=[
+                _make_ep_device(ort.OrtHardwareDeviceType.CPU),
+                _make_ep_device(ort.OrtHardwareDeviceType.GPU),
+                _make_ep_device(ort.OrtHardwareDeviceType.NPU),
+            ],
+        ):
+            devices = _get_available_devices()
+
+        assert devices == ("npu", "gpu", "cpu")
+
+    def test_duplicate_device_types_deduplicated(self) -> None:
+        """Multiple EP devices on the same device type collapse to one entry."""
+        import onnxruntime as ort
+
+        with patch(
+            "winml.modelkit.sysinfo.device.get_registered_ep_devices",
+            return_value=[
+                _make_ep_device(ort.OrtHardwareDeviceType.GPU),
+                _make_ep_device(ort.OrtHardwareDeviceType.GPU),
+                _make_ep_device(ort.OrtHardwareDeviceType.CPU),
+            ],
         ):
             devices = _get_available_devices()
 
         assert devices == ("gpu", "cpu")
-        assert "npu" not in devices
 
 
 class TestMappingConstants:


### PR DESCRIPTION
For a device without openvino gpu but have openvino cpu, the follow command will crash before

` winml compile -m "resnet-cpu\model.onnx" -v --ep openvino `

Because it will be resolved to gpu device since dml has gpu device