### PR TITLE
fix analyze bug

### DIFF
--- a/src/winml/modelkit/commands/analyze.py
+++ b/src/winml/modelkit/commands/analyze.py
@@ -770,7 +770,8 @@ def analyze(
             (candidate_ep, candidate_device)
             for candidate_ep in eps
             for candidate_device in devices
-            if candidate_ep in EP_SUPPORTED_DEVICES and candidate_device.lower() in EP_SUPPORTED_DEVICES[candidate_ep]
+            if candidate_ep in EP_SUPPORTED_DEVICES
+            and candidate_device.lower() in EP_SUPPORTED_DEVICES[candidate_ep]
         ]
         execution_pairs = _sort_ep_device_pairs(execution_pairs)
 

--- a/src/winml/modelkit/commands/analyze.py
+++ b/src/winml/modelkit/commands/analyze.py
@@ -770,7 +770,7 @@ def analyze(
             (candidate_ep, candidate_device)
             for candidate_ep in eps
             for candidate_device in devices
-            if candidate_device.lower() in EP_SUPPORTED_DEVICES[candidate_ep]
+            if candidate_ep in EP_SUPPORTED_DEVICES and candidate_device.lower() in EP_SUPPORTED_DEVICES[candidate_ep]
         ]
         execution_pairs = _sort_ep_device_pairs(execution_pairs)
 


### PR DESCRIPTION
fix analyze bug

(winml-cli) PS C:\Dev\MKs\ModelKit> winml analyze -m ../ModelKitArtifacts/models/opset17_ensured_value_info/aitk_opset17/onnx_models_wmk_exported/bert-base-multilingual-cased.onnx -v
[2026-05-26T12:01:29] ERROR: Analysis failed: 'OpenVINOExecutionProvider.AUTO'
[2026-05-26T12:01:29] ERROR: Full traceback:
Traceback (most recent call last):
  File "C:\Dev\MKs\ModelKit\src\winml\modelkit\commands\analyze.py", line 769, in analyze
    execution_pairs = [
                      ^
  File "C:\Dev\MKs\ModelKit\src\winml\modelkit\commands\analyze.py", line 773, in <listcomp>
    if candidate_device.lower() in EP_SUPPORTED_DEVICES[candidate_ep]
                                   ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
KeyError: 'OpenVINOExecutionProvider.AUTO'