### PR TITLE
fix: align analyzer API EP list with CLI

### DIFF
--- a/src/winml/modelkit/analyze/analyzer.py
+++ b/src/winml/modelkit/analyze/analyzer.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ..optim.config import WinMLOptimizationConfig
-from ..utils.constants import EPName, EPNameOrAlias, normalize_ep_name
+from ..utils.constants import EP_SUPPORTED_DEVICES, EPName, EPNameOrAlias, normalize_ep_name
 from .models.information import Information
 from .models.support_level import SupportLevel
 from .utils.timing_utils import make_timing_logger
@@ -684,20 +684,6 @@ class ONNXStaticAnalyzer:
 
         logger.info("Analyzing model from ModelProto")
 
-        # Determine which EPs to analyze
-        eps_to_analyze: list[EPName] = []
-        if ep_normalized is None:
-            # Analyze all supported EPs
-            eps_to_analyze = [
-                "QNNExecutionProvider",
-                "OpenVINOExecutionProvider",
-                "VitisAIExecutionProvider",
-                "NvTensorRTRTXExecutionProvider",
-            ]
-            logger.info("No EP specified, analyzing all supported EPs: %s", eps_to_analyze)
-        else:
-            eps_to_analyze = [ep_normalized]
-
         # Resolve device — rule files are device-specific (CPU/GPU/NPU).
         if device is not None and device.lower() == "auto":
             from ..sysinfo import resolve_device
@@ -708,6 +694,19 @@ class ONNXStaticAnalyzer:
         else:
             device_to_use = device if device is not None else "NPU"
             logger.info("Using device: %s", device_to_use)
+
+        # Determine which EPs to analyze
+        eps_to_analyze: list[EPName] = []
+        if ep_normalized is None:
+            # Analyze all EPs that support the target device
+            eps_to_analyze = [
+                ep_name
+                for ep_name, supported_devices in EP_SUPPORTED_DEVICES.items()
+                if device_to_use.lower() in supported_devices
+            ]
+            logger.info("No EP specified, analyzing all supported EPs: %s", eps_to_analyze)
+        else:
+            eps_to_analyze = [ep_normalized]
 
         # Step 1: Create ONNXModel and extract patterns (once)
         extraction_start = time.perf_counter()

--- a/src/winml/modelkit/analyze/models/output.py
+++ b/src/winml/modelkit/analyze/models/output.py
@@ -112,17 +112,15 @@ class AnalysisOutput(BaseModel):
         default_factory=datetime.now, description="Analysis timestamp"
     )
     metadata: ModelStats = Field(..., description="Model metadata and statistics")
-    results: list[EPSupport] = Field(
-        ..., max_length=4, description="Execution Provider support results (max 4)"
-    )
+    results: list[EPSupport] = Field(..., description="Execution Provider support results")
 
     @field_validator("results")
     @classmethod
-    def validate_ihv_types_unique(cls, v: list[EPSupport]) -> list[EPSupport]:
-        """Validate that IHV types are unique in the list."""
-        ihv_types = [item.ihv_type for item in v]
-        if len(ihv_types) != len(set(ihv_types)):
-            raise ValueError(f"Duplicate IHV types found: {ihv_types}")
+    def validate_ep_types_unique(cls, v: list[EPSupport]) -> list[EPSupport]:
+        """Validate that EP types are unique in the list."""
+        ep_types = [item.ep_type for item in v]
+        if len(ep_types) != len(set(ep_types)):
+            raise ValueError(f"Duplicate EP types found: {ep_types}")
         return v
 
     def model_dump_json(self, **kwargs: object) -> str:

--- a/tests/unit/analyze/models/test_output.py
+++ b/tests/unit/analyze/models/test_output.py
@@ -228,8 +228,8 @@ class TestAnalysisOutputValidation:
         )
         assert len(output.results) == 2
 
-        # Invalid: duplicate IHV types
-        with pytest.raises(ValidationError, match="Duplicate IHV types found"):
+        # Invalid: duplicate EP types
+        with pytest.raises(ValidationError, match="Duplicate EP types found"):
             AnalysisOutput(
                 metadata=ModelStats(
                     model_path="/test.onnx",

--- a/tests/unit/analyze/test_analyzer.py
+++ b/tests/unit/analyze/test_analyzer.py
@@ -899,17 +899,17 @@ class TestONNXStaticAnalyzer:
 
         # Assertions
         assert isinstance(result, AnalysisResult)
-        # Should have results for all 4 EPs: QNN, OpenVINO, VitisAI, NvTensorRTRTX
-        assert len(result.output.results) == 4
+        # Should have results for all NPU-capable EPs: QNN, OpenVINO, VitisAI
+        # (NvTensorRTRTX only supports GPU, so it's excluded for device=NPU)
+        assert len(result.output.results) == 3
 
-        ihv_types = {r.ihv_type for r in result.output.results}
-        assert IHVType.QC in ihv_types
-        assert IHVType.INTEL in ihv_types
-        assert IHVType.AMD in ihv_types
-        assert IHVType.NVIDIA in ihv_types
+        ep_types = {r.ep_type for r in result.output.results}
+        assert "QNNExecutionProvider" in ep_types
+        assert "OpenVINOExecutionProvider" in ep_types
+        assert "VitisAIExecutionProvider" in ep_types
 
-        # Verify RuntimeChecker was called 4 times (once per EP)
-        assert mock_runtime_checker_cls.call_count == 4
+        # Verify RuntimeChecker was called 3 times (once per NPU-capable EP)
+        assert mock_runtime_checker_cls.call_count == 3
 
     @patch("winml.modelkit.analyze.utils.ep_utils.has_rule_data_for_ep", return_value=True)
     @patch("winml.modelkit.analyze.core.onnx_loader.ONNXLoader")


### PR DESCRIPTION
## Summary
- Replace hardcoded 4-EP list in `analyze_from_proto(ep=None)` with dynamic lookup from `EP_SUPPORTED_DEVICES`, filtered by target device
- Remove `max_length=4` constraint on `AnalysisOutput.results` to support more than 4 EPs per device
- Change uniqueness validator from IHV type to EP type (multiple EPs can share the same IHV, e.g. CUDA and DML both map to MICROSOFT)

**Before:** `analyzer.analyze(ep=None)` always analyzed QNN, OpenVINO, VitisAI, NvTensorRTRTX regardless of device — NvTensorRTRTX was analyzed on NPU even though it only supports GPU.

**After:** EP list is derived from `EP_SUPPORTED_DEVICES` filtered by the target device, matching the CLI `--ep all` behavior exactly.