### PR TITLE
fix(sys): gate diagnostic sections behind -v; route json-mode logs to stderr

### DIFF
--- a/src/winml/modelkit/commands/sys.py
+++ b/src/winml/modelkit/commands/sys.py
@@ -386,11 +386,14 @@ def _output_text(info: dict[str, Any], verbose: bool = False) -> None:
 
         console.print(torch_table)
 
-    # Backend SDKs — only show when at least one SDK is installed
-    backends = info["backends"]
-    qnn = backends["qnn"]
-    ov = backends["openvino"]
-    if qnn["installed"] or ov["installed"]:
+    # Backend SDKs and Export Readiness are diagnostic info — only render
+    # under --verbose so the default `winml sys` stays focused on Python,
+    # libraries, devices, and EPs.
+    if verbose:
+        backends = info["backends"]
+        qnn = backends["qnn"]
+        ov = backends["openvino"]
+
         console.print("\n[bold blue]Backend SDKs[/bold blue]")
         backend_table = Table(show_header=False, box=None, padding=(0, 2))
         backend_table.add_column("Backend", style="bold")
@@ -398,17 +401,17 @@ def _output_text(info: dict[str, Any], verbose: bool = False) -> None:
         backend_table.add_column("Details")
 
         if qnn["installed"]:
-            qnn_details = qnn.get("path", "-")[:50]
-            backend_table.add_row("QNN SDK", "[green]Installed[/green]", qnn_details)
+            backend_table.add_row("QNN SDK", "[green]Installed[/green]", qnn.get("path", "-")[:50])
+        else:
+            backend_table.add_row("QNN SDK", "[yellow]Not found[/yellow]", "-")
         if ov["installed"]:
-            ov_details = ov.get("version", "-")
-            backend_table.add_row("OpenVINO", "[green]Installed[/green]", ov_details)
+            backend_table.add_row("OpenVINO", "[green]Installed[/green]", ov.get("version", "-"))
+        else:
+            backend_table.add_row("OpenVINO", "[yellow]Not found[/yellow]", "-")
 
         console.print(backend_table)
 
-    # Export Readiness — only show when at least one non-ONNX backend is ready
-    readiness = info["export_readiness"]
-    if readiness["qnn_ready"] or readiness["openvino_ready"]:
+        readiness = info["export_readiness"]
         console.print("\n[bold blue]Export Readiness[/bold blue]")
         ready_table = Table(show_header=False, box=None, padding=(0, 2))
         ready_table.add_column("Capability", style="bold")
@@ -416,10 +419,16 @@ def _output_text(info: dict[str, Any], verbose: bool = False) -> None:
 
         onnx_ready = "[green]Ready[/green]" if readiness["onnx_export"] else "[red]Not ready[/red]"
         ready_table.add_row("ONNX Export", onnx_ready)
-        if readiness["qnn_ready"]:
-            ready_table.add_row("QNN Compilation", "[green]Ready[/green]")
-        if readiness["openvino_ready"]:
-            ready_table.add_row("OpenVINO Conversion", "[green]Ready[/green]")
+        qnn_status = (
+            "[green]Ready[/green]" if readiness["qnn_ready"] else "[yellow]SDK required[/yellow]"
+        )
+        ready_table.add_row("QNN Compilation", qnn_status)
+        ov_status = (
+            "[green]Ready[/green]"
+            if readiness["openvino_ready"]
+            else "[yellow]Not installed[/yellow]"
+        )
+        ready_table.add_row("OpenVINO Conversion", ov_status)
 
         console.print(ready_table)
 
@@ -704,7 +713,13 @@ def sysinfo(
     # Route winml.modelkit logs through Rich so they never interleave with CLI output.
     # In normal mode suppress everything below WARNING; in debug mode show all levels.
     # Restore logger state on exit so tests using caplog are not affected.
+    #
+    # For --format json, send log records to stderr so DEBUG/WARNING lines do
+    # not corrupt the JSON payload on stdout (verbose+json was unparseable).
+    from rich.console import Console as _RichConsole
     from rich.logging import RichHandler
+
+    use_json = output_format.lower() == "json"
 
     log_level = logging.DEBUG if verbose else logging.WARNING
     pkg_logger = logging.getLogger("winml.modelkit")
@@ -712,15 +727,14 @@ def sysinfo(
     _saved_level = pkg_logger.level
     _saved_propagate = pkg_logger.propagate
     pkg_logger.handlers = [h for h in pkg_logger.handlers if not isinstance(h, RichHandler)]
-    rich_handler = RichHandler(console=_get_console(), show_path=False)
+    log_console = _RichConsole(stderr=True) if use_json else _get_console()
+    rich_handler = RichHandler(console=log_console, show_path=False)
     rich_handler.setLevel(log_level)
     pkg_logger.setLevel(log_level)
     pkg_logger.addHandler(rich_handler)
     pkg_logger.propagate = False
 
     try:
-        use_json = output_format.lower() == "json"
-
         # Handle --list-device and/or --list-ep (combinable)
         if list_device or list_ep:
             if use_json:

--- a/tests/e2e/test_sys_e2e.py
+++ b/tests/e2e/test_sys_e2e.py
@@ -52,11 +52,18 @@ def _run_sys(*args: str) -> tuple[int, str]:
 
 
 def _run_sys_json(*args: str) -> dict:
-    """Invoke ``winml sys ... --format json`` and return the parsed JSON payload."""
+    """Invoke ``winml sys ... --format json`` and return the parsed JSON payload.
+
+    Reads ``result.stdout`` (not ``result.output``) so DEBUG logs emitted on
+    stderr under ``--verbose`` do not corrupt the JSON payload — the
+    ``winml sys`` command routes its RichHandler to stderr when
+    ``--format json`` is active, but Click 8.4's ``result.output``
+    aggregates both streams.
+    """
     runner = CliRunner()
     result = runner.invoke(sysinfo, [*args, "--format", "json"], obj={}, catch_exceptions=False)
     assert result.exit_code == 0, f"sys failed (exit {result.exit_code}):\n{result.output}"
-    return json.loads(result.output)
+    return json.loads(result.stdout)
 
 
 def _torch_installed() -> bool:


### PR DESCRIPTION
## Summary

- Move `Backend SDKs` and `Export Readiness` panels into `--verbose`; verbose now lists all backends including not-installed rows so the section is informative even when no SDK is installed.
- Route the per-command `RichHandler` to stderr under `--format json` so DEBUG/WARNING logs no longer corrupt the JSON payload on stdout.
- Update `_run_sys_json` to read `result.stdout` (Click 8.4's `result.output` still aggregates stderr).

Fixes #736

## Before / After

### 1. Default `winml sys` — drops two diagnostic panels

Before (on a host with at least one backend SDK installed, the panels show up by default; below is the shape they took):

```
...
Backend SDKs
  QNN SDK     Installed    <path>
  OpenVINO    Installed    <version>

Export Readiness
  ONNX Export            Ready
  QNN Compilation        Ready
  OpenVINO Conversion    Ready
...
```

After — those panels are gone from default output; users only see Environment, ML Libraries, Devices, and Execution Providers.

### 2. `winml sys -v` — sections are now always populated

After (verbose now lists every backend regardless of install status, so the panel is meaningful on a stock dev box):

```
PyTorch Details
  CUDA Available    False

Backend SDKs
  QNN SDK     Not found    -
  OpenVINO    Not found    -

Export Readiness
  ONNX Export            Ready
  QNN Compilation        SDK required
  OpenVINO Conversion    Not installed
```

### 3. `winml sys --verbose --format json` — stdout is now valid JSON

Before — RichHandler writes DEBUG records to the same console as the JSON, so stdout starts with log lines and `json.loads` fails:

```
[05/26/26 10:35:28] DEBUG    OpenVINO not available
[05/26/26 10:35:29] DEBUG    Found EP: OpenVINOExecutionProvider at ...
                    DEBUG    Found EP: NvTensorRTRTXExecutionProvider at ...
{... JSON would appear here, never reached by parsers ...}
```

After — stdout contains only JSON; the same log records are emitted on stderr where they belong:

```
$ winml sys --verbose --format json 2>/dev/null | head
{
  "python": {
    "version": "3.11.14",
    "executable": "C:\\Projects\\WinML-ModelKit\\.venv\\Scripts\\python.exe",
    "implementation": "CPython"
  },
  "platform": {
    "system": "Windows",
    ...
```
