### PR TITLE
fix(test): add missing ep param to resolve_device mock in config e2e

### DIFF
--- a/tests/e2e/test_config_e2e.py
+++ b/tests/e2e/test_config_e2e.py
@@ -46,7 +46,9 @@ pytestmark = [pytest.mark.e2e, pytest.mark.network]
 def _mock_resolve_device():
     """Mock hardware detection to avoid failures in CI/test environments."""
 
-    def _resolve_device_mock(device: str = "auto") -> tuple[str, list[str]]:
+    def _resolve_device_mock(
+        device: str = "auto", *, ep: str | None = None
+    ) -> tuple[str, list[str]]:
         # Keep tests deterministic while preserving explicit device requests.
         normalized = (device or "auto").lower()
         if normalized in {"cpu", "gpu", "npu"}:


### PR DESCRIPTION
## Summary
- The `resolve_device()` function gained a keyword-only `ep` parameter in commit 146404fd, but the autouse mock in `test_config_e2e.py` was never updated to accept it
- All 44 e2e config tests fail with `got an unexpected keyword argument 'ep'` because the config command calls `resolve_device(device, ep=ep)` at `config.py:449`
- Added `*, ep: str | None = None` to the mock signature to match the production function

Fixes #732

🤖 Generated with [Claude Code](https://claude.ai/claude-code)