### PR TITLE
test(e2e): align feature-extraction e2e tests with #807 modality-aware logic

### DIFF
--- a/tests/e2e/test_eval_e2e.py
+++ b/tests/e2e/test_eval_e2e.py
@@ -292,25 +292,20 @@ class TestEvalPerTask:
         if is_host("qnn"):
             _assert_in_range(data["metrics"], "cosine_spearman", 40.0, 100.0)
 
-    @pytest.mark.parametrize(
-        "task",
-        ["image-feature-extraction", "feature-extraction"],
-    )
     def test_image_feature_extraction(
-        self, runner: CliRunner, tmp_path: Path, task: str,
+        self, runner: CliRunner, tmp_path: Path,
     ) -> None:
         # kNN accuracies reported as percentages 0..100.
         # --streaming avoids caching mini-imagenet.
-        # Parameterized over both task names accepted on the CLI:
-        #   - "image-feature-extraction" is the HF pipeline task name
-        #     and dispatches to the image evaluator directly.
-        #   - "feature-extraction" is bimodal; for a vision model it is
-        #     mapped internally to the HF pipeline name so the image
-        #     dataset and evaluator are selected.
+        # A vision embedding model's canonical task is image-feature-extraction
+        # (what `winml inspect` and auto-detection report); it dispatches to the
+        # image evaluator directly. 'feature-extraction' is text-only under the
+        # modality-aware task vocabulary, so it is not a valid task for a vision
+        # model (it would resolve to the text evaluator/dataset and fail).
         out = tmp_path / "result.json"
         _invoke(runner, [
             "-m", "facebook/dinov2-small",
-            "--task", task,
+            "--task", "image-feature-extraction",
             "--streaming",
             "--samples", SAMPLES,
             "-o", str(out),
@@ -318,9 +313,10 @@ class TestEvalPerTask:
         data = _assert_metrics_present(
             out, ["knn_top1_accuracy", "knn_top5_accuracy"],
         )
-        # DINOv2 features cluster strongly on mini-imagenet.
-        _assert_in_range(data["metrics"], "knn_top1_accuracy", 30.0, 100.0)
-        _assert_in_range(data["metrics"], "knn_top5_accuracy", 60.0, 100.0)
+        # Loose floors guard against degenerate output, not magnitude: with
+        # SAMPLES=10 the kNN estimate has heavy variance (cf. test_question_answering).
+        _assert_in_range(data["metrics"], "knn_top1_accuracy", 10.0, 100.0)
+        _assert_in_range(data["metrics"], "knn_top5_accuracy", 25.0, 100.0)
         top1 = data["metrics"]["knn_top1_accuracy"]
         top5 = data["metrics"]["knn_top5_accuracy"]
         assert top1 <= top5, f"top1 ({top1}) must be <= top5 ({top5})"

--- a/tests/e2e/test_quantize_e2e.py
+++ b/tests/e2e/test_quantize_e2e.py
@@ -572,27 +572,28 @@ class TestPerTaskDatasets:
         )
 
     @pytest.mark.network
-    def test_feature_extraction_with_pixel_values_uses_image_dataset(
+    def test_image_feature_extraction_uses_image_dataset(
         self, runner: CliRunner, onnx_dinov2: Path, tmp_path: Path
     ):
-        # For a vision model the bimodal task 'feature-extraction' must
-        # dispatch via the model's ONNX inputs (pixel_values) to
-        # ImageDataset for calibration. The task label in the log stays
-        # 'feature-extraction' (the resolver only swaps the dataset class).
+        # A vision embedding model's canonical task is image-feature-extraction
+        # (what `winml inspect` and auto-detection report); it maps directly to
+        # ImageDataset for calibration. Under the modality-aware task vocabulary
+        # 'feature-extraction' is text-only, so it is intentionally not a valid
+        # task for a vision model (its calibration dataset would be TextDataset).
         out = tmp_path / "d7.onnx"
 
         r = _invoke(
             runner,
             [
                 "-m", str(onnx_dinov2), "-o", str(out),
-                "--task", "feature-extraction",
+                "--task", "image-feature-extraction",
                 "--model-name", "facebook/dinov2-small",
                 "--samples", "4", "-v",
             ],
         )
         _assert_quantized_output(input_onnx=onnx_dinov2, output_onnx=out, stdout=r.output)
         assert (
-            "Creating feature-extraction dataset with ImageDataset" in r.output
+            "Creating image-feature-extraction dataset with ImageDataset" in r.output
         ), r.output
 
 


### PR DESCRIPTION
## What

`#807` (merged) made `detect_task` modality-aware and removed `#786`'s bimodal `feature-extraction` io_config reverse-reconstruction (in both `datasets` and `eval`). But `#786`'s e2e tests — still on `main` — assert the *old* bimodal behavior, so they now fail on `main`:

- `tests/e2e/test_quantize_e2e.py::TestPerTaskDatasets::test_feature_extraction_with_pixel_values_uses_image_dataset`
- `tests/e2e/test_eval_e2e.py::TestEvalPerTask::test_image_feature_extraction[feature-extraction]`

Both crash with `KeyError: Dinov2Config` — a vision model + `--task feature-extraction` now resolves to the text `TextDataset`, which tries to load a tokenizer DINOv2 does not have.

## Why update the tests (not revert the code)

Under the merged modality-aware task vocabulary:

- `feature-extraction` is the **text** feature task; a vision embedding model's canonical task is **`image-feature-extraction`**.
- `winml inspect` / auto-detect always report `image-feature-extraction` for a vision model (e.g. `facebook/dinov2-small`) — the tool never hands a user `--task feature-extraction` for a vision model.
- So explicit `--task feature-extraction` on a vision model is a genuine modality mismatch and is expected to error. The `#786` bimodal io_config dispatch (which silently recovered modality from the ONNX inputs) was deliberately removed in `#807`.

The e2e tests follow the new logic:

- **quantize**: `test_feature_extraction_with_pixel_values_uses_image_dataset` → `test_image_feature_extraction_uses_image_dataset`, asserting `--task image-feature-extraction` → `ImageDataset` (the canonical vision-feature calibration path).
- **eval**: drop the `feature-extraction` param from `test_image_feature_extraction` (vision feature = `image-feature-extraction`). Also loosen the kNN floors to sanity levels (10/25), consistent with this file's N=10 convention (*"Loose floors guard against degenerate output, not magnitude"*) — the previous 30/60 floors flaked at top1=20 on a 10-sample kNN.

## Heads-up for @zhenchaoni

This realigns the two e2e tests you added in `#786` and, by extension, accepts dropping the bimodal `--task feature-extraction`-on-a-vision-model capability `#786` introduced. That removal landed in `#807` (merged); this PR only updates the tests to match. If you'd rather keep that capability working (graceful) instead of erroring on the mismatch, that means restoring the io_config dispatch — happy to do that instead. Flagging for your call.
