### PR TITLE
ci: rename workflow display name to WinML CLI CI

### DIFF
--- a/.github/workflows/modelkit-ci.yml
+++ b/.github/workflows/modelkit-ci.yml
@@ -1,4 +1,4 @@
-name: ModelKit CI
+name: WinML CLI CI
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WinML CLI
 
-[![ModelKit CI](https://github.com/microsoft/winml-cli/actions/workflows/modelkit-ci.yml/badge.svg)](https://github.com/microsoft/winml-cli/actions/workflows/modelkit-ci.yml)
+[![WinML CLI CI](https://github.com/microsoft/winml-cli/actions/workflows/modelkit-ci.yml/badge.svg)](https://github.com/microsoft/winml-cli/actions/workflows/modelkit-ci.yml)
 ![Status](https://img.shields.io/badge/status-early%20access-blue)
 ![Python](https://img.shields.io/badge/python-3.11%2B-blue?logo=python&logoColor=white)
 ![License](https://img.shields.io/badge/license-MIT-green)


### PR DESCRIPTION
## Summary
- Rename the GitHub Actions workflow `name:` from `ModelKit CI` to `WinML CLI CI` so the badge label matches the project name.
- Update the README badge label accordingly. Workflow filename (`modelkit-ci.yml`) is kept so the badge SVG URL remains valid.