### PR TITLE
refactor(task): relocate map_task_synonym to loader.task as to_optimum_task

### DIFF
--- a/src/winml/modelkit/commands/build.py
+++ b/src/winml/modelkit/commands/build.py
@@ -273,8 +273,8 @@ def _validate_task_supported_for_model(
     Raises:
         ValueError: If the task is not supported for the model architecture.
     """
-    from ..export.io import TASK_SYNONYM_EXTENSIONS, ensure_hf_models_registered
-    from ..loader.task import get_supported_tasks, normalize_task
+    from ..export.io import ensure_hf_models_registered
+    from ..loader.task import TASK_SYNONYM_EXTENSIONS, get_supported_tasks, normalize_task
 
     if hf_config is None:
         from transformers import AutoConfig

--- a/src/winml/modelkit/commands/inspect.py
+++ b/src/winml/modelkit/commands/inspect.py
@@ -424,14 +424,13 @@ def _inspect_model_v2(
             import optimum.exporters.onnx.model_configs  # noqa: F401
             from optimum.exporters.tasks import TasksManager
 
-            # TasksManager expects normalized task names
-            from ..export.io import map_task_synonym
-            from ..loader import resolve_optimum_library
+            # TasksManager expects Optimum-canonical task names
+            from ..loader import resolve_optimum_library, to_optimum_task
 
             onnx_config_cls = TasksManager.get_exporter_config_constructor(
                 exporter="onnx",
                 model_type=model_type,
-                task=map_task_synonym(task),
+                task=to_optimum_task(task),
                 library_name=resolve_optimum_library(model_type),
             )
             if onnx_config_cls:

--- a/src/winml/modelkit/export/htp/exporter.py
+++ b/src/winml/modelkit/export/htp/exporter.py
@@ -470,14 +470,14 @@ class HTPExporter:
             logger.debug("Model has no config.model_type; skipping Optimum patcher.")
             return contextlib.nullcontext()
 
-        # TasksManager expects normalized task names
-        from ..io import map_task_synonym
+        # TasksManager expects Optimum-canonical task names
+        from ...loader import to_optimum_task
 
         try:
             cfg_cls = TasksManager.get_exporter_config_constructor(
                 "onnx",
                 model_type=model_type,
-                task=map_task_synonym(task),
+                task=to_optimum_task(task),
                 library_name="transformers",
             )
             return cfg_cls(model_config).patch_model_for_export(model)

--- a/src/winml/modelkit/export/io.py
+++ b/src/winml/modelkit/export/io.py
@@ -40,6 +40,7 @@ from optimum.utils.input_generators import (
     DummyTextInputGenerator,
 )
 
+from ..loader import to_optimum_task
 from .value_range import intercept_value_ranges
 
 
@@ -79,53 +80,13 @@ def ensure_hf_models_registered() -> None:
 
 
 # =============================================================================
-# Task Synonym Extensions (extends Optimum's TasksManager.map_from_synonym)
+# Task Synonym Extensions (relocated to loader.task — single source of truth)
 # =============================================================================
-
-# Extends Optimum's built-in task synonym mapping for tasks it doesn't recognize.
-# Optimum's map_from_synonym handles known synonyms like:
-#   - "image-feature-extraction" → "feature-extraction"
-# This dict adds mappings for tasks Optimum doesn't support at all.
-TASK_SYNONYM_EXTENSIONS: dict[str, str] = {
-    # next-sentence-prediction has same I/O as text-classification: input_ids → logits
-    "next-sentence-prediction": "text-classification",
-    # mask-generation is registered via register_onnx_overwrite for SAM2.
-    # Optimum incorrectly maps it to "feature-extraction"; preserve as-is.
-    "mask-generation": "mask-generation",
-}
-
-
-def map_task_synonym(task: str) -> str:
-    """Map task name to canonical form, extending Optimum's synonym mapping.
-
-    Our extensions take priority over Optimum's built-in synonym map.
-    If a task is found in ``TASK_SYNONYM_EXTENSIONS``, return immediately
-    without passing through Optimum (which may incorrectly normalize
-    custom-registered tasks like ``mask-generation``).
-
-    Args:
-        task: Task name (e.g., "next-sentence-prediction", "image-feature-extraction")
-
-    Returns:
-        Canonical task name (e.g., "text-classification", "feature-extraction")
-
-    Example:
-        >>> map_task_synonym("next-sentence-prediction")  # Our extension
-        'text-classification'
-        >>> map_task_synonym("mask-generation")  # Preserved (not Optimum-normalized)
-        'mask-generation'
-        >>> map_task_synonym("image-feature-extraction")  # Optimum's synonym
-        'feature-extraction'
-        >>> map_task_synonym("text-classification")  # Already canonical
-        'text-classification'
-    """
-    # Our extensions take priority — return early to prevent Optimum from
-    # incorrectly normalizing custom-registered tasks.
-    if task in TASK_SYNONYM_EXTENSIONS:
-        return TASK_SYNONYM_EXTENSIONS[task]
-
-    # Fallback: normalize via Optimum's built-in synonym mapping
-    return TasksManager.map_from_synonym(task)
+# ``TASK_SYNONYM_EXTENSIONS`` and the WinML -> Optimum collapse now live in
+# ``loader.task`` as ``to_optimum_task``. Both are imported above and re-exported
+# here; ``map_task_synonym`` is kept as a backward-compatible alias for existing
+# importers (and is identical to ``to_optimum_task``).
+map_task_synonym = to_optimum_task
 
 
 # =============================================================================
@@ -195,7 +156,7 @@ def _get_onnx_config(
 
     Args:
         model_type: HF model type (e.g., "bert", "clip_vision_model")
-        task: Task name (will be normalized via map_task_synonym)
+        task: Task name (will be collapsed to Optimum-canonical via to_optimum_task)
         hf_config: HuggingFace PretrainedConfig for OnnxConfig instantiation
         library_name: Source library (default: "transformers")
         exporter: Export backend (default: "onnx")
@@ -208,7 +169,7 @@ def _get_onnx_config(
     """
     ensure_hf_models_registered()
 
-    normalized_task = map_task_synonym(task)
+    normalized_task = to_optimum_task(task)
 
     # Route model_types whose Optimum OnnxConfig is registered under another
     # library (e.g. timm via "timm_wrapper" -> "timm") so the lookup succeeds

--- a/src/winml/modelkit/inspect/resolver.py
+++ b/src/winml/modelkit/inspect/resolver.py
@@ -355,15 +355,15 @@ def resolve_exporter(
         import optimum.exporters.onnx.model_configs  # noqa: F401
         from optimum.exporters.tasks import TasksManager
 
-        # TasksManager expects normalized task names
-        from ..export.io import map_task_synonym
+        # TasksManager expects Optimum-canonical task names
+        from ..loader import to_optimum_task
 
         # TasksManager uses underscores (sam2_video), not hyphens (sam2-video)
         # Use original model_type for TasksManager lookup
         onnx_config_cls = TasksManager.get_exporter_config_constructor(
             exporter="onnx",
             model_type=model_type,
-            task=map_task_synonym(task),
+            task=to_optimum_task(task),
             library_name=resolve_optimum_library(model_type),
         )
         if onnx_config_cls:

--- a/src/winml/modelkit/loader/__init__.py
+++ b/src/winml/modelkit/loader/__init__.py
@@ -29,17 +29,20 @@ from .config import WinMLLoaderConfig, resolve_loader_config
 from .task import (
     HF_TASK_DEFAULTS,
     KNOWN_TASKS,
+    TASK_SYNONYM_EXTENSIONS,
     get_supported_tasks,
     get_task_abbrev,
     normalize_task,
     resolve_optimum_library,
     resolve_task_and_model_class,
+    to_optimum_task,
 )
 
 
 __all__ = [
     "HF_TASK_DEFAULTS",
     "KNOWN_TASKS",
+    "TASK_SYNONYM_EXTENSIONS",
     "WinMLLoaderConfig",
     "get_supported_tasks",
     "get_task_abbrev",
@@ -49,6 +52,7 @@ __all__ = [
     "resolve_loader_config",
     "resolve_optimum_library",
     "resolve_task_and_model_class",
+    "to_optimum_task",
 ]
 
 

--- a/src/winml/modelkit/loader/task.py
+++ b/src/winml/modelkit/loader/task.py
@@ -10,6 +10,7 @@ Public API:
     resolve_task_and_model_class  - Main orchestrator (3 resolution cases)
     resolve_optimum_library      - Route a model_type to the Optimum export library
     normalize_task               - Map task aliases to canonical names
+    to_optimum_task              - Collapse a WinMLTask to its Optimum-canonical form
     get_task_abbrev              - Abbreviated task name for cache keys
     get_supported_tasks          - List ONNX-exportable tasks for a model type
 
@@ -502,6 +503,43 @@ def normalize_task(task: str) -> str:
     Returns:
         Canonical task name
     """
+    from optimum.exporters.tasks import TasksManager
+
+    return TasksManager.map_from_synonym(task)
+
+
+# WinML task-synonym extensions — extend Optimum's ``TasksManager.map_from_synonym``
+# for tasks it does not recognize or mis-maps. Entries here take priority over Optimum.
+TASK_SYNONYM_EXTENSIONS: dict[str, str] = {
+    # next-sentence-prediction has the same I/O as text-classification: input_ids -> logits
+    "next-sentence-prediction": "text-classification",
+    # mask-generation is registered via register_onnx_overwrite for SAM2.
+    # Optimum incorrectly maps it to "feature-extraction"; preserve as-is.
+    "mask-generation": "mask-generation",
+}
+
+
+def to_optimum_task(task: str) -> str:
+    """Map a task name to its Optimum-canonical form, extending Optimum's synonyms.
+
+    This is the single WinML -> Optimum boundary translation: call it only at the
+    moment of an Optimum API call (e.g. ``TasksManager.get_exporter_config_constructor``).
+    The result is lossy — modality-aware names collapse
+    (``image-feature-extraction`` -> ``feature-extraction``).
+
+    WinML extensions in ``TASK_SYNONYM_EXTENSIONS`` take priority and short-circuit
+    before Optimum, which may otherwise mis-normalize custom-registered tasks such as
+    ``mask-generation``.
+
+    Args:
+        task: Task name (a WinMLTask or an alias).
+
+    Returns:
+        Optimum-canonical task name.
+    """
+    if task in TASK_SYNONYM_EXTENSIONS:
+        return TASK_SYNONYM_EXTENSIONS[task]
+
     from optimum.exporters.tasks import TasksManager
 
     return TasksManager.map_from_synonym(task)

--- a/tests/unit/loader/test_task_boundary.py
+++ b/tests/unit/loader/test_task_boundary.py
@@ -1,0 +1,34 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Unit tests for ``to_optimum_task`` — the single WinML -> Optimum collapse boundary.
+
+``to_optimum_task`` is the relocated/renamed ``export.io.map_task_synonym``. It must
+reproduce that behavior verbatim: WinML extensions short-circuit before Optimum, and
+everything else passes through ``TasksManager.map_from_synonym`` (which collapses
+modality-aware names like ``image-feature-extraction`` to ``feature-extraction``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from winml.modelkit.loader import to_optimum_task
+
+
+@pytest.mark.parametrize(
+    "task, expected",
+    [
+        # Optimum collapses modality (image-feature-extraction -> feature-extraction).
+        ("image-feature-extraction", "feature-extraction"),
+        # WinML extension: routed to its Optimum-canonical target.
+        ("next-sentence-prediction", "text-classification"),
+        # WinML extension preserved as-is (Optimum would mis-map it otherwise).
+        ("mask-generation", "mask-generation"),
+        # Already-canonical task passes through unchanged.
+        ("text-classification", "text-classification"),
+    ],
+)
+def test_to_optimum_task(task: str, expected: str) -> None:
+    assert to_optimum_task(task) == expected


### PR DESCRIPTION
## What

PR1 of #800. Relocate `map_task_synonym` -> `loader/task.py::to_optimum_task` to establish a single WinML->Optimum task-collapse boundary.

## Changes

- `loader/task.py`: add `to_optimum_task` + `TASK_SYNONYM_EXTENSIONS` (moved from `export/io.py`); exported via `loader/__init__.py`.
- `export/io.py`: local implementation removed; `map_task_synonym` kept as a backward-compatible alias (`= to_optimum_task`); internal use repointed.
- Optimum-boundary call sites repointed to `to_optimum_task`: `commands/inspect.py`, `export/htp/exporter.py`, `inspect/resolver.py`.
- `commands/build.py`: `TASK_SYNONYM_EXTENSIONS` now imported from `loader`.
- New `tests/unit/loader/test_task_boundary.py` pins the collapse contract.

## Behavior

No behavior change. `map_task_synonym` stays importable from `export.io`; the collapse semantics (`image-feature-extraction` -> `feature-extraction`, WinML extensions preserved) are byte-identical. Existing synonym and #777/#782 regression tests stay green.

Sets up PR2 (#800), which adds the modality-aware `detect_task` and relies on this single collapse boundary.
