### PR TITLE
Allow expand user folder if ~ is in the path

### DIFF
--- a/scripts/e2e_eval/run_eval.py
+++ b/scripts/e2e_eval/run_eval.py
@@ -809,7 +809,9 @@ def _build_dataset(ds_config: dict, timeout: int) -> None:
         return
 
     script_path = Path(build_script)
-    cache_dir = Path(ds_config.get("dataset", EVAL_DATASETS_CACHE / script_path.stem))
+    cache_dir = Path(
+        ds_config.get("dataset", EVAL_DATASETS_CACHE / script_path.stem)
+    ).expanduser()
 
     if (cache_dir / "dataset_info.json").exists():
         safe_print(f"    dataset: cached ({cache_dir})")

--- a/src/winml/modelkit/eval/base_evaluator.py
+++ b/src/winml/modelkit/eval/base_evaluator.py
@@ -89,8 +89,9 @@ class WinMLEvaluator:
             ds.samples,
         )
         try:
-            if ds.path and Path(ds.path).is_dir():
-                dataset = load_from_disk(ds.path)
+            ds_path = Path(ds.path).expanduser() if ds.path else None
+            if ds_path and ds_path.is_dir():
+                dataset = load_from_disk(str(ds_path))
             else:
                 dataset = load_dataset(
                     ds.path,


### PR DESCRIPTION
In our eval dataset, some of them are from local folder. The path could contain ~ which means the local user folder. This PR is to add an `expanduser` call to support converting ~ to the user folder path.