### PR TITLE
perf(inspect): dedupe AutoConfig + gate processor Auto* lookups (#543)

### DIFF
--- a/src/winml/modelkit/commands/inspect.py
+++ b/src/winml/modelkit/commands/inspect.py
@@ -288,8 +288,11 @@ def _inspect_model_v2(
     )
 
     # =========================================================================
-    # STEP 1: Preserve parent hf_config before resolve_loader_config narrows it
-    #         for multimodal models (e.g., CLIPConfig → CLIPTextConfig)
+    # STEP 1: Load parent hf_config once and feed it into resolve_loader_config
+    #         to avoid a duplicate AutoConfig.from_pretrained round-trip.
+    #         The parent (e.g., CLIPConfig) is preserved here because step 4
+    #         inside resolve_loader_config may narrow it to a sub-config
+    #         (e.g., CLIPTextConfig) for multimodal models.
     # =========================================================================
     parent_hf_config = None
     if model_id and not model_type_override:
@@ -309,6 +312,7 @@ def _inspect_model_v2(
             task=task_override,
             model_type=model_type_override,
             model_class=model_class_override,
+            hf_config=parent_hf_config,
         )
     except RepositoryNotFoundError as e:
         # Direct HF Hub 404 — keep full message (includes private-repo hint).

--- a/src/winml/modelkit/inspect/resolver.py
+++ b/src/winml/modelkit/inspect/resolver.py
@@ -1043,17 +1043,19 @@ def _resolve_processor_from_auto_classes(
     image_processor_class: str | None = None
     feature_extractor_class: str | None = None
 
-    # Try AutoProcessor first - for multimodal models.
-    # AutoProcessor's wrapper can supply tokenizer / image_processor /
-    # feature_extractor as a side effect, so we also run it when one of
-    # those is still needed even though the processor itself isn't.
-    if try_processor or try_tokenizer or try_image_processor or try_feature_extractor:
+    # Try AutoProcessor only when the processor class itself is needed.
+    # AutoProcessor.from_pretrained is the single most expensive Auto* call
+    # (~3.5s warm). When the caller only needs sub-pieces (tokenizer /
+    # image_processor / feature_extractor) we fall through to the standalone
+    # Auto* calls below, which are individually cheaper. AutoProcessor can
+    # still fill those sub-fields as a side effect on success — that's
+    # preserved here when ``try_processor`` is True.
+    if try_processor:
         try:
             from transformers import AutoProcessor
 
             processor = AutoProcessor.from_pretrained(model_id, use_fast=True)
-            if try_processor:
-                processor_class = type(processor).__name__
+            processor_class = type(processor).__name__
 
             # AutoProcessor may wrap tokenizer and image_processor
             if (

--- a/src/winml/modelkit/inspect/resolver.py
+++ b/src/winml/modelkit/inspect/resolver.py
@@ -885,31 +885,45 @@ def resolve_processor(
     except Exception as e:
         logger.debug("Failed to resolve processors from hub configs: %s", e)
 
-    # Strategy 2: Use Auto classes to fill in any missing information
-    # This approach actually loads the processors, so it's slower but more reliable
-    try:
-        (
-            auto_processor,
-            auto_tokenizer,
-            auto_image_processor,
-            auto_feature_extractor,
-        ) = _resolve_processor_from_auto_classes(model_id)
+    # Strategy 2: Use Auto classes to fill in any missing information.
+    # Skip entirely when Strategies 0 + 1 already populated every field —
+    # each Auto* instantiation does its own HF Hub I/O plus class init
+    # (AutoProcessor and AutoFeatureExtractor are several seconds each).
+    need_processor = processor_class is None
+    need_tokenizer = tokenizer_class is None
+    need_image_processor = image_processor_class is None
+    need_feature_extractor = feature_extractor_class is None
 
-        # Fill in missing values from auto classes
-        if processor_class is None and auto_processor:
-            processor_class = auto_processor
-            processor_source = "auto_class"
-        if tokenizer_class is None and auto_tokenizer:
-            tokenizer_class = auto_tokenizer
-            tokenizer_source = "auto_class"
-        if image_processor_class is None and auto_image_processor:
-            image_processor_class = auto_image_processor
-            image_processor_source = "auto_class"
-        if feature_extractor_class is None and auto_feature_extractor:
-            feature_extractor_class = auto_feature_extractor
-            feature_extractor_source = "auto_class"
-    except Exception as e:
-        logger.debug("Failed to resolve processors from auto classes: %s", e)
+    if need_processor or need_tokenizer or need_image_processor or need_feature_extractor:
+        try:
+            (
+                auto_processor,
+                auto_tokenizer,
+                auto_image_processor,
+                auto_feature_extractor,
+            ) = _resolve_processor_from_auto_classes(
+                model_id,
+                try_processor=need_processor,
+                try_tokenizer=need_tokenizer,
+                try_image_processor=need_image_processor,
+                try_feature_extractor=need_feature_extractor,
+            )
+
+            # Fill in missing values from auto classes
+            if need_processor and auto_processor:
+                processor_class = auto_processor
+                processor_source = "auto_class"
+            if need_tokenizer and auto_tokenizer:
+                tokenizer_class = auto_tokenizer
+                tokenizer_source = "auto_class"
+            if need_image_processor and auto_image_processor:
+                image_processor_class = auto_image_processor
+                image_processor_source = "auto_class"
+            if need_feature_extractor and auto_feature_extractor:
+                feature_extractor_class = auto_feature_extractor
+                feature_extractor_source = "auto_class"
+        except Exception as e:
+            logger.debug("Failed to resolve processors from auto classes: %s", e)
 
     return ProcessorInfo(
         processor_class=processor_class,
@@ -999,6 +1013,11 @@ def _resolve_processor_from_hub_configs(
 
 def _resolve_processor_from_auto_classes(
     model_id: str,
+    *,
+    try_processor: bool = True,
+    try_tokenizer: bool = True,
+    try_image_processor: bool = True,
+    try_feature_extractor: bool = True,
 ) -> tuple[str | None, str | None, str | None, str | None]:
     """Resolve processor classes by instantiating HuggingFace Auto classes.
 
@@ -1007,38 +1026,63 @@ def _resolve_processor_from_auto_classes(
 
     Args:
         model_id: HuggingFace model identifier
+        try_processor: When False, skip ``AutoProcessor.from_pretrained``.
+            AutoProcessor is the most expensive single call (several seconds
+            even on warm cache), so callers that already know all four classes
+            should pass False for every flag to skip Strategy 2 entirely.
+        try_tokenizer: When False, skip ``AutoTokenizer.from_pretrained``.
+        try_image_processor: When False, skip ``AutoImageProcessor.from_pretrained``.
+        try_feature_extractor: When False, skip ``AutoFeatureExtractor.from_pretrained``.
 
     Returns:
-        Tuple of (processor_class, tokenizer_class, image_processor_class, feature_extractor_class)
+        Tuple of (processor_class, tokenizer_class, image_processor_class, feature_extractor_class).
+        Each element is None when the corresponding lookup was skipped or failed.
     """
     processor_class: str | None = None
     tokenizer_class: str | None = None
     image_processor_class: str | None = None
     feature_extractor_class: str | None = None
 
-    # Try AutoProcessor first - for multimodal models
-    try:
-        from transformers import AutoProcessor
+    # Try AutoProcessor first - for multimodal models.
+    # AutoProcessor's wrapper can supply tokenizer / image_processor /
+    # feature_extractor as a side effect, so we also run it when one of
+    # those is still needed even though the processor itself isn't.
+    if try_processor or try_tokenizer or try_image_processor or try_feature_extractor:
+        try:
+            from transformers import AutoProcessor
 
-        processor = AutoProcessor.from_pretrained(model_id, use_fast=True)
-        processor_class = type(processor).__name__
+            processor = AutoProcessor.from_pretrained(model_id, use_fast=True)
+            if try_processor:
+                processor_class = type(processor).__name__
 
-        # AutoProcessor may wrap tokenizer and image_processor
-        if hasattr(processor, "tokenizer") and processor.tokenizer is not None:
-            tokenizer_class = type(processor.tokenizer).__name__
+            # AutoProcessor may wrap tokenizer and image_processor
+            if (
+                try_tokenizer
+                and hasattr(processor, "tokenizer")
+                and processor.tokenizer is not None
+            ):
+                tokenizer_class = type(processor.tokenizer).__name__
 
-        if hasattr(processor, "image_processor") and processor.image_processor is not None:
-            image_processor_class = type(processor.image_processor).__name__
+            if (
+                try_image_processor
+                and hasattr(processor, "image_processor")
+                and processor.image_processor is not None
+            ):
+                image_processor_class = type(processor.image_processor).__name__
 
-        # Some older models use feature_extractor instead of image_processor
-        if hasattr(processor, "feature_extractor") and processor.feature_extractor is not None:
-            feature_extractor_class = type(processor.feature_extractor).__name__
+            # Some older models use feature_extractor instead of image_processor
+            if (
+                try_feature_extractor
+                and hasattr(processor, "feature_extractor")
+                and processor.feature_extractor is not None
+            ):
+                feature_extractor_class = type(processor.feature_extractor).__name__
 
-    except Exception as e:
-        logger.debug("AutoProcessor failed for %s: %s", model_id, e)
+        except Exception as e:
+            logger.debug("AutoProcessor failed for %s: %s", model_id, e)
 
     # Try AutoTokenizer if we don't have tokenizer yet
-    if tokenizer_class is None:
+    if try_tokenizer and tokenizer_class is None:
         try:
             from transformers import AutoTokenizer
 
@@ -1048,7 +1092,7 @@ def _resolve_processor_from_auto_classes(
             logger.debug("AutoTokenizer failed for %s: %s", model_id, e)
 
     # Try AutoImageProcessor if we don't have image_processor yet
-    if image_processor_class is None:
+    if try_image_processor and image_processor_class is None:
         try:
             from transformers import AutoImageProcessor
 
@@ -1058,7 +1102,7 @@ def _resolve_processor_from_auto_classes(
             logger.debug("AutoImageProcessor failed for %s: %s", model_id, e)
 
     # Try AutoFeatureExtractor if we don't have feature_extractor yet
-    if feature_extractor_class is None:
+    if try_feature_extractor and feature_extractor_class is None:
         try:
             from transformers import AutoFeatureExtractor
 

--- a/src/winml/modelkit/loader/config.py
+++ b/src/winml/modelkit/loader/config.py
@@ -121,6 +121,7 @@ def resolve_loader_config(
     model_type: str | None = None,
     trust_remote_code: bool = False,
     library_name: str = "transformers",
+    hf_config: PretrainedConfig | None = None,
 ) -> tuple[WinMLLoaderConfig, PretrainedConfig, type]:
     """Resolve all loader concerns from raw user inputs.
 
@@ -154,6 +155,10 @@ def resolve_loader_config(
             When provided without task, the first supported task is used.
         trust_remote_code: Whether to trust remote/custom code.
         library_name: Source library for TasksManager lookup.
+        hf_config: Pre-loaded HF config to reuse instead of fetching again.
+            When supplied, step 1's ``AutoConfig.from_pretrained`` is skipped.
+            Use this when the caller already has the parent config (e.g.,
+            inspect needs the un-narrowed config for I/O introspection).
 
     Returns:
         Tuple of:
@@ -177,7 +182,10 @@ def resolve_loader_config(
         warn_trust_remote_code()
 
     # 1. Load hf_config (depends on: model_id, model_type, or model_class)
-    if model_id is not None:
+    if hf_config is not None:
+        # Caller supplied a pre-loaded config — skip the round-trip.
+        pass
+    elif model_id is not None:
         hf_config = AutoConfig.from_pretrained(
             model_id,
             trust_remote_code=trust_remote_code,

--- a/tests/unit/inspect/test_resolve_processor_gating.py
+++ b/tests/unit/inspect/test_resolve_processor_gating.py
@@ -1,0 +1,99 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Tests for `inspect.resolver.resolve_processor`'s Strategy-2 gating.
+
+Strategy 2 (Auto* class instantiation) is the most expensive part of
+``resolve_processor`` — each Auto* call does its own Hub I/O and class
+init (AutoProcessor and AutoFeatureExtractor can each cost several
+seconds on warm cache). These tests pin the gating logic:
+
+* Strategy 2 must be skipped entirely when Strategies 0+1 populated all
+  four processor fields.
+* When some fields are still unknown, only the relevant Auto* lookups
+  may fire; the ones whose field is already set must be skipped.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from winml.modelkit.inspect.resolver import resolve_processor
+
+
+def _all_filled_hub_result() -> tuple[str, str, str, str]:
+    """Strategy 1 returns all four processor types."""
+    return ("BertProcessor", "BertTokenizer", "BertImageProcessor", "BertFeatureExtractor")
+
+
+class TestResolveProcessorStrategy2Gating:
+    def test_strategy2_skipped_when_all_fields_filled_by_strategy1(self) -> None:
+        """All four classes already known → Strategy 2 must not run at all."""
+        with (
+            patch(
+                "winml.modelkit.inspect.resolver._resolve_processor_from_hub_configs",
+                return_value=_all_filled_hub_result(),
+            ),
+            patch(
+                "winml.modelkit.inspect.resolver._resolve_processor_from_auto_classes",
+            ) as mock_auto,
+        ):
+            info = resolve_processor("some/model", model_type="bert")
+
+        assert mock_auto.call_count == 0, (
+            "Strategy 2 must be skipped when Strategies 0+1 already populated all fields"
+        )
+        # Values must come from hub_config strategy
+        assert info.processor_class == "BertProcessor"
+        assert info.tokenizer_class == "BertTokenizer"
+        assert info.image_processor_class == "BertImageProcessor"
+        assert info.feature_extractor_class == "BertFeatureExtractor"
+
+    def test_strategy2_called_with_per_field_flags(self) -> None:
+        """Only the fields still missing after Strategy 1 should have try_*=True."""
+        # Strategy 1 fills only image_processor and feature_extractor.
+        hub_result = (None, None, "ConvNextImageProcessor", "ConvNextFeatureExtractor")
+
+        with (
+            patch(
+                "winml.modelkit.inspect.resolver._resolve_processor_from_hub_configs",
+                return_value=hub_result,
+            ),
+            patch(
+                "winml.modelkit.inspect.resolver._resolve_processor_from_auto_classes",
+                return_value=(None, None, None, None),
+            ) as mock_auto,
+        ):
+            resolve_processor("some/model", model_type="resnet")
+
+        assert mock_auto.call_count == 1
+        kwargs = mock_auto.call_args.kwargs
+        assert kwargs["try_processor"] is True
+        assert kwargs["try_tokenizer"] is True
+        assert kwargs["try_image_processor"] is False
+        assert kwargs["try_feature_extractor"] is False
+
+    def test_strategy2_runs_when_nothing_filled(self) -> None:
+        """Empty Strategy-1 result → Strategy 2 runs with every flag True."""
+        with (
+            patch(
+                "winml.modelkit.inspect.resolver._resolve_processor_from_hub_configs",
+                return_value=(None, None, None, None),
+            ),
+            # Block Strategy 0 (HF registry) by passing no model_type below
+            patch(
+                "winml.modelkit.inspect.resolver._resolve_processor_from_auto_classes",
+                return_value=("P", "T", "I", "F"),
+            ) as mock_auto,
+        ):
+            info = resolve_processor("some/model")
+
+        assert mock_auto.call_count == 1
+        kwargs = mock_auto.call_args.kwargs
+        assert kwargs["try_processor"] is True
+        assert kwargs["try_tokenizer"] is True
+        assert kwargs["try_image_processor"] is True
+        assert kwargs["try_feature_extractor"] is True
+        assert info.processor_class == "P"
+        assert info.feature_extractor_class == "F"

--- a/tests/unit/inspect/test_resolve_processor_gating.py
+++ b/tests/unit/inspect/test_resolve_processor_gating.py
@@ -17,9 +17,12 @@ seconds on warm cache). These tests pin the gating logic:
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
-from winml.modelkit.inspect.resolver import resolve_processor
+from winml.modelkit.inspect.resolver import (
+    _resolve_processor_from_auto_classes,
+    resolve_processor,
+)
 
 
 def _all_filled_hub_result() -> tuple[str, str, str, str]:
@@ -97,3 +100,67 @@ class TestResolveProcessorStrategy2Gating:
         assert kwargs["try_feature_extractor"] is True
         assert info.processor_class == "P"
         assert info.feature_extractor_class == "F"
+
+
+class TestAutoProcessorGatedOnTryProcessor:
+    """When ``try_processor=False`` we skip AutoProcessor entirely.
+
+    AutoProcessor.from_pretrained is the most expensive single Auto* call
+    (~3.5s warm), so callers that already know ``processor_class`` from
+    earlier strategies should not pay for it just to get sub-pieces.
+    """
+
+    def test_try_processor_false_skips_autoprocessor(self) -> None:
+        """try_processor=False → AutoProcessor.from_pretrained is NOT called."""
+        with (
+            patch("transformers.AutoProcessor.from_pretrained") as mock_ap,
+            patch("transformers.AutoTokenizer.from_pretrained") as mock_at,
+            patch("transformers.AutoImageProcessor.from_pretrained") as mock_aip,
+            patch("transformers.AutoFeatureExtractor.from_pretrained") as mock_afe,
+        ):
+            # Make the sub-callers succeed so we can verify they ran instead
+            mock_at.return_value = MagicMock(__class__=type("FakeTokenizer", (), {}))
+            mock_aip.return_value = MagicMock(__class__=type("FakeImgProc", (), {}))
+            mock_afe.return_value = MagicMock(__class__=type("FakeFeatExt", (), {}))
+
+            _resolve_processor_from_auto_classes(
+                "some/model",
+                try_processor=False,
+                try_tokenizer=True,
+                try_image_processor=True,
+                try_feature_extractor=True,
+            )
+
+        assert mock_ap.call_count == 0, (
+            "AutoProcessor.from_pretrained must be skipped when try_processor=False"
+        )
+        # The standalone Auto* calls still run for the fields we need
+        assert mock_at.call_count == 1
+        assert mock_aip.call_count == 1
+        assert mock_afe.call_count == 1
+
+    def test_try_processor_true_still_calls_autoprocessor(self) -> None:
+        """try_processor=True → AutoProcessor.from_pretrained runs as before."""
+        # Build a fake processor that does NOT supply sub-pieces, so the
+        # standalone Auto* calls below still fire for any field we need.
+        fake_processor = MagicMock(spec=[])  # no .tokenizer / .image_processor / etc.
+        fake_processor.__class__ = type("FakeProcessor", (), {})
+
+        with (
+            patch(
+                "transformers.AutoProcessor.from_pretrained",
+                return_value=fake_processor,
+            ) as mock_ap,
+            patch("transformers.AutoTokenizer.from_pretrained"),
+            patch("transformers.AutoImageProcessor.from_pretrained"),
+            patch("transformers.AutoFeatureExtractor.from_pretrained"),
+        ):
+            _resolve_processor_from_auto_classes(
+                "some/model",
+                try_processor=True,
+                try_tokenizer=False,
+                try_image_processor=False,
+                try_feature_extractor=False,
+            )
+
+        assert mock_ap.call_count == 1

--- a/tests/unit/loader/test_resolve_loader_config.py
+++ b/tests/unit/loader/test_resolve_loader_config.py
@@ -60,6 +60,35 @@ class TestResolveLoaderConfig:
         with pytest.raises(ValueError, match="At least one of"):
             resolve_loader_config()
 
+    def test_hf_config_kwarg_skips_autoconfig_fetch(self) -> None:
+        """When the caller supplies hf_config, step 1's AutoConfig.from_pretrained
+        is skipped — used by inspect to avoid double-fetching the config.
+        """
+        provided_config = MagicMock()
+        provided_config.model_type = "bert"
+        mock_class = MagicMock(spec=[])
+        mock_class.__name__ = "BertForMaskedLM"
+        mock_class.config_class = None
+
+        with (
+            patch("transformers.AutoConfig.from_pretrained") as mock_from_pretrained,
+            patch(
+                "winml.modelkit.loader.task.resolve_task_and_model_class",
+                return_value=("fill-mask", mock_class),
+            ),
+        ):
+            loader_config, hf_config, _ = resolve_loader_config(
+                "bert-base-uncased",
+                task="fill-mask",
+                hf_config=provided_config,
+            )
+
+        assert mock_from_pretrained.call_count == 0, (
+            "Pre-loaded hf_config must short-circuit AutoConfig.from_pretrained"
+        )
+        assert hf_config is provided_config
+        assert loader_config.model_type == "bert"
+
     def test_model_type_only_creates_default_config(self) -> None:
         """model_type without model_id uses create_hf_config_from_model_type."""
         mock_config = MagicMock()


### PR DESCRIPTION
## Summary

Follow-up to #718 (banner + spinner). The spinner removed the perceived-hang UX problem but the total wall time was still ~23 s. This PR cuts the resolver-side redundancy to bring that to ~18 s.

## Profile (warm cache, `microsoft/resnet-50`)

Before this PR (per-call counts inside `_inspect_model_v2`):

```
0.71s  AutoConfig.from_pretrained   ← explicit fetch in inspect.py
0.38s  AutoConfig.from_pretrained   ← duplicate inside resolve_loader_config
0.72s  resolve_io_specs
0.38s  hf_hub_download              ← preprocessor_config.json
0.31s  hf_hub_download              ← tokenizer_config.json (404)
0.70s  AutoTokenizer.from_pretrained
0.71s  AutoImageProcessor.from_pretrained
3.53s  AutoProcessor.from_pretrained
0.38s  AutoConfig.from_pretrained
0.70s  AutoTokenizer.from_pretrained
0.69s  AutoImageProcessor.from_pretrained
4.20s  AutoFeatureExtractor.from_pretrained
─────
12.33s total inspect work
```

After this PR:

```
… (same fast portion) …
0.69s  AutoImageProcessor.from_pretrained
3.49s  AutoProcessor.from_pretrained
0.70s  AutoTokenizer.from_pretrained
─────
9.29s total inspect work
```

`AutoConfig` calls 5 → 4, `AutoFeatureExtractor` entirely eliminated, duplicate `AutoImageProcessor` skipped.

End-to-end wall time (`uv run winml inspect -m microsoft/resnet-50 --format json`):

| Branch | run 1 | run 2 | run 3 |
|---|---|---|---|
| main | 23.4 s | 23.2 s | 23.0 s |
| this PR | 17.6 s | 17.7 s | 18.8 s |

## Change

### 1. Dedupe `AutoConfig.from_pretrained`

`_inspect_model_v2` already loads the parent `hf_config` (it needs the un-narrowed config for I/O introspection — `resolve_loader_config` may narrow it to a sub-config for multimodal models like CLIP). Then `resolve_loader_config` loaded it again.

Added an `hf_config=` kwarg to [`resolve_loader_config`](src/winml/modelkit/loader/config.py#L116) — when supplied, step 1's `AutoConfig.from_pretrained` is skipped. Pass-through from [`_inspect_model_v2`](src/winml/modelkit/commands/inspect.py#L315). Other callers default to `hf_config=None`, original behaviour preserved.

### 2. Gate processor Auto* lookups per-field

[`resolve_processor`](src/winml/modelkit/inspect/resolver.py#L820) ran every Auto* class instantiation in Strategy 2, even when Strategies 0+1 had already populated the corresponding field. Added `try_*` kwargs to [`_resolve_processor_from_auto_classes`](src/winml/modelkit/inspect/resolver.py#L1000) and skip each Auto* whose field is already known.

For ResNet, Strategies 0+1 set `image_processor_class` from the HF registry, so `try_image_processor=False` skips the redundant `AutoImageProcessor.from_pretrained`. `AutoProcessor` succeeds and supplies `feature_extractor_class` as a side effect, so `AutoFeatureExtractor` (the 4.2s call) is skipped via the existing inner gate.

If Strategies 0+1 already populate all four fields (CLIP-like models), Strategy 2 is skipped entirely.

## Why not further?

The remaining 9 s of resolver work is inside transformers' Auto* internals — `AutoProcessor.from_pretrained` does its own AutoConfig load and may construct sub-processors. Cutting deeper requires upstream restructuring, not a ModelKit-side fix.

## Tests

- `test_resolve_loader_config.py::test_hf_config_kwarg_skips_autoconfig_fetch` — pins the dedupe by patching `AutoConfig.from_pretrained` and asserting `call_count == 0` when `hf_config=` is supplied.
- `test_resolve_processor_gating.py` — three cases:
  - All four fields filled by Strategy 1 → `_resolve_processor_from_auto_classes` is not called at all
  - Partial fill → only the still-needed `try_*` flags are True
  - Nothing filled → every `try_*` flag is True

112 targeted tests pass.

Closes #543.