### PR TITLE
Standardize product naming to "WinML CLI" (#510)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![PyPI release](https://img.shields.io/pypi/v/winml-cli)](https://pypi.org/project/winml-cli/)
 ![License](https://img.shields.io/badge/license-MIT-green)
 
-**Windows ML CLI** is a command line tool for building **portable, performant, and high-quality** AI models for Windows ML. It takes you from a source model — whether from Hugging Face or your own pipeline — to a hardware-optimized artifact in a reproducible workflow.
+**WinML CLI** is a command line tool for building **portable, performant, and high-quality** AI models for Windows ML. It takes you from a source model — whether from Hugging Face or your own pipeline — to a hardware-optimized artifact in a reproducible workflow.
 
 Purpose-built for Windows hardware diversity, the CLI handles conversion, graph optimization, and compilation across AMD, Intel, NVIDIA, and Qualcomm targets. The CLI fits naturally into CI/CD pipelines so teams can validate and ship models easily.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "setuptools>=61", "wheel" ]
 [project]
 name = "winml-cli"
 version = "0.1.0"
-description = "Accelerate Model Deployment on WinML"
+description = "Accelerate Model Deployment on Windows ML"
 readme = "README.md"
 keywords = [ "onnx", "winml" ]
 license = { text = "MIT" }

--- a/src/winml/modelkit/__init__.py
+++ b/src/winml/modelkit/__init__.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-"""WinML CLI - Accelerate Model Deployment on WinML.
+"""WinML CLI - Accelerate Model Deployment on Windows ML.
 
 WinML CLI provides tools for converting PyTorch models to optimized ONNX format
 with support for QNN (Qualcomm Neural Processing SDK) and OpenVINO backends.

--- a/src/winml/modelkit/cli.py
+++ b/src/winml/modelkit/cli.py
@@ -240,7 +240,7 @@ class LazyGroup(ActionGroup):
     invoke_without_command=True,
     context_settings={"help_option_names": ["-h", "--help"]},
 )
-@click.version_option(version=__version__, prog_name="winml")
+@click.version_option(version=__version__, prog_name="WinML CLI")
 @verbosity_options()
 @click.option(
     "--debug",
@@ -251,9 +251,9 @@ class LazyGroup(ActionGroup):
 )
 @click.pass_context
 def main(ctx: click.Context, verbose: int, quiet: bool, debug: bool) -> None:
-    """WinML CLI - Accelerate Model Deployment on WinML.
+    """WinML CLI - Accelerate Model Deployment on Windows ML.
 
-    Universal ONNX export with various WinML execution providers support.
+    Universal ONNX export with various Windows ML execution providers support.
     """
     # --debug is a backward-compat alias for -vv
     if debug:

--- a/src/winml/modelkit/commands/analyze.py
+++ b/src/winml/modelkit/commands/analyze.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-"""Analyze command for winml CLI.
+"""Analyze command for WinML CLI.
 
 Analyzes ONNX models for runtime support with Rich Live stacked bar
 visualization, showing real-time per-node progress display.

--- a/src/winml/modelkit/commands/compile.py
+++ b/src/winml/modelkit/commands/compile.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-"""Compile command for winml CLI.
+"""Compile command for WinML CLI.
 
 This module provides the compile command that compiles ONNX models to
 EP-specific formats (e.g., QNN EPContext).

--- a/src/winml/modelkit/commands/export.py
+++ b/src/winml/modelkit/commands/export.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-"""Export command for winml CLI.
+"""Export command for WinML CLI.
 
 This module provides the export command that uses export_onnx() as the single
 implementation path for HuggingFace to ONNX model conversion.

--- a/src/winml/modelkit/commands/optimize.py
+++ b/src/winml/modelkit/commands/optimize.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-"""Optimize command for winml CLI.
+"""Optimize command for WinML CLI.
 
 This module provides the optimize command that uses the capability-driven
 optimizer for ONNX model optimization with fusion and graph optimizations.

--- a/src/winml/modelkit/commands/quantize.py
+++ b/src/winml/modelkit/commands/quantize.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-"""Quantize command for winml CLI.
+"""Quantize command for WinML CLI.
 
 This module provides the quantize command that inserts QDQ (Quantize-Dequantize)
 nodes into ONNX models for quantization-aware inference.

--- a/src/winml/modelkit/serve/app.py
+++ b/src/winml/modelkit/serve/app.py
@@ -721,7 +721,7 @@ def _register_routes(app: FastAPI, *, mode: str) -> None:
         "/v1/cli/{command}",
         response_model=CliResponse,
         tags=["cli"],
-        summary="Run any winml CLI command",
+        summary="Run any WinML CLI command",
     )
     async def cli_command(command: str, request: CliRequest) -> CliResponse:
         """Proxy to the CLI wrapper — available in all server modes."""

--- a/src/winml/modelkit/serve/cli_api.py
+++ b/src/winml/modelkit/serve/cli_api.py
@@ -5,7 +5,7 @@
 
 """Phase 0: CLI-as-API FastAPI application.
 
-Wraps every winml CLI command as a REST endpoint using Click's CliRunner.
+Wraps every WinML CLI command as a REST endpoint using Click's CliRunner.
 Each request is stateless — the model loads, runs, and unloads within a
 single CliRunner.invoke() call.
 
@@ -220,7 +220,7 @@ def _extract_json_from_stdout(stdout: str) -> dict[str, Any] | list[Any] | None:
 
 
 def _invoke(command: str, args: dict[str, Any]) -> CliResponse:
-    """Invoke a winml CLI command via CliRunner and return a CliResponse.
+    """Invoke a WinML CLI command via CliRunner and return a CliResponse.
 
     Applies the per-command JSON extraction strategy to populate ``result``.
     """
@@ -331,7 +331,7 @@ async def health() -> HealthResponse:
     "/v1/cli/{command}",
     response_model=CliResponse,
     tags=["CLI"],
-    summary="Invoke a winml CLI command",
+    summary="Invoke a WinML CLI command",
     responses={
         200: {"description": "Command invoked (check exit_code for success/failure)"},
         404: {"description": "Unknown command name"},

--- a/src/winml/modelkit/serve/static/index.html
+++ b/src/winml/modelkit/serve/static/index.html
@@ -823,7 +823,7 @@ canvas.spark{width:100%;height:60px;display:block}
             <code>GET /v1/resources</code> &mdash; Memory and request stats<br>
             <code>GET /v1/models/{id}/stats</code> &mdash; Live latency stats for a model<br>
             <code>GET /v1/logs</code> &mdash; Poll recent log lines<br>
-            <code>POST /v1/cli/{command}</code> &mdash; Run any winml CLI command
+            <code>POST /v1/cli/{command}</code> &mdash; Run any WinML CLI command
           </div>
         </div>
 

--- a/src/winml/modelkit/utils/console.py
+++ b/src/winml/modelkit/utils/console.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
-"""Shared console output utilities for winml CLI commands.
+"""Shared console output utilities for WinML CLI commands.
 
 Provides consistent Rich-based formatting for:
 - Config command: headers, I/O specs, resolution summary

--- a/tests/cli/test_help_cli.py
+++ b/tests/cli/test_help_cli.py
@@ -212,3 +212,7 @@ class TestOptionsSection:
         result = _invoke("--version")
         assert result.exit_code == 0
         assert __version__ in result.output
+
+    def test_version_uses_canonical_product_name(self) -> None:
+        """``winml --version`` must brand the product as 'WinML CLI' (issue #510)."""
+        assert "WinML CLI" in _invoke("--version").output


### PR DESCRIPTION
## Summary

Fixes #510 — multiple brand spellings (`WML`, `WinML`, `winml`, `Windows ML`) appeared inconsistently across user-visible output.

`WML` / `WML ModelKit` were already gone and the codebase had mostly standardized on `WinML CLI`. This PR finishes the job by enforcing one canonical scheme everywhere:

- **`WinML CLI`** — the product/tool name
- **`winml`** — the literal command
- **`Windows ML`** — the OS platform models deploy to

## Changes

**User-visible**
- `winml --version` now prints `WinML CLI, version 0.1.0` (was `winml, version 0.1.0`)
- Top-level `--help` description uses `Windows ML` for the platform instead of bare `WinML`
- `pyproject.toml` description → `Accelerate Model Deployment on Windows ML`
- `README.md` lead-in `**Windows ML CLI**` → `**WinML CLI**` (matches the title)

**Internal docstrings normalized** (`winml CLI` → `WinML CLI`): package `__init__`, command modules (analyze/compile/export/optimize/quantize), `utils/console.py`, and the `serve` module.

**Test** — added `test_version_uses_canonical_product_name` locking the canonical product name in `--version` output.

## Left intentionally unchanged
- `Windows ML` where it refers to the OS platform/runtime (banner subtitle, `sys` OS-service detection, `device.py` ORT-build comments, README platform descriptions)
- `WinML Inference Class` — a technical term in `inspect` output

> Note: the issue text suggested `WinML ModelKit`, but that predates the codebase's move to `WinML CLI` (banner art, package name, README title). Standardizing on `WinML CLI` is the smaller, against-the-grain-free change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
