### PR TITLE
fix(inspect): validate --task at Click time with clean error (#546)

### DIFF
--- a/src/winml/modelkit/commands/inspect.py
+++ b/src/winml/modelkit/commands/inspect.py
@@ -40,6 +40,27 @@ _stderr_console = Console(stderr=True, highlight=False)
 _LOCAL_FILE_EXTS = frozenset({".onnx", ".pt", ".pth", ".safetensors", ".bin"})
 
 
+def _validate_task(
+    ctx: click.Context, param: click.Parameter, value: str | None
+) -> str | None:
+    """Click-time validation for --task against the hand-coded KNOWN_TASKS set.
+
+    Imports only ..loader.task to keep validation cheap — going through optimum
+    would cost ~10s on a warm cache and defeats fail-fast on bad input.
+    """
+    if value is None:
+        return None
+    from ..loader.task import KNOWN_TASKS
+
+    if value in KNOWN_TASKS:
+        return value
+    examples = ", ".join(sorted(KNOWN_TASKS)[:5])
+    raise click.UsageError(
+        f"Invalid task '{value}'. Valid: {examples}, ... ({len(KNOWN_TASKS)} total). "
+        f"See 'winml inspect --list-tasks' for the full list."
+    )
+
+
 def _looks_like_local_path(model_id: str) -> bool:
     """Return True when model_id is explicitly a local path.
 
@@ -86,6 +107,7 @@ def _looks_like_local_path(model_id: str) -> bool:
     "-t",
     "--task",
     default=None,
+    callback=_validate_task,
     help="Override auto-detected task (e.g., image-classification, feature-extraction)",
 )
 @click.option(

--- a/tests/unit/commands/test_inspect_cli.py
+++ b/tests/unit/commands/test_inspect_cli.py
@@ -111,6 +111,43 @@ class TestInspectCliInterface:
         result = runner.invoke(inspect, ["-m", "test", "-f", "xml"], obj={})
         assert result.exit_code != 0
 
+    def test_invalid_task_rejected_at_click_time(self, runner: CliRunner) -> None:
+        """`--task bogus-task` must fail with a clean error before any heavy work.
+
+        Patches _inspect_model_v2 to assert validation kicks in *before* the API
+        is reached — fail-fast on bad input.
+        """
+        from winml.modelkit.commands.inspect import inspect
+
+        with patch(_INSPECT_MODEL) as mock_api:
+            result = runner.invoke(
+                inspect, ["-m", "test", "--task", "bogus-task"], obj={}
+            )
+            assert result.exit_code == 2, f"Expected exit 2, got {result.exit_code}"
+            mock_api.assert_not_called()
+            # User-facing error must name the bad value and point to --list-tasks,
+            # and must NOT leak internal optimum jargon (see issue #546).
+            assert "bogus-task" in result.output
+            assert "--list-tasks" in result.output
+            assert "TasksManager" not in result.output
+            assert "optimum" not in result.output.lower()
+
+    def test_valid_task_accepted(
+        self,
+        runner: CliRunner,
+        mock_inspect_result: MagicMock,
+    ) -> None:
+        from winml.modelkit.commands.inspect import inspect
+
+        with (
+            patch(_INSPECT_MODEL, return_value=mock_inspect_result),
+            patch(_OUTPUT_TABLE),
+        ):
+            result = runner.invoke(
+                inspect, ["-m", "test", "--task", "image-classification"], obj={}
+            )
+            assert result.exit_code == 0, f"Failed: {result.output}"
+
 
 # =============================================================================
 # OUTPUT FORMAT TESTS


### PR DESCRIPTION
## Summary

Closes #546.

`winml inspect --task bogus-task` was leaking optimum's internal `TasksManager` class name and pointing users to optimum docs:

> Error: Inspection error: Task 'bogus-task' not supported by TasksManager. Check optimum documentation for supported tasks.

Now the value is validated at Click parse time against the hand-coded `KNOWN_TASKS` set, before any heavy imports:

```
$ winml inspect -m microsoft/resnet-50 --task bogus-task
Usage: winml inspect [OPTIONS]
Try 'winml inspect --help' for help.

Error: Invalid task 'bogus-task'. Valid: audio-classification, audio-frame-classification, audio-xvector, automatic-speech-recognition, depth-estimation, ... (35 total). See 'winml inspect --list-tasks' for the full list.
```

- Exit code 2 (Click UsageError)
- No third-party class names; no optimum-docs pointer
- Callback imports only `..loader.task.KNOWN_TASKS` — avoids the ~10s optimum/transformers cold start, so the fail-fast stays fast
- `--list-tasks` and valid `--task` paths unchanged
