### PR TITLE
Fix pyarrow version which causes winml eval crash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,11 @@ dependencies = [
   "click>=8.4",
   "colorama>=0.4.6",
   "datasets>=4.1.1",
+  # pyarrow 24.0.0 crashes (0xC0000005) on Windows when its C extension is
+  # loaded after the WinML/ORT EP DLLs (see _preload_bundled_onnxruntime_dll
+  # in winml.modelkit.__init__). Cap to <24 until upstream is fixed; re-test
+  # 24.x patches / 25.x before relaxing.
+  "pyarrow>=21,<24",
   "diffusers>=0.36",
   "evaluate>=0.4.6",
   "fastapi>=0.135.3",


### PR DESCRIPTION
Fixes #749

## PR Description

**Fix: `winml eval` crash when `--device` is not specified**

### Problem

Running `winml eval` without an explicit `--device` flag crashes the process with an access violation (`0xC0000005`) during dataset loading.

### Root Cause

The crash is triggered by a DLL incompatibility between `pyarrow` 24.x and the WinML/ONNX Runtime EP DLLs:

1. When `--device` is omitted, `winml eval` resolves the device and preloads the EP DLLs (via `_preload_bundled_onnxruntime_dll`) **before** importing the `datasets` package.
2. Importing `datasets` then loads `pyarrow`'s C extension on top of the already-loaded EP DLLs.
3. `pyarrow` 24.x ships a native binary that conflicts with the WinML EP DLLs in this load order, causing the access violation.

This was only reproducible with `pyarrow` 24.x; versions ≤ 23 load cleanly regardless of order.

### Fix

Cap `pyarrow` to `>=21,<24` in pyproject.toml. This stays within the range required by `datasets` (which needs `pyarrow>=21`), so no other dependencies are affected.

The existing comment above the pin already documents the crash details and the conditions for revisiting the cap (re-test 24.x patches / 25.x before relaxing).

### Validation

- `uv run winml eval -m microsoft/resnet-50 --samples 100` now completes without `--device` specified.
- No change to runtime behavior for users who already pinned `pyarrow < 24`.