### PR TITLE
docs: fix duplicate Releases row and switch install to pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ See the [Supported Tasks](#supported-tasks) and [Supported Model Types](#support
 |---|---|
 | Windows | Windows 11 24H2 or later (required for NPU support; earlier versions work for CPU/GPU) |
 | Python | 3.11 |
-| Package manager | [`uv`](https://github.com/astral-sh/uv) |
+| Package manager | [uv](https://github.com/astral-sh/uv) |
 | WinML CLI | [PyPI](https://pypi.org/project/winml-cli/) |
 
 ### Installation

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ source .venv/Scripts/activate
 **2. Install winml-cli**
 
 ```bash
-pip install winml-cli
+uv pip install winml-cli
 ```
 
 **3. Verify your environment**

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ See the [Supported Tasks](#supported-tasks) and [Supported Model Types](#support
 | Windows | Windows 11 24H2 or later (required for NPU support; earlier versions work for CPU/GPU) |
 | Python | 3.11 |
 | Package manager | [`uv`](https://github.com/astral-sh/uv) |
-| **WinML CLI** | [PyPI](https://pypi.org/project/winml-cli/) |
+| WinML CLI | [PyPI](https://pypi.org/project/winml-cli/) |
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ See the [Supported Tasks](#supported-tasks) and [Supported Model Types](#support
 | Windows | Windows 11 24H2 or later (required for NPU support; earlier versions work for CPU/GPU) |
 | Python | 3.11 |
 | Package manager | [`uv`](https://github.com/astral-sh/uv) |
-| **WinML CLI** (Python wheel) | [Releases](https://github.com/microsoft/winml-cli/releases) |
-| **WinML CLI** (Python wheel) | [Releases](https://github.com/microsoft/winml-cli/releases) |
+| **WinML CLI** | [PyPI](https://pypi.org/project/winml-cli/) |
+
 ### Installation
 
 WinML CLI requires **Python 3.11** and is distributed as a Python wheel. We recommend [uv](https://docs.astral.sh/uv/) for fast, reproducible environment setup.
@@ -76,10 +76,10 @@ Activate it:
 source .venv/Scripts/activate
 ```
 
-**2. Install from wheel**
+**2. Install winml-cli**
 
 ```bash
-uv pip install winml_cli-<version>-py3-none-any.whl
+pip install winml-cli
 ```
 
 **3. Verify your environment**


### PR DESCRIPTION
## Summary

- Removed the duplicated `WinML CLI (Python wheel) | [Releases]` row in the Prerequisites table.
- Updated the install step from `uv pip install winml_cli-<version>-py3-none-any.whl` to `pip install winml-cli`.
- Updated the Prerequisites entry to point at PyPI instead of GitHub Releases, keeping the table and install instructions consistent.