### PR TITLE
fix(test): skip test_compile_enabled on non-QNN hosts

### DIFF
--- a/tests/e2e/test_config_e2e.py
+++ b/tests/e2e/test_config_e2e.py
@@ -32,6 +32,7 @@ from unittest.mock import patch
 import pytest
 from click.testing import CliRunner
 
+from tests.e2e.require_ep import require_ep
 from winml.modelkit.commands.config import config
 
 
@@ -372,6 +373,7 @@ class TestConfigFlagVariations:
 
     def test_compile_enabled(self) -> None:
         """--compile (negated default) should produce a compile section."""
+        require_ep("qnn")
         data = _run_config(
             "-m",
             self.MODEL,


### PR DESCRIPTION
## Summary
- `test_compile_enabled` passes `--compile -d npu` which requires QNN EP to resolve a `compile_provider`
- On non-QNN hosts (e.g. TensorRT), `resolve_eps("npu")` returns an empty list, so `compile` is `None` — expected behavior
- Added `require_ep("qnn")` gate to skip cleanly on hosts without QNN


🤖 Generated with [Claude Code](https://claude.com/claude-code)