### PR TITLE
fix: config validates device/EP combination without system check

### DIFF
--- a/src/winml/modelkit/commands/analyze.py
+++ b/src/winml/modelkit/commands/analyze.py
@@ -649,7 +649,7 @@ def _ep_name_device_display_name(ep_name: str, device_name: str) -> str:
     ),
 )
 @cli_utils.verbosity_options
-@cli_utils.build_config_option
+@cli_utils.build_config_option()
 @cli_utils.output_option("Save JSON output to file")
 @click.option(
     "--information/--no-information",

--- a/src/winml/modelkit/commands/compile.py
+++ b/src/winml/modelkit/commands/compile.py
@@ -104,7 +104,7 @@ console = Console()
     default=False,
     help="List available compilers for the selected device and exit",
 )
-@cli_utils.build_config_option
+@cli_utils.build_config_option()
 @click.pass_context
 def compile(
     ctx: click.Context,

--- a/src/winml/modelkit/commands/config.py
+++ b/src/winml/modelkit/commands/config.py
@@ -430,18 +430,12 @@ def config(
 
             console.print("   \u2699\ufe0f  [bold]Resolution:[/bold]")
 
-            # Fix #4: Device from resolve_device (existing API)
-            from ..sysinfo import resolve_device as _rd
+            # Use the same resolution logic as the config generation to determine what to display
+            from ..sysinfo import resolve_check_device_ep
 
-            _resolved_dev, _ = _rd(device, ep=ep)
+            _resolved_dev, _, _resolved_eps = resolve_check_device_ep(device=device, ep=ep)
             console.print(f"      Device:     [cyan]{_resolved_dev.upper()}[/cyan]")
-
-            # EP — only shown when user explicitly passed --ep
-            if ep:
-                from ..utils.constants import normalize_ep_name
-
-                _ep_full = normalize_ep_name(ep) or ep
-                console.print(f"      EP:         [cyan]{_ep_full}[/cyan]")
+            console.print(f"      EP:         [cyan]{_resolved_eps[0]}[/cyan]")
 
             # Quant types — display exactly what config contains
             if _quant:

--- a/src/winml/modelkit/commands/config.py
+++ b/src/winml/modelkit/commands/config.py
@@ -174,6 +174,9 @@ def config(
 
     Requires at least one of -m/--model, --model-type, or --model-class.
 
+    If device is auto or EP is None, they are inferred from the system configuration.
+    If both are specified, the combination is only validated but not against the system.
+
     \b
     Examples:
         # Basic usage - auto-detect everything

--- a/src/winml/modelkit/commands/config.py
+++ b/src/winml/modelkit/commands/config.py
@@ -104,7 +104,10 @@ def _is_onnx_file(model_input: str) -> bool:
     "audio: feature_size, nb_max_frames, audio_sequence_length.",
 )
 @cli_utils.device_option(
-    required=False, optional_message="Affects compile config.", default="auto", include_auto=True
+    required=False,
+    optional_message="Affects quant/compile config.",
+    default="auto",
+    include_auto=True,
 )
 @cli_utils.ep_option(
     required=False,

--- a/src/winml/modelkit/commands/config.py
+++ b/src/winml/modelkit/commands/config.py
@@ -64,14 +64,7 @@ def _is_onnx_file(model_input: str) -> bool:
 
 
 @click.command("config")
-@click.option(
-    "-m",
-    "--model",
-    "hf_model",
-    default=None,
-    help="HuggingFace model ID (e.g., microsoft/resnet-50) or path to .onnx file. "
-    "Optional when --model-type is provided.",
-)
+@cli_utils.model_option(required=False, optional_message="Optional when --model-type is provided.")
 @click.option(
     "-t",
     "--task",
@@ -97,12 +90,7 @@ def _is_onnx_file(model_input: str) -> bool:
     default=None,
     help="Generate configs for submodules matching this class name (e.g., ResNetConvLayer)",
 )
-@click.option(
-    "-c",
-    "--config",
-    "config_file",
-    type=click.Path(exists=True),
-    default=None,
+@cli_utils.build_config_option(
     help="JSON config file with overrides (WinMLBuildConfig format)",
 )
 @click.option(
@@ -115,13 +103,8 @@ def _is_onnx_file(model_input: str) -> bool:
     "vision: height, width, num_channels; "
     "audio: feature_size, nb_max_frames, audio_sequence_length.",
 )
-@click.option(
-    "-d",
-    "--device",
-    "device",
-    type=click.Choice(["auto", "npu", "gpu", "cpu"], case_sensitive=False),
-    default="auto",
-    help="Target device (affects quant/compile config). Default: auto (no changes to config).",
+@cli_utils.device_option(
+    required=False, optional_message="Affects compile config.", default="auto", include_auto=True
 )
 @cli_utils.ep_option(
     required=False,
@@ -165,7 +148,7 @@ def _is_onnx_file(model_input: str) -> bool:
 )
 @cli_utils.trust_remote_code_option()
 def config(
-    hf_model: str | None,
+    model: str | None,
     task: str | None,
     model_class: str | None,
     model_type: str | None,
@@ -226,6 +209,7 @@ def config(
     if verbose:
         logging.basicConfig(level=logging.DEBUG)
 
+    hf_model = model  # rename for clarity in this function
     # Validate: at least one of -m, --model-type, or --model-class is required
     if hf_model is None and model_type is None and model_class is None:
         # Show header even for errors

--- a/src/winml/modelkit/commands/eval.py
+++ b/src/winml/modelkit/commands/eval.py
@@ -140,7 +140,7 @@ logger = logging.getLogger(__name__)
     default=False,
     help="Print expected dataset schema for the given --task and exit.",
 )
-@cli_utils.build_config_option
+@cli_utils.build_config_option()
 @click.pass_context
 def eval(
     ctx: click.Context,
@@ -191,8 +191,7 @@ def eval(
         if schema is None:
             supported = ", ".join(sorted(TASK_SCHEMAS))
             raise click.UsageError(
-                f"Task '{task_arg}' is not supported by `winml eval`. "
-                f"Supported tasks: {supported}."
+                f"Task '{task_arg}' is not supported by `winml eval`. Supported tasks: {supported}."
             )
         _print_schema(task_arg, schema)
         return

--- a/src/winml/modelkit/commands/export.py
+++ b/src/winml/modelkit/commands/export.py
@@ -128,7 +128,7 @@ def _delete_onnx_with_external_data(onnx_path: Path) -> None:
     default=None,
     help='JSON with shape overrides (e.g., {"sequence_length": 2048, "height": 640}).',
 )
-@cli_utils.build_config_option
+@cli_utils.build_config_option()
 @click.pass_context
 def export(
     ctx: click.Context,
@@ -267,6 +267,7 @@ def export(
 
     # Always auto-resolve input/output tensors via loader + Optimum
     from ..export import ONNXConfigNotFoundError
+
     try:
         from ..export import resolve_export_config as resolve_cfg
 

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -756,6 +756,7 @@ def _perf_modules(
 # Report Generation
 # =============================================================================
 
+
 def _device_string(req_device: str, act_device: str, ep_name: EPName | None) -> str:
     device_str = f"{req_device} ({act_device})" if req_device != act_device else act_device
     if ep_name:
@@ -1195,7 +1196,7 @@ def _run_onnx_benchmark(
     default=False,
     help="Enable verbose output",
 )
-@cli_utils.build_config_option
+@cli_utils.build_config_option()
 @click.pass_context
 def perf(
     ctx: click.Context,

--- a/src/winml/modelkit/commands/quantize.py
+++ b/src/winml/modelkit/commands/quantize.py
@@ -107,7 +107,7 @@ console = Console()
     default=False,
     help="Enable verbose output",
 )
-@cli_utils.build_config_option
+@cli_utils.build_config_option()
 @click.pass_context
 def quantize(
     ctx: click.Context,

--- a/src/winml/modelkit/config/build.py
+++ b/src/winml/modelkit/config/build.py
@@ -326,10 +326,10 @@ def resolve_quant_compile_config(
         Tuple of (quant_config, compile_config). Either may be None when the
         policy does not require that stage (e.g., CPU with fp32).
     """
-    from ..sysinfo import resolve_device
+    from ..sysinfo import resolve_check_device_ep
     from .precision import resolve_precision
 
-    resolved_device, available_devices = resolve_device(device=device, ep=ep)
+    resolved_device, available_devices, resolved_eps = resolve_check_device_ep(device=device, ep=ep)
     logger.info(
         "Device resolved: %s (available: %s)",
         resolved_device,
@@ -339,7 +339,7 @@ def resolve_quant_compile_config(
     policy = resolve_precision(
         device=resolved_device,
         precision=precision,
-        ep=ep,
+        ep=resolved_eps[0],
         available_devices=available_devices,
         task=task,
     )
@@ -625,12 +625,12 @@ def generate_hf_build_config(
     # =========================================================================
     # STEP 4.5: Apply device/precision policy (affects quant + compile only)
     # =========================================================================
-    from ..sysinfo import resolve_device
+    from ..sysinfo import resolve_check_device_ep
     from .precision import resolve_precision
 
     # ALWAYS detect hardware — even when device="auto" — so we don't
     # blindly default to QNN on machines without an NPU (#412).
-    resolved_device, available_devices = resolve_device(device=device, ep=ep)
+    resolved_device, available_devices, resolved_eps = resolve_check_device_ep(device=device, ep=ep)
     logger.info(
         "Device resolved: %s (available: %s)",
         resolved_device,
@@ -640,7 +640,7 @@ def generate_hf_build_config(
     policy = resolve_precision(
         device=resolved_device,
         precision=precision,
-        ep=ep,
+        ep=resolved_eps[0],
         available_devices=available_devices,
         task=parent_config.loader.task,
     )

--- a/src/winml/modelkit/sysinfo/__init__.py
+++ b/src/winml/modelkit/sysinfo/__init__.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-from .device import get_device_ep_map, get_ep_device_map, resolve_device, resolve_eps
+from .device import check_device, get_device_ep_map, get_ep_device_map, resolve_device, resolve_eps
 from .hardware import CPU, GPU, NPU
 from .software import OS
 from .sysinfo import SysInfo
@@ -14,6 +14,7 @@ __all__ = [
     "NPU",
     "OS",
     "SysInfo",
+    "check_device",
     "get_device_ep_map",
     "get_ep_device_map",
     "resolve_device",

--- a/src/winml/modelkit/sysinfo/__init__.py
+++ b/src/winml/modelkit/sysinfo/__init__.py
@@ -2,7 +2,13 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-from .device import check_device, get_device_ep_map, get_ep_device_map, resolve_device, resolve_eps
+from .device import (
+    get_device_ep_map,
+    get_ep_device_map,
+    resolve_check_device_ep,
+    resolve_device,
+    resolve_eps,
+)
 from .hardware import CPU, GPU, NPU
 from .software import OS
 from .sysinfo import SysInfo
@@ -14,9 +20,9 @@ __all__ = [
     "NPU",
     "OS",
     "SysInfo",
-    "check_device",
     "get_device_ep_map",
     "get_ep_device_map",
+    "resolve_check_device_ep",
     "resolve_device",
     "resolve_eps",
 ]

--- a/src/winml/modelkit/sysinfo/device.py
+++ b/src/winml/modelkit/sysinfo/device.py
@@ -240,12 +240,19 @@ def resolve_check_device_ep(
 
     Raises:
         ValueError: If the requested device or EP combination is not valid.
+
+    Returns:
+    Tuple of (resolved_device, available_devices, available_eps) where:
+    - resolved_device: The device that should be used based on the input parameters.
+    - available_devices: List of devices that are compatible with the first in available_eps
+    - available_eps: List of EPs that are compatible with the resolved device.
     """
     ep_name = normalize_ep_name(ep)
     if device == "auto" or ep_name is None:
-        resolved_device, available_devices = resolve_device(device=device, ep=ep_name)
+        resolved_device, _ = resolve_device(device=device, ep=ep_name)
         available_eps: list[EPName] = resolve_eps(resolved_device) if ep_name is None else [ep_name]
-        return resolved_device, available_devices, available_eps
+        supported_devices = EP_SUPPORTED_DEVICES[available_eps[0]]
+        return resolved_device, list(supported_devices), available_eps
 
     if ep_name not in EP_SUPPORTED_DEVICES:
         raise ValueError(f"Unknown EP '{ep}'. Expected one of: {sorted(EP_SUPPORTED_DEVICES)}")

--- a/src/winml/modelkit/sysinfo/device.py
+++ b/src/winml/modelkit/sysinfo/device.py
@@ -243,7 +243,7 @@ def resolve_check_device_ep(
     """
     ep_name = normalize_ep_name(ep)
     if device == "auto" or ep_name is None:
-        resolved_device, available_devices = resolve_device(device=device, ep=ep)
+        resolved_device, available_devices = resolve_device(device=device, ep=ep_name)
         available_eps: list[EPName] = resolve_eps(resolved_device) if ep_name is None else [ep_name]
         return resolved_device, available_devices, available_eps
 

--- a/src/winml/modelkit/sysinfo/device.py
+++ b/src/winml/modelkit/sysinfo/device.py
@@ -144,35 +144,6 @@ def _get_available_eps() -> frozenset[EPName]:
     return frozenset(ep for eps in _get_device_ep_map_from_ort().values() for ep in eps)
 
 
-def check_device(*, device: str = "auto", ep: EPNameOrAlias | None = None) -> None:
-    """Check that the requested device and/or EP combination is valid, raising if not.
-
-    Ideal for commands that do not need the device + ep actually exists on the system.
-
-    Args:
-        device: "auto", "npu", "gpu", or "cpu".
-        ep: Optional EP short name (e.g., "qnn", "dml"). When set,
-            availability is checked and an error is raised if no compatible EP
-            is found.
-
-    Raises:
-        ValueError: If the requested device or EP combination is not valid.
-    """
-    if device == "auto":
-        return  # "auto" is always valid
-    ep_name = normalize_ep_name(ep)
-    if ep_name is None:
-        return  # No specific EP requested, so no compatibility check needed
-    if ep_name not in EP_SUPPORTED_DEVICES:
-        raise ValueError(f"Unknown EP '{ep}'. Expected one of: {sorted(EP_SUPPORTED_DEVICES)}")
-    supported_devices = EP_SUPPORTED_DEVICES[ep_name]
-    if device.lower() not in supported_devices:
-        raise ValueError(
-            f"EP '{ep}' does not support device '{device}'. "
-            f"Supported devices for {ep_name}: {', '.join(supported_devices)}."
-        )
-
-
 def resolve_device(
     device: str = "auto",
     *,
@@ -252,3 +223,36 @@ def resolve_eps(resolved_device: str) -> list[EPName]:
     device = resolved_device.lower()
     available_eps = set(_get_device_ep_map_from_ort().get(device, ()))
     return [ep for ep in _DEVICE_EP_MAP.get(device, []) if ep in available_eps]
+
+
+def resolve_check_device_ep(
+    *, device: str = "auto", ep: EPNameOrAlias | None = None
+) -> tuple[str, list[str], list[EPName]]:
+    """Resolve or check that the requested device and/or EP combination is valid, raising if not.
+
+    Ideal for commands that do not need the device + ep actually exists on the system.
+
+    Args:
+        device: "auto", "npu", "gpu", or "cpu".
+        ep: Optional EP short name (e.g., "qnn", "dml"). When set,
+            availability is checked and an error is raised if no compatible EP
+            is found.
+
+    Raises:
+        ValueError: If the requested device or EP combination is not valid.
+    """
+    ep_name = normalize_ep_name(ep)
+    if device == "auto" or ep_name is None:
+        resolved_device, available_devices = resolve_device(device=device, ep=ep)
+        available_eps: list[EPName] = resolve_eps(resolved_device) if ep_name is None else [ep_name]
+        return resolved_device, available_devices, available_eps
+
+    if ep_name not in EP_SUPPORTED_DEVICES:
+        raise ValueError(f"Unknown EP '{ep}'. Expected one of: {sorted(EP_SUPPORTED_DEVICES)}")
+    supported_devices = EP_SUPPORTED_DEVICES[ep_name]
+    if device.lower() not in supported_devices:
+        raise ValueError(
+            f"EP '{ep}' does not support device '{device}'. "
+            f"Supported devices for {ep_name}: {', '.join(supported_devices)}."
+        )
+    return device.lower(), list(supported_devices), [ep_name]

--- a/src/winml/modelkit/sysinfo/device.py
+++ b/src/winml/modelkit/sysinfo/device.py
@@ -144,6 +144,35 @@ def _get_available_eps() -> frozenset[EPName]:
     return frozenset(ep for eps in _get_device_ep_map_from_ort().values() for ep in eps)
 
 
+def check_device(*, device: str = "auto", ep: EPNameOrAlias | None = None) -> None:
+    """Check that the requested device and/or EP combination is valid, raising if not.
+
+    Ideal for commands that do not need the device + ep actually exists on the system.
+
+    Args:
+        device: "auto", "npu", "gpu", or "cpu".
+        ep: Optional EP short name (e.g., "qnn", "dml"). When set,
+            availability is checked and an error is raised if no compatible EP
+            is found.
+
+    Raises:
+        ValueError: If the requested device or EP combination is not valid.
+    """
+    if device == "auto":
+        return  # "auto" is always valid
+    ep_name = normalize_ep_name(ep)
+    if ep_name is None:
+        return  # No specific EP requested, so no compatibility check needed
+    if ep_name not in EP_SUPPORTED_DEVICES:
+        raise ValueError(f"Unknown EP '{ep}'. Expected one of: {sorted(EP_SUPPORTED_DEVICES)}")
+    supported_devices = EP_SUPPORTED_DEVICES[ep_name]
+    if device.lower() not in supported_devices:
+        raise ValueError(
+            f"EP '{ep}' does not support device '{device}'. "
+            f"Supported devices for {ep_name}: {', '.join(supported_devices)}."
+        )
+
+
 def resolve_device(
     device: str = "auto",
     *,

--- a/src/winml/modelkit/utils/cli.py
+++ b/src/winml/modelkit/utils/cli.py
@@ -74,7 +74,7 @@ def model_path_option(required=True):
     )
 
 
-def model_option(required=True):
+def model_option(required=True, optional_message=None):
     """Add --model option that accepts any model reference.
 
     Accepts a HuggingFace model ID, build output directory, or .onnx file path.
@@ -86,12 +86,15 @@ def model_option(required=True):
     Returns:
         Decorator function
     """
+    help = "Model: HF model ID, build output directory, or .onnx file path"
+    if optional_message:
+        help = f"{help}. {optional_message}"
     return click.option(
         "--model",
         "-m",
         required=required,
         default=None,
-        help="Model: HF model ID, build output directory, or .onnx file path",
+        help=help,
     )
 
 
@@ -209,17 +212,21 @@ def verbosity_options(f):
     return f  # noqa: RET504
 
 
-def build_config_option(func):
+def build_config_option(help: str | None = None):
     """Add -c/--config option for WinMLBuildConfig JSON file."""
+    if help is None:
+        help = (
+            "WinMLBuildConfig JSON file (from winml config). "
+            "Provides defaults; explicit CLI options take precedence."
+        )
     return click.option(
         "-c",
         "--config",
         "config_file",
         type=click.Path(exists=True, path_type=Path),
         default=None,
-        help="WinMLBuildConfig JSON file (from winml config). "
-        "Provides defaults; explicit CLI options take precedence.",
-    )(func)
+        help=help,
+    )
 
 
 def trust_remote_code_option(optional_message: str | None = None):

--- a/src/winml/modelkit/utils/cli.py
+++ b/src/winml/modelkit/utils/cli.py
@@ -172,6 +172,7 @@ def device_option(required=True, optional_message=None, default="NPU", include_a
         help_text = f"{help_text}. {optional_message}"
 
     return click.option(
+        "-d",
         "--device",
         required=required,
         default=default if not required else None,

--- a/tests/cli/test_catalog_cli.py
+++ b/tests/cli/test_catalog_cli.py
@@ -182,7 +182,7 @@ class TestCatalogCliSurface:
     def test_invalid_device_choice_exits_two(self) -> None:
         result = _run("--device", "TPU")
         assert result.exit_code == 2
-        assert "Invalid value for '--device'" in result.output
+        assert "Invalid value for '-d' / '--device'" in result.output
 
     def test_short_flags_accepted(self, type_task_pair: tuple[str, str], tmp_path: Path) -> None:
         """-t / -k short aliases are accepted by the parser."""

--- a/tests/unit/commands/test_build.py
+++ b/tests/unit/commands/test_build.py
@@ -30,15 +30,29 @@ _DEVICE_TO_EPS = {
 }
 
 
+def _fake_resolve_check_device_ep(*, device: str = "auto", ep: str | None = None):
+    """Side effect for resolve_check_device_ep that honours the requested device.
+
+    The build command's --device path calls resolve_quant_compile_config which
+    in turn calls resolve_check_device_ep. Tests pass explicit devices like
+    "npu", "gpu", "cpu" -- echo them back with a canonical EP so the downstream
+    precision policy resolves deterministically.
+    """
+    resolved = device.lower() if device != "auto" else "npu"
+    eps = _DEVICE_TO_EPS.get(resolved, ["CPUExecutionProvider"])
+    return resolved, ["npu", "gpu", "cpu"], eps
+
+
 @pytest.fixture(autouse=True)
 def mock_resolve_device():
-    """Mock resolve_device / resolve_eps to avoid hardware detection.
+    """Mock device/EP resolution to avoid hardware detection.
 
-    The build command calls resolve_device() / resolve_eps() to auto-select
-    an EP when ``--ep`` is not specified. Both must be mocked to avoid
-    slow DLL scanning and WinML SDK discovery on CI runners without WinML
-    installed. WinMLEPRegistry.get_instance is also patched defensively
-    for any downstream code path that may touch it.
+    The build command calls ``resolve_device`` / ``resolve_eps`` to auto-select
+    an EP when ``--ep`` is not specified, and ``resolve_check_device_ep`` (via
+    ``resolve_quant_compile_config``) when ``--device`` is explicit. All three
+    must be mocked to avoid slow DLL scanning and WinML SDK discovery on CI
+    runners without WinML installed. ``WinMLEPRegistry.get_instance`` is also
+    patched defensively for any downstream code path that may touch it.
     """
     mock_registry = MagicMock()
     mock_registry.is_ep_available.return_value = False
@@ -51,6 +65,10 @@ def mock_resolve_device():
         patch(
             "winml.modelkit.sysinfo.resolve_eps",
             side_effect=lambda device: list(_DEVICE_TO_EPS.get(device, [])),
+        ),
+        patch(
+            "winml.modelkit.sysinfo.resolve_check_device_ep",
+            side_effect=_fake_resolve_check_device_ep,
         ),
         patch(
             "winml.modelkit.session.ep_registry.WinMLEPRegistry.get_instance",

--- a/tests/unit/commands/test_config_cli.py
+++ b/tests/unit/commands/test_config_cli.py
@@ -25,14 +25,15 @@ from click.testing import CliRunner, Result
 
 @pytest.fixture(autouse=True)
 def mock_resolve_device():
-    """Mock resolve_device to avoid hardware detection in all config CLI tests.
+    """Mock resolve_check_device_ep to avoid hardware detection in CLI tests.
 
-    The config command may call resolve_device() for device/precision resolution.
-    We mock it at the source module since it's a lazy import.
+    The config command calls resolve_check_device_ep() (lazy import) for
+    device/EP resolution and display. We mock at the source module since the
+    import happens at call time.
     """
     with patch(
-        "winml.modelkit.sysinfo.resolve_device",
-        return_value=("npu", ["npu", "gpu", "cpu"]),
+        "winml.modelkit.sysinfo.resolve_check_device_ep",
+        return_value=("npu", ["npu", "gpu", "cpu"], ["QNNExecutionProvider"]),
     ):
         yield
 

--- a/tests/unit/config/conftest.py
+++ b/tests/unit/config/conftest.py
@@ -4,10 +4,11 @@
 # --------------------------------------------------------------------------
 """Shared fixtures for config tests.
 
-Mocks ``resolve_device`` and ``resolve_eps`` to avoid slow EP discovery
-in CI and to keep ``compile_provider`` resolution deterministic regardless
-of which EPs the test host has installed (e.g., OpenVINO would otherwise
-out-rank QNN/DML/CPU under the dynamic resolution in ``resolve_precision``).
+Mocks ``resolve_check_device_ep`` and ``resolve_eps`` to avoid slow EP
+discovery in CI and to keep ``compile_provider`` resolution deterministic
+regardless of which EPs the test host has installed (e.g., OpenVINO would
+otherwise out-rank QNN/DML/CPU under the dynamic resolution in
+``resolve_precision``).
 """
 
 from unittest.mock import patch
@@ -26,7 +27,10 @@ _DEVICE_TO_EPS = {
 def mock_resolve_device():
     """Mock device + EP resolution globally for all config tests.
 
-    - ``resolve_device``: stubbed so EP discovery via WinML doesn't slow CI.
+    - ``resolve_check_device_ep``: stubbed so EP discovery via WinML doesn't
+      slow CI. ``build.py`` calls this (not ``resolve_device`` directly), so
+      patching the higher-level entry point is what intercepts the lazy
+      import in ``generate_hf_build_config`` / ``resolve_quant_compile_config``.
     - ``resolve_eps``: returns a canonical single-EP list per device so
       ``resolve_precision`` produces deterministic ``compile_provider``
       values (QNN for npu, DML for gpu, CPU→None for cpu) independent of
@@ -34,8 +38,8 @@ def mock_resolve_device():
     """
     with (
         patch(
-            "winml.modelkit.sysinfo.resolve_device",
-            return_value=("npu", ["npu", "gpu", "cpu"]),
+            "winml.modelkit.sysinfo.resolve_check_device_ep",
+            return_value=("npu", ["npu", "gpu", "cpu"], ["QNNExecutionProvider"]),
         ),
         patch(
             "winml.modelkit.config.precision.resolve_eps",

--- a/tests/unit/config/test_build.py
+++ b/tests/unit/config/test_build.py
@@ -1975,10 +1975,18 @@ class TestDevicePrecisionIntegration:
             ),
             patch("winml.modelkit.models.hf.MODEL_BUILD_CONFIGS", {}),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
                 return_value=(
                     "npu" if device == "auto" else device,
                     ["npu", "gpu", "cpu"],
+                    [
+                        {
+                            "npu": "QNNExecutionProvider",
+                            "gpu": "DmlExecutionProvider",
+                            "cpu": "CPUExecutionProvider",
+                            "auto": "QNNExecutionProvider",
+                        }[device]
+                    ],
                 ),
             ),
         ):
@@ -2043,8 +2051,8 @@ class TestDevicePrecisionIntegration:
         # Default compile provider is "qnn" (from WinMLCompileConfig -> EPConfig)
         assert result.compile.ep_config.provider == "qnn"
 
-    def test_auto_auto_still_calls_resolve_device(self) -> None:
-        """device='auto' + precision='auto' DOES call resolve_device (#412).
+    def test_auto_auto_still_calls_resolve_check_device_ep(self) -> None:
+        """device='auto' + precision='auto' DOES call resolve_check_device_ep (#412).
 
         Previously this was skipped, causing EPConfig to default to 'qnn'
         on machines without an NPU. Now we always detect hardware.
@@ -2064,9 +2072,9 @@ class TestDevicePrecisionIntegration:
             ),
             patch("winml.modelkit.models.hf.MODEL_BUILD_CONFIGS", {}),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("npu", ["npu", "gpu", "cpu"]),
-            ) as mock_rd,
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("npu", ["npu", "gpu", "cpu"], ["QNNExecutionProvider"]),
+            ) as mock_rcde,
         ):
             generate_build_config(
                 "bert-base-uncased",
@@ -2074,10 +2082,10 @@ class TestDevicePrecisionIntegration:
                 precision="auto",
             )
 
-        mock_rd.assert_called_once_with(device="auto", ep=None)
+        mock_rcde.assert_called_once_with(device="auto", ep=None)
 
-    def test_explicit_precision_triggers_resolve_device(self) -> None:
-        """device='auto' + precision='int8' DOES call resolve_device."""
+    def test_explicit_precision_triggers_resolve_check_device_ep(self) -> None:
+        """device='auto' + precision='int8' DOES call resolve_check_device_ep."""
         with (
             patch(
                 "winml.modelkit.config.build.resolve_loader_config",
@@ -2093,9 +2101,9 @@ class TestDevicePrecisionIntegration:
             ),
             patch("winml.modelkit.models.hf.MODEL_BUILD_CONFIGS", {}),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("npu", ["npu", "gpu", "cpu"]),
-            ) as mock_rd,
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("npu", ["npu", "gpu", "cpu"], ["QNNExecutionProvider"]),
+            ) as mock_rcde,
         ):
             generate_build_config(
                 "bert-base-uncased",
@@ -2103,7 +2111,7 @@ class TestDevicePrecisionIntegration:
                 precision="int8",
             )
 
-        mock_rd.assert_called_once()
+        mock_rcde.assert_called_once()
 
 
 # =============================================================================
@@ -2138,8 +2146,8 @@ class TestDevicePrecisionCli:
             ),
             "registry": patch("winml.modelkit.models.hf.MODEL_BUILD_CONFIGS", {}),
             "device": patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("npu", ["npu", "gpu", "cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("npu", ["npu", "gpu", "cpu"], ["QNNExecutionProvider"]),
             ),
         }
 
@@ -2176,8 +2184,8 @@ class TestDevicePrecisionCli:
     def test_device_gpu_precision_fp16(self, tmp_path) -> None:
         """--device gpu --precision fp16 → no quant, compile.provider=dml."""
         self._patches["device"] = patch(
-            "winml.modelkit.sysinfo.resolve_device",
-            return_value=("gpu", ["gpu", "cpu"]),
+            "winml.modelkit.sysinfo.resolve_check_device_ep",
+            return_value=("gpu", ["gpu", "cpu"], ["DmlExecutionProvider"]),
         )
         result, output_file = self._invoke(
             tmp_path,
@@ -2192,8 +2200,8 @@ class TestDevicePrecisionCli:
     def test_device_cpu_precision_fp32(self, tmp_path) -> None:
         """--device cpu --precision fp32 → no quant, no compile."""
         self._patches["device"] = patch(
-            "winml.modelkit.sysinfo.resolve_device",
-            return_value=("cpu", ["cpu"]),
+            "winml.modelkit.sysinfo.resolve_check_device_ep",
+            return_value=("cpu", ["cpu"], ["CPUExecutionProvider"]),
         )
         result, output_file = self._invoke(
             tmp_path,
@@ -2271,8 +2279,8 @@ class TestConfigOnnxAutoDetect:
             patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
             patch("winml.modelkit.onnx.is_quantized_onnx", return_value=False),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("npu", ["npu", "gpu", "cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("npu", ["npu", "gpu", "cpu"], ["QNNExecutionProvider"]),
             ),
         ):
             runner = CliRunner()
@@ -2349,8 +2357,8 @@ class TestGenerateBuildConfigOnnxPath:
             patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
             patch("winml.modelkit.onnx.is_quantized_onnx", return_value=False),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("npu", ["npu", "cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("npu", ["npu", "cpu"], ["QNNExecutionProvider"]),
             ),
         ):
             config = generate_onnx_build_config(str(onnx_file), device="npu")
@@ -2371,8 +2379,8 @@ class TestGenerateBuildConfigOnnxPath:
             patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
             patch("winml.modelkit.onnx.is_quantized_onnx", return_value=False),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("cpu", ["cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("cpu", ["cpu"], ["CPUExecutionProvider"]),
             ),
         ):
             config = generate_onnx_build_config(str(onnx_file), device="cpu")
@@ -2390,8 +2398,8 @@ class TestGenerateBuildConfigOnnxPath:
             patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
             patch("winml.modelkit.onnx.is_quantized_onnx", return_value=True),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("npu", ["npu", "cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("npu", ["npu", "cpu"], ["QNNExecutionProvider"]),
             ),
         ):
             config = generate_onnx_build_config(str(onnx_file), device="npu")
@@ -2409,8 +2417,8 @@ class TestGenerateBuildConfigOnnxPath:
             patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
             patch("winml.modelkit.onnx.is_quantized_onnx", return_value=True),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("cpu", ["cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("cpu", ["cpu"], ["CPUExecutionProvider"]),
             ),
         ):
             config = generate_onnx_build_config(str(onnx_file), device="cpu")
@@ -2469,8 +2477,8 @@ class TestGenerateBuildConfigOnnxPath:
                 patch("winml.modelkit.onnx.is_compiled_onnx", return_value=is_compiled),
                 patch("winml.modelkit.onnx.is_quantized_onnx", return_value=is_quantized),
                 patch(
-                    "winml.modelkit.sysinfo.resolve_device",
-                    return_value=("cpu", ["cpu"]),
+                    "winml.modelkit.sysinfo.resolve_check_device_ep",
+                    return_value=("cpu", ["cpu"], ["CPUExecutionProvider"]),
                 ),
             ):
                 config = generate_onnx_build_config(str(onnx_file))
@@ -2492,8 +2500,8 @@ class TestGenerateBuildConfigOnnxPath:
                 patch("winml.modelkit.onnx.is_compiled_onnx", return_value=is_compiled),
                 patch("winml.modelkit.onnx.is_quantized_onnx", return_value=is_quantized),
                 patch(
-                    "winml.modelkit.sysinfo.resolve_device",
-                    return_value=("cpu", ["cpu"]),
+                    "winml.modelkit.sysinfo.resolve_check_device_ep",
+                    return_value=("cpu", ["cpu"], ["CPUExecutionProvider"]),
                 ),
             ):
                 config = generate_onnx_build_config(str(onnx_file))
@@ -2511,8 +2519,8 @@ class TestGenerateBuildConfigOnnxPath:
             patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
             patch("winml.modelkit.onnx.is_quantized_onnx", return_value=False),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("cpu", ["cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("cpu", ["cpu"], ["CPUExecutionProvider"]),
             ),
         ):
             config = generate_onnx_build_config(
@@ -2531,8 +2539,8 @@ class TestGenerateBuildConfigOnnxPath:
             patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
             patch("winml.modelkit.onnx.is_quantized_onnx", return_value=False),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("cpu", ["cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("cpu", ["cpu"], ["CPUExecutionProvider"]),
             ),
         ):
             config = generate_onnx_build_config(str(onnx_file))
@@ -2559,8 +2567,8 @@ class TestGenerateBuildConfigOnnxPath:
             patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
             patch("winml.modelkit.onnx.is_quantized_onnx", return_value=False),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("npu", ["npu", "cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("npu", ["npu", "cpu"], ["QNNExecutionProvider"]),
             ),
         ):
             config = generate_onnx_build_config(
@@ -2588,8 +2596,8 @@ class TestGenerateBuildConfigOnnxPath:
             patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
             patch("winml.modelkit.onnx.is_quantized_onnx", return_value=False),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("npu", ["npu", "cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("npu", ["npu", "cpu"], ["QNNExecutionProvider"]),
             ),
             patch(
                 "winml.modelkit.config.build.merge_config",
@@ -2650,8 +2658,8 @@ class TestGenerateBuildConfigOnnxPath:
             patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
             patch("winml.modelkit.onnx.is_quantized_onnx", return_value=False),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("npu", ["npu", "cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("npu", ["npu", "cpu"], ["QNNExecutionProvider"]),
             ),
         ):
             config = generate_onnx_build_config(
@@ -2677,8 +2685,8 @@ class TestGenerateBuildConfigOnnxPath:
             patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
             patch("winml.modelkit.onnx.is_quantized_onnx", return_value=False),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("cpu", ["cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("cpu", ["cpu"], ["CPUExecutionProvider"]),
             ),
         ):
             config = generate_onnx_build_config(str(onnx_file))
@@ -2696,8 +2704,8 @@ class TestGenerateBuildConfigOnnxPath:
             patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
             patch("winml.modelkit.onnx.is_quantized_onnx", return_value=False),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("cpu", ["cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("cpu", ["cpu"], ["CPUExecutionProvider"]),
             ),
         ):
             config = generate_onnx_build_config(Path(onnx_file))
@@ -2717,8 +2725,8 @@ class TestGenerateBuildConfigOnnxPath:
             patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
             patch("winml.modelkit.onnx.is_quantized_onnx", return_value=False),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("auto", ["npu", "gpu", "cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("auto", ["npu", "gpu", "cpu"], ["CPUExecutionProvider"]),
             ),
         ):
             config = generate_onnx_build_config(str(onnx_file))
@@ -2752,8 +2760,8 @@ class TestGenerateBuildConfigOnnxPath:
             patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
             patch("winml.modelkit.onnx.is_quantized_onnx", return_value=False),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("gpu", ["gpu", "cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("gpu", ["gpu", "cpu"], ["DmlExecutionProvider"]),
             ),
         ):
             config = generate_onnx_build_config(str(onnx_file), device="gpu")
@@ -2771,8 +2779,8 @@ class TestGenerateBuildConfigOnnxPath:
             patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
             patch("winml.modelkit.onnx.is_quantized_onnx", return_value=False),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("gpu", ["gpu", "cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("gpu", ["gpu", "cpu"], ["DmlExecutionProvider"]),
             ),
         ):
             config = generate_onnx_build_config(
@@ -2800,8 +2808,8 @@ class TestResolveQuantCompileConfig:
     def test_auto_auto_returns_none_none(self) -> None:
         """device=auto + precision=auto returns (None, None)."""
         with patch(
-            "winml.modelkit.sysinfo.resolve_device",
-            return_value=("auto", ["npu", "gpu", "cpu"]),
+            "winml.modelkit.sysinfo.resolve_check_device_ep",
+            return_value=("auto", ["npu", "gpu", "cpu"], ["CPUExecutionProvider"]),
         ):
             quant, compile_cfg = resolve_quant_compile_config()
 
@@ -2811,8 +2819,8 @@ class TestResolveQuantCompileConfig:
     def test_npu_returns_quant_and_compile(self) -> None:
         """device=npu returns (WinMLQuantizationConfig, WinMLCompileConfig)."""
         with patch(
-            "winml.modelkit.sysinfo.resolve_device",
-            return_value=("npu", ["npu", "cpu"]),
+            "winml.modelkit.sysinfo.resolve_check_device_ep",
+            return_value=("npu", ["npu", "cpu"], ["QNNExecutionProvider"]),
         ):
             quant, compile_cfg = resolve_quant_compile_config(device="npu")
 
@@ -2825,8 +2833,8 @@ class TestResolveQuantCompileConfig:
     def test_gpu_returns_none_quant_and_none_compile(self) -> None:
         """device=gpu returns (None, None) — DML has no offline compile step."""
         with patch(
-            "winml.modelkit.sysinfo.resolve_device",
-            return_value=("gpu", ["gpu", "cpu"]),
+            "winml.modelkit.sysinfo.resolve_check_device_ep",
+            return_value=("gpu", ["gpu", "cpu"], ["DmlExecutionProvider"]),
         ):
             quant, compile_cfg = resolve_quant_compile_config(device="gpu")
 
@@ -2836,8 +2844,8 @@ class TestResolveQuantCompileConfig:
     def test_cpu_returns_none_none(self) -> None:
         """device=cpu returns (None, None) since CPU has no compile provider."""
         with patch(
-            "winml.modelkit.sysinfo.resolve_device",
-            return_value=("cpu", ["cpu"]),
+            "winml.modelkit.sysinfo.resolve_check_device_ep",
+            return_value=("cpu", ["cpu"], ["CPUExecutionProvider"]),
         ):
             quant, compile_cfg = resolve_quant_compile_config(device="cpu")
 
@@ -2851,9 +2859,13 @@ class TestResolveQuantCompileConfig:
         Device is stored in ep_config.device (not provider_options) to avoid
         crashes when trtrtx gets device_type in add_provider_for_devices.
         """
+        # The mock must echo the requested ep back as available_eps[0] —
+        # resolve_quant_compile_config forwards available_eps[0] to
+        # resolve_precision, so the ep argument to resolve_precision needs to
+        # match what the user passed (nv_tensorrt_rtx).
         with patch(
-            "winml.modelkit.sysinfo.resolve_device",
-            return_value=("gpu", ["gpu", "cpu"]),
+            "winml.modelkit.sysinfo.resolve_check_device_ep",
+            return_value=("gpu", ["gpu", "cpu"], ["NvTensorRTRTXExecutionProvider"]),
         ):
             _quant, compile_cfg = resolve_quant_compile_config(
                 device="gpu",
@@ -2872,8 +2884,8 @@ class TestResolveQuantCompileConfig:
         """
         with (
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("gpu", ["gpu", "cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("gpu", ["gpu", "cpu"], ["DmlExecutionProvider"]),
             ),
             patch(
                 "winml.modelkit.config.precision.resolve_precision",
@@ -2890,8 +2902,8 @@ class TestResolveQuantCompileConfig:
     def test_explicit_int8_precision_on_npu(self) -> None:
         """Explicit precision=int8 on npu produces uint8 quant."""
         with patch(
-            "winml.modelkit.sysinfo.resolve_device",
-            return_value=("npu", ["npu", "cpu"]),
+            "winml.modelkit.sysinfo.resolve_check_device_ep",
+            return_value=("npu", ["npu", "cpu"], ["QNNExecutionProvider"]),
         ):
             quant, _compile_cfg = resolve_quant_compile_config(
                 device="npu",
@@ -2905,8 +2917,8 @@ class TestResolveQuantCompileConfig:
     def test_explicit_fp32_precision_no_quant(self) -> None:
         """Explicit precision=fp32 produces no quantization."""
         with patch(
-            "winml.modelkit.sysinfo.resolve_device",
-            return_value=("gpu", ["gpu", "cpu"]),
+            "winml.modelkit.sysinfo.resolve_check_device_ep",
+            return_value=("gpu", ["gpu", "cpu"], ["DmlExecutionProvider"]),
         ):
             quant, _compile_cfg = resolve_quant_compile_config(
                 device="gpu",

--- a/tests/unit/config/test_build_onnx.py
+++ b/tests/unit/config/test_build_onnx.py
@@ -124,8 +124,8 @@ class TestConfigOnnxAutoDetect:
             patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
             patch("winml.modelkit.onnx.is_quantized_onnx", return_value=False),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("npu", ["npu", "gpu", "cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("npu", ["npu", "gpu", "cpu"], ["QNNExecutionProvider"]),
             ),
         ):
             runner = CliRunner()
@@ -202,8 +202,8 @@ class TestGenerateBuildConfigOnnxPath:
             patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
             patch("winml.modelkit.onnx.is_quantized_onnx", return_value=False),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("npu", ["npu", "cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("npu", ["npu", "cpu"], ["QNNExecutionProvider"]),
             ),
         ):
             config = generate_onnx_build_config(str(onnx_file), device="npu")
@@ -224,8 +224,8 @@ class TestGenerateBuildConfigOnnxPath:
             patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
             patch("winml.modelkit.onnx.is_quantized_onnx", return_value=False),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("cpu", ["cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("cpu", ["cpu"], ["CPUExecutionProvider"]),
             ),
         ):
             config = generate_onnx_build_config(str(onnx_file), device="cpu")
@@ -243,8 +243,8 @@ class TestGenerateBuildConfigOnnxPath:
             patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
             patch("winml.modelkit.onnx.is_quantized_onnx", return_value=True),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("npu", ["npu", "cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("npu", ["npu", "cpu"], ["QNNExecutionProvider"]),
             ),
         ):
             config = generate_onnx_build_config(str(onnx_file), device="npu")
@@ -262,8 +262,8 @@ class TestGenerateBuildConfigOnnxPath:
             patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
             patch("winml.modelkit.onnx.is_quantized_onnx", return_value=True),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("cpu", ["cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("cpu", ["cpu"], ["CPUExecutionProvider"]),
             ),
         ):
             config = generate_onnx_build_config(str(onnx_file), device="cpu")
@@ -322,8 +322,8 @@ class TestGenerateBuildConfigOnnxPath:
                 patch("winml.modelkit.onnx.is_compiled_onnx", return_value=is_compiled),
                 patch("winml.modelkit.onnx.is_quantized_onnx", return_value=is_quantized),
                 patch(
-                    "winml.modelkit.sysinfo.resolve_device",
-                    return_value=("cpu", ["cpu"]),
+                    "winml.modelkit.sysinfo.resolve_check_device_ep",
+                    return_value=("cpu", ["cpu"], ["CPUExecutionProvider"]),
                 ),
             ):
                 config = generate_onnx_build_config(str(onnx_file))
@@ -345,8 +345,8 @@ class TestGenerateBuildConfigOnnxPath:
                 patch("winml.modelkit.onnx.is_compiled_onnx", return_value=is_compiled),
                 patch("winml.modelkit.onnx.is_quantized_onnx", return_value=is_quantized),
                 patch(
-                    "winml.modelkit.sysinfo.resolve_device",
-                    return_value=("cpu", ["cpu"]),
+                    "winml.modelkit.sysinfo.resolve_check_device_ep",
+                    return_value=("cpu", ["cpu"], ["CPUExecutionProvider"]),
                 ),
             ):
                 config = generate_onnx_build_config(str(onnx_file))
@@ -364,8 +364,8 @@ class TestGenerateBuildConfigOnnxPath:
             patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
             patch("winml.modelkit.onnx.is_quantized_onnx", return_value=False),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("cpu", ["cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("cpu", ["cpu"], ["CPUExecutionProvider"]),
             ),
         ):
             config = generate_onnx_build_config(
@@ -384,8 +384,8 @@ class TestGenerateBuildConfigOnnxPath:
             patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
             patch("winml.modelkit.onnx.is_quantized_onnx", return_value=False),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("cpu", ["cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("cpu", ["cpu"], ["CPUExecutionProvider"]),
             ),
         ):
             config = generate_onnx_build_config(str(onnx_file))
@@ -412,8 +412,8 @@ class TestGenerateBuildConfigOnnxPath:
             patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
             patch("winml.modelkit.onnx.is_quantized_onnx", return_value=False),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("npu", ["npu", "cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("npu", ["npu", "cpu"], ["QNNExecutionProvider"]),
             ),
         ):
             config = generate_onnx_build_config(
@@ -441,8 +441,8 @@ class TestGenerateBuildConfigOnnxPath:
             patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
             patch("winml.modelkit.onnx.is_quantized_onnx", return_value=False),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("npu", ["npu", "cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("npu", ["npu", "cpu"], ["QNNExecutionProvider"]),
             ),
             patch(
                 "winml.modelkit.config.build.merge_config",
@@ -503,8 +503,8 @@ class TestGenerateBuildConfigOnnxPath:
             patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
             patch("winml.modelkit.onnx.is_quantized_onnx", return_value=False),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("npu", ["npu", "cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("npu", ["npu", "cpu"], ["QNNExecutionProvider"]),
             ),
         ):
             config = generate_onnx_build_config(
@@ -530,8 +530,8 @@ class TestGenerateBuildConfigOnnxPath:
             patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
             patch("winml.modelkit.onnx.is_quantized_onnx", return_value=False),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("cpu", ["cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("cpu", ["cpu"], ["CPUExecutionProvider"]),
             ),
         ):
             config = generate_onnx_build_config(str(onnx_file))
@@ -549,8 +549,8 @@ class TestGenerateBuildConfigOnnxPath:
             patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
             patch("winml.modelkit.onnx.is_quantized_onnx", return_value=False),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("cpu", ["cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("cpu", ["cpu"], ["CPUExecutionProvider"]),
             ),
         ):
             config = generate_onnx_build_config(Path(onnx_file))
@@ -570,8 +570,8 @@ class TestGenerateBuildConfigOnnxPath:
             patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
             patch("winml.modelkit.onnx.is_quantized_onnx", return_value=False),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("auto", ["npu", "gpu", "cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("auto", ["npu", "gpu", "cpu"], ["CPUExecutionProvider"]),
             ),
         ):
             config = generate_onnx_build_config(str(onnx_file))
@@ -609,8 +609,8 @@ class TestGenerateBuildConfigOnnxPath:
             patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
             patch("winml.modelkit.onnx.is_quantized_onnx", return_value=False),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("gpu", ["gpu", "cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("gpu", ["gpu", "cpu"], ["DmlExecutionProvider"]),
             ),
         ):
             config = generate_onnx_build_config(str(onnx_file), device="gpu")
@@ -631,8 +631,8 @@ class TestGenerateBuildConfigOnnxPath:
             patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
             patch("winml.modelkit.onnx.is_quantized_onnx", return_value=False),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("gpu", ["gpu", "cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("gpu", ["gpu", "cpu"], ["DmlExecutionProvider"]),
             ),
         ):
             config = generate_onnx_build_config(
@@ -659,8 +659,8 @@ class TestResolveQuantCompileConfig:
     def test_auto_auto_returns_none_none(self) -> None:
         """device=auto + precision=auto returns (None, None)."""
         with patch(
-            "winml.modelkit.sysinfo.resolve_device",
-            return_value=("auto", ["npu", "gpu", "cpu"]),
+            "winml.modelkit.sysinfo.resolve_check_device_ep",
+            return_value=("auto", ["npu", "gpu", "cpu"], ["CPUExecutionProvider"]),
         ):
             quant, compile_cfg = resolve_quant_compile_config()
 
@@ -670,8 +670,8 @@ class TestResolveQuantCompileConfig:
     def test_npu_returns_quant_and_compile(self) -> None:
         """device=npu returns (WinMLQuantizationConfig, WinMLCompileConfig)."""
         with patch(
-            "winml.modelkit.sysinfo.resolve_device",
-            return_value=("npu", ["npu", "cpu"]),
+            "winml.modelkit.sysinfo.resolve_check_device_ep",
+            return_value=("npu", ["npu", "cpu"], ["QNNExecutionProvider"]),
         ):
             quant, compile_cfg = resolve_quant_compile_config(device="npu")
 
@@ -684,8 +684,8 @@ class TestResolveQuantCompileConfig:
     def test_gpu_returns_none_quant_and_none_compile(self) -> None:
         """device=gpu returns (None, None) — DML has no EPContext step."""
         with patch(
-            "winml.modelkit.sysinfo.resolve_device",
-            return_value=("gpu", ["gpu", "cpu"]),
+            "winml.modelkit.sysinfo.resolve_check_device_ep",
+            return_value=("gpu", ["gpu", "cpu"], ["DmlExecutionProvider"]),
         ):
             quant, compile_cfg = resolve_quant_compile_config(device="gpu")
 
@@ -695,8 +695,8 @@ class TestResolveQuantCompileConfig:
     def test_cpu_returns_none_none(self) -> None:
         """device=cpu returns (None, None) since CPU has no compile provider."""
         with patch(
-            "winml.modelkit.sysinfo.resolve_device",
-            return_value=("cpu", ["cpu"]),
+            "winml.modelkit.sysinfo.resolve_check_device_ep",
+            return_value=("cpu", ["cpu"], ["CPUExecutionProvider"]),
         ):
             quant, compile_cfg = resolve_quant_compile_config(device="cpu")
 
@@ -710,9 +710,13 @@ class TestResolveQuantCompileConfig:
         Device is stored in ep_config.device (not provider_options) to avoid
         crashes when trtrtx gets device_type in add_provider_for_devices.
         """
+        # The mock must echo the requested ep back as available_eps[0] —
+        # resolve_quant_compile_config forwards available_eps[0] to
+        # resolve_precision, so the ep argument to resolve_precision needs to
+        # match what the user passed (nv_tensorrt_rtx).
         with patch(
-            "winml.modelkit.sysinfo.resolve_device",
-            return_value=("gpu", ["gpu", "cpu"]),
+            "winml.modelkit.sysinfo.resolve_check_device_ep",
+            return_value=("gpu", ["gpu", "cpu"], ["NvTensorRTRTXExecutionProvider"]),
         ):
             _quant, compile_cfg = resolve_quant_compile_config(
                 device="gpu",
@@ -731,8 +735,8 @@ class TestResolveQuantCompileConfig:
         """
         with (
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("gpu", ["gpu", "cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("gpu", ["gpu", "cpu"], ["DmlExecutionProvider"]),
             ),
             patch(
                 "winml.modelkit.config.precision.resolve_precision",
@@ -749,8 +753,8 @@ class TestResolveQuantCompileConfig:
     def test_explicit_int8_precision_on_npu(self) -> None:
         """Explicit precision=int8 on npu produces uint8 quant."""
         with patch(
-            "winml.modelkit.sysinfo.resolve_device",
-            return_value=("npu", ["npu", "cpu"]),
+            "winml.modelkit.sysinfo.resolve_check_device_ep",
+            return_value=("npu", ["npu", "cpu"], ["QNNExecutionProvider"]),
         ):
             quant, _compile_cfg = resolve_quant_compile_config(
                 device="npu",
@@ -764,8 +768,8 @@ class TestResolveQuantCompileConfig:
     def test_explicit_fp32_precision_no_quant(self) -> None:
         """Explicit precision=fp32 produces no quantization."""
         with patch(
-            "winml.modelkit.sysinfo.resolve_device",
-            return_value=("gpu", ["gpu", "cpu"]),
+            "winml.modelkit.sysinfo.resolve_check_device_ep",
+            return_value=("gpu", ["gpu", "cpu"], ["DmlExecutionProvider"]),
         ):
             quant, _compile_cfg = resolve_quant_compile_config(
                 device="gpu",

--- a/tests/unit/models/auto/test_auto_onnx.py
+++ b/tests/unit/models/auto/test_auto_onnx.py
@@ -50,8 +50,8 @@ class TestFromOnnx:
             patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
             patch("winml.modelkit.onnx.is_quantized_onnx", return_value=False),
             patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("npu", ["npu", "cpu"]),
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("npu", ["npu", "cpu"], ["QNNExecutionProvider"]),
             ),
             patch(
                 "winml.modelkit.config.precision.resolve_eps",

--- a/tests/unit/sysinfo/test_device.py
+++ b/tests/unit/sysinfo/test_device.py
@@ -501,13 +501,16 @@ class TestResolveCheckDeviceEp:
 
     The function has two distinct code paths:
 
-    - **Path A** — ``device == "auto"`` OR ``ep is None``. Delegates to
-      :func:`resolve_device` + :func:`resolve_eps`. System-aware: it raises if
-      the requested device/EP is not actually present.
-    - **Path B** — explicit device AND explicit ep. Validates only against the
-      static ``EP_SUPPORTED_DEVICES`` mapping. Does **not** consult ORT, so it
-      succeeds on hosts with no EPs installed — the point being that some
-      callers just want to validate a (device, ep) pair, not run it.
+    - **Path A** — ``device == "auto"`` OR ``ep is None``. Resolves the
+      concrete device via :func:`resolve_device` (system-aware: raises if the
+      device/EP is not present) and the EP list via :func:`resolve_eps`. The
+      returned ``available_devices`` is the *static* device set for the first
+      available EP (``EP_SUPPORTED_DEVICES[available_eps[0]]``), not the
+      runtime-available list — keeps the contract symmetric with Path B.
+    - **Path B** — explicit device AND explicit ep. Validates only against
+      ``EP_SUPPORTED_DEVICES``. Does **not** consult ORT, so it succeeds on
+      hosts with no EPs installed — for callers that just want to validate a
+      (device, ep) pair without running it.
     """
 
     def test_auto_no_ep_delegates_to_system(self) -> None:
@@ -524,7 +527,10 @@ class TestResolveCheckDeviceEp:
             )
 
         assert device == "npu"
-        assert available_devices == ["npu", "gpu", "cpu"]
+        # available_devices is EP_SUPPORTED_DEVICES[available_eps[0]] (static),
+        # not the runtime device list. QNN supports npu/gpu, so cpu is absent
+        # even though the mocked system has it.
+        assert available_devices == ["npu", "gpu"]
         # When ep=None, available_eps comes from resolve_eps -- the full list
         # of EPs that target the resolved device, not a single explicit ep.
         assert available_eps == ["QNNExecutionProvider"]
@@ -560,7 +566,9 @@ class TestResolveCheckDeviceEp:
             )
 
         assert device == "npu"
-        assert available_devices == ["npu", "cpu"]
+        # available_devices reflects the static EP_SUPPORTED_DEVICES for QNN
+        # (npu, gpu) rather than what the mocked system advertises.
+        assert available_devices == ["npu", "gpu"]
         assert available_eps == ["QNNExecutionProvider"]
 
     def test_explicit_device_and_ep_uses_static_mapping(self) -> None:

--- a/tests/unit/sysinfo/test_device.py
+++ b/tests/unit/sysinfo/test_device.py
@@ -14,6 +14,7 @@ from winml.modelkit.sysinfo.device import (
     _DEVICE_EP_MAP,
     _EP_DEVICE_MAP,
     _get_available_devices,
+    resolve_check_device_ep,
     resolve_device,
     resolve_eps,
 )
@@ -493,3 +494,149 @@ class TestResolveEps:
             assert resolve_eps("npu") == []
             assert resolve_eps("gpu") == []
             assert resolve_eps("cpu") == []
+
+
+class TestResolveCheckDeviceEp:
+    """Tests for resolve_check_device_ep().
+
+    The function has two distinct code paths:
+
+    - **Path A** — ``device == "auto"`` OR ``ep is None``. Delegates to
+      :func:`resolve_device` + :func:`resolve_eps`. System-aware: it raises if
+      the requested device/EP is not actually present.
+    - **Path B** — explicit device AND explicit ep. Validates only against the
+      static ``EP_SUPPORTED_DEVICES`` mapping. Does **not** consult ORT, so it
+      succeeds on hosts with no EPs installed — the point being that some
+      callers just want to validate a (device, ep) pair, not run it.
+    """
+
+    def test_auto_no_ep_delegates_to_system(self) -> None:
+        """device='auto', ep=None -> Path A: device + EPs come from system probe."""
+        with _patch_device_ep_map(
+            {
+                "npu": ("QNNExecutionProvider",),
+                "gpu": ("DmlExecutionProvider",),
+                "cpu": ("CPUExecutionProvider",),
+            }
+        ):
+            device, available_devices, available_eps = resolve_check_device_ep(
+                device="auto", ep=None
+            )
+
+        assert device == "npu"
+        assert available_devices == ["npu", "gpu", "cpu"]
+        # When ep=None, available_eps comes from resolve_eps -- the full list
+        # of EPs that target the resolved device, not a single explicit ep.
+        assert available_eps == ["QNNExecutionProvider"]
+
+    def test_auto_with_ep_returns_single_ep(self) -> None:
+        """device='auto', ep='qnn' -> Path A: available_eps narrows to [ep_name]."""
+        with _patch_device_ep_map(
+            {
+                "npu": ("QNNExecutionProvider",),
+                "gpu": ("QNNExecutionProvider", "DmlExecutionProvider"),
+                "cpu": ("CPUExecutionProvider",),
+            }
+        ):
+            device, available_devices, available_eps = resolve_check_device_ep(
+                device="auto", ep="qnn"
+            )
+
+        assert device == "npu"
+        assert available_devices == ["npu", "gpu"]
+        # Even though gpu also advertises DML, the EP filter pins this to qnn.
+        assert available_eps == ["QNNExecutionProvider"]
+
+    def test_explicit_device_no_ep_delegates(self) -> None:
+        """device='npu', ep=None -> Path A (ep_name is None): goes through resolve_device."""
+        with _patch_device_ep_map(
+            {
+                "npu": ("QNNExecutionProvider",),
+                "cpu": ("CPUExecutionProvider",),
+            }
+        ):
+            device, available_devices, available_eps = resolve_check_device_ep(
+                device="npu", ep=None
+            )
+
+        assert device == "npu"
+        assert available_devices == ["npu", "cpu"]
+        assert available_eps == ["QNNExecutionProvider"]
+
+    def test_explicit_device_and_ep_uses_static_mapping(self) -> None:
+        """device='npu', ep='qnn' -> Path B: returns from static EP_SUPPORTED_DEVICES.
+
+        The available_devices is the EP's supported set ('npu', 'gpu' for QNN),
+        not what the system actually exposes.
+        """
+        with _patch_device_ep_map(
+            {
+                "npu": ("QNNExecutionProvider",),
+                "cpu": ("CPUExecutionProvider",),
+            }
+        ):
+            device, available_devices, available_eps = resolve_check_device_ep(
+                device="npu", ep="qnn"
+            )
+
+        assert device == "npu"
+        assert sorted(available_devices) == ["gpu", "npu"]
+        assert available_eps == ["QNNExecutionProvider"]
+
+    def test_path_b_does_not_require_system_eps(self) -> None:
+        """Path B succeeds when the system has no EPs registered at all.
+
+        This is the key contract for callers that only need to *validate* a
+        (device, ep) pair without running it.
+        """
+        with _patch_device_ep_map({}):
+            device, available_devices, available_eps = resolve_check_device_ep(
+                device="npu", ep="qnn"
+            )
+
+        assert device == "npu"
+        assert "npu" in available_devices
+        assert available_eps == ["QNNExecutionProvider"]
+
+    def test_explicit_device_unsupported_by_ep_raises(self) -> None:
+        """device='cpu' + ep='qnn' -> ValueError: QNN does not support CPU."""
+        with (
+            _patch_device_ep_map({}),
+            pytest.raises(ValueError, match="does not support device 'cpu'"),
+        ):
+            resolve_check_device_ep(device="cpu", ep="qnn")
+
+    def test_explicit_unknown_ep_raises(self) -> None:
+        """device='npu' + ep='tpu' -> ValueError: 'Unknown EP'."""
+        with (
+            _patch_device_ep_map({}),
+            pytest.raises(ValueError, match="Unknown EP 'tpu'"),
+        ):
+            resolve_check_device_ep(device="npu", ep="tpu")
+
+    def test_auto_unknown_ep_raises_from_delegate(self) -> None:
+        """device='auto' + ep='tpu' -> Path A delegates to resolve_device, which raises.
+
+        Confirms the error message is consistent across paths so users get the
+        same diagnostic regardless of whether they passed an explicit device.
+        """
+        with (
+            _patch_device_ep_map(
+                {
+                    "npu": ("QNNExecutionProvider",),
+                    "cpu": ("CPUExecutionProvider",),
+                }
+            ),
+            pytest.raises(ValueError, match="Unknown EP 'tpu'"),
+        ):
+            resolve_check_device_ep(device="auto", ep="tpu")
+
+    def test_case_insensitive(self) -> None:
+        """Device and EP arguments are case-insensitive."""
+        with _patch_device_ep_map({}):
+            device, _available_devices, available_eps = resolve_check_device_ep(
+                device="NPU", ep="QNN"
+            )
+
+        assert device == "npu"
+        assert available_eps == ["QNNExecutionProvider"]


### PR DESCRIPTION
## Summary

- Adds `resolve_check_device_ep` helper that validates a (device, EP) combination without requiring the device/EP to actually exist on the system. Closes #765.
- `commands/config.py` and `config/build.py` now use `resolve_check_device_ep` instead of `resolve_device` so `winml config` no longer hard-fails on hosts where the requested EP isn't installed.
- When `device=auto` or `ep=None`, the helper delegates to the existing `resolve_device` + `resolve_eps` flow (system-aware behavior preserved). When both `device` and `ep` are explicit, it only validates against the static `EP_SUPPORTED_DEVICES` mapping.
- CLI cleanup: `-m/--model`, `-c/--config`, `--device` for the config command now use the shared `cli_utils.*_option` decorators.

## Tests

- New `TestResolveCheckDeviceEp` class in `tests/unit/sysinfo/test_device.py` covering both code paths (delegation and static-only) plus error cases (unknown EP, unsupported device, case-insensitivity).
- Existing config-test mocks updated from `resolve_device` to `resolve_check_device_ep` (`tests/unit/config/conftest.py`, `tests/unit/config/test_build.py`, `tests/unit/config/test_build_onnx.py`, `tests/unit/commands/test_config_cli.py`) so the lazy import in `config/build.py` is intercepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)