### PR TITLE
Remove WindowsAppRuntimeVersion from SysInfo

### DIFF
--- a/src/winml/modelkit/sysinfo/sysinfo.py
+++ b/src/winml/modelkit/sysinfo/sysinfo.py
@@ -2,39 +2,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-import re
-
 from .hardware import CPU, GPU, NPU, RAM
 from .software import OS, EPPackage, PipPackage, PythonRuntime
-
-
-class WindowsAppRuntimeVersion:
-    """Represents the Windows App Runtime version from pip packages."""
-
-    _package_name_suffix = "-Microsoft.Windows.ApplicationModel.DynamicDependency.Bootstrap"
-
-    def __init__(self, pip_packages: list[PipPackage]) -> None:
-        """Initialize Windows App Runtime version from pip packages."""
-        version = None
-        for package in pip_packages:
-            if package.name.endswith(self._package_name_suffix):
-                version = package.version
-                break
-        if version is None:
-            raise ValueError(
-                f"Package ending with '{self._package_name_suffix}' not found in pip packages."
-            )
-        version = re.sub(r"^\d+!", "", version)
-        version = re.sub(r"\.dev(\d+)", r"-experimental\1", version)
-        # .dev0 are converted from -experimental packages instead of -experimental0
-        if version.endswith("-experimental0"):
-            version = version[:-1]
-        self._version = version
-
-    @property
-    def version(self) -> str:
-        """Windows App Runtime version."""
-        return self._version
 
 
 class SysInfo:
@@ -50,7 +19,6 @@ class SysInfo:
         self._python_runtime = PythonRuntime.get()
         self._pip_packages = PipPackage.get_all()
         self._ep_packages = EPPackage.get_all()
-        self._windows_app_runtime_version = WindowsAppRuntimeVersion(self._pip_packages)
 
     @property
     def cpu_list(self) -> list[CPU]:
@@ -92,11 +60,6 @@ class SysInfo:
         """List of execution provider packages."""
         return self._ep_packages
 
-    @property
-    def windows_app_runtime_version(self) -> WindowsAppRuntimeVersion:
-        """Windows App Runtime version."""
-        return self._windows_app_runtime_version
-
     def to_dict(self) -> dict:
         """Convert all system information to a dictionary."""
         return {
@@ -108,5 +71,4 @@ class SysInfo:
             "pythonRuntime": self._python_runtime.to_dict(),
             "pipPackages": [pkg.to_dict() for pkg in self._pip_packages],
             "epPackages": [pkg.to_dict() for pkg in self._ep_packages],
-            "windowsAppRuntimeVersion": self._windows_app_runtime_version.version,
         }


### PR DESCRIPTION
## Summary

- Drop the `WindowsAppRuntimeVersion` class, attribute, property, and `windowsAppRuntimeVersion` field in `SysInfo.to_dict()` from `src/winml/modelkit/sysinfo/sysinfo.py`.
- Remove the now-unused `import re`.

Nothing else in the codebase referenced these symbols. Integration `runtime_checker` fixtures still contain the field inside their stored `sys_info` blob, but the test helper ignores `sys_info` during comparison, and the field will disappear naturally next time those fixtures are regenerated.