### PR TITLE
Implement tensor similarity evaluator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ dependencies = [
   "torchinfo>=1.8",
   "torchmetrics[detection]>=1.0",
   "torchvision>=0.24",
+  "tqdm>=4.67",
   "transformers>=4.57",
   "uvicorn[standard]>=0.42.0",
   "windowsml==2.0.300",
@@ -82,7 +83,6 @@ optional-dependencies.dev = [
   "ruff>=0.14",
   "seaborn>=0.13",
   "timm>=1.0.20",
-  "tqdm>=4.67",
   "types-colorama>=0.4.15.20250801",
 ]
 optional-dependencies.audio = [ "soundfile>=0.13" ]

--- a/scripts/e2e_eval/run_pytorch_baseline.py
+++ b/scripts/e2e_eval/run_pytorch_baseline.py
@@ -339,7 +339,7 @@ def main() -> None:
 
         from winml.modelkit.eval.evaluate import get_evaluator_class
 
-        evaluator_cls = get_evaluator_class(task)
+        evaluator_cls = get_evaluator_class(eval_config)
         task_evaluator = evaluator_cls(eval_config, pytorch_model)
 
         metrics = task_evaluator.compute()

--- a/src/winml/modelkit/commands/eval.py
+++ b/src/winml/modelkit/commands/eval.py
@@ -16,7 +16,7 @@ import click
 from rich.console import Console
 
 from ..utils import cli as cli_utils
-from ..utils.eval_utils import TASK_SCHEMAS, TaskSchema
+from ..utils.eval_utils import EVAL_MODES, TASK_SCHEMAS, EvalMode, TaskSchema
 
 
 if TYPE_CHECKING:
@@ -149,7 +149,7 @@ logger = logging.getLogger(__name__)
 )
 @click.option(
     "--mode",
-    type=click.Choice(["onnx", "compare"], case_sensitive=False),
+    type=click.Choice(EVAL_MODES, case_sensitive=False),
     default="onnx",
     show_default=True,
     help=(
@@ -182,7 +182,7 @@ def eval(
     dataset_script: str | None,
     trust_remote_code: bool,
     show_schema: bool,
-    mode: str,
+    mode: EvalMode,
     config_file: Path | None,
 ) -> None:
     r"""Evaluate a model for a task.

--- a/src/winml/modelkit/commands/eval.py
+++ b/src/winml/modelkit/commands/eval.py
@@ -147,6 +147,18 @@ logger = logging.getLogger(__name__)
     default=False,
     help="Print expected dataset schema for the given --task and exit.",
 )
+@click.option(
+    "--mode",
+    type=click.Choice(["onnx", "compare"], case_sensitive=False),
+    default="onnx",
+    show_default=True,
+    help=(
+        "Evaluation mode. "
+        "'onnx' (default): evaluate the ONNX candidate on the dataset. "
+        "'compare': compare ONNX vs HF reference output tensors on identical "
+        "random inputs and report tensor-similarity metrics per output tensor."
+    ),
+)
 @cli_utils.build_config_option()
 @click.pass_context
 def eval(
@@ -170,6 +182,7 @@ def eval(
     dataset_script: str | None,
     trust_remote_code: bool,
     show_schema: bool,
+    mode: str,
     config_file: Path | None,
 ) -> None:
     r"""Evaluate a model for a task.
@@ -505,7 +518,8 @@ def display_eval_report(result: EvalResult, console: Console) -> None:
     console.print()
     console.print(f"[dim]Task:[/dim]       {cfg.task}")
     console.print(f"[dim]Device:[/dim]     {cfg.device}")
-    console.print(f"[dim]Dataset:[/dim]    {ds.path}")
+    if ds.path:
+        console.print(f"[dim]Dataset:[/dim]    {ds.path}")
     console.print(f"[dim]Samples:[/dim]    {ds.samples}")
     if cfg.model_path:
         console.print(f"[dim]ONNX:[/dim]       {cfg.model_path}")

--- a/src/winml/modelkit/eval/__init__.py
+++ b/src/winml/modelkit/eval/__init__.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     from .metrics.top_k_accuracy import TopKAccuracyMetric
     from .object_detection_evaluator import WinMLObjectDetectionEvaluator
     from .question_answering_evaluator import WinMLQuestionAnsweringEvaluator
+    from .tensor_similarity_evaluator import TensorSimilarityEvaluator
     from .text_classification_evaluator import WinMLTextClassificationEvaluator
     from .token_classification_evaluator import WinMLTokenClassificationEvaluator
     from .zero_shot_classification_evaluator import WinMLZeroShotClassificationEvaluator
@@ -63,6 +64,8 @@ _LAZY_ATTRS: dict[str, str] = {
         ".zero_shot_classification_evaluator:WinMLZeroShotClassificationEvaluator",
     "WinMLZeroShotImageClassificationEvaluator":
         ".zero_shot_image_classification_evaluator:WinMLZeroShotImageClassificationEvaluator",
+    "TensorSimilarityEvaluator":
+        ".tensor_similarity_evaluator:TensorSimilarityEvaluator",
     # Metrics (defer numpy / scipy / torch / torchmetrics until first use)
     "ClassificationMetric":
         ".metrics.classification:ClassificationMetric",
@@ -110,6 +113,7 @@ __all__ = [
     "MeanIoUMetric",
     "PseudoPerplexityMetric",
     "SpearmanCorrelationMetric",
+    "TensorSimilarityEvaluator",
     "TopKAccuracyMetric",
     "WinMLEvaluationConfig",
     "WinMLEvaluator",

--- a/src/winml/modelkit/eval/config.py
+++ b/src/winml/modelkit/eval/config.py
@@ -87,6 +87,13 @@ class WinMLEvaluationConfig:
             device-to-provider mapping when provided.
         dataset: Dataset configuration.
         output_path: Path to write JSON results.
+        mode: Evaluation mode.
+
+            - ``"onnx"`` (default): evaluate the ONNX candidate on the
+              labeled dataset.
+            - ``"compare"``: compare ONNX vs HF reference output tensors
+              on identical random inputs and report tensor-similarity
+              metrics per output tensor.
 
     Usage:
         config = WinMLEvaluationConfig(
@@ -103,6 +110,7 @@ class WinMLEvaluationConfig:
     ep: EPNameOrAlias | None = None
     dataset: DatasetConfig = field(default_factory=DatasetConfig)
     output_path: Path | None = field(default=None, metadata={"cli_name": "output"})
+    mode: str = "onnx"
 
     def to_dict(self) -> dict:
         """Convert to dictionary for serialization."""
@@ -121,6 +129,8 @@ class WinMLEvaluationConfig:
         result["dataset"] = self.dataset.to_dict()
         if self.output_path is not None:
             result["output_path"] = str(self.output_path)
+        if self.mode != "onnx":
+            result["mode"] = self.mode
         return result
 
     @classmethod
@@ -148,4 +158,5 @@ class WinMLEvaluationConfig:
             ep=data.get("ep"),
             dataset=dataset,
             output_path=(Path(data["output_path"]) if data.get("output_path") else None),
+            mode=data.get("mode", "onnx"),
         )

--- a/src/winml/modelkit/eval/config.py
+++ b/src/winml/modelkit/eval/config.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from ..utils.constants import EPNameOrAlias
+from ..utils.eval_utils import EvalMode
 
 
 @dataclass
@@ -87,7 +88,7 @@ class WinMLEvaluationConfig:
             device-to-provider mapping when provided.
         dataset: Dataset configuration.
         output_path: Path to write JSON results.
-        mode: Evaluation mode.
+        mode: Evaluation mode (see :data:`EvalMode`).
 
             - ``"onnx"`` (default): evaluate the ONNX candidate on the
               labeled dataset.
@@ -110,7 +111,7 @@ class WinMLEvaluationConfig:
     ep: EPNameOrAlias | None = None
     dataset: DatasetConfig = field(default_factory=DatasetConfig)
     output_path: Path | None = field(default=None, metadata={"cli_name": "output"})
-    mode: str = "onnx"
+    mode: EvalMode = "onnx"
 
     def to_dict(self) -> dict:
         """Convert to dictionary for serialization."""

--- a/src/winml/modelkit/eval/evaluate.py
+++ b/src/winml/modelkit/eval/evaluate.py
@@ -289,7 +289,16 @@ def evaluate(config: WinMLEvaluationConfig) -> EvalResult:
     copies via ``dataclasses.replace`` and ``deepcopy`` so the original
     config and any module-level defaults remain untouched.
     """
-    config = replace(config, task=_resolve_task(config), dataset=deepcopy(config.dataset))
+    from ..utils.eval_utils import EVAL_MODES
+
+    mode = config.mode if config.mode is not None else "onnx"
+    if mode not in EVAL_MODES:
+        raise ValueError(
+            f"Invalid mode {mode!r}; expected one of {EVAL_MODES} or None."
+        )
+    config = replace(
+        config, mode=mode, task=_resolve_task(config), dataset=deepcopy(config.dataset)
+    )
     if config.mode != "compare" and config.dataset.path is None:
         default = _DEFAULT_DATASETS.get(config.task)
         if default is None:

--- a/src/winml/modelkit/eval/evaluate.py
+++ b/src/winml/modelkit/eval/evaluate.py
@@ -57,16 +57,19 @@ _EVALUATOR_REGISTRY: dict[str, str] = {
         "winml.modelkit.eval.zero_shot_classification_evaluator:WinMLZeroShotClassificationEvaluator",
     "zero-shot-image-classification":
         "winml.modelkit.eval.zero_shot_image_classification_evaluator:WinMLZeroShotImageClassificationEvaluator",
+    "compare-tensor":
+        "winml.modelkit.eval.tensor_similarity_evaluator:TensorSimilarityEvaluator",
 }
 
 
-def get_evaluator_class(task: str) -> type[WinMLEvaluator]:
+def get_evaluator_class(config: WinMLEvaluationConfig) -> type[WinMLEvaluator]:
     """Return the evaluator class for *task*, or raise ValueError if unsupported."""
-    spec = _EVALUATOR_REGISTRY.get(task)
+    key = "compare-tensor" if config.mode == "compare" else config.task
+    spec = _EVALUATOR_REGISTRY.get(key)
     if spec is None:
         supported = ", ".join(sorted(_EVALUATOR_REGISTRY))
         raise ValueError(
-            f"Task '{task}' is not supported by `winml eval`. "
+            f"Task '{key}' is not supported by `winml eval`. "
             f"Supported tasks: {supported}."
         )
     module_path, class_name = spec.rsplit(":", 1)
@@ -278,7 +281,7 @@ def evaluate(config: WinMLEvaluationConfig) -> EvalResult:
     config and any module-level defaults remain untouched.
     """
     config = replace(config, task=_resolve_task(config), dataset=deepcopy(config.dataset))
-    if config.dataset.path is None:
+    if config.mode != "compare" and config.dataset.path is None:
         default = _DEFAULT_DATASETS.get(config.task)
         if default is None:
             raise ValueError(
@@ -309,7 +312,7 @@ def evaluate(config: WinMLEvaluationConfig) -> EvalResult:
 
     from ..utils.eval_utils import DatasetValidationError
 
-    cls = get_evaluator_class(config.task)
+    cls = get_evaluator_class(config)
     try:
         console.print("[bold]Loading dataset and evaluating...[/bold]")
         task_evaluator = cls(config, model)
@@ -342,15 +345,16 @@ def print_config(config: WinMLEvaluationConfig) -> None:
     if config.ep is not None:
         output_console.print(f"[bold blue]EP:[/bold blue] {config.ep}")
     output_console.print(f"[bold blue]Precision:[/bold blue] {config.precision}")
-    output_console.print(f"[bold blue]Dataset:[/bold blue] {ds.path}")
-    if ds.name:
-        output_console.print(f"[bold blue]Dataset name:[/bold blue] {ds.name}")
-    output_console.print(f"[bold blue]Split:[/bold blue] {ds.split}")
-    output_console.print(f"[bold blue]Samples:[/bold blue] {ds.samples}")
-    output_console.print(f"[bold blue]Shuffle:[/bold blue] {ds.shuffle} (seed={ds.seed})")
-    output_console.print(f"[bold blue]Streaming:[/bold blue] {ds.streaming}")
-    if ds.columns_mapping:
-        cols = ", ".join(f"{k}={v}" for k, v in ds.columns_mapping.items())
-        output_console.print(f"[bold blue]Columns:[/bold blue] {cols}")
+    if config.mode != "compare":
+        output_console.print(f"[bold blue]Dataset:[/bold blue] {ds.path}")
+        if ds.name:
+            output_console.print(f"[bold blue]Dataset name:[/bold blue] {ds.name}")
+        output_console.print(f"[bold blue]Split:[/bold blue] {ds.split}")
+        output_console.print(f"[bold blue]Samples:[/bold blue] {ds.samples}")
+        output_console.print(f"[bold blue]Shuffle:[/bold blue] {ds.shuffle} (seed={ds.seed})")
+        output_console.print(f"[bold blue]Streaming:[/bold blue] {ds.streaming}")
+        if ds.columns_mapping:
+            cols = ", ".join(f"{k}={v}" for k, v in ds.columns_mapping.items())
+            output_console.print(f"[bold blue]Columns:[/bold blue] {cols}")
     if config.output_path is not None:
         output_console.print(f"[bold blue]Output:[/bold blue] {config.output_path}")

--- a/src/winml/modelkit/eval/metrics/tensor_similarity.py
+++ b/src/winml/modelkit/eval/metrics/tensor_similarity.py
@@ -118,9 +118,13 @@ class TensorSimilarityMetric:
                 arr = np.asarray(finite, dtype=np.float64)
                 mean_val = float(arr.mean())
                 std_val = float(arr.std())
+            elif all(v == math.inf for v in values):
+                mean_val, std_val = math.inf, 0.0
+            elif all(v == -math.inf for v in values):
+                mean_val, std_val = -math.inf, 0.0
             else:
-                mean_val = math.inf
-                std_val = 0.0
+                # Any NaN, or a mix of +inf and -inf: un-summarizable.
+                mean_val, std_val = math.nan, math.nan
             result[f"{metric}_mean"] = mean_val
             result[f"{metric}_std"] = std_val
             result[f"{metric}_min"] = float(min(values))

--- a/src/winml/modelkit/eval/metrics/tensor_similarity.py
+++ b/src/winml/modelkit/eval/metrics/tensor_similarity.py
@@ -1,0 +1,133 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+"""Tensor-similarity metrics for compare-mode (ONNX vs HF reference parity).
+
+A :class:`TensorSimilarityMetric` instance accumulates per-sample scalar
+metrics across ``(prediction, reference)`` tensor pairs via ``update``
+and reports ``{f"{metric}_{stat}": float}`` (4 stats per metric: mean,
+std, min, max) via ``compute``. The per-sample math (SQNR, PSNR, cosine,
+MSE, max abs diff) mirrors the team-wide ``eval_tensors`` library so
+numbers match bit-for-bit on the same ``.npy`` pair.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+
+_SCALAR_METRICS = (
+    "sqnr_db",
+    "psnr_db",
+    "cosine_similarity",
+    "mse",
+    "max_abs_diff",
+)
+
+
+def _sqnr_db(ref: np.ndarray, test: np.ndarray) -> float:
+    """``10 * log10(sum(ref^2) / sum((ref-test)^2))``. ``+inf`` if identical."""
+    signal = float(np.sum(ref * ref))
+    noise = float(np.sum((ref - test) ** 2))
+    if noise == 0.0:
+        return math.inf
+    if signal == 0.0:
+        return -math.inf
+    return 10.0 * math.log10(signal / noise)
+
+
+def _mse(ref: np.ndarray, test: np.ndarray) -> float:
+    return float(np.mean((ref - test) ** 2))
+
+
+def _max_abs_diff(ref: np.ndarray, test: np.ndarray) -> float:
+    return float(np.max(np.abs(ref - test)))
+
+
+def _psnr_db(ref: np.ndarray, mse_val: float) -> float:
+    """``10 * log10(peak^2 / mse)``, ``peak = max(|ref|)``."""
+    if mse_val == 0.0:
+        return math.inf
+    peak = float(np.max(np.abs(ref)))
+    if peak == 0.0:
+        return -math.inf
+    return 10.0 * math.log10((peak * peak) / mse_val)
+
+
+def _cosine_similarity(ref: np.ndarray, test: np.ndarray) -> float:
+    """``dot(ref, test) / (||ref|| * ||test||)``, asymmetric zero handling.
+
+    Both inputs all-zero -> ``1.0`` (identical zero vectors).
+    Exactly one input all-zero -> ``0.0`` (a dead vector against a live
+    one is NOT a perfect match, even though the angle is undefined).
+    """
+    norm_ref = float(np.linalg.norm(ref))
+    norm_test = float(np.linalg.norm(test))
+    if norm_ref == 0.0 and norm_test == 0.0:
+        return 1.0
+    if norm_ref == 0.0 or norm_test == 0.0:
+        return 0.0
+    return float(np.dot(ref, test) / (norm_ref * norm_test))
+
+
+class TensorSimilarityMetric:
+    """Streaming per-sample tensor-parity metrics.
+
+    Each ``update(prediction, reference)`` computes the 5 scalar metrics
+    on the pair and appends them to internal per-metric lists. ``compute``
+    aggregates each list to ``mean`` / ``std`` / ``min`` / ``max`` and
+    returns a flat ``{f"{metric}_{stat}": float}`` dict ready for direct
+    consumption by the generic eval report renderer. ``mean`` and ``std``
+    are computed over only the finite values so a single bit-identical
+    sample (``sqnr_db = +inf``, ``psnr_db = +inf``) does not poison
+    the aggregate.
+    """
+
+    def __init__(self) -> None:
+        self._per_sample: dict[str, list[float]] = {m: [] for m in _SCALAR_METRICS}
+
+    def update(self, prediction: np.ndarray, reference: np.ndarray) -> None:
+        """Compute all scalar metrics on one pair and append to per-metric lists."""
+        if prediction.shape != reference.shape:
+            raise ValueError(
+                f"shape mismatch: prediction {prediction.shape} vs "
+                f"reference {reference.shape}",
+            )
+        ref = reference.astype(np.float64).ravel()
+        test = prediction.astype(np.float64).ravel()
+
+        mse_val = _mse(ref, test)
+        self._per_sample["sqnr_db"].append(_sqnr_db(ref, test))
+        self._per_sample["psnr_db"].append(_psnr_db(ref, mse_val))
+        self._per_sample["cosine_similarity"].append(_cosine_similarity(ref, test))
+        self._per_sample["mse"].append(mse_val)
+        self._per_sample["max_abs_diff"].append(_max_abs_diff(ref, test))
+
+    def compute(self) -> dict[str, float]:
+        """Return ``{f"{metric}_{stat}": float}`` for stats mean/std/min/max."""
+        result: dict[str, float] = {}
+        for metric, values in self._per_sample.items():
+            if not values:
+                continue
+            finite = [v for v in values if math.isfinite(v)]
+            if finite:
+                arr = np.asarray(finite, dtype=np.float64)
+                mean_val = float(arr.mean())
+                std_val = float(arr.std())
+            else:
+                mean_val = math.inf
+                std_val = 0.0
+            result[f"{metric}_mean"] = mean_val
+            result[f"{metric}_std"] = std_val
+            result[f"{metric}_min"] = float(min(values))
+            result[f"{metric}_max"] = float(max(values))
+        return result
+
+    def reset(self) -> None:
+        """Clear all accumulated per-sample values."""
+        for k in self._per_sample:
+            self._per_sample[k] = []

--- a/src/winml/modelkit/eval/tensor_similarity_evaluator.py
+++ b/src/winml/modelkit/eval/tensor_similarity_evaluator.py
@@ -39,7 +39,7 @@ class TensorSimilarityEvaluator:
         from ..models.winml.composite_model import WinMLCompositeModel
 
         if isinstance(model, WinMLCompositeModel):
-            sub_tasks = list(type(model)._SUB_MODEL_CONFIG.values())
+            sub_tasks = list(getattr(type(model), "_SUB_MODEL_CONFIG", {}).values())
             raise TypeError(
                 "--mode compare does not support composite models directly. "
                 f"Run compare per sub-component instead (sub-tasks: {sub_tasks}). "
@@ -81,9 +81,9 @@ class TensorSimilarityEvaluator:
 
         ds = self.config.dataset
         return RandomDataset(
-            model_path=str(self.model._onnx_path),
-            max_samples=int(ds.samples or 100),
-            seed=int(ds.seed or 42),
+            model_path=str(self.model.onnx_path),
+            max_samples=int(ds.samples if ds.samples is not None else 100),
+            seed=int(ds.seed if ds.seed is not None else 42),
         )
 
     def compute(self) -> dict[str, dict[str, float]]:
@@ -98,7 +98,7 @@ class TensorSimilarityEvaluator:
 
         from .metrics.tensor_similarity import TensorSimilarityMetric
 
-        input_names = list(self.data._io_config["input_names"])
+        input_names = list(self.model.io_config["input_names"])
         metrics: dict[str, TensorSimilarityMetric] = {}
         common_keys: list[str] | None = None
         ort_keys: set[str] = set()

--- a/src/winml/modelkit/eval/tensor_similarity_evaluator.py
+++ b/src/winml/modelkit/eval/tensor_similarity_evaluator.py
@@ -1,0 +1,170 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+"""Tensor-similarity evaluator.
+
+Runs an ONNX candidate and an HF PyTorch reference on identical random
+inputs (drawn from :class:`RandomDataset` over the candidate's ONNX I/O)
+and reports per-output tensor-parity metrics (SQNR, PSNR, cosine, MSE,
+max absolute diff) via :class:`TensorSimilarityMetric`.
+
+No labeled dataset, no HF pipeline, no preprocessor — any divergence
+reflects the build pipeline (optimize / quantize / compile) only.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+
+if TYPE_CHECKING:
+    from ..models.winml.base import WinMLPreTrainedModel
+    from .config import WinMLEvaluationConfig
+
+
+logger = logging.getLogger(__name__)
+
+
+class TensorSimilarityEvaluator:
+    """Per-output tensor parity between an ONNX candidate and an HF reference."""
+
+    def __init__(
+        self,
+        config: WinMLEvaluationConfig,
+        model: WinMLPreTrainedModel,
+    ) -> None:
+        from ..models.winml.composite_model import WinMLCompositeModel
+
+        if isinstance(model, WinMLCompositeModel):
+            sub_tasks = list(type(model)._SUB_MODEL_CONFIG.values())
+            raise TypeError(
+                "--mode compare does not support composite models directly. "
+                f"Run compare per sub-component instead (sub-tasks: {sub_tasks}). "
+                "Example: winml eval --mode compare --task <sub_task> "
+                f"--model <sub_onnx_path> --model-id {config.model_id}"
+            )
+        self.config = config
+        self.model = model
+        self.reference_model = self._load_reference_model()
+        self.data = self.prepare_data()
+
+    def _load_reference_model(self) -> Any:
+        """Load the HF PyTorch reference model on CPU/fp32 in eval mode.
+
+        Resolves the appropriate ``AutoModelFor*`` class via
+        :func:`resolve_task_and_model_class` so no task-specific mapping is
+        needed here.
+        """
+        import torch
+        from transformers import AutoConfig
+
+        from ..loader.task import resolve_task_and_model_class
+
+        if self.config.model_id is None:
+            raise ValueError(
+                "model_id is required to load the HF reference model."
+            )
+
+        hf_config = AutoConfig.from_pretrained(self.config.model_id)
+        _, cls = resolve_task_and_model_class(hf_config, task=self.config.task)
+        logger.info("Loading HF reference %s on CPU/fp32", cls.__name__)
+        return cls.from_pretrained(
+            self.config.model_id, dtype=torch.float32
+        ).eval()
+
+    def prepare_data(self) -> Any:
+        """Build a RandomDataset over the candidate ONNX's I/O spec."""
+        from ..datasets.random_dataset import RandomDataset
+
+        ds = self.config.dataset
+        return RandomDataset(
+            model_path=str(self.model._onnx_path),
+            max_samples=int(ds.samples or 100),
+            seed=int(ds.seed or 42),
+        )
+
+    def compute(self) -> dict[str, dict[str, float]]:
+        """Run paired inference and return display-ready per-metric per-output values.
+
+        Returns ``{f"{metric}_{stat}": {output_name: float}}`` — the flat shape
+        the generic eval report renderer prints as one row per ``{metric}_{stat}``
+        with ``output_name=value`` cells joined across outputs.
+        """
+        import torch
+        from tqdm import tqdm
+
+        from .metrics.tensor_similarity import TensorSimilarityMetric
+
+        input_names = list(self.data._io_config["input_names"])
+        metrics: dict[str, TensorSimilarityMetric] = {}
+        common_keys: list[str] | None = None
+        ort_keys: set[str] = set()
+        hf_keys: set[str] = set()
+
+        with torch.no_grad():
+            for i in tqdm(range(len(self.data)), desc="compare", unit="sample"):
+                row = self.data[i]
+                sample = {name: row[name] for name in input_names}
+
+                ort_out = self._inference_model(self.model, sample)
+                hf_out = self._inference_model(self.reference_model, sample)
+
+                if common_keys is None:
+                    ort_keys, hf_keys = set(ort_out), set(hf_out)
+                    common_keys = [name for name in hf_out if name in ort_keys & hf_keys]
+                    if not common_keys:
+                        raise ValueError(
+                            f"ONNX and HF reference output names do not overlap. "
+                            f"ONNX: {sorted(ort_keys)}, HF: {sorted(hf_keys)}."
+                        )
+
+                for name in common_keys:
+                    metrics.setdefault(name, TensorSimilarityMetric()).update(
+                        ort_out[name], hf_out[name],
+                    )
+
+        if ort_keys != hf_keys:
+            logger.warning(
+                "ONNX and HF reference output names differ. "
+                "ONNX: %s, HF: %s.",
+                sorted(ort_keys),
+                sorted(hf_keys),
+            )
+
+        # Pivot per-output flat dicts -> {stat_key: {output: value}}.
+        pivoted: dict[str, dict[str, float]] = {}
+        for output_name, metric in metrics.items():
+            for stat_key, value in metric.compute().items():
+                pivoted.setdefault(stat_key, {})[output_name] = value
+        return pivoted
+
+    @staticmethod
+    def _inference_model(
+        model: Any, sample: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Run one sample through a model and return its named tensor outputs.
+
+        Uniform for both backends: HF embeddings require int64 indices, so
+        any narrower integer tensor is upcast here. WinMLSession down-casts
+        to the ORT graph's declared dtype on its side, so the same dict
+        feeds both ``WinMLPreTrainedModel`` and an HF reference model.
+        """
+        import torch
+
+        inputs = {
+            k: (
+                v.to(torch.int64)
+                if v.dtype in (torch.int8, torch.int16, torch.int32)
+                else v
+            )
+            for k, v in sample.items()
+        }
+        output = model(**inputs)
+        return {
+            name: tensor.detach().cpu().numpy()
+            for name, tensor in output.items()
+            if isinstance(tensor, torch.Tensor)
+        }

--- a/src/winml/modelkit/models/winml/base.py
+++ b/src/winml/modelkit/models/winml/base.py
@@ -99,6 +99,11 @@ class WinMLPreTrainedModel(PreTrainedModel, ABC):
         """ONNX I/O metadata (delegated to session)."""
         return self._session.io_config
 
+    @property
+    def onnx_path(self) -> Path:
+        """Path to the ONNX model file."""
+        return self._onnx_path
+
     def _format_inputs(
         self,
         data: torch.Tensor | np.ndarray | list | dict | None = None,

--- a/src/winml/modelkit/models/winml/feature_extraction.py
+++ b/src/winml/modelkit/models/winml/feature_extraction.py
@@ -12,9 +12,10 @@ Pipeline execution (export/optimize/compile) is done by WinMLAutoModel factory.
 from __future__ import annotations
 
 import logging
+from collections import OrderedDict
 from typing import Any
 
-from transformers.modeling_outputs import BaseModelOutput
+from transformers.utils import ModelOutput
 
 from .base import WinMLPreTrainedModel
 
@@ -22,36 +23,40 @@ from .base import WinMLPreTrainedModel
 logger = logging.getLogger(__name__)
 
 
+class FeatureExtractionModelOutput(ModelOutput):
+    """ModelOutput backed directly by the ONNX session output dict.
+
+    Preserves output names and order so HF pipelines (`output[0]`) and
+    TensorSimilarityEvaluator (`output["name"]`) both work without a
+    per-schema dataclass.
+    """
+
+    def __init__(self, data: dict[str, Any]):
+        OrderedDict.__init__(self, data)
+
+    def __post_init__(self) -> None:
+        # Bypass ModelOutput's dataclass-driven population; OrderedDict
+        # is already populated via __init__.
+        pass
+
+
 class WinMLModelForFeatureExtraction(WinMLPreTrainedModel):
     """WinML model for feature extraction.
 
-    Supports:
-    - feature-extraction (text, e.g. sentence-transformers)
+    Supports text and image feature-extraction plus sentence-similarity.
 
-    Returns BaseModelOutput with last_hidden_state so the HF
-    feature-extraction pipeline can consume it via output[0].
-
-    ONNX output handling (shape-based, architecture-agnostic):
-    - 3-D [B, seq_len, hidden_dim]: used directly as last_hidden_state.
-    - 2-D [B, hidden_dim]: unsqueezed to [B, 1, hidden_dim] so downstream
-      mean-pooling is a no-op.
+    Returns a ModelOutput whose entries mirror the ONNX exporter's declared
+    output names and order. HF pipelines consume output[0] positionally;
+    TensorSimilarityEvaluator consumes by name. Both work without renaming
+    or reshaping ONNX outputs.
     """
 
-    def forward(self, **kwargs: Any) -> BaseModelOutput:
+    def forward(self, **kwargs: Any) -> ModelOutput:
         """Run feature extraction inference.
 
-        Accepts all tokenizer/processor outputs via **kwargs and passes them
-        directly to the ONNX session, keeping the implementation architecture-agnostic.
-
-        Returns:
-            BaseModelOutput with last_hidden_state tensor
+        Returns a ModelOutput with one entry per ONNX output in declared
+        order. Tensors keep their native rank (no unsqueeze); downstream
+        pooling handles 1-D and 2-D after raw[0].
         """
-        formatted = self._format_inputs(**kwargs)
-        outputs = self._run_inference(formatted)
-
-        last_hidden_state = next(iter(outputs.values()))
-        if last_hidden_state.dim() == 2:
-            # Already pooled [B, hidden_dim] -> wrap as [B, 1, hidden_dim]
-            last_hidden_state = last_hidden_state.unsqueeze(1)
-
-        return BaseModelOutput(last_hidden_state=last_hidden_state)
+        outputs = self._run_inference(self._format_inputs(**kwargs))
+        return FeatureExtractionModelOutput(outputs)

--- a/src/winml/modelkit/utils/eval_utils.py
+++ b/src/winml/modelkit/utils/eval_utils.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal, TypeAlias, get_args
 
+
 EvalMode: TypeAlias = Literal["onnx", "compare"]
 
 EVAL_MODES: tuple[EvalMode, ...] = get_args(EvalMode)

--- a/src/winml/modelkit/utils/eval_utils.py
+++ b/src/winml/modelkit/utils/eval_utils.py
@@ -13,6 +13,11 @@ that importing it does not load the heavy ``winml.modelkit.eval`` package
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Literal, TypeAlias, get_args
+
+EvalMode: TypeAlias = Literal["onnx", "compare"]
+
+EVAL_MODES: tuple[EvalMode, ...] = get_args(EvalMode)
 
 
 @dataclass(frozen=True)

--- a/tests/e2e/test_eval_e2e.py
+++ b/tests/e2e/test_eval_e2e.py
@@ -826,15 +826,16 @@ class TestEvalAdditionalOptions:
                 f"cosine outside [-1, 1] for {output_name}: min={lo}, max={hi}"
             )
 
-        # fp16 parity on QNN should be near-perfect (>= 0.95). VitisAI/CPU
-        # paths can degrade more, so gate the magnitude check on QNN.
-        if is_host("qnn"):
-            cos_mean = metrics["cosine_similarity_mean"]
-            for output_name, value in cos_mean.items():
-                assert value >= 0.95, (
-                    f"cosine_similarity_mean[{output_name}]={value} "
-                    "unexpectedly low"
-                )
+        # fp16 parity: QNN should be near-perfect (>= 0.95); CPU/VitisAI
+        # paths can degrade more, but a 0.5 sanity floor still catches
+        # total-breakage regressions on non-QNN runners.
+        cos_mean = metrics["cosine_similarity_mean"]
+        threshold = 0.95 if is_host("qnn") else 0.5
+        for output_name, value in cos_mean.items():
+            assert value >= threshold, (
+                f"cosine_similarity_mean[{output_name}]={value} "
+                f"below {threshold} sanity floor"
+            )
 
 
 # ===========================================================================

--- a/tests/e2e/test_eval_e2e.py
+++ b/tests/e2e/test_eval_e2e.py
@@ -766,6 +766,76 @@ class TestEvalAdditionalOptions:
         assert result.exit_code != 0
         assert "trust-remote-code" in result.output.lower(), result.output
 
+    def test_compare_mode_image_classification(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        # --mode compare runs the ONNX candidate and the HF PyTorch reference
+        # on the same random inputs and reports per-output tensor-parity
+        # metrics in display-ready flat shape:
+        #   {f"{metric}_{stat}": {output_name: float}}
+        # over 5 metrics (sqnr_db, psnr_db, cosine_similarity, mse,
+        # max_abs_diff) x 4 stats (mean, std, min, max) = 20 top-level keys.
+        out = tmp_path / "result.json"
+        _invoke(runner, [
+            "--mode", "compare",
+            "-m", "microsoft/resnet-50",
+            "--task", "image-classification",
+            "--precision", "fp16",
+            "--samples", SAMPLES,
+            "-o", str(out),
+        ])
+        assert out.exists(), f"output file not created: {out}"
+        data = json.loads(out.read_text())
+        metrics = data.get("metrics", {})
+        assert metrics, f"missing or empty 'metrics': {data}"
+
+        expected_metrics = ("sqnr_db", "psnr_db", "cosine_similarity", "mse", "max_abs_diff")
+        expected_stats = ("mean", "std", "min", "max")
+        expected_keys = {f"{m}_{s}" for m in expected_metrics for s in expected_stats}
+        assert expected_keys.issubset(metrics), (
+            f"missing flat metric keys: {sorted(expected_keys - set(metrics))}"
+        )
+
+        # Each top-level value is {output_name: float}. ResNet-50 image-
+        # classification exposes a single `logits` output, but we don't
+        # hardcode the name — just assert non-empty and floats.
+        per_output_names: set[str] | None = None
+        for key in expected_keys:
+            row = metrics[key]
+            assert isinstance(row, dict) and row, (
+                f"metrics[{key!r}] not a non-empty dict: {row!r}"
+            )
+            assert all(isinstance(v, (int, float)) for v in row.values()), (
+                f"non-numeric value in metrics[{key!r}]: {row!r}"
+            )
+            names = set(row)
+            if per_output_names is None:
+                per_output_names = names
+            else:
+                assert names == per_output_names, (
+                    f"output-name set drift between {key!r} ({names}) and "
+                    f"siblings ({per_output_names})"
+                )
+
+        # Cosine bounds: min <= max in [-1, 1] per output.
+        cos_min = metrics["cosine_similarity_min"]
+        cos_max = metrics["cosine_similarity_max"]
+        for output_name in per_output_names or ():
+            lo, hi = cos_min[output_name], cos_max[output_name]
+            assert -1.0 <= lo <= hi <= 1.0, (
+                f"cosine outside [-1, 1] for {output_name}: min={lo}, max={hi}"
+            )
+
+        # fp16 parity on QNN should be near-perfect (>= 0.95). VitisAI/CPU
+        # paths can degrade more, so gate the magnitude check on QNN.
+        if is_host("qnn"):
+            cos_mean = metrics["cosine_similarity_mean"]
+            for output_name, value in cos_mean.items():
+                assert value >= 0.95, (
+                    f"cosine_similarity_mean[{output_name}]={value} "
+                    "unexpectedly low"
+                )
+
 
 # ===========================================================================
 # G. CLI-validation error paths (fast — no model load)

--- a/tests/unit/eval/test_depth_estimation_evaluator.py
+++ b/tests/unit/eval/test_depth_estimation_evaluator.py
@@ -11,7 +11,7 @@ import pytest
 import torch
 from PIL import Image as PILImage
 
-from winml.modelkit.eval import WinMLDepthEstimationEvaluator
+from winml.modelkit.eval import WinMLDepthEstimationEvaluator, WinMLEvaluationConfig
 from winml.modelkit.eval.evaluate import _EVALUATOR_REGISTRY
 
 
@@ -69,7 +69,10 @@ class TestRegistry:
     def test_depth_estimation_get_evaluator_class(self):
         from winml.modelkit.eval import get_evaluator_class
 
-        assert get_evaluator_class("depth-estimation") is WinMLDepthEstimationEvaluator
+        assert (
+            get_evaluator_class(WinMLEvaluationConfig(task="depth-estimation"))
+            is WinMLDepthEstimationEvaluator
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/eval/test_eval.py
+++ b/tests/unit/eval/test_eval.py
@@ -111,7 +111,7 @@ class TestGetEvaluatorClass:
     """Tests for get_evaluator_class registry lookup."""
 
     def test_registered_task_returns_class(self):
-        from winml.modelkit.eval import WinMLEvaluator, get_evaluator_class
+        from winml.modelkit.eval import WinMLEvaluationConfig, WinMLEvaluator, get_evaluator_class
         from winml.modelkit.eval.evaluate import _EVALUATOR_REGISTRY
 
         # _EVALUATOR_REGISTRY stores "module_path:ClassName" strings so that
@@ -123,25 +123,31 @@ class TestGetEvaluatorClass:
             assert isinstance(spec, str) and ":" in spec, (
                 f"Registry value for {task!r} must be a 'module:Class' string."
             )
-            cls = get_evaluator_class(task)
+            cls = get_evaluator_class(WinMLEvaluationConfig(task=task))
             assert isinstance(cls, type)
-            assert issubclass(cls, WinMLEvaluator)
+            # Task evaluators inherit from WinMLEvaluator; "compare-tensor"
+            # is a non-task entry (TensorSimilarityEvaluator) with its own
+            # shape and is exempt from the base-class check.
+            if task != "compare-tensor":
+                assert issubclass(cls, WinMLEvaluator)
             # The resolved class must match the qualified name in the spec.
             module_path, class_name = spec.rsplit(":", 1)
             assert cls.__module__ == module_path
             assert cls.__name__ == class_name
 
     def test_unsupported_task_raises_value_error(self):
-        from winml.modelkit.eval import get_evaluator_class
+        from winml.modelkit.eval import WinMLEvaluationConfig, get_evaluator_class
 
         with pytest.raises(ValueError, match="not supported by `winml eval`"):
-            get_evaluator_class("made-up-task")
+            get_evaluator_class(WinMLEvaluationConfig(task="made-up-task"))
 
     def test_evaluator_registry_matches_schema_tasks(self):
         from winml.modelkit.eval.evaluate import _EVALUATOR_REGISTRY
         from winml.modelkit.utils.eval_utils import TASK_SCHEMAS
 
-        assert set(_EVALUATOR_REGISTRY) == set(TASK_SCHEMAS)
+        # "compare-tensor" is a non-task evaluator entry (no labeled-dataset
+        # schema); exclude it from the task<->schema equivalence check.
+        assert set(_EVALUATOR_REGISTRY) - {"compare-tensor"} == set(TASK_SCHEMAS)
 
 
 class TestEvaluate:

--- a/tests/unit/eval/test_eval.py
+++ b/tests/unit/eval/test_eval.py
@@ -172,6 +172,46 @@ class TestGetEvaluatorClass:
 class TestEvaluate:
     """Tests for evaluate() entry point."""
 
+    def test_invalid_mode_raises(self):
+        """evaluate() rejects unknown mode values with a clear error."""
+        import importlib
+        import sys
+
+        eval_mod = sys.modules.get(
+            "winml.modelkit.eval.evaluate",
+        ) or importlib.import_module("winml.modelkit.eval.evaluate")
+
+        config = WinMLEvaluationConfig(model_id="test/model", task="feature-extraction")
+        config.mode = "hf"  # bypass dataclass type hint
+
+        with pytest.raises(ValueError, match="Invalid mode"):
+            eval_mod.evaluate(config)
+
+    def test_none_mode_normalizes_to_onnx(self):
+        """evaluate() treats mode=None as the default onnx mode."""
+        import importlib
+        import sys
+
+        eval_mod = sys.modules.get(
+            "winml.modelkit.eval.evaluate",
+        ) or importlib.import_module("winml.modelkit.eval.evaluate")
+
+        config = WinMLEvaluationConfig(
+            model_id="test/model",
+            task="image-classification",
+            dataset=DatasetConfig(path="imagenet-1k"),
+        )
+        config.mode = None  # bypass dataclass type hint
+
+        evaluator = MagicMock()
+        evaluator.compute.return_value = {"accuracy": 1.0}
+        with (
+            patch.object(eval_mod, "_load_model", return_value=MagicMock()),
+            patch.object(eval_mod, "get_evaluator_class", return_value=lambda *_a, **_k: evaluator),
+        ):
+            result = eval_mod.evaluate(config)
+        assert result.config.mode == "onnx"
+
     def test_no_dataset_no_default_raises(self):
         """Tasks without a default dataset raise ValueError."""
         import importlib

--- a/tests/unit/eval/test_image_feature_extraction_evaluator.py
+++ b/tests/unit/eval/test_image_feature_extraction_evaluator.py
@@ -184,11 +184,12 @@ class TestExtractImageEmbedding:
 
 class TestImageFeatureExtractionEvaluatorRegistry:
     def test_registered_in_evaluator_registry(self):
+        from winml.modelkit.eval import WinMLEvaluationConfig
         from winml.modelkit.eval.evaluate import _EVALUATOR_REGISTRY, get_evaluator_class
 
         assert "image-feature-extraction" in _EVALUATOR_REGISTRY
         assert (
-            get_evaluator_class("image-feature-extraction")
+            get_evaluator_class(WinMLEvaluationConfig(task="image-feature-extraction"))
             is WinMLImageFeatureExtractionEvaluator
         )
 

--- a/tests/unit/eval/test_image_to_text_evaluator.py
+++ b/tests/unit/eval/test_image_to_text_evaluator.py
@@ -67,11 +67,15 @@ class TestAlignLabels:
 
 class TestRegistry:
     def test_registered(self):
+        from winml.modelkit.eval import WinMLEvaluationConfig
         from winml.modelkit.eval.evaluate import _EVALUATOR_REGISTRY, get_evaluator_class
 
         assert "image-to-text" in _EVALUATOR_REGISTRY
         # Registry stores "module:Class" strings now (lazy resolution).
-        assert get_evaluator_class("image-to-text") is WinMLImageToTextEvaluator
+        assert (
+            get_evaluator_class(WinMLEvaluationConfig(task="image-to-text"))
+            is WinMLImageToTextEvaluator
+        )
 
 
 class TestCompute:

--- a/tests/unit/eval/test_tensor_similarity_evaluator.py
+++ b/tests/unit/eval/test_tensor_similarity_evaluator.py
@@ -1,0 +1,104 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+"""Unit tests for TensorSimilarityEvaluator.
+
+Focuses on the ``_inference_model`` static helper and the composite-model
+guard in ``__init__``. Per-sample metric math lives in
+:mod:`TensorSimilarityMetric` (see ``test_tensor_similarity_metric.py``)
+and end-to-end ``compute()`` is covered by ``tests/e2e/test_eval_e2e.py``.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import numpy as np
+import pytest
+import torch
+from transformers import PretrainedConfig
+from transformers.modeling_outputs import BaseModelOutput
+
+from winml.modelkit.eval import DatasetConfig, WinMLEvaluationConfig
+from winml.modelkit.eval.tensor_similarity_evaluator import TensorSimilarityEvaluator
+from winml.modelkit.models.winml.composite_model import WinMLCompositeModel
+
+
+# ---------------------------------------------------------------------------
+# _inference_model
+# ---------------------------------------------------------------------------
+
+class _EchoModel:
+    """Minimal stand-in that returns a BaseModelOutput from the inputs."""
+
+    def __init__(self, output_dict):
+        self._output = output_dict
+        self.last_call_dtypes: dict[str, torch.dtype] = {}
+
+    def __call__(self, **inputs):
+        self.last_call_dtypes = {k: v.dtype for k, v in inputs.items()}
+        return BaseModelOutput(last_hidden_state=self._output["last_hidden_state"])
+
+
+class TestInferenceModel:
+    def test_upcasts_narrow_int_to_int64(self):
+        model = _EchoModel({"last_hidden_state": torch.zeros(1, 4)})
+        sample = {
+            "input_ids": torch.zeros(1, 8, dtype=torch.int32),
+            "attention_mask": torch.ones(1, 8, dtype=torch.int8),
+        }
+        TensorSimilarityEvaluator._inference_model(model, sample)
+        assert model.last_call_dtypes["input_ids"] == torch.int64
+        assert model.last_call_dtypes["attention_mask"] == torch.int64
+
+    def test_leaves_int64_and_float_untouched(self):
+        model = _EchoModel({"last_hidden_state": torch.zeros(1, 4)})
+        sample = {
+            "input_ids": torch.zeros(1, 8, dtype=torch.int64),
+            "pixel_values": torch.zeros(1, 3, 4, 4, dtype=torch.float32),
+        }
+        TensorSimilarityEvaluator._inference_model(model, sample)
+        assert model.last_call_dtypes["input_ids"] == torch.int64
+        assert model.last_call_dtypes["pixel_values"] == torch.float32
+
+    def test_returns_numpy_dict_only_for_tensor_fields(self):
+        model = _EchoModel({"last_hidden_state": torch.arange(6.0).reshape(1, 2, 3)})
+        out = TensorSimilarityEvaluator._inference_model(
+            model, {"input_ids": torch.zeros(1, 2, dtype=torch.int64)}
+        )
+        assert set(out) == {"last_hidden_state"}
+        assert isinstance(out["last_hidden_state"], np.ndarray)
+        assert out["last_hidden_state"].shape == (1, 2, 3)
+
+
+# ---------------------------------------------------------------------------
+# composite-model guard in __init__
+# ---------------------------------------------------------------------------
+
+class _FakeCompositeModel(WinMLCompositeModel):
+    _SUB_MODEL_CONFIG: ClassVar[dict[str, str]] = {
+        "encoder": "image-feature-extraction",
+        "decoder": "text-generation",
+    }
+
+
+class TestCompositeGuard:
+    def test_rejects_composite_with_helpful_message(self):
+        composite = _FakeCompositeModel(
+            sub_models={}, config=PretrainedConfig()
+        )
+        config = WinMLEvaluationConfig(
+            model_id="Salesforce/blip-image-captioning-base",
+            task="image-to-text",
+            mode="compare",
+            dataset=DatasetConfig(),
+        )
+        with pytest.raises(TypeError) as exc:
+            TensorSimilarityEvaluator(config, composite)
+        msg = str(exc.value)
+        assert "composite" in msg.lower()
+        assert "image-feature-extraction" in msg
+        assert "text-generation" in msg
+        assert "Salesforce/blip-image-captioning-base" in msg

--- a/tests/unit/eval/test_tensor_similarity_metric.py
+++ b/tests/unit/eval/test_tensor_similarity_metric.py
@@ -121,6 +121,54 @@ class TestDegenerateSignal:
 
 
 # ---------------------------------------------------------------------------
+# All-non-finite aggregation: must NOT misreport as +inf "perfect"
+# ---------------------------------------------------------------------------
+
+class TestAllNonFiniteAggregation:
+    def test_all_nan_predictions_aggregate_to_nan(self):
+        # A model that emits NaN poisons cosine / MSE; the aggregate must
+        # surface this as NaN, not as a false "+inf perfect match".
+        ref = np.array([1.0, 2.0, 3.0, 4.0])
+        nan_pred = np.full(4, math.nan)
+        m = TensorSimilarityMetric()
+        m.update(nan_pred, ref)
+        m.update(nan_pred, ref)
+        r = m.compute()
+        assert math.isnan(r["cosine_similarity_mean"])
+        assert math.isnan(r["cosine_similarity_std"])
+        assert math.isnan(r["mse_mean"])
+
+    def test_all_neg_inf_aggregates_to_neg_inf(self):
+        # Two samples of (zero ref, non-zero test) -> SQNR/PSNR are all -inf.
+        ref = np.zeros(4)
+        test = np.array([0.1, 0.2, 0.3, 0.4])
+        m = TensorSimilarityMetric()
+        m.update(test, ref)
+        m.update(test, ref)
+        r = m.compute()
+        assert r["sqnr_db_mean"] == -math.inf
+        assert r["sqnr_db_std"] == 0.0
+        assert r["psnr_db_mean"] == -math.inf
+        assert r["psnr_db_std"] == 0.0
+
+    def test_mixed_pos_inf_and_neg_inf_aggregates_to_nan(self):
+        # One identical sample (+inf SQNR) + one zero-ref/nonzero-test sample
+        # (-inf SQNR). No finite values, mixed signs -> NaN.
+        ref_a = np.array([1.0, 2.0, 3.0, 4.0])
+        ref_b = np.zeros(4)
+        test_b = np.array([0.1, 0.2, 0.3, 0.4])
+        m = TensorSimilarityMetric()
+        m.update(ref_a, ref_a)   # SQNR = +inf
+        m.update(test_b, ref_b)  # SQNR = -inf
+        r = m.compute()
+        assert math.isnan(r["sqnr_db_mean"])
+        assert math.isnan(r["sqnr_db_std"])
+        # min/max remain well-defined.
+        assert r["sqnr_db_min"] == -math.inf
+        assert r["sqnr_db_max"] == math.inf
+
+
+# ---------------------------------------------------------------------------
 # Multi-sample aggregation (mean/std/min/max)
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/eval/test_tensor_similarity_metric.py
+++ b/tests/unit/eval/test_tensor_similarity_metric.py
@@ -1,0 +1,152 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+"""Unit tests for TensorSimilarityMetric."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from winml.modelkit.eval.metrics.tensor_similarity import (
+    _SCALAR_METRICS,
+    TensorSimilarityMetric,
+)
+
+
+_STATS = ("mean", "std", "min", "max")
+
+
+# ---------------------------------------------------------------------------
+# Per-metric numerical correctness on a single (pred, ref) pair
+# ---------------------------------------------------------------------------
+
+class TestPerSampleMath:
+    def test_identical_inputs(self):
+        m = TensorSimilarityMetric()
+        x = np.array([1.0, -2.0, 3.0, 4.5], dtype=np.float32)
+        m.update(x, x)
+        r = m.compute()
+        # Identical tensors: SQNR/PSNR = +inf; cosine = 1; MSE = 0; max|diff| = 0.
+        assert r["sqnr_db_max"] == math.inf
+        assert r["psnr_db_max"] == math.inf
+        assert r["cosine_similarity_mean"] == pytest.approx(1.0)
+        assert r["mse_mean"] == 0.0
+        assert r["max_abs_diff_mean"] == 0.0
+        # No finite SQNR/PSNR samples -> mean falls back to +inf.
+        assert r["sqnr_db_mean"] == math.inf
+        assert r["psnr_db_mean"] == math.inf
+
+    def test_known_diff(self):
+        # ref=[1,2,3,4], test=ref + 0.1 everywhere.
+        ref = np.array([1.0, 2.0, 3.0, 4.0])
+        test = ref + 0.1
+        m = TensorSimilarityMetric()
+        m.update(test, ref)
+        r = m.compute()
+
+        # MSE = 0.01, max|diff| = 0.1
+        assert r["mse_mean"] == pytest.approx(0.01)
+        assert r["max_abs_diff_mean"] == pytest.approx(0.1)
+
+        # SQNR = 10*log10(sum(ref^2) / sum(noise^2)) = 10*log10(30 / 0.04)
+        expected_sqnr = 10.0 * math.log10(30.0 / 0.04)
+        assert r["sqnr_db_mean"] == pytest.approx(expected_sqnr)
+
+        # PSNR = 10*log10(peak^2 / mse), peak = 4
+        expected_psnr = 10.0 * math.log10(16.0 / 0.01)
+        assert r["psnr_db_mean"] == pytest.approx(expected_psnr)
+
+        # Cosine: dot(ref,test)/(|ref||test|).
+        expected_cos = float(np.dot(ref, test) / (np.linalg.norm(ref) * np.linalg.norm(test)))
+        assert r["cosine_similarity_mean"] == pytest.approx(expected_cos)
+
+    def test_multidim_returns_scalar_metrics(self):
+        rng = np.random.default_rng(0)
+        ref = rng.standard_normal((1, 100, 92)).astype(np.float32)
+        test = ref + rng.standard_normal((1, 100, 92)).astype(np.float32) * 0.01
+        m = TensorSimilarityMetric()
+        m.update(test, ref)
+        r = m.compute()
+        for metric in _SCALAR_METRICS:
+            assert isinstance(r[f"{metric}_mean"], float)
+            assert math.isfinite(r[f"{metric}_mean"])
+
+    def test_shape_mismatch_raises(self):
+        m = TensorSimilarityMetric()
+        with pytest.raises(ValueError, match="shape mismatch"):
+            m.update(np.zeros((2, 3)), np.zeros((2, 4)))
+
+
+# ---------------------------------------------------------------------------
+# Cosine zero-vector convention (asymmetric)
+# ---------------------------------------------------------------------------
+
+class TestCosineZeroHandling:
+    def test_both_zero_returns_one(self):
+        z = np.zeros(8)
+        m = TensorSimilarityMetric()
+        m.update(z, z)
+        assert m.compute()["cosine_similarity_mean"] == pytest.approx(1.0)
+
+    def test_one_zero_returns_zero(self):
+        z = np.zeros(8)
+        nz = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
+        m = TensorSimilarityMetric()
+        m.update(z, nz)
+        m.update(nz, z)
+        r = m.compute()
+        assert r["cosine_similarity_min"] == pytest.approx(0.0)
+        assert r["cosine_similarity_max"] == pytest.approx(0.0)
+        assert r["cosine_similarity_mean"] == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# SQNR/PSNR degenerate signal: -inf, not 0
+# ---------------------------------------------------------------------------
+
+class TestDegenerateSignal:
+    def test_zero_ref_nonzero_test_yields_neg_inf(self):
+        ref = np.zeros(4)
+        test = np.array([0.1, 0.2, 0.3, 0.4])
+        m = TensorSimilarityMetric()
+        m.update(test, ref)
+        r = m.compute()
+        assert r["sqnr_db_min"] == -math.inf
+        assert r["psnr_db_min"] == -math.inf
+
+
+# ---------------------------------------------------------------------------
+# Multi-sample aggregation (mean/std/min/max)
+# ---------------------------------------------------------------------------
+
+class TestAggregation:
+    def test_mean_filters_non_finite(self):
+        # Two finite SQNR samples + one +inf sample (identical pair).
+        # Mean should ignore +inf so it stays finite.
+        m = TensorSimilarityMetric()
+        ref = np.array([1.0, 2.0, 3.0])
+        m.update(ref + 0.1, ref)
+        m.update(ref + 0.2, ref)
+        m.update(ref, ref)
+        r = m.compute()
+        assert math.isfinite(r["sqnr_db_mean"])
+        assert r["sqnr_db_max"] == math.inf
+
+    def test_summary_keys(self):
+        m = TensorSimilarityMetric()
+        m.update(np.array([1.0, 2.0]), np.array([1.1, 2.1]))
+        r = m.compute()
+        expected = {f"{metric}_{stat}" for metric in _SCALAR_METRICS for stat in _STATS}
+        assert set(r) == expected
+        assert all(isinstance(v, float) for v in r.values())
+
+    def test_reset_clears_state(self):
+        m = TensorSimilarityMetric()
+        m.update(np.array([1.0, 2.0]), np.array([1.1, 2.1]))
+        m.reset()
+        assert m.compute() == {}

--- a/tests/unit/eval/test_zero_shot_classification_evaluator.py
+++ b/tests/unit/eval/test_zero_shot_classification_evaluator.py
@@ -109,11 +109,13 @@ def make_evaluator(
 
 class TestRegistry:
     def test_evaluator_registered(self) -> None:
+        from winml.modelkit.eval import WinMLEvaluationConfig
         from winml.modelkit.eval.evaluate import _EVALUATOR_REGISTRY, get_evaluator_class
 
         assert "zero-shot-classification" in _EVALUATOR_REGISTRY
         assert (
-            get_evaluator_class("zero-shot-classification") is WinMLZeroShotClassificationEvaluator
+            get_evaluator_class(WinMLEvaluationConfig(task="zero-shot-classification"))
+            is WinMLZeroShotClassificationEvaluator
         )
 
     def test_default_dataset_registered(self) -> None:

--- a/tests/unit/models/auto/test_feature_extraction.py
+++ b/tests/unit/models/auto/test_feature_extraction.py
@@ -6,7 +6,8 @@
 """Tests for WinMLModelForFeatureExtraction.
 
 Validates forward pass I/O contract: accepts arbitrary **kwargs (architecture-agnostic),
-returns BaseModelOutput with last_hidden_state.
+returns a ModelOutput subclass whose fields mirror the ONNX exporter's declared
+output names and order.
 """
 
 from __future__ import annotations
@@ -15,7 +16,7 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import torch
-from transformers.modeling_outputs import BaseModelOutput
+from transformers.utils import ModelOutput
 
 
 def create_mock_model():
@@ -57,11 +58,11 @@ class TestWinMLModelForFeatureExtractionBasic:
 
 
 class TestForwardLastHiddenState:
-    def test_returns_base_model_output(self):
+    def test_returns_model_output(self):
         model = create_mock_model()
         input_ids = torch.ones(1, 8, dtype=torch.long)
         result = model.forward(input_ids=input_ids)
-        assert isinstance(result, BaseModelOutput)
+        assert isinstance(result, ModelOutput)
 
     def test_last_hidden_state_shape(self):
         model = create_mock_model()
@@ -70,6 +71,7 @@ class TestForwardLastHiddenState:
         }
         result = model.forward(input_ids=torch.ones(1, 8, dtype=torch.long))
         assert result.last_hidden_state.shape == (1, 8, 384)
+        assert result[0].shape == (1, 8, 384)
 
     def test_optional_inputs_forwarded(self):
         model = create_mock_model()
@@ -96,10 +98,10 @@ class TestForwardLastHiddenState:
         assert "token_type_ids" not in call_kwargs
 
 
-class TestForwardSentenceEmbedding:
-    """When ONNX exports a pre-pooled sentence_embedding, it should be wrapped."""
+class TestForwardPreservesOnnxOutputNames:
+    """ONNX output names and shapes are exposed verbatim (no rename, no unsqueeze)."""
 
-    def test_sentence_embedding_unsqueezed(self):
+    def test_pre_pooled_output_preserved(self):
         from winml.modelkit.models.winml import WinMLModelForFeatureExtraction
 
         model = WinMLModelForFeatureExtraction.__new__(WinMLModelForFeatureExtraction)
@@ -119,21 +121,22 @@ class TestForwardSentenceEmbedding:
 
         result = model.forward(input_ids=torch.ones(1, 8, dtype=torch.long))
 
-        # [B, hidden_dim] -> [B, 1, hidden_dim]
-        assert result.last_hidden_state.shape == (1, 1, 384)
+        assert result.sentence_embedding.shape == (1, 384)
+        assert result[0].shape == (1, 384)
 
-    def test_generic_2d_output_unsqueezed(self):
-        """Any unknown 2-D output is wrapped as [B, 1, H]."""
+    def test_multi_output_preserves_order_and_names(self):
+        """CLIP-style export with projected embedding first, hidden states second."""
         from winml.modelkit.models.winml import WinMLModelForFeatureExtraction
 
         model = WinMLModelForFeatureExtraction.__new__(WinMLModelForFeatureExtraction)
         mock_session = MagicMock()
         mock_session.io_config = {
-            "input_names": ["input_ids"],
-            "output_names": ["pooler_output"],
+            "input_names": ["input_ids", "attention_mask"],
+            "output_names": ["text_embeds", "last_hidden_state"],
         }
         mock_session.run.return_value = {
-            "pooler_output": np.zeros((1, 768), dtype=np.float32),
+            "text_embeds": np.zeros((1, 768), dtype=np.float32),
+            "last_hidden_state": np.zeros((1, 77, 768), dtype=np.float32),
         }
         mock_session.device = "cpu"
         model._session = mock_session
@@ -141,5 +144,9 @@ class TestForwardSentenceEmbedding:
         model._onnx_path = "mock.onnx"
         model._device = "cpu"
 
-        result = model.forward(input_ids=torch.ones(1, 8, dtype=torch.long))
-        assert result.last_hidden_state.shape == (1, 1, 768)
+        result = model.forward(input_ids=torch.ones(1, 77, dtype=torch.long))
+
+        assert result.text_embeds.shape == (1, 768)
+        assert result.last_hidden_state.shape == (1, 77, 768)
+        # HF pipelines consume output[0]; must match exporter's first output.
+        assert result[0].shape == (1, 768)


### PR DESCRIPTION
Fixes #804

## Implement tensor similarity evaluator

### Summary

Adds a new `compare` mode to `winml eval` that compares an ONNX candidate against its HF PyTorch reference on identical random inputs and reports per-output tensor-parity metrics (SQNR, PSNR, cosine similarity, MSE, max absolute diff). This isolates divergence introduced by the build pipeline (optimize / quantize / compile) from data- or pipeline-related differences — there is no labeled dataset, no HF `pipeline`, and no preprocessor in the loop.

### Motivation

Task-level metrics (top-1, mIoU, BLEU, ...) tell us *whether* an optimized model still works, but not *how much* the optimize/quantize/compile passes perturbed the raw tensors. Tensor-similarity gives a fast, label-free, dataset-free signal for build-pipeline regressions and for picking quantization configs.

### Usage

```bash
winml eval --mode compare -m microsoft/resnet-50 --task image-classification --precision fp16 --samples 100
```

### What's new

- **`winml eval --mode {onnx,compare}`** — new Click option on `winml eval`. `onnx` (default) is the existing dataset-driven flow; `compare` activates the new evaluator.
- **`TensorSimilarityEvaluator`** (tensor_similarity_evaluator.py) — loads the HF reference on CPU/fp32 via `resolve_task_and_model_class`, draws inputs from `RandomDataset` over the candidate's ONNX I/O spec, runs both backends per sample, and aggregates per-output metrics.
- **`TensorSimilarityMetric`** (tensor_similarity.py) — stateful `update` / `compute` / `reset` metric mirroring `MeanIoUMetric`. Per-sample math is bit-equivalent to the team-wide `eval_tensors` reference library on the same `.npy` pair.
- **Dispatch** — `evaluate.py` registers `"compare-tensor"` and `get_evaluator_class` routes to it when `config.mode == "compare"`; compare mode bypasses default-dataset resolution and the dataset section of `print_config`.
- **Config** — `WinMLEvaluationConfig.mode: str = "onnx"`; `to_dict` only emits `mode` when non-default.

### Output shape

`compute()` returns display-ready flat dict so the existing generic eval report renders without a custom renderer:

```python
{
    f"{metric}_{stat}": {output_name: float},  # 5 metrics × 4 stats = 20 keys
    ...
}
```

Stats are `mean / std / min / max`. The renderer prints one row per `{metric}_{stat}` with `output_name=value` cells joined across outputs.

### Notable design choices

- **Output-name overlap, not strict equality.** ONNX and HF output sets can differ (HF often exposes auxiliary tensors). We compute on the intersection and warn on divergence rather than failing.
- **Composite-model guard.** Multi-component models (e.g. BLIP) raise a `TypeError` with guidance to run `compare` per sub-component — there is no canonical "one HF reference" for the composite.
- **int dtype normalization.** Narrow int tensors are upcast to int64 before inference so HF embeddings accept them; `WinMLSession` down-casts to the ORT graph's declared dtype on its side. The same input dict feeds both backends.
- **Architecture-agnostic.** No model-specific names, layer patterns, or hardcoded outputs anywhere in metric or evaluator code.

### Tests

- test_tensor_similarity_metric.py — 10 unit tests for the metric (numerics, identity, stat shape, reset, empty-state error).
- test_tensor_similarity_evaluator.py — 4 unit tests (composite-model guard, output-name overlap, dispatch).
- test_eval.py — `get_evaluator_class` updated to take `WinMLEvaluationConfig`; `"compare-tensor"` exempted from the task-schema set check.
- `tests/e2e/test_eval_e2e.py::test_compare_mode_image_classification` — full CLI run on `microsoft/resnet-50` fp16: asserts the 20-key flat shape, per-output cosine bounds `[-1, 1]`, and (QNN host only) `cosine_similarity_mean >= 0.95`.

53 unit tests pass; ruff clean.

### Out of scope (follow-ups)

- `--mode hf` (run the HF pipeline on a labeled dataset as the reference for task-level metrics) — placeholder removed from this PR; will land as a separate change.
- A custom renderer for compare mode (currently uses the generic table).
