### PR TITLE
Validate model ID and task in `winml export` command

### DIFF
--- a/src/winml/modelkit/commands/export.py
+++ b/src/winml/modelkit/commands/export.py
@@ -264,6 +264,7 @@ def export(
         console.print(f"[dim]Shape overrides: {shape_overrides}[/dim]")
 
     # Always auto-resolve input/output tensors via loader + Optimum
+    from ..export import ONNXConfigNotFoundError
     try:
         from ..export import resolve_export_config as resolve_cfg
 
@@ -282,6 +283,19 @@ def export(
             console.print(
                 f"[dim]Auto-resolved output specs: {[t.name for t in output_tensors]}[/dim]"
             )
+    except ONNXConfigNotFoundError as e:
+        # model_type is not registered in Optimum's TasksManager (e.g. CLIP/SigLIP
+        # sub-encoder variants like clip-text-model / clip-vision-model that only
+        # live in MODEL_BUILD_CONFIGS, or a model_type from a newer transformers
+        # release we don't know yet). Fall through: downstream MODEL_BUILD_CONFIGS
+        # lookup or user-supplied --input-specs takes over.
+        logger.debug("I/O tensor auto-resolution unavailable: %s", e)
+    except ValueError as e:
+        # Mirrors `winml config`: surface (model, task) incompatibility raised by
+        # Optimum's TasksManager as a clean usage error instead of letting it fall
+        # through to a misleading "Unrecognized configuration class" traceback
+        # later in load_hf_model.
+        raise click.UsageError(str(e)) from e
     except Exception as e:
         logger.debug("I/O tensor auto-resolution failed: %s", e)
 

--- a/tests/unit/commands/test_export.py
+++ b/tests/unit/commands/test_export.py
@@ -612,6 +612,114 @@ class TestExportAutoResolveInputTensors:
             assert config.input_tensors is not None
 
 
+class TestExportTaskValidation:
+    """Test export surfaces (model, task) incompatibility cleanly.
+
+    Mirrors `winml config`'s behavior: a `ValueError` raised by Optimum's
+    `TasksManager` for an unsupported (model_type, task) pair must surface as
+    a clean `click.UsageError` instead of falling through to a misleading
+    "Unrecognized configuration class" traceback from `load_hf_model`.
+
+    The narrow exception type (`ONNXConfigNotFoundError`, a `ValueError`
+    subclass) used for models not registered in Optimum at all must continue
+    to be swallowed so registry-only models (e.g., BLIP-style) are unaffected.
+    """
+
+    def test_export_raises_usage_error_for_incompatible_task(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        """Incompatible (model, task) -> clean UsageError, no misleading traceback.
+
+        Mocks the same ValueError that Optimum's TasksManager raises (and that
+        `winml config` already surfaces) to confirm the export command now
+        propagates it instead of swallowing it.
+        """
+        from winml.modelkit.commands.export import export
+
+        optimum_message = (
+            "resnet doesn't support task text-classification for the onnx backend. "
+            "Supported tasks are: feature-extraction, image-classification."
+        )
+
+        with (
+            patch("winml.modelkit.loader.load_hf_model") as mock_load,
+            patch(
+                "winml.modelkit.export.resolve_export_config",
+                side_effect=ValueError(optimum_message),
+            ),
+            patch("winml.modelkit.export.export_pytorch") as mock_export,
+        ):
+            output_path = tmp_path / "model.onnx"
+            result = runner.invoke(
+                export,
+                [
+                    "--model",
+                    "microsoft/resnet-50",
+                    "--task",
+                    "text-classification",
+                    "--output",
+                    str(output_path),
+                ],
+                obj={"debug": False},
+            )
+
+            assert result.exit_code != 0, (
+                f"Expected non-zero exit, got {result.exit_code}\n{result.output}"
+            )
+            # Exact Optimum message is preserved verbatim, matching `winml config`.
+            assert optimum_message in result.output
+            # Should NOT be wrapped with the generic "Export failed:" prefix
+            # (that's the swallowed-then-rethrown path we're avoiding).
+            assert "Export failed" not in result.output
+            # Should fail fast — never reach model loading or actual export.
+            mock_load.assert_not_called()
+            mock_export.assert_not_called()
+
+    def test_export_continues_when_onnx_config_not_found(
+        self,
+        runner: CliRunner,
+        mock_export_onnx: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """ONNXConfigNotFoundError (model not in Optimum) -> command continues.
+
+        Guards against the regression where naively catching `ValueError`
+        would also catch `ONNXConfigNotFoundError` (a `ValueError` subclass)
+        and break models that rely on MODEL_BUILD_CONFIGS or manual specs.
+        """
+        from winml.modelkit.commands.export import export
+        from winml.modelkit.export import ONNXConfigNotFoundError
+
+        with (
+            patch("winml.modelkit.loader.load_hf_model") as mock_load,
+            patch(
+                "winml.modelkit.export.resolve_export_config",
+                side_effect=ONNXConfigNotFoundError(
+                    "No OnnxConfig registered for model_type='some-custom-model'..."
+                ),
+            ),
+        ):
+            mock_model = MagicMock()
+            mock_load.return_value = (mock_model, None, "feature-extraction")
+
+            output_path = tmp_path / "model.onnx"
+            result = runner.invoke(
+                export,
+                ["--model", "some-custom-model", "--output", str(output_path)],
+                obj={"debug": False},
+            )
+
+            # ONNXConfigNotFoundError must NOT surface as a UsageError.
+            # Command must proceed past auto-resolution into load_hf_model / export.
+            mock_load.assert_called_once()
+            mock_export_onnx.assert_called_once()
+            assert result.exit_code == 0, (
+                f"Expected exit 0, got {result.exit_code}\n{result.output}"
+            )
+
+
 class TestExportOutputDirectory:
     """Test export output directory handling."""
 


### PR DESCRIPTION
## Validate model ID and task in `winml export` command, using the same ways as `winml config`

Fixes #537.

### Fix

`commands/export.py` already calls `resolve_export_config()` upfront — the same validator `winml config` relies on — but its result was wrapped in a blanket `except Exception` that silently swallowed Optimum's `ValueError("{model_type} doesn't support task {task} for the {exporter} backend. …")`. The error then resurfaced later inside `load_hf_model` as a misleading `AutoModelFor*` traceback after the model had already been downloaded.

The fix narrows that block into a three-tier ladder mirroring `commands/config.py`:

```python
except ONNXConfigNotFoundError as e:
    # model_type not in Optimum's TasksManager (e.g. CLIP/SigLIP sub-encoder
    # variants that only live in MODEL_BUILD_CONFIGS). Fall through to
    # downstream registry / --input-specs.
    logger.debug("I/O tensor auto-resolution unavailable: %s", e)
except ValueError as e:
    # Mirrors `winml config`: surface (model, task) incompatibility raised by
    # Optimum's TasksManager as a clean usage error.
    raise click.UsageError(str(e)) from e
except Exception as e:
    logger.debug("I/O tensor auto-resolution failed: %s", e)
```

The `except ValueError` branch is the change that closes #537 — same Optimum `ValueError`, same `click.UsageError` translation that `winml config` uses at `commands/config.py:496-497`. `ONNXConfigNotFoundError` must be caught first because it's a `ValueError` subclass and continues to need silent fallthrough for models registered only in `MODEL_BUILD_CONFIGS` (CLIP/SigLIP sub-encoders).

### Before / after

```
$ winml export -m microsoft/resnet-50 --task text-generation -o test.onnx

# Before
Starting HTP export...
Export failed: Unrecognized configuration class
'transformers.models.resnet.configuration_resnet.ResNetConfig' for this kind
of AutoModel: AutoModelForCausalLM.
Model type should be one of ApertusConfig, ArceeConfig, … [~100 more lines]
Traceback (most recent call last): … [6 frames into transformers internals]

# After
Error: resnet doesn't support task text-generation for the onnx backend.
Supported tasks are: feature-extraction, image-classification.
```

Identical wording to `winml config`. Fails fast — no model download.

### Validation

Ran a programmatic gate-parity check against `winml config` over all `(model_id, task)` combinations in `scripts/e2e_eval/testsets/models_all.json`, plus composite-model variants (CLIP / BLIP / T5 / Donut / SigLIP — monolithic and split). **Zero false-negatives**: every combination accepted by `winml config` is also accepted by `winml export`.

### Tests

Added `TestExportTaskValidation` in `tests/unit/commands/test_export.py`:

- Incompatible `(model, task)` → non-zero exit, verbatim Optimum message, no `"Export failed:"` prefix, `load_hf_model` / `export_pytorch` never called.
- `ONNXConfigNotFoundError` → command proceeds past auto-resolution (guards registry-only models).
