### PR TITLE
fix: align `winml catalog` `-t` short flag with other commands (#541)

### DIFF
--- a/src/winml/modelkit/commands/catalog.py
+++ b/src/winml/modelkit/commands/catalog.py
@@ -363,14 +363,13 @@ def _save_json(data: Any, path: Path) -> None:
 @click.command()
 @click.option(
     "--model-type",
-    "-t",
     default=None,
     metavar="TYPE",
     help="Filter by model architecture (e.g. bert, roberta, vit).",
 )
 @click.option(
     "--task",
-    "-k",
+    "-t",
     default=None,
     metavar="TASK",
     help="Filter by HuggingFace task (e.g. text-classification, image-segmentation).",

--- a/tests/cli/test_catalog_cli.py
+++ b/tests/cli/test_catalog_cli.py
@@ -184,15 +184,35 @@ class TestCatalogCliSurface:
         assert result.exit_code == 2
         assert "Invalid value for '--device'" in result.output
 
-    def test_short_flags_accepted(self, type_task_pair: tuple[str, str], tmp_path: Path) -> None:
-        """-t / -k short aliases are accepted by the parser."""
-        model_type, task = type_task_pair
-        models = _run_json(tmp_path / "out.json", "-t", model_type, "-k", task)
-        assert len(models) > 0, f"Expected at least one {model_type}/{task} model"
-        assert all(
-            m["model_type"].lower() == model_type.lower() and m["task"].lower() == task.lower()
-            for m in models
-        )
+    def test_short_flag_task_accepted(
+        self, type_task_pair: tuple[str, str], tmp_path: Path
+    ) -> None:
+        """``-t`` is the short alias for ``--task`` (consistent with other commands)."""
+        _, task = type_task_pair
+        models = _run_json(tmp_path / "out.json", "-t", task)
+        assert len(models) > 0, f"Expected at least one model with task {task}"
+        assert all(m["task"].lower() == task.lower() for m in models)
+
+    def test_model_type_has_no_short_flag(
+        self, help_output: str, model_types: list[str], tmp_path: Path
+    ) -> None:
+        """``-t`` must mean ``--task`` here, matching inspect/export/config.
+
+        Regression guard for issue #541: ``-t`` previously bound to
+        ``--model-type`` in catalog only, while every other command used
+        ``-t`` for ``--task``.
+        """
+        assert "-t, --task" in help_output
+        assert "-t, --model-type" not in help_output
+
+        # A real model_type passed via -t must be interpreted as a task,
+        # so the result is disjoint from filtering by --model-type.
+        if not model_types:
+            pytest.skip("catalog has no model_types to probe")
+        mtype = model_types[0]
+        as_task = _run_json(tmp_path / "as_task.json", "-t", mtype)
+        as_mtype = _run_json(tmp_path / "as_mtype.json", "--model-type", mtype)
+        assert _model_ids(as_task).isdisjoint(_model_ids(as_mtype)) or len(as_task) == 0
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Fixes #541.

`winml catalog` was the only command where `-t` did NOT mean `--task`:

| Command   | `-t` means       |
|-----------|------------------|
| `inspect` | `--task`         |
| `export`  | `--task`         |
| `config`  | `--task`         |
| `catalog` | `--model-type` (inconsistent) |

A user who has memorized `-t` to mean `--task` in 3 commands would type
`-t image-classification` against `winml catalog` and silently get
`--model-type=image-classification` (no such model type) instead.

## Change

In `src/winml/modelkit/commands/catalog.py`:
- Dropped the `-t` short from `--model-type` (no short alias now).
- Moved `-t` to `--task` (replacing the previous `-k`).

`--model-type` is still fully supported via its long form.

Adds a regression guard test (`test_model_type_has_no_short_flag`) that
checks both the `--help` output AND that passing a model_type via `-t`
is interpreted as a task. All 115 catalog tests pass.