### PR TITLE
test(e2e): parse result.stdout for JSON to avoid stderr contamination

### DIFF
--- a/tests/e2e/test_config_e2e.py
+++ b/tests/e2e/test_config_e2e.py
@@ -14,8 +14,9 @@ Note: Device resolution (resolve_device) requires hardware detection that
 may fail in test environments. We mock it to return ("cpu", ["cpu"]).
 
 Note: The config command writes JSON to stdout via print() and Rich status
-messages to stderr via Console(stderr=True). CliRunner captures both in
-result.output. We extract JSON by finding the first '{' or '[' character.
+messages to stderr via Console(stderr=True). We parse result.stdout (the
+clean JSON channel) so that -v/--verbose log lines on stderr never corrupt
+the payload. _extract_json still scans defensively for the JSON object.
 
 Markers:
     e2e: Full end-to-end test with real models
@@ -88,11 +89,11 @@ def _mock_resolve_device():
 
 
 def _extract_json(output: str) -> dict | list:
-    """Extract JSON object/array from mixed CLI output.
+    """Extract JSON object/array from CLI stdout.
 
-    The config command mixes Rich status messages (stderr) with JSON
-    (stdout) in CliRunner output. Find the first '{' or '[' that
-    starts a valid JSON payload.
+    The config command prints JSON to stdout; this defensively scans for
+    the first '{' or '[' that starts a valid JSON payload in case any
+    non-JSON noise (e.g. a stray print) leaks onto stdout.
     """
     decoder = json.JSONDecoder()
     # JSON is printed as its own line; probing only line starts avoids
@@ -113,7 +114,7 @@ def _run_config(*args: str) -> dict:
     runner = CliRunner()
     result = runner.invoke(config, list(args), catch_exceptions=False)
     assert result.exit_code == 0, f"config failed (exit {result.exit_code}):\n{result.output}"
-    return _extract_json(result.output)
+    return _extract_json(result.stdout)
 
 
 def _assert_hf_config_structure(data: dict) -> None:

--- a/tests/e2e/test_inspect_e2e.py
+++ b/tests/e2e/test_inspect_e2e.py
@@ -60,10 +60,15 @@ def _run_json(*args: str) -> dict:
     """Invoke inspect with *args + '-f json' and return parsed JSON.
 
     Asserts exit_code == 0 and that the output is valid JSON.
+
+    Parses ``result.stdout`` (not ``result.output``): under Click 8.4
+    ``result.output`` interleaves stderr into stdout, so ``-v`` log lines
+    emitted on stderr would corrupt the JSON. stdout carries only the
+    structured payload, matching how real JSON consumers read the command.
     """
     result = _run(*args, "-f", "json")
     assert result.exit_code == 0, f"inspect exited {result.exit_code}:\n{result.output}"
-    return json.loads(result.output)
+    return json.loads(result.stdout)
 
 
 def _run_network(model: str, task: str | None = None) -> dict:
@@ -77,7 +82,7 @@ def _run_network(model: str, task: str | None = None) -> dict:
         args.extend(["-t", task])
     result = CliRunner().invoke(inspect, args, obj={}, catch_exceptions=False)
     assert result.exit_code == 0, f"inspect failed (exit {result.exit_code}):\n{result.output}"
-    return json.loads(result.output)
+    return json.loads(result.stdout)
 
 
 def _assert_common_structure(data: dict, model_id: str, expected_task: str) -> None:
@@ -229,7 +234,7 @@ class TestInspectBert:
             obj={},
         )
         if result.exit_code == 0:
-            data = json.loads(result.output)
+            data = json.loads(result.stdout)
             assert "model_id" in data
         else:
             assert "Traceback (most recent call last)" not in result.output

--- a/tests/e2e/test_run_e2e.py
+++ b/tests/e2e/test_run_e2e.py
@@ -196,7 +196,7 @@ class TestFeatureImageClassification:
             catch_exceptions=False,
         )
         assert result.exit_code == 0
-        data = json.loads(result.output)
+        data = json.loads(result.stdout)
         assert data["task"] == "image-classification"
         assert isinstance(data["predictions"], list)
         assert len(data["predictions"]) > 0
@@ -227,7 +227,7 @@ class TestFeatureImageClassification:
             catch_exceptions=False,
         )
         assert result.exit_code == 0
-        data = json.loads(result.output)
+        data = json.loads(result.stdout)
         assert len(data["predictions"]) > 0
 
 
@@ -274,7 +274,7 @@ class TestFeatureTextClassification:
             catch_exceptions=False,
         )
         assert result.exit_code == 0
-        data = json.loads(result.output)
+        data = json.loads(result.stdout)
         assert "predictions" in data
 
     def test_pipeline_param(self, runner: CliRunner, text_model: str) -> None:
@@ -295,7 +295,7 @@ class TestFeatureTextClassification:
             catch_exceptions=False,
         )
         assert result.exit_code == 0
-        data = json.loads(result.output)
+        data = json.loads(result.stdout)
         assert "predictions" in data
 
 
@@ -327,7 +327,7 @@ class TestFeatureOutputFormats:
             catch_exceptions=False,
         )
         assert result.exit_code == 0
-        data = json.loads(result.output)
+        data = json.loads(result.stdout)
         assert {"task", "predictions", "latency_ms", "device"}.issubset(data.keys())
 
     def test_output_to_file(
@@ -363,7 +363,7 @@ class TestFeatureSchema:
             catch_exceptions=False,
         )
         assert result.exit_code == 0
-        data = json.loads(result.output)
+        data = json.loads(result.stdout)
         assert "task" in data
         assert isinstance(data["inputs"], list)
 
@@ -404,7 +404,7 @@ class TestSchemaAllModels:
             catch_exceptions=False,
         )
         assert result.exit_code == 0, f"--schema failed (exit {result.exit_code}):\n{result.output}"
-        data = json.loads(result.output)
+        data = json.loads(result.stdout)
         assert "task" in data
         assert isinstance(data["inputs"], list)
         if data["inputs"]:
@@ -446,7 +446,7 @@ class TestInferenceAllModels:
         assert schema_result.exit_code == 0, (
             f"--schema failed (exit {schema_result.exit_code}):\n{schema_result.output}"
         )
-        schema = json.loads(schema_result.output)
+        schema = json.loads(schema_result.stdout)
 
         # Step 2: Build inference args
         input_args = _build_inference_args(schema["inputs"], task, test_image)
@@ -465,7 +465,7 @@ class TestInferenceAllModels:
         assert result.exit_code == 0, (
             f"Inference failed (exit {result.exit_code}):\n{result.output}"
         )
-        data = _extract_json(result.output)
+        data = _extract_json(result.stdout)
         assert "task" in data
         assert "latency_ms" in data
         assert data["latency_ms"] > 0


### PR DESCRIPTION
The inspect/run/config E2E helpers parsed result.output, which under Click 8.4 interleaves stderr into stdout. After #793 made the logger attach a real stderr handler, -v/--verbose INFO lines landed in result.output and broke json.loads (JSONDecodeError on the leading log line). Parse the dedicated result.stdout channel instead, matching how real JSON consumers read these commands.

- test_inspect_e2e.py: fixes the failing -v / -v-short tests (3 sites)
- test_run_e2e.py: hardens 8 naive json.loads(result.output) sites
- test_config_e2e.py: read stdout in _run_config (used by test_verbose_flag)