### PR TITLE
fix(inspect): show banner + spinner during HF metadata fetch (#543)

### DIFF
--- a/src/winml/modelkit/commands/inspect.py
+++ b/src/winml/modelkit/commands/inspect.py
@@ -28,7 +28,11 @@ from rich.console import Console
 
 
 logger = logging.getLogger(__name__)
+# `console` is stdout-bound — table/JSON output goes here.
+# `_stderr_console` is for banners and spinners so they never contaminate
+# stdout (important for `--format json` consumers parsing the output).
 console = Console()
+_stderr_console = Console(stderr=True, highlight=False)
 
 # File extensions that unambiguously indicate a local file path.
 # HF model IDs routinely contain dots in version numbers (Phi-3.5, Qwen2.5, …)
@@ -176,6 +180,15 @@ def inspect(
         if not _p.exists():
             raise click.ClickException(f"Local path '{model_id}' does not exist.")
 
+    # Print a banner BEFORE the heavy import chain / network calls so users
+    # see immediate feedback instead of ~14 s of silence and assume the
+    # command hung (see #543). Banner + spinner go to stderr so `--format
+    # json` consumers still get clean stdout. Suppressed in --quiet mode.
+    quiet = bool(ctx.obj and ctx.obj.get("quiet"))
+    target = model_id or model_type or model_class
+    if not quiet:
+        _stderr_console.print(f"[dim]Inspecting [bold]{target}[/bold] …[/dim]")
+
     from ..inspect import InspectError, ModelNotFoundError, NetworkError
     from ..inspect.formatter import output_json, output_table
 
@@ -188,13 +201,26 @@ def inspect(
         logging.getLogger("winml.modelkit").setLevel(logging.DEBUG)
 
     try:
-        result = _inspect_model_v2(
-            model_id=model_id,
-            task_override=task,
-            model_type_override=model_type,
-            model_class_override=model_class,
-            include_hierarchy=hierarchy,
-        )
+        if quiet:
+            result = _inspect_model_v2(
+                model_id=model_id,
+                task_override=task,
+                model_type_override=model_type,
+                model_class_override=model_class,
+                include_hierarchy=hierarchy,
+            )
+        else:
+            with _stderr_console.status(
+                f"[bold cyan]Resolving {target}…[/bold cyan]",
+                spinner="dots",
+            ):
+                result = _inspect_model_v2(
+                    model_id=model_id,
+                    task_override=task,
+                    model_type_override=model_type,
+                    model_class_override=model_class,
+                    include_hierarchy=hierarchy,
+                )
 
         if output_format.lower() == "json":
             click.echo(output_json(result, verbose=verbose))

--- a/tests/cli/test_inspect_cli.py
+++ b/tests/cli/test_inspect_cli.py
@@ -114,3 +114,45 @@ class TestInspectListTasks:
         assert result.exit_code == 0
         lines = [line.strip() for line in result.output.splitlines() if line.strip()]
         assert lines == sorted(lines), "Task list is not sorted"
+
+
+# ===========================================================================
+# Progress feedback (banner + spinner) — fixes #543's 14s silence
+# ===========================================================================
+
+
+class TestInspectProgressFeedback:
+    """Banner must print to stderr before heavy work; stdout must stay clean."""
+
+    def test_banner_appears_on_stderr_for_model_type(self) -> None:
+        """`winml inspect --model-type bert` prints an "Inspecting…" banner on stderr."""
+        result = _run("--model-type", "bert")
+        assert result.exit_code == 0
+        assert "Inspecting" in result.stderr
+        assert "bert" in result.stderr
+
+    def test_json_stdout_is_clean(self) -> None:
+        """--format json output on stdout must be parseable JSON with no banner."""
+        import json
+
+        result = _run("--model-type", "bert", "--format", "json")
+        assert result.exit_code == 0
+        # Banner must not contaminate stdout — JSON consumers parse this directly.
+        assert "Inspecting" not in result.stdout
+        # And stdout must in fact be valid JSON.
+        json.loads(result.stdout)
+
+    def test_quiet_suppresses_banner(self) -> None:
+        """The --quiet flag must suppress the inspect banner on stderr."""
+        from click.testing import CliRunner
+
+        from winml.modelkit.cli import main
+
+        # Use the top-level `main` group so --quiet (a group option) is parsed.
+        result = CliRunner().invoke(
+            main,
+            ["--quiet", "inspect", "--model-type", "bert", "--format", "json"],
+            obj={},
+        )
+        assert result.exit_code == 0
+        assert "Inspecting" not in result.stderr


### PR DESCRIPTION
## Summary

`winml inspect -m <id>` used to print nothing for ~14 s before the first table panel appeared, leading users to assume the command had hung and Ctrl-C. This PR is the **UX-only** first step toward fixing #543 — it gives the user immediate feedback while leaving the underlying resolver work untouched.

## Before / After

**Before (main)** — 14 seconds of silence after pressing Enter:

```
t=0.0s   $ winml inspect -m microsoft/resnet-50
                                                  ┐
                                                  │
                                                  │  silent — user thinks it hung
                                                  │  Ctrl-C-bait
                                                  │
t=14.0s  ╭──────────── Inspect Result ───────────╮┘
         │ model_id          microsoft/resnet-50 │
         │ task              image-classification│
         │ …                                     │
         ╰───────────────────────────────────────╯
t=24.3s  $
```

**After (this PR)** — feedback at 1.2 s, spinner ticking during the work:

```
t=0.0s   $ winml inspect -m microsoft/resnet-50
t=1.2s   Inspecting microsoft/resnet-50 …
         ⠋ Resolving microsoft/resnet-50…    ← spinner ticks
         ⠙ Resolving microsoft/resnet-50…
         ⠹ Resolving microsoft/resnet-50…
t=23.0s  ╭──────────── Inspect Result ───────────╮
         │ model_id          microsoft/resnet-50 │
         │ task              image-classification│
         │ …                                     │
         ╰───────────────────────────────────────╯
         $
```

The 23 s total wall time is unchanged — that's the resolver-restructure follow-up's territory. What changes here is that the user gets immediate confirmation the command is alive and what it's working on, so the "did it hang?" Ctrl-C cycle stops.

## Change

- New stderr-bound `_stderr_console` so banner/spinner can't contaminate `--format json` output on stdout.
- Print `Inspecting <target> …` on stderr as the first thing the `inspect` callback does after argument validation — before the heavy `transformers` / `optimum` import chain begins.
- Wrap `_inspect_model_v2(...)` in `_stderr_console.status(...)` so a spinner ticks during the multi-second resolver work in TTY contexts. Rich auto-disables in non-TTY contexts (CI, piped output) so nothing is rendered there.
- `--quiet` suppresses both banner and spinner.

## Measurements (warm cache, `microsoft/resnet-50`)

| Metric | main | this PR |
|---|---|---|
| First user-visible output (stderr) | ~14 s | ~1.2 s |
| Total wall time | ~23 s | ~23 s |
| Stdout under `--format json` | clean | clean |

The 1.2 s floor is dominated by `winml` CLI startup (`onnxruntime` import via `utils.constants`). Cutting the 23 s total down to <3 s requires deduping the two `AutoConfig.from_pretrained` calls and gating the unconditional `AutoProcessor`/`AutoTokenizer`/`AutoImageProcessor` instantiation in `inspect.resolver.resolve_processor`. That belongs in a follow-up PR — it touches different code paths and has different risk.

## Tests

`tests/cli/test_inspect_cli.py::TestInspectProgressFeedback`:
- `test_banner_appears_on_stderr_for_model_type` — banner lands on stderr
- `test_json_stdout_is_clean` — `--format json` stdout is valid JSON with no banner
- `test_quiet_suppresses_banner` — `--quiet inspect …` produces no banner

Partially addresses #543.