### PR TITLE
feat(monitor): query all NPU/GPU engines and take max utilization

### DIFF
--- a/src/winml/modelkit/session/monitor/_pdh.py
+++ b/src/winml/modelkit/session/monitor/_pdh.py
@@ -241,27 +241,32 @@ class PdhQuery:
 
 def build_adapter_query(
     luid: str,
-    engine_type: str = "Compute",
+    engine_types: tuple[str, ...] = ("Compute",),
     *,
     pid: int | None = None,
 ) -> PdhQuery:
     """Build a PdhQuery for any GPU/NPU adapter.
 
-    Generic builder that works for NPU (Compute engine), GPU (3D engine),
-    or any other adapter type.
+    Registers per-process Utilization Percentage and Running Time counters
+    for *every* engine on the adapter whose engtype starts with one of
+    *engine_types*. NPUs typically expose several ``Compute_*`` engines and
+    the runtime may schedule work on any of them; GPUs run DML on either the
+    ``3D`` engine or a ``Compute_*`` engine depending on the operator. Names
+    are suffixed with the engtype (``util_Compute_0``, ``running_time_3D``,
+    ...) so callers can aggregate (e.g. max utilization) across engines.
 
     Args:
         luid: Adapter LUID string (e.g. ``"0x00000000_0x00015A33"``).
-        engine_type: Engine type to monitor (e.g. ``"Compute"`` for NPU,
-            ``"3D"`` for GPU). Must match an engine type on the adapter.
+        engine_types: Engtype prefixes to register. An engine is included
+            when its engtype starts with any of these strings.
         pid: Process ID to monitor. Defaults to current process.
 
     Returns:
-        An opened PdhQuery with utilization, running time, and memory
-        counters registered.
+        An opened PdhQuery with util/running-time counters for every matched
+        engine plus the adapter's per-process memory counters.
 
     Raises:
-        ValueError: If the LUID or engine type is not found.
+        ValueError: If the LUID is unknown or no engtype matches.
     """
     if pid is None:
         pid = os.getpid()
@@ -271,37 +276,35 @@ def build_adapter_query(
     if adapter_info is None:
         raise ValueError(f"LUID {luid} not found in adapter enumeration")
 
-    # Find the matching engine type
-    matched_engine = None
-    for et in sorted(adapter_info.engine_types):
-        if et.startswith(engine_type):
-            matched_engine = et
-            break
-    if matched_engine is None:
+    matched_engines = [
+        et
+        for et in sorted(adapter_info.engine_types)
+        if any(et.startswith(prefix) for prefix in engine_types)
+    ]
+    if not matched_engines:
         raise ValueError(
-            f"Engine type '{engine_type}' not found on adapter {luid}. "
+            f"No engtype matching {engine_types!r} on adapter {luid}. "
             f"Available: {sorted(adapter_info.engine_types)}"
         )
-    eng_num = adapter_info.engine_map[matched_engine][0]
 
     query = PdhQuery()
     query.open()
 
-    # Per-process engine counters
-    query.add_counter(
-        "utilization_pct",
-        rf"\GPU Engine(pid_{pid}_luid_{luid}"
-        rf"_phys_0_eng_{eng_num}_engtype_{matched_engine})\Utilization Percentage",
-        fmt="double",
-    )
-    query.add_counter(
-        "running_time_ns",
-        rf"\GPU Engine(pid_{pid}_luid_{luid}"
-        rf"_phys_0_eng_{eng_num}_engtype_{matched_engine})\Running Time",
-        fmt="large",
-    )
+    for engtype in matched_engines:
+        eng_num = adapter_info.engine_map[engtype][0]
+        query.add_counter(
+            f"util_{engtype}",
+            rf"\GPU Engine(pid_{pid}_luid_{luid}"
+            rf"_phys_0_eng_{eng_num}_engtype_{engtype})\Utilization Percentage",
+            fmt="double",
+        )
+        query.add_counter(
+            f"running_time_{engtype}",
+            rf"\GPU Engine(pid_{pid}_luid_{luid}"
+            rf"_phys_0_eng_{eng_num}_engtype_{engtype})\Running Time",
+            fmt="large",
+        )
 
-    # Per-process memory
     query.add_counter(
         "memory_local_bytes",
         rf"\GPU Process Memory(pid_{pid}_luid_{luid}_phys_0)\Local Usage",
@@ -317,7 +320,7 @@ def build_adapter_query(
 
 
 def build_npu_query(npu_luid: str, pid: int | None = None) -> PdhQuery:
-    """Convenience wrapper: build a query for the NPU (Compute engine).
+    """Convenience wrapper: build a query for every Compute engine on the NPU.
 
     Args:
         npu_luid: NPU LUID string.
@@ -326,11 +329,15 @@ def build_npu_query(npu_luid: str, pid: int | None = None) -> PdhQuery:
     Returns:
         An opened PdhQuery configured for NPU monitoring.
     """
-    return build_adapter_query(npu_luid, engine_type="Compute", pid=pid)
+    # Neural: OpenVINO NPU
+    return build_adapter_query(npu_luid, engine_types=("Compute", "Neural"), pid=pid)
 
 
 def build_gpu_query(gpu_luid: str, pid: int | None = None) -> PdhQuery:
-    """Convenience wrapper: build a query for the GPU (3D engine).
+    """Convenience wrapper: build a query for the GPU's 3D + Compute engines.
+
+    DML can dispatch to either the 3D engine or a Compute engine depending on
+    operator/driver, so both are registered and aggregated by ``PdhPoller``.
 
     Args:
         gpu_luid: GPU LUID string.
@@ -339,7 +346,8 @@ def build_gpu_query(gpu_luid: str, pid: int | None = None) -> PdhQuery:
     Returns:
         An opened PdhQuery configured for GPU monitoring.
     """
-    return build_adapter_query(gpu_luid, engine_type="3D", pid=pid)
+    # Compute: OpenVINO GPU
+    return build_adapter_query(gpu_luid, engine_types=("3D", "Compute"), pid=pid)
 
 
 # ---------------------------------------------------------------------------
@@ -399,8 +407,12 @@ class PdhPoller:
         self._memory_shared_bytes: list[int] = []
         self._cpu_samples: list[float] = []
         self._ram_used_bytes: list[int] = []
-        self._running_time_start_ns: int | None = None
-        self._running_time_end_ns: int | None = None
+        # Per-engtype snapshots of the monotonic Running Time counter. Stored
+        # as dicts because an adapter exposes multiple engines (e.g. several
+        # Compute_* on an NPU; 3D + Compute_* on a GPU) and the total adapter
+        # time is the sum of per-engine deltas.
+        self._running_time_start_ns: dict[str, int] = {}
+        self._running_time_end_ns: dict[str, int] = {}
 
     def start(self) -> None:
         """Resolve target device, register PDH counters, start background thread.
@@ -466,9 +478,11 @@ class PdhPoller:
             self._query.prime()
 
             initial = self._query.collect(interval=0.05)
-            rt = initial.get("running_time_ns")
-            if rt is not None:
-                self._running_time_start_ns = rt
+            self._running_time_start_ns = {
+                k: v
+                for k, v in initial.items()
+                if k.startswith("running_time_") and v is not None
+            }
 
             self._stop_event.clear()
             self._thread = threading.Thread(
@@ -494,9 +508,11 @@ class PdhPoller:
         if self._query is not None:
             try:
                 final = self._query._collect_once()
-                rt = final.get("running_time_ns")
-                if rt is not None:
-                    self._running_time_end_ns = rt
+                self._running_time_end_ns = {
+                    k: v
+                    for k, v in final.items()
+                    if k.startswith("running_time_") and v is not None
+                }
             except Exception:
                 pass
             self._query.close()
@@ -518,7 +534,15 @@ class PdhPoller:
         while not self._stop_event.is_set():
             try:
                 values = self._query._collect_once()
-                util = values.get("utilization_pct")
+                # Take the max across all engines for this adapter — the
+                # workload can land on any of the registered engtypes and only
+                # the active one reports non-zero utilization.
+                util_vals = [
+                    v
+                    for k, v in values.items()
+                    if k.startswith("util_") and v is not None
+                ]
+                util = max(util_vals) if util_vals else None
                 mem_local = values.get("memory_local_bytes")
                 mem_shared = values.get("memory_shared_bytes")
                 cpu_raw = values.get("cpu_pct_raw")
@@ -702,10 +726,19 @@ class PdhPoller:
 
     @property
     def running_time_delta_ns(self) -> int:
-        """Total adapter (NPU/GPU) running time delta in nanoseconds."""
-        if self._running_time_start_ns is None or self._running_time_end_ns is None:
-            return 0
-        return max(0, self._running_time_end_ns - self._running_time_start_ns)
+        """Total adapter (NPU/GPU) running time delta in nanoseconds.
+
+        Sums per-engine deltas because the Running Time counter is
+        engine-scoped and a single workload can use several engines in
+        parallel — total adapter compute time is their sum, not the max.
+        """
+        total = 0
+        for key, end in self._running_time_end_ns.items():
+            start = self._running_time_start_ns.get(key)
+            if start is None:
+                continue
+            total += max(0, end - start)
+        return total
 
     @staticmethod
     def is_npu_available() -> bool:

--- a/src/winml/modelkit/session/monitor/_pdh.py
+++ b/src/winml/modelkit/session/monitor/_pdh.py
@@ -534,9 +534,10 @@ class PdhPoller:
         while not self._stop_event.is_set():
             try:
                 values = self._query._collect_once()
-                # Take the max across all engines for this adapter — the
-                # workload can land on any of the registered engtypes and only
-                # the active one reports non-zero utilization.
+                # util_* counters are per-engine ratios over the same sample
+                # window, so max reports the most-loaded engine on the adapter.
+                # Don't sum — that would exceed 100% and duplicate what the
+                # additive running-time delta already measures.
                 util_vals = [
                     v
                     for k, v in values.items()
@@ -728,9 +729,10 @@ class PdhPoller:
     def running_time_delta_ns(self) -> int:
         """Total adapter (NPU/GPU) running time delta in nanoseconds.
 
-        Sums per-engine deltas because the Running Time counter is
-        engine-scoped and a single workload can use several engines in
-        parallel — total adapter compute time is their sum, not the max.
+        Per-engine deltas are summed: Running Time is wall-clock ns each
+        engine was busy, and engines are independent HW resources that can
+        run in parallel, so total adapter compute time is additive. (This is
+        the opposite of util — see :meth:`_poll_loop`.)
         """
         total = 0
         for key, end in self._running_time_end_ns.items():

--- a/tests/unit/session/test_ep_monitor.py
+++ b/tests/unit/session/test_ep_monitor.py
@@ -8,9 +8,10 @@ from __future__ import annotations
 
 import json
 import sys
+import threading
 import time
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -433,6 +434,67 @@ class TestPdhPoller:
         assert isinstance(result, list)
         for val in result:
             assert isinstance(val, float)
+
+    def test_poll_loop_takes_max_util_across_engines(self):
+        """`_poll_loop` must reduce per-engine ``util_*`` samples with max.
+
+        Pins the contract that multi-engine util collapses to the busiest
+        engine's reading -- a future swap to mean/sum would silently change
+        every perf summary, so guard it here.
+        """
+        from winml.modelkit.session.monitor._pdh import PdhPoller
+
+        poller = PdhPoller.__new__(PdhPoller)
+        poller._stop_event = threading.Event()
+        poller._lock = threading.Lock()
+        poller._poll_interval_s = 0.0
+        poller._util_samples = []
+        poller._memory_local_bytes = []
+        poller._memory_shared_bytes = []
+        poller._cpu_samples = []
+        poller._ram_used_bytes = []
+
+        sample = {
+            "util_Compute_0": 80.0,
+            "util_Compute_1": 30.0,
+            "util_3D": 10.0,
+            "memory_local_bytes": None,
+            "memory_shared_bytes": None,
+            "cpu_pct_raw": None,
+            "ram_working_set_bytes": None,
+        }
+
+        def collect_then_stop():
+            poller._stop_event.set()
+            return sample
+
+        poller._query = MagicMock()
+        poller._query._collect_once.side_effect = collect_then_stop
+
+        poller._poll_loop()
+
+        assert poller._util_samples == [80.0]
+
+    def test_running_time_delta_sums_across_engines(self):
+        """``running_time_delta_ns`` must add per-engine deltas.
+
+        Each engine's Running Time counter is independent wall-clock work,
+        so total adapter compute time is additive. A future swap to max
+        would silently halve numbers on multi-engine workloads.
+        """
+        from winml.modelkit.session.monitor._pdh import PdhPoller
+
+        poller = PdhPoller.__new__(PdhPoller)
+        poller._running_time_start_ns = {
+            "running_time_Compute_0": 1000,
+            "running_time_3D": 500,
+        }
+        poller._running_time_end_ns = {
+            "running_time_Compute_0": 1500,
+            "running_time_3D": 800,
+        }
+        # (1500 - 1000) + (800 - 500) = 800
+        assert poller.running_time_delta_ns == 800
 
 
 # ============================================================================

--- a/tests/unit/session/test_ep_monitor.py
+++ b/tests/unit/session/test_ep_monitor.py
@@ -289,10 +289,13 @@ class TestPdhModule:
             pytest.skip("No NPU detected")
 
         query = build_npu_query(luid)
-        assert "utilization_pct" in query.counter_names
-        assert "running_time_ns" in query.counter_names
-        assert "memory_local_bytes" in query.counter_names
-        assert "memory_shared_bytes" in query.counter_names
+        names = query.counter_names
+        # build_npu_query registers one util_* and one running_time_* counter
+        # per Compute_* engine on the adapter, plus the shared memory pair.
+        assert any(n.startswith("util_Compute") for n in names)
+        assert any(n.startswith("running_time_Compute") for n in names)
+        assert "memory_local_bytes" in names
+        assert "memory_shared_bytes" in names
         query.close()
 
 


### PR DESCRIPTION
## Summary
- `PdhPoller` previously locked onto a single engine per adapter (first alphabetical `Compute*` for NPU, `3D` for GPU). On NPUs with multiple `Compute_*` engines, work scheduled to a non-monitored engine read as 0% utilization; on GPUs where DML lands on a Compute engine, the `3D`-only query missed the activity entirely.
- `build_adapter_query` now takes `engine_types: tuple[str, ...]` and registers one `util_<engtype>` + `running_time_<engtype>` counter per matching engine. `build_npu_query` covers all `Compute_*`; `build_gpu_query` covers both `3D` and `Compute_*`.
- `PdhPoller._poll_loop` aggregates samples with `max()` across `util_*` keys — each counter is a per-engine ratio over the same sample window, so max reports the most-loaded engine. Summing percentages would exceed 100% on multi-engine adapters and duplicate the signal that running-time already provides.
- `running_time_delta_ns` sums per-engine deltas — Running Time is wall-clock ns per engine, and engines are independent HW that can run in parallel, so total adapter compute time is additive.
- Adapter resolution (`resolve_adapter_luid`) is untouched; this only changes how counters are registered and aggregated for the resolved adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)