### PR TITLE
ci(e2e): trigger E2E Test pipeline on new release/* branches

### DIFF
--- a/.pipelines/Modelkit E2E Test.yml
+++ b/.pipelines/Modelkit E2E Test.yml
@@ -19,10 +19,19 @@
 #   * Manual queue-time runs (with selectable parameters) for ad-hoc
 #     validation.
 #   * Daily scheduled run at 00:00 Beijing time (16:00 UTC the prior
-#     day), staggered 8 h away from the weekly Eval Report cron.
-#   * No PR/CI trigger. Failures do not block PR merges.
+#     day) on `main`, staggered 8 h away from the weekly Eval Report cron.
+#   * CI trigger on `release/*` branches — fires on the initial push
+#     that creates a new release branch so each new release branch gets
+#     an automatic E2E run. (Subsequent pushes to a release branch will
+#     also trigger a run, which is acceptable since release branches
+#     typically see few commits.)
+#   * No PR trigger. Failures do not block PR merges.
 
-trigger: none
+trigger:
+  batch: true
+  branches:
+    include:
+      - release/*
 
 schedules:
   - cron: '0 16 * * *'


### PR DESCRIPTION
## What

Add a CI trigger to the `Modelkit E2E Test` pipeline so each push to a `release/*` branch (including the initial push that creates a new release branch) automatically runs the pipeline.

```yaml
trigger:
  batch: true
  branches:
    include:
      - release/*
```

## Why

Today the E2E Test pipeline only runs:
- Manually (queue-time), or
- Daily at 00:00 UTC+8 on `main`.

When a new `release/*` branch is cut, there is no automatic E2E validation against it. This change ensures every new release branch gets an E2E run as soon as it's pushed, so we catch release-specific regressions before publishing.

## Behavior

- **New release branch created** -> fires on the initial push (which is how a branch is created in git), giving us the "trigger when a new release branch appears" semantics.
- **Subsequent commits on a release branch** -> also trigger a run. Release branches typically see few commits, so this is acceptable.
- **`batch: true`** -> coalesces rapid successive pushes into a single run, avoiding contention on the shared self-hosted agents (QNN / OV / AMD).
- **Daily `main` schedule** -> unchanged.
- **PRs** -> still not triggered; E2E failures don't block PR merges.