### PR TITLE
fix(inspect): suppress banner and spinner in JSON mode

### DIFF
--- a/src/winml/modelkit/commands/inspect.py
+++ b/src/winml/modelkit/commands/inspect.py
@@ -482,9 +482,14 @@ def _inspect_model_v2(
         task=task,
     )
 
+    # Use the parent model_type for the user-facing result.  For multimodal
+    # models (CLIP, etc.) `loader_config.model_type` is the narrowed sub-config
+    # type (e.g. "clip_text_model"), but users expect the top-level type ("clip").
+    display_model_type = getattr(parent_hf_config, "model_type", model_type)
+
     return InspectResult(
-        model_id=model_id or model_type or model_class_override or "unknown",
-        model_type=model_type,
+        model_id=model_id or display_model_type or model_class_override or "unknown",
+        model_type=display_model_type,
         architectures=architectures,
         task=task,
         task_source=task_source,

--- a/src/winml/modelkit/commands/inspect.py
+++ b/src/winml/modelkit/commands/inspect.py
@@ -186,13 +186,10 @@ def inspect(
     # Print a banner BEFORE the heavy import chain / network calls so users
     # see immediate feedback instead of ~14 s of silence and assume the
     # command hung (see #543). Banner + spinner go to stderr so `--format
-    # json` consumers still get clean stdout. Suppressed in --quiet mode
-    # and in JSON mode (Click 8.4 mixes stderr into CliRunner.result.output,
-    # and JSON consumers expect clean stdout regardless).
+    # json` consumers still get clean stdout. Suppressed in --quiet mode.
     quiet = bool(ctx.obj and ctx.obj.get("quiet"))
-    json_mode = output_format.lower() == "json"
     target = model_id or model_type or model_class
-    if not quiet and not json_mode:
+    if not quiet:
         _stderr_console.print(f"[dim]Inspecting [bold]{target}[/bold] …[/dim]")
 
     from ..inspect import InspectError, ModelNotFoundError, NetworkError
@@ -207,7 +204,7 @@ def inspect(
         logging.getLogger("winml.modelkit").setLevel(logging.DEBUG)
 
     try:
-        if quiet or json_mode:
+        if quiet:
             result = _inspect_model_v2(
                 model_id=model_id,
                 task_override=task,

--- a/src/winml/modelkit/commands/inspect.py
+++ b/src/winml/modelkit/commands/inspect.py
@@ -482,10 +482,16 @@ def _inspect_model_v2(
         task=task,
     )
 
-    # Use the parent model_type for the user-facing result.  For multimodal
+    # Use the top-level model_type for the user-facing result.  For multimodal
     # models (CLIP, etc.) `loader_config.model_type` is the narrowed sub-config
     # type (e.g. "clip_text_model"), but users expect the top-level type ("clip").
-    display_model_type = getattr(parent_hf_config, "model_type", model_type)
+    #
+    # Precedence:
+    #   1. model_type_override  — user explicitly passed --model-type
+    #   2. parent_hf_config     — pre-narrowing config (only when model_id was
+    #                             provided and AutoConfig succeeded in step 1)
+    #   3. model_type           — narrowed loader_config.model_type (fallback)
+    display_model_type = model_type_override or getattr(parent_hf_config, "model_type", model_type)
 
     return InspectResult(
         model_id=model_id or display_model_type or model_class_override or "unknown",

--- a/src/winml/modelkit/commands/inspect.py
+++ b/src/winml/modelkit/commands/inspect.py
@@ -186,10 +186,13 @@ def inspect(
     # Print a banner BEFORE the heavy import chain / network calls so users
     # see immediate feedback instead of ~14 s of silence and assume the
     # command hung (see #543). Banner + spinner go to stderr so `--format
-    # json` consumers still get clean stdout. Suppressed in --quiet mode.
+    # json` consumers still get clean stdout. Suppressed in --quiet mode
+    # and in JSON mode (Click 8.4 mixes stderr into CliRunner.result.output,
+    # and JSON consumers expect clean stdout regardless).
     quiet = bool(ctx.obj and ctx.obj.get("quiet"))
+    json_mode = output_format.lower() == "json"
     target = model_id or model_type or model_class
-    if not quiet:
+    if not quiet and not json_mode:
         _stderr_console.print(f"[dim]Inspecting [bold]{target}[/bold] …[/dim]")
 
     from ..inspect import InspectError, ModelNotFoundError, NetworkError
@@ -204,7 +207,7 @@ def inspect(
         logging.getLogger("winml.modelkit").setLevel(logging.DEBUG)
 
     try:
-        if quiet:
+        if quiet or json_mode:
             result = _inspect_model_v2(
                 model_id=model_id,
                 task_override=task,

--- a/tests/e2e/test_inspect_e2e.py
+++ b/tests/e2e/test_inspect_e2e.py
@@ -59,25 +59,28 @@ EXPECTED_TOP_KEYS = {
 def _run_json(*args: str) -> dict:
     """Invoke inspect with *args + '-f json' and return parsed JSON.
 
-    Asserts exit_code == 0 and that the output is valid JSON.
+    Reads ``result.stdout`` (not ``result.output``) so the banner and
+    spinner emitted on stderr do not corrupt the JSON payload — Click 8.4's
+    ``result.output`` aggregates both streams.
     """
     result = _run(*args, "-f", "json")
     assert result.exit_code == 0, f"inspect exited {result.exit_code}:\n{result.output}"
-    return json.loads(result.output)
+    return json.loads(result.stdout)
 
 
 def _run_network(model: str, task: str | None = None) -> dict:
     """Invoke inspect with a real model ID and return parsed JSON output.
 
-    Raises AssertionError when the command exits non-zero or the
-    output is not valid JSON.
+    Reads ``result.stdout`` (not ``result.output``) so the banner and
+    spinner emitted on stderr do not corrupt the JSON payload — Click 8.4's
+    ``result.output`` aggregates both streams.
     """
     args: list[str] = ["-m", model, "-f", "json"]
     if task:
         args.extend(["-t", task])
     result = CliRunner().invoke(inspect, args, obj={}, catch_exceptions=False)
     assert result.exit_code == 0, f"inspect failed (exit {result.exit_code}):\n{result.output}"
-    return json.loads(result.output)
+    return json.loads(result.stdout)
 
 
 def _assert_common_structure(data: dict, model_id: str, expected_task: str) -> None:

--- a/tests/e2e/test_inspect_e2e.py
+++ b/tests/e2e/test_inspect_e2e.py
@@ -59,28 +59,25 @@ EXPECTED_TOP_KEYS = {
 def _run_json(*args: str) -> dict:
     """Invoke inspect with *args + '-f json' and return parsed JSON.
 
-    Reads ``result.stdout`` (not ``result.output``) so the banner and
-    spinner emitted on stderr do not corrupt the JSON payload — Click 8.4's
-    ``result.output`` aggregates both streams.
+    Asserts exit_code == 0 and that the output is valid JSON.
     """
     result = _run(*args, "-f", "json")
     assert result.exit_code == 0, f"inspect exited {result.exit_code}:\n{result.output}"
-    return json.loads(result.stdout)
+    return json.loads(result.output)
 
 
 def _run_network(model: str, task: str | None = None) -> dict:
     """Invoke inspect with a real model ID and return parsed JSON output.
 
-    Reads ``result.stdout`` (not ``result.output``) so the banner and
-    spinner emitted on stderr do not corrupt the JSON payload — Click 8.4's
-    ``result.output`` aggregates both streams.
+    Raises AssertionError when the command exits non-zero or the
+    output is not valid JSON.
     """
     args: list[str] = ["-m", model, "-f", "json"]
     if task:
         args.extend(["-t", task])
     result = CliRunner().invoke(inspect, args, obj={}, catch_exceptions=False)
     assert result.exit_code == 0, f"inspect failed (exit {result.exit_code}):\n{result.output}"
-    return json.loads(result.stdout)
+    return json.loads(result.output)
 
 
 def _assert_common_structure(data: dict, model_id: str, expected_task: str) -> None:


### PR DESCRIPTION
## Summary

Fixes #734

Two fixes for `winml inspect` e2e test failures:

**1. JSON mode: suppress banner and spinner (20 failures)**
- Click 8.4 removed `mix_stderr` and always mixes stderr into `CliRunner.result.output`
- The banner ("Inspecting …") and spinner added in #718 write to stderr via `_stderr_console`, contaminating the JSON payload and causing `JSONDecodeError` in all JSON-parsing tests
- Suppress banner and spinner when `--format json` is requested — JSON consumers expect clean stdout

**2. CLIP model_type: use parent config type (2 failures)**
- For multimodal models (CLIP), `resolve_loader_config` narrows the hf_config to a sub-config (e.g. `clip_text_model`), which is correct for internal registry lookups
- But the user-facing `InspectResult.model_type` should show the parent type (`clip`), not the narrowed sub-config type
- Use `parent_hf_config.model_type` for the display field while keeping the narrowed type for internal resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)