### PR TITLE
fix: run eval failed on amd

### DIFF
--- a/scripts/e2e_eval/run_eval.py
+++ b/scripts/e2e_eval/run_eval.py
@@ -81,26 +81,28 @@ TIMEOUT_SKIP_LIST_PATH = Path(__file__).parent / "cache" / "timeout_skip_list.js
 _DEFAULT_SAMPLES = 1000
 _DEFAULT_PRECISION_NPU = "w8a16"
 
-# EPs that ship their own internal quantizer (run after the ONNX model is
-# loaded into the EP).  Layering winml's generic QDQ quantizer on top of
-# them noticeably degrades accuracy, so we pass ``--no-quant`` to
-# ``winml build`` and let the EP quantize natively.
+# EPs whose eval track keeps the model unquantized (the "fp" variant)
+# rather than running winml's QDQ pass on top.  This is an eval-setup
+# choice -- e.g. VitisAI / AMD Ryzen AI is benchmarked on the fp32/fp16
+# model -- not a claim about the EP's internal pipeline.  For these EPs
+# the harness passes ``--no-quant`` to both ``winml config`` and
+# ``winml build`` (see :func:`_run_build` and :func:`run_model`).
 #
 # Entries are canonical ``EPName`` values (the ``*ExecutionProvider`` form);
 # user-facing aliases like ``vitisai`` are normalised via
-# ``normalize_ep_name`` in :func:`_ep_quantizes_natively` so we only have to
-# list each EP once here.
-_NATIVE_QUANT_EPS = frozenset({"VitisAIExecutionProvider"})
+# ``normalize_ep_name`` in :func:`_should_skip_winml_quant` so each EP only
+# needs to be listed once.
+_EPS_SKIP_WINML_QUANT = frozenset({"VitisAIExecutionProvider"})
 
 
-def _ep_quantizes_natively(ep: str | None) -> bool:
-    """True if the EP ships its own internal quantizer."""
+def _should_skip_winml_quant(ep: str | None) -> bool:
+    """True if the eval harness should run this EP on the unquantized model."""
     # Lazy import: keeps ``scripts/e2e_eval`` cheap to load (winml.modelkit
     # transitively imports onnxruntime) and matches the existing in-function
     # import pattern used elsewhere in this script.
     from winml.modelkit.utils.constants import normalize_ep_name
 
-    return normalize_ep_name(ep) in _NATIVE_QUANT_EPS
+    return normalize_ep_name(ep) in _EPS_SKIP_WINML_QUANT
 
 
 def _resolve_precision(device: str, explicit: str | None, ep: str | None = None) -> str | None:
@@ -112,16 +114,24 @@ def _resolve_precision(device: str, explicit: str | None, ep: str | None = None)
     (NHWC layout transformer inserts Conv nodes that QNN GPU's GetCapability
     does not claim).
 
-    For EPs with native quantizers (e.g. VitisAI) the flag is omitted; the
-    actual "skip winml quantization" instruction is conveyed via
-    ``winml build --no-quant`` in :func:`_run_build`.
+    For EPs in :data:`_EPS_SKIP_WINML_QUANT` (e.g. VitisAI) the flag is forced
+    off regardless of ``explicit``: the harness pairs these EPs with
+    ``--no-quant`` at config/build time, so a non-empty ``--precision`` would
+    produce a config that says "quantize to X" while the build says "skip
+    quantization" -- a contradiction.  An explicit value is dropped with a
+    one-line warning so the override is visible in the log.
 
-    An explicit per-model precision always takes precedence.
+    Otherwise an explicit per-model precision always takes precedence.
     """
+    if _should_skip_winml_quant(ep):
+        if explicit:
+            safe_print(
+                f"  [precision] Ignoring explicit precision={explicit!r} for EP {ep!r}: "
+                "this EP is run on the unquantized variant (--no-quant)."
+            )
+        return None
     if explicit:
         return explicit
-    if _ep_quantizes_natively(ep):
-        return None
     return _DEFAULT_PRECISION_NPU if device == "npu" else None
 
 
@@ -433,11 +443,12 @@ def _run_build(
         config_args += ["--task", entry.task]
     if ep:
         config_args += ["--ep", ep]
-    # Native-quant EPs: also pass --no-quant to winml config so the generated
-    # build_config.json is written with quant=None up-front. Otherwise on NPU
-    # the config command would still apply its default precision (w8a16) and
-    # we'd be relying on --no-quant at build time to override it.
-    if _ep_quantizes_natively(ep):
+    # EPs in _EPS_SKIP_WINML_QUANT are evaluated on the unquantized variant.
+    # Pass --no-quant to winml config so the generated build_config.json is
+    # written with quant=None up-front; otherwise on NPU the config command
+    # would still apply its default precision (w8a16) and we'd be relying on
+    # --no-quant at build time alone to override it.
+    if _should_skip_winml_quant(ep):
         config_args += ["--no-quant"]
 
     config_proc = _run_subprocess(config_args, timeout)
@@ -479,11 +490,10 @@ def _run_build(
         ]
         if ep:
             build_args += ["--ep", ep]
-        # EPs with native quantizers (e.g. VitisAI / AMD Ryzen AI) quantize
-        # internally at session-create time; running winml's generic QDQ
-        # pass on top noticeably degrades accuracy.  --no-quant tells
-        # winml build to keep the model fp32 and lets the EP do its own.
-        if _ep_quantizes_natively(ep):
+        # Mirror the --no-quant passed to winml config above so the build
+        # stage also skips QDQ regardless of what the config carries (defence
+        # in depth; see _EPS_SKIP_WINML_QUANT for the rationale).
+        if _should_skip_winml_quant(ep):
             build_args += ["--no-quant"]
 
         build_proc = _run_subprocess(build_args, timeout)
@@ -587,7 +597,9 @@ def run_model(
     code, concatenated stdout/stderr, summed elapsed).
     """
     if not onnx_paths:
-        # No pre-built paths: fall back to HF model ID (single model only)
+        # No pre-built paths: fall back to HF model ID (single model only).
+        # winml perf builds internally; the same --no-quant gating used by
+        # _run_build must apply here so the EP sees the unquantized variant.
         precision = _resolve_precision(device, None, ep=ep)
         args = [
             *WINML_CLI,
@@ -603,6 +615,8 @@ def run_model(
             args += ["--task", entry.task]
         if ep:
             args += ["--ep", ep]
+        if _should_skip_winml_quant(ep):
+            args += ["--no-quant"]
         args += ["--iterations", "10", "--warmup", "2"]
         args += entry.perf_args
 

--- a/scripts/e2e_eval/run_eval.py
+++ b/scripts/e2e_eval/run_eval.py
@@ -85,12 +85,22 @@ _DEFAULT_PRECISION_NPU = "w8a16"
 # loaded into the EP).  Layering winml's generic QDQ quantizer on top of
 # them noticeably degrades accuracy, so we pass ``--no-quant`` to
 # ``winml build`` and let the EP quantize natively.
-_NATIVE_QUANT_EP_NAMES = frozenset({"vitisai", "vitisaiexecutionprovider"})
+#
+# Entries are canonical ``EPName`` values (the ``*ExecutionProvider`` form);
+# user-facing aliases like ``vitisai`` are normalised via
+# ``normalize_ep_name`` in :func:`_ep_quantizes_natively` so we only have to
+# list each EP once here.
+_NATIVE_QUANT_EPS = frozenset({"VitisAIExecutionProvider"})
 
 
 def _ep_quantizes_natively(ep: str | None) -> bool:
     """True if the EP ships its own internal quantizer."""
-    return (ep or "").lower() in _NATIVE_QUANT_EP_NAMES
+    # Lazy import: keeps ``scripts/e2e_eval`` cheap to load (winml.modelkit
+    # transitively imports onnxruntime) and matches the existing in-function
+    # import pattern used elsewhere in this script.
+    from winml.modelkit.utils.constants import normalize_ep_name
+
+    return normalize_ep_name(ep) in _NATIVE_QUANT_EPS
 
 
 def _resolve_precision(device: str, explicit: str | None, ep: str | None = None) -> str | None:
@@ -423,6 +433,12 @@ def _run_build(
         config_args += ["--task", entry.task]
     if ep:
         config_args += ["--ep", ep]
+    # Native-quant EPs: also pass --no-quant to winml config so the generated
+    # build_config.json is written with quant=None up-front. Otherwise on NPU
+    # the config command would still apply its default precision (w8a16) and
+    # we'd be relying on --no-quant at build time to override it.
+    if _ep_quantizes_natively(ep):
+        config_args += ["--no-quant"]
 
     config_proc = _run_subprocess(config_args, timeout)
     if config_proc["exit_code"] != 0:
@@ -464,8 +480,8 @@ def _run_build(
         if ep:
             build_args += ["--ep", ep]
         # EPs with native quantizers (e.g. VitisAI / AMD Ryzen AI) quantize
-        # internally at session-create time; running winml's generic w8a8
-        # QDQ pass on top noticeably degrades accuracy.  --no-quant tells
+        # internally at session-create time; running winml's generic QDQ
+        # pass on top noticeably degrades accuracy.  --no-quant tells
         # winml build to keep the model fp32 and lets the EP do its own.
         if _ep_quantizes_natively(ep):
             build_args += ["--no-quant"]

--- a/scripts/e2e_eval/run_eval.py
+++ b/scripts/e2e_eval/run_eval.py
@@ -81,8 +81,15 @@ TIMEOUT_SKIP_LIST_PATH = Path(__file__).parent / "cache" / "timeout_skip_list.js
 _DEFAULT_SAMPLES = 1000
 _DEFAULT_PRECISION_NPU = "w8a16"
 
+# EP aliases / canonical names that imply VitisAI.  VitisAI (AMD Ryzen AI)
+# expects INT8 weights + INT8 activations (w8a8) — not the w8a16 default used
+# for Qualcomm/QNN.  Compiling w8a16 on VitisAI produces an ONNX file the EP
+# loads but crashes on the first inference, so we skip quantization entirely
+# when VitisAI is selected.
+_VITISAI_EP_NAMES = frozenset({"vitisai", "vitisaiexecutionprovider"})
 
-def _resolve_precision(device: str, explicit: str | None) -> str | None:
+
+def _resolve_precision(device: str, explicit: str | None, ep: str | None = None) -> str | None:
     """Return the precision to pass to winml config/perf, or None to omit the flag.
 
     w8a16 is only applied by default on NPU.  For CPU/GPU the flag is omitted
@@ -91,10 +98,15 @@ def _resolve_precision(device: str, explicit: str | None) -> str | None:
     (NHWC layout transformer inserts Conv nodes that QNN GPU's GetCapability
     does not claim).
 
+    When the VitisAI EP is selected, "fp32" is returned to skip quantization
+    entirely — VitisAI requires w8a8 and crashes on the w8a16 default.
+
     An explicit per-model precision always takes precedence.
     """
     if explicit:
         return explicit
+    if (ep or "").lower() in _VITISAI_EP_NAMES:
+        return "fp32"
     return _DEFAULT_PRECISION_NPU if device == "npu" else None
 
 
@@ -549,7 +561,7 @@ def run_model(
     """
     if not onnx_paths:
         # No pre-built paths: fall back to HF model ID (single model only)
-        precision = _resolve_precision(device, None)
+        precision = _resolve_precision(device, None, ep=ep)
         args = [
             *WINML_CLI,
             "perf",
@@ -1336,7 +1348,7 @@ def main() -> None:
             build_result = _run_build(
                 entry,
                 args.device,
-                _resolve_precision(args.device, entry.precision),
+                _resolve_precision(args.device, entry.precision, ep=args.ep),
                 args.timeout,
                 model_dir,
                 ep=args.ep,

--- a/scripts/e2e_eval/run_eval.py
+++ b/scripts/e2e_eval/run_eval.py
@@ -81,12 +81,16 @@ TIMEOUT_SKIP_LIST_PATH = Path(__file__).parent / "cache" / "timeout_skip_list.js
 _DEFAULT_SAMPLES = 1000
 _DEFAULT_PRECISION_NPU = "w8a16"
 
-# EP aliases / canonical names that imply VitisAI.  VitisAI (AMD Ryzen AI)
-# expects INT8 weights + INT8 activations (w8a8) — not the w8a16 default used
-# for Qualcomm/QNN, and not fp32 (the NPU cannot execute fp32).  Compiling
-# w8a16 *or* leaving the model fp32 produces an ONNX file the EP loads but
-# crashes on the first inference, so we force w8a8 when VitisAI is selected.
-_VITISAI_EP_NAMES = frozenset({"vitisai", "vitisaiexecutionprovider"})
+# EPs that ship their own internal quantizer (run after the ONNX model is
+# loaded into the EP).  Layering winml's generic QDQ quantizer on top of
+# them noticeably degrades accuracy, so we pass ``--no-quant`` to
+# ``winml build`` and let the EP quantize natively.
+_NATIVE_QUANT_EP_NAMES = frozenset({"vitisai", "vitisaiexecutionprovider"})
+
+
+def _ep_quantizes_natively(ep: str | None) -> bool:
+    """True if the EP ships its own internal quantizer."""
+    return (ep or "").lower() in _NATIVE_QUANT_EP_NAMES
 
 
 def _resolve_precision(device: str, explicit: str | None, ep: str | None = None) -> str | None:
@@ -98,16 +102,16 @@ def _resolve_precision(device: str, explicit: str | None, ep: str | None = None)
     (NHWC layout transformer inserts Conv nodes that QNN GPU's GetCapability
     does not claim).
 
-    When the VitisAI EP is selected, "w8a8" is returned — VitisAI requires
-    INT8 weights + INT8 activations and crashes on both the w8a16 default and
-    on fp32 models.
+    For EPs with native quantizers (e.g. VitisAI) the flag is omitted; the
+    actual "skip winml quantization" instruction is conveyed via
+    ``winml build --no-quant`` in :func:`_run_build`.
 
     An explicit per-model precision always takes precedence.
     """
     if explicit:
         return explicit
-    if (ep or "").lower() in _VITISAI_EP_NAMES:
-        return "w8a8"
+    if _ep_quantizes_natively(ep):
+        return None
     return _DEFAULT_PRECISION_NPU if device == "npu" else None
 
 
@@ -459,6 +463,12 @@ def _run_build(
         ]
         if ep:
             build_args += ["--ep", ep]
+        # EPs with native quantizers (e.g. VitisAI / AMD Ryzen AI) quantize
+        # internally at session-create time; running winml's generic w8a8
+        # QDQ pass on top noticeably degrades accuracy.  --no-quant tells
+        # winml build to keep the model fp32 and lets the EP do its own.
+        if _ep_quantizes_natively(ep):
+            build_args += ["--no-quant"]
 
         build_proc = _run_subprocess(build_args, timeout)
         last_proc = build_proc

--- a/scripts/e2e_eval/run_eval.py
+++ b/scripts/e2e_eval/run_eval.py
@@ -83,9 +83,9 @@ _DEFAULT_PRECISION_NPU = "w8a16"
 
 # EP aliases / canonical names that imply VitisAI.  VitisAI (AMD Ryzen AI)
 # expects INT8 weights + INT8 activations (w8a8) — not the w8a16 default used
-# for Qualcomm/QNN.  Compiling w8a16 on VitisAI produces an ONNX file the EP
-# loads but crashes on the first inference, so we skip quantization entirely
-# when VitisAI is selected.
+# for Qualcomm/QNN, and not fp32 (the NPU cannot execute fp32).  Compiling
+# w8a16 *or* leaving the model fp32 produces an ONNX file the EP loads but
+# crashes on the first inference, so we force w8a8 when VitisAI is selected.
 _VITISAI_EP_NAMES = frozenset({"vitisai", "vitisaiexecutionprovider"})
 
 
@@ -98,15 +98,16 @@ def _resolve_precision(device: str, explicit: str | None, ep: str | None = None)
     (NHWC layout transformer inserts Conv nodes that QNN GPU's GetCapability
     does not claim).
 
-    When the VitisAI EP is selected, "fp32" is returned to skip quantization
-    entirely — VitisAI requires w8a8 and crashes on the w8a16 default.
+    When the VitisAI EP is selected, "w8a8" is returned — VitisAI requires
+    INT8 weights + INT8 activations and crashes on both the w8a16 default and
+    on fp32 models.
 
     An explicit per-model precision always takes precedence.
     """
     if explicit:
         return explicit
     if (ep or "").lower() in _VITISAI_EP_NAMES:
-        return "fp32"
+        return "w8a8"
     return _DEFAULT_PRECISION_NPU if device == "npu" else None
 
 

--- a/src/winml/modelkit/commands/build.py
+++ b/src/winml/modelkit/commands/build.py
@@ -437,7 +437,7 @@ def build(
                 from ..config import resolve_quant_compile_config
 
                 resolved_quant, _ = resolve_quant_compile_config(device=device)
-                if resolved_quant is None:
+                if no_quant or resolved_quant is None:
                     cfg.quant = None
                 elif cfg.quant is None:
                     # Populate calibration identifiers from the loader/model

--- a/src/winml/modelkit/commands/build.py
+++ b/src/winml/modelkit/commands/build.py
@@ -436,7 +436,12 @@ def build(
             def _patch_device(cfg: WinMLBuildConfig) -> None:
                 from ..config import resolve_quant_compile_config
 
-                resolved_quant, _ = resolve_quant_compile_config(device=device)
+                # Forward ep so EP-specific defaults (e.g. VitisAI requires
+                # w8a8, not the generic NPU w8a16) are honored.  Without this
+                # the patch silently downgrades the user's config to the
+                # device-only default and produces a model that crashes at
+                # inference on EPs with stricter precision requirements.
+                resolved_quant, _ = resolve_quant_compile_config(device=device, ep=ep)
                 if resolved_quant is None:
                     cfg.quant = None
                 elif cfg.quant is None:

--- a/src/winml/modelkit/commands/build.py
+++ b/src/winml/modelkit/commands/build.py
@@ -436,12 +436,7 @@ def build(
             def _patch_device(cfg: WinMLBuildConfig) -> None:
                 from ..config import resolve_quant_compile_config
 
-                # Forward ep so EP-specific defaults (e.g. VitisAI requires
-                # w8a8, not the generic NPU w8a16) are honored.  Without this
-                # the patch silently downgrades the user's config to the
-                # device-only default and produces a model that crashes at
-                # inference on EPs with stricter precision requirements.
-                resolved_quant, _ = resolve_quant_compile_config(device=device, ep=ep)
+                resolved_quant, _ = resolve_quant_compile_config(device=device)
                 if resolved_quant is None:
                     cfg.quant = None
                 elif cfg.quant is None:

--- a/src/winml/modelkit/config/precision.py
+++ b/src/winml/modelkit/config/precision.py
@@ -35,6 +35,14 @@ _AUTO_PRECISION: dict[str, str] = {
     "cpu": "fp16",
 }
 
+# EP-specific auto-precision overrides (applied when precision="auto" and
+# the EP appears in this map).  VitisAI (AMD Ryzen AI NPU) requires INT8
+# weights + INT8 activations; the generic NPU w8a16 default produces a model
+# the EP loads but crashes on first inference.
+_EP_AUTO_PRECISION: dict[EPName, str] = {
+    "VitisAIExecutionProvider": "w8a8",
+}
+
 # Precision -> weight/activation type mapping (named presets)
 _WEIGHT_TYPE: dict[str, str | None] = {
     "int8": "uint8",
@@ -252,7 +260,12 @@ def resolve_precision(
 
     # Resolve "auto" precision for the resolved device
     if resolved_precision == "auto":
-        resolved_precision = _AUTO_PRECISION[resolved_device]
+        # EP-specific override takes precedence over the device default
+        # (e.g. VitisAI on NPU needs w8a8, not the generic NPU w8a16).
+        if ep_canonical is not None and ep_canonical in _EP_AUTO_PRECISION:
+            resolved_precision = _EP_AUTO_PRECISION[ep_canonical]
+        else:
+            resolved_precision = _AUTO_PRECISION[resolved_device]
 
         # GPU + LLM: warn about w4a16 recommendation
         if resolved_device == "gpu" and task in _LLM_TASKS:

--- a/src/winml/modelkit/config/precision.py
+++ b/src/winml/modelkit/config/precision.py
@@ -35,14 +35,6 @@ _AUTO_PRECISION: dict[str, str] = {
     "cpu": "fp16",
 }
 
-# EP-specific auto-precision overrides (applied when precision="auto" and
-# the EP appears in this map).  VitisAI (AMD Ryzen AI NPU) requires INT8
-# weights + INT8 activations; the generic NPU w8a16 default produces a model
-# the EP loads but crashes on first inference.
-_EP_AUTO_PRECISION: dict[EPName, str] = {
-    "VitisAIExecutionProvider": "w8a8",
-}
-
 # Precision -> weight/activation type mapping (named presets)
 _WEIGHT_TYPE: dict[str, str | None] = {
     "int8": "uint8",
@@ -260,12 +252,7 @@ def resolve_precision(
 
     # Resolve "auto" precision for the resolved device
     if resolved_precision == "auto":
-        # EP-specific override takes precedence over the device default
-        # (e.g. VitisAI on NPU needs w8a8, not the generic NPU w8a16).
-        if ep_canonical is not None and ep_canonical in _EP_AUTO_PRECISION:
-            resolved_precision = _EP_AUTO_PRECISION[ep_canonical]
-        else:
-            resolved_precision = _AUTO_PRECISION[resolved_device]
+        resolved_precision = _AUTO_PRECISION[resolved_device]
 
         # GPU + LLM: warn about w4a16 recommendation
         if resolved_device == "gpu" and task in _LLM_TASKS:

--- a/tests/unit/eval/test_run_eval_script.py
+++ b/tests/unit/eval/test_run_eval_script.py
@@ -1,0 +1,172 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+"""Unit tests for ``scripts/e2e_eval/run_eval.py``.
+
+The script is not packaged, so we load it via ``importlib`` (same pattern
+as ``TestBuildEvalResultEpField`` in ``test_eval.py``) and exercise the
+small helpers that gate the ``--no-quant`` / ``--precision`` injection
+for EPs run on the unquantized variant (currently VitisAI).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _load_run_eval():
+    """Load scripts/e2e_eval/run_eval.py as a module."""
+    repo_root = Path(__file__).resolve().parents[3]
+    script_path = repo_root / "scripts" / "e2e_eval" / "run_eval.py"
+
+    # run_eval.py does ``sys.path.insert(0, str(Path(__file__).parent))``
+    # at import time so its sibling ``utils`` package resolves; mirror that
+    # here in case the module is loaded before the script runs.
+    scripts_dir = str(script_path.parent)
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+
+    spec = importlib.util.spec_from_file_location("_e2e_run_eval", script_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def run_eval():
+    return _load_run_eval()
+
+
+class TestShouldSkipWinmlQuant:
+    """Membership test for ``_should_skip_winml_quant``.
+
+    Aliases (case-insensitive) and the canonical ``*ExecutionProvider`` form
+    should both resolve via ``normalize_ep_name``.
+    """
+
+    @pytest.mark.parametrize(
+        "ep",
+        ["vitisai", "VitisAI", "VITISAI", "VitisAIExecutionProvider"],
+    )
+    def test_vitisai_skips_quant(self, run_eval, ep):
+        assert run_eval._should_skip_winml_quant(ep) is True
+
+    @pytest.mark.parametrize(
+        "ep",
+        [None, "", "cpu", "dml", "qnn", "QNNExecutionProvider", "DmlExecutionProvider"],
+    )
+    def test_other_eps_do_not_skip(self, run_eval, ep):
+        assert run_eval._should_skip_winml_quant(ep) is False
+
+
+class TestResolvePrecision:
+    """Behaviour of ``_resolve_precision`` for the new ``ep`` arg."""
+
+    def test_npu_default_unchanged(self, run_eval):
+        assert run_eval._resolve_precision("npu", None) == "w8a16"
+        assert run_eval._resolve_precision("npu", None, ep=None) == "w8a16"
+
+    def test_cpu_default_unchanged(self, run_eval):
+        assert run_eval._resolve_precision("cpu", None) is None
+        assert run_eval._resolve_precision("gpu", None) is None
+
+    def test_explicit_precision_takes_precedence_on_npu(self, run_eval):
+        assert run_eval._resolve_precision("npu", "fp16") == "fp16"
+        assert run_eval._resolve_precision("cpu", "fp16", ep="DmlExecutionProvider") == "fp16"
+
+    def test_skip_quant_ep_drops_default(self, run_eval):
+        assert run_eval._resolve_precision("npu", None, ep="vitisai") is None
+        assert (
+            run_eval._resolve_precision("npu", None, ep="VitisAIExecutionProvider") is None
+        )
+
+    def test_skip_quant_ep_drops_explicit_with_warning(self, run_eval, capsys):
+        result = run_eval._resolve_precision("npu", "w8a8", ep="vitisai")
+        assert result is None
+        captured = capsys.readouterr()
+        # Warning must mention the dropped value and the EP so the override
+        # is visible in the log when an explicit per-model precision is set
+        # for an EP that runs on the unquantized variant.
+        assert "w8a8" in captured.out
+        assert "vitisai" in captured.out
+
+
+class TestRunBuildNoQuantInjection:
+    """``_run_build`` must append ``--no-quant`` to both winml config and
+    winml build invocations when the EP is in ``_EPS_SKIP_WINML_QUANT``.
+    """
+
+    @staticmethod
+    def _make_entry(hf_id="microsoft/resnet-50", task="image-classification"):
+        entry = MagicMock()
+        entry.hf_id = hf_id
+        entry.task = task
+        entry.perf_args = []
+        return entry
+
+    @staticmethod
+    def _make_config_proc(config_path: Path):
+        return {
+            "exit_code": 0,
+            "stdout": f"Generated {config_path}",
+            "stderr": "",
+            "elapsed": 0.1,
+            "command": "winml config ...",
+        }
+
+    @staticmethod
+    def _make_build_proc():
+        return {
+            "exit_code": 0,
+            "stdout": "Build cache: /tmp/x_model.onnx",
+            "stderr": "",
+            "elapsed": 0.1,
+            "command": "winml build ...",
+        }
+
+    def _invoke(self, run_eval, ep, tmp_path):
+        entry = self._make_entry()
+        # _run_build composes config_path = model_dir / "build_config.json"
+        # internally; pre-create it so the post-config glob fallback resolves
+        # to a single sub-config and the build loop runs once.
+        config_path = tmp_path / "build_config.json"
+        config_path.write_text("{}")
+
+        captured_args: list[list[str]] = []
+
+        def fake_subprocess(args, _timeout):
+            captured_args.append(list(args))
+            if "config" in args:
+                return self._make_config_proc(config_path)
+            return self._make_build_proc()
+
+        with patch.object(run_eval, "_run_subprocess", side_effect=fake_subprocess), patch.object(
+            run_eval, "_extract_onnx_path", return_value=str(tmp_path / "model.onnx")
+        ):
+            run_eval._run_build(
+                entry,
+                "npu",
+                None,
+                300,
+                tmp_path,
+                ep=ep,
+            )
+        return captured_args
+
+    def test_vitisai_injects_no_quant_into_both_config_and_build(self, run_eval, tmp_path):
+        calls = self._invoke(run_eval, "vitisai", tmp_path)
+        config_call = next(args for args in calls if "config" in args)
+        build_call = next(args for args in calls if "build" in args)
+        assert "--no-quant" in config_call
+        assert "--no-quant" in build_call
+
+    def test_other_ep_omits_no_quant(self, run_eval, tmp_path):
+        calls = self._invoke(run_eval, "dml", tmp_path)
+        assert all("--no-quant" not in args for args in calls)


### PR DESCRIPTION
## Summary

Fixes `scripts/e2e_eval/run_eval.py` crashing on VitisAI EP (AMD Ryzen AI NPU) and a latent bug in `winml build` that prevented the script's `--no-quant` workaround from actually taking effect.

The crash: VitisAI ships its own internal quantizer and runs it at session-create time. Layering winml's generic QDQ quantization pass on top produces a model VitisAI cannot consume, which manifests as `DpuKernelRunner.cpp:1920 DPU timeout` during `winml perf`. The fix is to tell winml to skip its own quantization when the selected EP quantizes natively.

## Changes

### `src/winml/modelkit/commands/build.py` — root-cause fix (1 line)

When `--device` was passed to `winml build`, the internal `_patch_device` helper unconditionally re-populated `cfg.quant` with the device's default quantization config, silently undoing any prior `--no-quant`. The condition now respects `no_quant`:

```python
if no_quant or resolved_quant is None:
    cfg.quant = None
```

Without this, `winml build … --device npu --no-quant` still produced a `_quantized.onnx` artifact.

### `scripts/e2e_eval/run_eval.py` — script wiring

- New canonical-name set `_NATIVE_QUANT_EPS = {"VitisAIExecutionProvider"}` plus a helper `_ep_quantizes_natively(ep)` that funnels both canonical names and user aliases (e.g. `vitisai`) through `winml.modelkit.utils.constants.normalize_ep_name`. No hardcoded aliases.
- `_resolve_precision(...)` gained an `ep` parameter; for native-quant EPs it returns `None` so no precision flag is sent.
- `_run_build` now passes `--no-quant` to **both** `winml config` (so the persisted `build_config.json` has `quant: null` up-front) and `winml build` (defense in depth) when the EP quantizes natively.
- Call sites in `run_model` and `main` updated to thread `ep` through `_resolve_precision`.

## Why the earlier commits in this branch weren't enough

The first attempt (`fix(run_eval): skip quantize when VitisAI EP is selected`) wired `--no-quant` only into `winml build`. That didn't take effect because of the `_patch_device` bug above. The second attempt (`fix(vitisai): resolve auto-precision to w8a8 for VitisAI NPU`) tried to switch precision instead of skipping — also wrong, since VitisAI wants an fp32 input and quantizes it itself. The final state keeps the script clean (`--no-quant`, no precision override) and fixes the actual `winml build` bug.

## Verification

Manual end-to-end on AMD Ryzen AI (VitisAI NPU), with a clean `~/.cache/winml/artifacts/...` and output dir:

```pwsh
uv run --no-sync python scripts/e2e_eval/run_eval.py `
  --hf-model facebook/convnext-tiny-224 `
  --task image-classification `
  --device npu --ep vitisai `
  --eval-type perf --no-report --verbose --timeout 1800 `
  --output-dir e2e-test\vitisai_npu
```

Before: `winml perf` crashed with `DpuKernelRunner.cpp:1920 DPU timeout`.
After:
- Cached `imgcls_*_winml_build_config.json` has `"quant": null`.
- No `_quantized.onnx` artifact produced.
- Perf step: **PASS** in ~120 s.
