### PR TITLE
feat: add --allow-unsupported-nodes to perf/build/eval/run

### DIFF
--- a/src/winml/modelkit/build/common.py
+++ b/src/winml/modelkit/build/common.py
@@ -36,6 +36,7 @@ def run_optimize_analyze_loop(
     ep: EPNameOrAlias | None = None,
     device: str | None = None,
     max_optim_iterations: int = 0,
+    allow_unsupported_nodes: bool = False,
     on_ep_start: Any = None,
     on_node_result: Any = None,
     on_iteration_start: Any = None,
@@ -62,6 +63,9 @@ def run_optimize_analyze_loop(
         device: Target device for the analyzer.
         max_optim_iterations: Maximum autoconf re-optimization rounds.
             0 means optimize+analyze only (no autoconf re-optimization).
+        allow_unsupported_nodes: If True, log a warning instead of raising when
+            unsupported nodes persist after analysis, letting the build proceed
+            (the EP may still run them, e.g. via CPU fallback).
         analyze_output_path: Optional path to write the full analysis result as
             JSON. Written after every analyze pass; each pass overwrites the
             previous one so the file always reflects the most recent analysis.
@@ -95,6 +99,7 @@ def run_optimize_analyze_loop(
             ep=ep,
             device=device,
             max_optim_iterations=max_optim_iterations,
+            allow_unsupported_nodes=allow_unsupported_nodes,
             config=config,
             on_ep_start=on_ep_start,
             on_node_result=on_node_result,
@@ -119,6 +124,7 @@ def _run_analyze_loop(
     device: str | None,
     max_optim_iterations: int,
     config: WinMLBuildConfig,
+    allow_unsupported_nodes: bool = False,
     on_ep_start: Any = None,
     on_node_result: Any = None,
     on_iteration_start: Any = None,
@@ -225,10 +231,18 @@ def _run_analyze_loop(
         )
 
     if analysis is not None and analysis.has_errors:
-        raise RuntimeError(
+        message = (
             f"Unsupported nodes persist after {analyze_iterations} analyze "
             f"pass(es): {analysis.lint.error_patterns}"
         )
+        if allow_unsupported_nodes:
+            logger.warning(
+                "%s. Continuing anyway (allow_unsupported_nodes=True); the EP may "
+                "fall back to another device for these nodes.",
+                message,
+            )
+        else:
+            raise RuntimeError(message)
 
     analyze_black_nodes = analysis.lint.errors if analysis else 0
 

--- a/src/winml/modelkit/build/hf.py
+++ b/src/winml/modelkit/build/hf.py
@@ -122,6 +122,8 @@ def build_hf_model(
             - ``hack_max_optim_iterations`` (int, default 3): TEMPORARY HACK —
               Max analyzer iterations. 0 disables analyzer.
               TODO: Move to global env / build config.
+            - ``allow_unsupported_nodes`` (bool, default False): If True, warn
+              instead of raising when unsupported nodes persist after analysis.
             - ``use_external_data`` (bool, default True): Whether to use ONNX
               external data format. Default True for large model compatibility.
               TODO: Move to global env / build config.
@@ -136,6 +138,7 @@ def build_hf_model(
     """
     # TODO: Move hack_max_optim_iterations to global env config
     hack_max_optim_iterations: int = kwargs.pop("hack_max_optim_iterations", 3)
+    allow_unsupported_nodes: bool = kwargs.pop("allow_unsupported_nodes", False)
 
     # ONNX-level kwargs forwarded to export, optimize, quantize stages
     onnx_kwargs = {
@@ -275,6 +278,7 @@ def build_hf_model(
             ep=ep,
             device=device,
             max_optim_iterations=hack_max_optim_iterations,
+            allow_unsupported_nodes=allow_unsupported_nodes,
             analyze_output_path=analyze_result_path,
             **onnx_kwargs,
         )

--- a/src/winml/modelkit/build/onnx.py
+++ b/src/winml/modelkit/build/onnx.py
@@ -61,6 +61,8 @@ def build_onnx_model(
         **kwargs: Additional options:
             - ``hack_max_optim_iterations`` (int, default 3): Max analyzer
               iterations. 0 disables analyzer.
+            - ``allow_unsupported_nodes`` (bool, default False): If True, warn
+              instead of raising when unsupported nodes persist after analysis.
             - ``use_external_data`` (bool, default True): Whether to use ONNX
               external data format.
 
@@ -73,6 +75,7 @@ def build_onnx_model(
         RuntimeError: If a pipeline stage fails.
     """
     hack_max_optim_iterations: int = kwargs.pop("hack_max_optim_iterations", 3)
+    allow_unsupported_nodes: bool = kwargs.pop("allow_unsupported_nodes", False)
     onnx_kwargs = {
         "use_external_data": kwargs.get("use_external_data", True),
     }
@@ -178,6 +181,7 @@ def build_onnx_model(
                 ep=ep,
                 device=device,
                 max_optim_iterations=hack_max_optim_iterations,
+                allow_unsupported_nodes=allow_unsupported_nodes,
                 analyze_output_path=analyze_result_path,
                 **onnx_kwargs,
             )

--- a/src/winml/modelkit/commands/build.py
+++ b/src/winml/modelkit/commands/build.py
@@ -490,13 +490,7 @@ def _validate_loader_tasks_for_model(
     default=None,
     help="Maximum autoconf re-optimization rounds (default: 3). --no-analyze sets this to 0.",
 )
-@click.option(
-    "--allow-unsupported-nodes",
-    is_flag=True,
-    default=False,
-    help="Continue the build instead of failing when the analyzer reports "
-    "unsupported nodes (the EP may fall back to another device for them).",
-)
+@cli_utils.allow_unsupported_nodes_option()
 @cli_utils.trust_remote_code_option(
     optional_message="Trust remote code for custom model architectures (e.g., Mu2)."
 )

--- a/src/winml/modelkit/commands/build.py
+++ b/src/winml/modelkit/commands/build.py
@@ -669,8 +669,10 @@ def build(
             extra_kwargs["hack_max_optim_iterations"] = max_optim_iterations
         if trust_remote_code:
             extra_kwargs["trust_remote_code"] = True
-        if allow_unsupported_nodes:
-            extra_kwargs["allow_unsupported_nodes"] = True
+        # Always set (even when False) so downstream pipeline functions can rely
+        # on the key being present, matching the module-mode path which passes
+        # allow_unsupported_nodes explicitly regardless of its value.
+        extra_kwargs["allow_unsupported_nodes"] = allow_unsupported_nodes
 
         if isinstance(config_or_configs, list):
             # ---- MODULE MODE: array config, one build per submodule ----

--- a/src/winml/modelkit/commands/build.py
+++ b/src/winml/modelkit/commands/build.py
@@ -166,6 +166,7 @@ def _build_modules(
     rebuild: bool = False,
     ep: EPNameOrAlias | None = None,
     device: str | None = None,
+    allow_unsupported_nodes: bool = False,
 ) -> list[BuildResult]:
     """Build each module config using init-weight parent for submodule extraction.
 
@@ -182,6 +183,8 @@ def _build_modules(
         rebuild: If True, overwrite existing artifacts.
         ep: Target execution provider for analyzer.
         device: Target device for analyzer.
+        allow_unsupported_nodes: If True, warn instead of failing the build when
+            the analyzer reports unsupported nodes that persist.
 
     Returns:
         List of BuildResult in the same order as *configs*.
@@ -222,6 +225,7 @@ def _build_modules(
             rebuild=rebuild,
             ep=ep,
             device=device,
+            allow_unsupported_nodes=allow_unsupported_nodes,
         )
         results.append(result)
 
@@ -486,6 +490,13 @@ def _validate_loader_tasks_for_model(
     default=None,
     help="Maximum autoconf re-optimization rounds (default: 3). --no-analyze sets this to 0.",
 )
+@click.option(
+    "--allow-unsupported-nodes",
+    is_flag=True,
+    default=False,
+    help="Continue the build instead of failing when the analyzer reports "
+    "unsupported nodes (the EP may fall back to another device for them).",
+)
 @cli_utils.trust_remote_code_option(
     optional_message="Trust remote code for custom model architectures (e.g., Mu2)."
 )
@@ -505,6 +516,7 @@ def build(
     device: str,
     no_analyze: bool,
     max_optim_iterations: int | None,
+    allow_unsupported_nodes: bool,
     trust_remote_code: bool,
     verbose: int,
     quiet: bool,
@@ -663,6 +675,8 @@ def build(
             extra_kwargs["hack_max_optim_iterations"] = max_optim_iterations
         if trust_remote_code:
             extra_kwargs["trust_remote_code"] = True
+        if allow_unsupported_nodes:
+            extra_kwargs["allow_unsupported_nodes"] = True
 
         if isinstance(config_or_configs, list):
             # ---- MODULE MODE: array config, one build per submodule ----
@@ -697,6 +711,7 @@ def build(
                 rebuild=rebuild,
                 ep=ep,
                 device=device,
+                allow_unsupported_nodes=allow_unsupported_nodes,
             )
 
             # Report per-module results
@@ -967,6 +982,7 @@ def _run_optimize_stage(
     stage_timings: list[tuple[str, float | None]],
     show_io_first: bool = False,
     analyze_output_path: Path | None = None,
+    allow_unsupported_nodes: bool = False,
 ) -> tuple[Path, float]:
     """Run the optimize stage inside a StageLive context.
 
@@ -1075,6 +1091,7 @@ def _run_optimize_stage(
             ep=ep,
             device=device,
             max_optim_iterations=max_iters,
+            allow_unsupported_nodes=allow_unsupported_nodes,
             on_ep_start=_on_ep_start,
             on_node_result=_on_node_result,
             on_iteration_start=_on_iteration_start,
@@ -1296,6 +1313,7 @@ def _build_hf_pipeline(
     from ..utils.console import StageLive
 
     max_iters: int = extra_kwargs.pop("hack_max_optim_iterations", 3)
+    allow_unsupported_nodes: bool = extra_kwargs.pop("allow_unsupported_nodes", False)
     model_label = model_id or "random-init"
 
     # ── Validate + setup ─────────────────────────────────────────
@@ -1374,6 +1392,7 @@ def _build_hf_pipeline(
         stage_timings=stage_timings,
         show_io_first=False,
         analyze_output_path=analyze_result_path,
+        allow_unsupported_nodes=allow_unsupported_nodes,
     )
 
     # Persist config after autoconf
@@ -1420,6 +1439,7 @@ def _build_onnx_pipeline(
     from ..onnx import copy_onnx_model
 
     max_iters: int = extra_kwargs.pop("hack_max_optim_iterations", 3)
+    allow_unsupported_nodes: bool = extra_kwargs.pop("allow_unsupported_nodes", False)
 
     # ── Validate + setup ─────────────────────────────────────────
     if not onnx_path.exists():
@@ -1468,6 +1488,7 @@ def _build_onnx_pipeline(
         stage_timings=stage_timings,
         show_io_first=True,
         analyze_output_path=analyze_result_path,
+        allow_unsupported_nodes=allow_unsupported_nodes,
     )
 
     config_path.write_text(json.dumps(config.to_dict(), indent=2))

--- a/src/winml/modelkit/commands/eval.py
+++ b/src/winml/modelkit/commands/eval.py
@@ -142,6 +142,7 @@ logger = logging.getLogger(__name__)
     help="Path to a Python script that builds the evaluation dataset.",
 )
 @cli_utils.trust_remote_code_option(optional_message="Required when --dataset-script is used.")
+@cli_utils.allow_unsupported_nodes_option()
 @click.option(
     "--schema",
     "show_schema",
@@ -174,6 +175,7 @@ def eval(
     quiet: bool,
     dataset_script: str | None,
     trust_remote_code: bool,
+    allow_unsupported_nodes: bool,
     show_schema: bool,
     config_file: Path | None,
 ) -> None:

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -79,6 +79,7 @@ class BenchmarkConfig:
     no_quantize: bool = False
     rebuild: bool = False
     ignore_cache: bool = False
+    allow_unsupported_nodes: bool = False
     monitor: bool = False
     ep: EPNameOrAlias | None = None
     shape_config: dict | None = None
@@ -346,6 +347,7 @@ class PerfBenchmark:
             "use_cache": use_cache,
             "force_rebuild": force_rebuild,
             "shape_config": self.config.shape_config,
+            "allow_unsupported_nodes": self.config.allow_unsupported_nodes,
         }
 
         if is_onnx:
@@ -525,6 +527,7 @@ def _perf_modules(
     device: str = "auto",
     ep: EPNameOrAlias | None = None,
     precision: str = "auto",
+    allow_unsupported_nodes: bool = False,
 ) -> None:
     """Run per-module build and benchmark for matching submodules.
 
@@ -548,6 +551,8 @@ def _perf_modules(
         ep: Explicit execution provider (e.g., "qnn", "dml"). Overrides
             device-to-provider mapping when set.
         precision: Precision mode passed through to the build stage.
+        allow_unsupported_nodes: If True, warn instead of failing the build when
+            the analyzer reports unsupported nodes that persist.
     """
     import difflib
     import json as json_mod
@@ -644,6 +649,7 @@ def _perf_modules(
                     pytorch_model=submodule,
                     ep=ep,
                     device=resolved_device,
+                    allow_unsupported_nodes=allow_unsupported_nodes,
                 )
 
                 # Benchmark using WinMLSession
@@ -1174,6 +1180,13 @@ def _run_onnx_benchmark(
     help="Build from scratch in a temp folder (discard after benchmarking)",
 )
 @click.option(
+    "--allow-unsupported-nodes",
+    is_flag=True,
+    default=False,
+    help="Continue the build instead of failing when the analyzer reports "
+    "unsupported nodes (the EP may fall back to another device for them).",
+)
+@click.option(
     "--module",
     "module_class",
     default=None,
@@ -1215,6 +1228,7 @@ def perf(
     no_quantize: bool,
     rebuild: bool,
     ignore_cache: bool,
+    allow_unsupported_nodes: bool,
     module_class: str | None,
     monitor: bool,
     op_tracing: str | None,
@@ -1307,6 +1321,7 @@ def perf(
             device=device.lower(),
             ep=ep,
             precision=precision.lower(),
+            allow_unsupported_nodes=allow_unsupported_nodes,
         )
         return
 
@@ -1347,6 +1362,7 @@ def perf(
         no_quantize=no_quantize,
         rebuild=rebuild,
         ignore_cache=ignore_cache,
+        allow_unsupported_nodes=allow_unsupported_nodes,
         monitor=monitor,
         ep=ep,
         shape_config=shape_config,

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -1179,13 +1179,7 @@ def _run_onnx_benchmark(
     default=False,
     help="Build from scratch in a temp folder (discard after benchmarking)",
 )
-@click.option(
-    "--allow-unsupported-nodes",
-    is_flag=True,
-    default=False,
-    help="Continue the build instead of failing when the analyzer reports "
-    "unsupported nodes (the EP may fall back to another device for them).",
-)
+@cli_utils.allow_unsupported_nodes_option()
 @click.option(
     "--module",
     "module_class",

--- a/src/winml/modelkit/commands/run.py
+++ b/src/winml/modelkit/commands/run.py
@@ -497,6 +497,7 @@ def _print_input_hint(engine: Any) -> None:
     default=False,
     help="Auto-connect to a running winml serve instance instead of embedded inference",
 )
+@cli_utils.allow_unsupported_nodes_option()
 @click.pass_context
 def run(
     ctx: click.Context,
@@ -514,6 +515,7 @@ def run(
     port: int,
     connect_host: str,
     connect: bool,
+    allow_unsupported_nodes: bool,
 ) -> None:
     r"""Run one-shot inference on a model.
 
@@ -626,7 +628,13 @@ def run(
         # prints (from optimum, onnxruntime, etc.) don't contaminate
         # structured output (--format json) or text output parsing.
         with contextlib.redirect_stdout(sys.stderr):
-            engine.load(model, task=task, device=device, ep=ep)
+            engine.load(
+                model,
+                task=task,
+                device=device,
+                ep=ep,
+                allow_unsupported_nodes=allow_unsupported_nodes,
+            )
     except (OSError, ValueError, RuntimeError) as exc:
         click.echo(f"Error loading model: {exc}", err=True)
         ctx.exit(3)

--- a/src/winml/modelkit/eval/config.py
+++ b/src/winml/modelkit/eval/config.py
@@ -107,6 +107,7 @@ class WinMLEvaluationConfig:
     device: str = "auto"
     precision: str = "auto"
     ep: EPNameOrAlias | None = None
+    allow_unsupported_nodes: bool = False
     dataset: DatasetConfig = field(default_factory=DatasetConfig)
     output_path: Path | None = field(default=None, metadata={"cli_name": "output"})
 
@@ -124,6 +125,8 @@ class WinMLEvaluationConfig:
             result["precision"] = self.precision
         if self.ep is not None:
             result["ep"] = self.ep
+        if self.allow_unsupported_nodes:
+            result["allow_unsupported_nodes"] = self.allow_unsupported_nodes
         result["dataset"] = self.dataset.to_dict()
         if self.output_path is not None:
             result["output_path"] = str(self.output_path)
@@ -153,6 +156,7 @@ class WinMLEvaluationConfig:
             device=data.get("device", "auto"),
             precision=data.get("precision", "auto"),
             ep=data.get("ep"),
+            allow_unsupported_nodes=data.get("allow_unsupported_nodes", False),
             dataset=dataset,
             output_path=(Path(data["output_path"]) if data.get("output_path") else None),
         )

--- a/src/winml/modelkit/eval/evaluate.py
+++ b/src/winml/modelkit/eval/evaluate.py
@@ -213,6 +213,7 @@ def _load_model(config: WinMLEvaluationConfig) -> WinMLPreTrainedModel:
         device=config.device,
         precision=config.precision,
         ep=config.ep,
+        allow_unsupported_nodes=config.allow_unsupported_nodes,
     )
 
 

--- a/src/winml/modelkit/inference/engine.py
+++ b/src/winml/modelkit/inference/engine.py
@@ -308,7 +308,9 @@ class InferenceEngine:
             device: "auto" | "cpu" | "gpu" | "npu".
             ep: Explicit EP short name (e.g. "dml", "qnn").  Overrides device.
             allow_unsupported_nodes: If True, warn instead of raising when the
-                analyzer reports unsupported nodes during an HF build.
+                analyzer reports unsupported nodes during an HF build. Note: has
+                no effect when loading from a pre-built ONNX file or a cached
+                build directory (no build/analyze step runs in those paths).
         """
         self._model_path = str(model_path)
         self._device = device

--- a/src/winml/modelkit/inference/engine.py
+++ b/src/winml/modelkit/inference/engine.py
@@ -298,6 +298,7 @@ class InferenceEngine:
         task: str | None = None,
         device: str = "auto",
         ep: EPNameOrAlias | None = None,
+        allow_unsupported_nodes: bool = False,
     ) -> None:
         """Load model from model_path.
 
@@ -306,6 +307,8 @@ class InferenceEngine:
             task: Required when model_path is a raw .onnx file.
             device: "auto" | "cpu" | "gpu" | "npu".
             ep: Explicit EP short name (e.g. "dml", "qnn").  Overrides device.
+            allow_unsupported_nodes: If True, warn instead of raising when the
+                analyzer reports unsupported nodes during an HF build.
         """
         self._model_path = str(model_path)
         self._device = device
@@ -330,13 +333,25 @@ class InferenceEngine:
                         path,
                         model_id,
                     )
-                    self._load_from_hf(model_id, task=task, device=device, ep=ep)
+                    self._load_from_hf(
+                        model_id,
+                        task=task,
+                        device=device,
+                        ep=ep,
+                        allow_unsupported_nodes=allow_unsupported_nodes,
+                    )
                 else:
                     raise
         elif path.suffix == ".onnx" and path.exists():
             self._load_from_onnx(path, task=task, device=device, ep=ep)
         else:
-            self._load_from_hf(str(model_path), task=task, device=device, ep=ep)
+            self._load_from_hf(
+                str(model_path),
+                task=task,
+                device=device,
+                ep=ep,
+                allow_unsupported_nodes=allow_unsupported_nodes,
+            )
 
         # Create HF pipeline for preprocess + postprocess
         self._pipeline = self._create_pipeline()
@@ -965,11 +980,18 @@ class InferenceEngine:
         task: str | None,
         device: str,
         ep: EPNameOrAlias | None,
+        allow_unsupported_nodes: bool = False,
     ) -> None:
         from ..models.auto import WinMLAutoModel
 
         self._model_id = model_id
-        self._model = WinMLAutoModel.from_pretrained(model_id, task=task, device=device, ep=ep)
+        self._model = WinMLAutoModel.from_pretrained(
+            model_id,
+            task=task,
+            device=device,
+            ep=ep,
+            allow_unsupported_nodes=allow_unsupported_nodes,
+        )
         self._task = (
             task
             or getattr(self._model, "task", None)

--- a/src/winml/modelkit/models/auto.py
+++ b/src/winml/modelkit/models/auto.py
@@ -109,6 +109,7 @@ class WinMLAutoModel:
         use_cache: bool = True,
         force_rebuild: bool = False,
         skip_build: bool = False,
+        allow_unsupported_nodes: bool = False,
         session_options: Any | None = None,
         hf_config: PretrainedConfig | None = None,
         **kwargs: Any,
@@ -128,6 +129,9 @@ class WinMLAutoModel:
             cache_dir: Override cache directory.
             use_cache: Whether to use persistent cache.
             force_rebuild: Force rebuild even if cached.
+            allow_unsupported_nodes: If True, warn instead of raising when the
+                analyzer reports unsupported nodes during the build. Has no
+                effect when ``skip_build=True`` (no analyze step runs).
             hf_config: HF ``PretrainedConfig`` for composite (dict) dispatch only.
                 Required when ``onnx_path`` is a dict so the composite registry
                 lookup can resolve ``(model_type, task)``. Ignored for single-file
@@ -217,6 +221,7 @@ class WinMLAutoModel:
             rebuild=force_rebuild,
             ep=ep,
             device=device,
+            allow_unsupported_nodes=allow_unsupported_nodes,
             **kwargs,
         )
 
@@ -353,6 +358,7 @@ class WinMLAutoModel:
                     precision=precision,
                     config=config,
                     cache_dir=cache_dir,
+                    allow_unsupported_nodes=allow_unsupported_nodes,
                     **kwargs,
                 )
 

--- a/src/winml/modelkit/models/auto.py
+++ b/src/winml/modelkit/models/auto.py
@@ -247,6 +247,7 @@ class WinMLAutoModel:
         trust_remote_code: bool = False,
         shape_config: dict | None = None,
         no_compile: bool = False,
+        allow_unsupported_nodes: bool = False,
         **kwargs: Any,
     ) -> WinMLPreTrainedModel:
         """Load appropriate WinML model based on task detection.
@@ -278,6 +279,9 @@ class WinMLAutoModel:
             shape_config: Shape overrides passed to generate_build_config().
                 Valid keys -- text: sequence_length; vision: height, width;
                 audio: feature_size, nb_max_frames, audio_sequence_length.
+            allow_unsupported_nodes: If True, warn instead of raising when the
+                analyzer reports unsupported nodes that persist; the build
+                proceeds and the EP may fall back to another device for them.
             **kwargs: Additional arguments
 
         Returns:
@@ -311,6 +315,7 @@ class WinMLAutoModel:
                 cache_dir=cache_dir,
                 use_cache=use_cache,
                 force_rebuild=force_rebuild,
+                allow_unsupported_nodes=allow_unsupported_nodes,
                 **kwargs,
             )
 
@@ -431,6 +436,7 @@ class WinMLAutoModel:
             cache_key=cache_key,
             ep=resolved_ep,
             device=device,
+            allow_unsupported_nodes=allow_unsupported_nodes,
         )
         onnx_path = result.final_onnx_path
 

--- a/src/winml/modelkit/utils/cli.py
+++ b/src/winml/modelkit/utils/cli.py
@@ -304,6 +304,34 @@ def trust_remote_code_option(optional_message: str | None = None) -> Callable[[F
     )
 
 
+def allow_unsupported_nodes_option(optional_message: str | None = None) -> Callable[[F], F]:
+    """Add shared --allow-unsupported-nodes option to a Click command.
+
+    When set, the build's optimize/analyze loop logs a warning instead of
+    raising when unsupported nodes persist after analysis, so the build
+    proceeds (the EP may fall back to another device for those nodes).
+
+    Args:
+        optional_message: Extra command-specific guidance appended to help text.
+
+    Returns:
+        Decorator function.
+    """
+    help_text = (
+        "Continue the build instead of failing when the analyzer reports "
+        "unsupported nodes (the EP may fall back to another device for them)."
+    )
+    if optional_message:
+        help_text = f"{help_text} {optional_message}"
+
+    return click.option(
+        "--allow-unsupported-nodes",
+        is_flag=True,
+        default=False,
+        help=help_text,
+    )
+
+
 def load_build_config(config_path: Path) -> tuple[WinMLBuildConfig, dict]:
     """Load a WinMLBuildConfig from a JSON file.
 

--- a/tests/unit/build/test_common.py
+++ b/tests/unit/build/test_common.py
@@ -1,0 +1,113 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Tests for build.common — the optimize/analyze loop.
+
+Focus: the ``allow_unsupported_nodes`` gate around the "unsupported nodes
+persist" RuntimeError. Mock-based, no real optimize/analyze.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from winml.modelkit.build.common import run_optimize_analyze_loop
+from winml.modelkit.config import WinMLBuildConfig
+
+
+def _config() -> WinMLBuildConfig:
+    """Minimal config with autoconf enabled and no optim flags."""
+    config = WinMLBuildConfig.from_dict(
+        {
+            "loader": {"task": "depth-estimation"},
+            "export": {"opset_version": 17},
+            "optim": {},
+            "quant": None,
+            "compile": {"execution_provider": "openvino"},
+        }
+    )
+    config.auto = True
+    return config
+
+
+def _errored_analysis():
+    """AnalyzeResult that reports unsupported nodes and no autoconf opportunities."""
+    from winml.modelkit.analyze import AnalyzeResult, LintResult
+    from winml.modelkit.optim import WinMLOptimizationConfig
+
+    opt = WinMLOptimizationConfig()  # empty -> autoconf converges immediately
+    lint = LintResult(
+        errors=1,
+        warnings=0,
+        info=0,
+        passed=False,
+        error_patterns=["Resize"],
+        warning_patterns=[],
+        information=[],
+        optimization_config=opt,
+    )
+    return AnalyzeResult(lint=lint, optimization_config=opt)
+
+
+def _patched_loop(tmp_path: Path):
+    """Patch the loop's stage functions to avoid real optimize/analyze/copy."""
+    return (
+        patch(
+            "winml.modelkit.build.common.optimize_onnx",
+            side_effect=lambda **kw: Path(kw["output"]).write_text("mock"),
+        ),
+        patch(
+            "winml.modelkit.build.common.analyze_onnx",
+            return_value=_errored_analysis(),
+        ),
+        patch(
+            "winml.modelkit.build.common.copy_onnx_model",
+            side_effect=lambda src, dst: Path(dst).write_text("mock"),
+        ),
+    )
+
+
+class TestAllowUnsupportedNodesGate:
+    """The unsupported-nodes RuntimeError is gated by allow_unsupported_nodes."""
+
+    def test_raises_by_default(self, tmp_path: Path) -> None:
+        model = tmp_path / "in.onnx"
+        model.write_text("mock")
+        optimized = tmp_path / "out.onnx"
+        p_opt, p_analyze, p_copy = _patched_loop(tmp_path)
+        expect_raise = pytest.raises(RuntimeError, match="Unsupported nodes persist")
+
+        with p_opt, p_analyze, p_copy, expect_raise:
+            run_optimize_analyze_loop(
+                model_path=model,
+                optimized_path=optimized,
+                config=_config(),
+                ep="openvino",
+                device="gpu",
+                max_optim_iterations=1,
+            )
+
+    def test_warns_instead_of_raising_when_allowed(self, tmp_path: Path, caplog) -> None:
+        model = tmp_path / "in.onnx"
+        model.write_text("mock")
+        optimized = tmp_path / "out.onnx"
+        p_opt, p_analyze, p_copy = _patched_loop(tmp_path)
+
+        with p_opt, p_analyze, p_copy, caplog.at_level("WARNING"):
+            result = run_optimize_analyze_loop(
+                model_path=model,
+                optimized_path=optimized,
+                config=_config(),
+                ep="openvino",
+                device="gpu",
+                max_optim_iterations=1,
+                allow_unsupported_nodes=True,
+            )
+
+        # No raise; loop returns its 5-tuple and logs a warning.
+        assert result[0] == optimized
+        assert "Unsupported nodes persist" in caplog.text

--- a/tests/unit/build/test_common.py
+++ b/tests/unit/build/test_common.py
@@ -97,7 +97,9 @@ class TestAllowUnsupportedNodesGate:
         optimized = tmp_path / "out.onnx"
         p_opt, p_analyze, p_copy = _patched_loop(tmp_path)
 
-        with p_opt, p_analyze, p_copy, caplog.at_level("WARNING"):
+        with p_opt, p_analyze, p_copy, caplog.at_level(
+            "WARNING", logger="winml.modelkit.build.common"
+        ):
             result = run_optimize_analyze_loop(
                 model_path=model,
                 optimized_path=optimized,

--- a/tests/unit/commands/test_build.py
+++ b/tests/unit/commands/test_build.py
@@ -525,6 +525,26 @@ class TestBuildFlagPassthrough:
             == 5
         )
 
+    def test_allow_unsupported_nodes_sets_extra_kwarg(
+        self, tmp_path: Path, mock_run_single_build: MagicMock
+    ):
+        """``--allow-unsupported-nodes`` sets ``extra_kwargs['allow_unsupported_nodes']``."""
+        cfg = _make_minimal_config_file(tmp_path)
+        result = _invoke([*self._base_args(cfg, tmp_path), "--allow-unsupported-nodes"])
+        assert result.exit_code == 0, result.output
+        extras = mock_run_single_build.call_args.kwargs["extra_kwargs"]
+        assert extras.get("allow_unsupported_nodes") is True
+
+    def test_allow_unsupported_nodes_absent_by_default(
+        self, tmp_path: Path, mock_run_single_build: MagicMock
+    ):
+        """Without the flag, ``allow_unsupported_nodes`` is not forwarded."""
+        cfg = _make_minimal_config_file(tmp_path)
+        result = _invoke(self._base_args(cfg, tmp_path))
+        assert result.exit_code == 0, result.output
+        extras = mock_run_single_build.call_args.kwargs["extra_kwargs"]
+        assert "allow_unsupported_nodes" not in extras
+
     def test_no_analyze_wins_over_max_iterations(
         self, tmp_path: Path, mock_run_single_build: MagicMock
     ):

--- a/tests/unit/commands/test_build.py
+++ b/tests/unit/commands/test_build.py
@@ -535,15 +535,15 @@ class TestBuildFlagPassthrough:
         extras = mock_run_single_build.call_args.kwargs["extra_kwargs"]
         assert extras.get("allow_unsupported_nodes") is True
 
-    def test_allow_unsupported_nodes_absent_by_default(
+    def test_allow_unsupported_nodes_false_by_default(
         self, tmp_path: Path, mock_run_single_build: MagicMock
     ):
-        """Without the flag, ``allow_unsupported_nodes`` is not forwarded."""
+        """Without the flag, ``allow_unsupported_nodes`` is forwarded as False."""
         cfg = _make_minimal_config_file(tmp_path)
         result = _invoke(self._base_args(cfg, tmp_path))
         assert result.exit_code == 0, result.output
         extras = mock_run_single_build.call_args.kwargs["extra_kwargs"]
-        assert "allow_unsupported_nodes" not in extras
+        assert extras.get("allow_unsupported_nodes") is False
 
     def test_no_analyze_wins_over_max_iterations(
         self, tmp_path: Path, mock_run_single_build: MagicMock

--- a/tests/unit/commands/test_eval.py
+++ b/tests/unit/commands/test_eval.py
@@ -384,6 +384,47 @@ class TestEvalConfigPrecedence:
         # And config-file dataset.samples (33) wins over CLI default
         assert cfg.dataset.samples == 33
 
+    @pytest.mark.parametrize(
+        ("extra_args", "expected"),
+        [(["--allow-unsupported-nodes"], True), ([], False)],
+    )
+    def test_allow_unsupported_nodes_flag_propagates(
+        self,
+        runner: CliRunner,
+        extra_args,
+        expected,
+    ):
+        """``--allow-unsupported-nodes`` maps to the eval config field."""
+        from winml.modelkit.commands.eval import eval as eval_cmd
+
+        captured_cfg = {}
+
+        def _fake_evaluate(cfg):
+            captured_cfg["cfg"] = cfg
+
+            class _R:
+                config = cfg
+                metrics = {"accuracy": 1.0}  # noqa: RUF012
+
+                def to_dict(self):
+                    return {"metrics": self.metrics, "config": cfg.to_dict()}
+
+            return _R()
+
+        with (
+            patch("winml.modelkit.eval.evaluate", side_effect=_fake_evaluate),
+            patch("winml.modelkit.commands.eval._resolve_device", return_value=None),
+            patch("winml.modelkit.commands.eval._write_and_display", return_value=None),
+        ):
+            result = runner.invoke(
+                eval_cmd,
+                ["-m", "microsoft/resnet-50", "--task", "image-classification", *extra_args],
+                obj={"debug": False},
+            )
+
+        assert result.exit_code == 0, result.output
+        assert captured_cfg["cfg"].allow_unsupported_nodes is expected
+
 
 # ---------------------------------------------------------------------------
 # --label-mapping wiring (Click Path → label_mapping_file str)

--- a/tests/unit/commands/test_run.py
+++ b/tests/unit/commands/test_run.py
@@ -322,6 +322,7 @@ class TestRunCLI:
             task=None,
             device="auto",
             ep=None,
+            allow_unsupported_nodes=False,
         )
         engine.predict.assert_called_once_with(inputs={"text": "hello world"})
 
@@ -464,6 +465,7 @@ class TestRunCLI:
             task="image-classification",
             device="auto",
             ep=None,
+            allow_unsupported_nodes=False,
         )
 
     def test_device_and_ep_forwarded(self, runner: CliRunner) -> None:
@@ -490,6 +492,7 @@ class TestRunCLI:
             task=None,
             device="gpu",
             ep="qnn",
+            allow_unsupported_nodes=False,
         )
 
     # ---- -P / --param tests ----

--- a/tests/unit/commands/test_run_spec.py
+++ b/tests/unit/commands/test_run_spec.py
@@ -98,7 +98,7 @@ class TestModelOption:
         with patch(_ENGINE_PATH, return_value=engine):
             runner.invoke(run, ["--model", "microsoft/resnet-50", "--text", "x"])
         engine.load.assert_called_once_with(
-            "microsoft/resnet-50", task=None, device="auto", ep=None
+            "microsoft/resnet-50", task=None, device="auto", ep=None, allow_unsupported_nodes=False
         )
 
 

--- a/tests/unit/eval/test_eval.py
+++ b/tests/unit/eval/test_eval.py
@@ -1288,6 +1288,7 @@ class TestLoadModel:
             device="cpu",
             precision="auto",
             ep=None,
+            allow_unsupported_nodes=False,
         )
         assert result is mock_model
 

--- a/tests/unit/inference/test_engine.py
+++ b/tests/unit/inference/test_engine.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import inspect
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from winml.modelkit.inference import (
     TASK_REGISTRY,
@@ -301,6 +301,34 @@ class TestPredictTaskOverride:
 # ---------------------------------------------------------------------------
 # load_schema_only
 # ---------------------------------------------------------------------------
+
+
+class TestLoadForwardsAllowUnsupportedNodes:
+    def test_load_from_hf_forwards_flag(self) -> None:
+        """``allow_unsupported_nodes`` reaches WinMLAutoModel.from_pretrained."""
+        engine = InferenceEngine()
+        captured: dict[str, Any] = {}
+
+        fake_model = MagicMock()
+        fake_model.task = "text-classification"
+
+        def _fake_from_pretrained(model_id: str, **kwargs: Any) -> MagicMock:
+            captured.update(kwargs)
+            return fake_model
+
+        with patch(
+            "winml.modelkit.models.auto.WinMLAutoModel.from_pretrained",
+            side_effect=_fake_from_pretrained,
+        ):
+            engine._load_from_hf(
+                "some/model",
+                task="text-classification",
+                device="cpu",
+                ep=None,
+                allow_unsupported_nodes=True,
+            )
+
+        assert captured.get("allow_unsupported_nodes") is True
 
 
 class TestLoadSchemaOnly:

--- a/tests/unit/models/auto/test_auto_onnx.py
+++ b/tests/unit/models/auto/test_auto_onnx.py
@@ -145,6 +145,31 @@ class TestFromOnnx:
         assert call_kwargs["ep"] == "qnn"
         assert call_kwargs["device"] == "npu"
 
+    def test_passes_allow_unsupported_nodes_to_build(self, fake_onnx: Path, tmp_path: Path):
+        """from_onnx() forwards allow_unsupported_nodes through to build_onnx_model."""
+        with (
+            patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
+            patch("winml.modelkit.onnx.is_quantized_onnx", return_value=False),
+            patch(
+                "winml.modelkit.sysinfo.resolve_device",
+                return_value=("cpu", ["cpu"]),
+            ),
+            patch("winml.modelkit.build.build_onnx_model") as mock_build,
+            patch("winml.modelkit.models.auto.get_winml_class") as mock_get_class,
+        ):
+            mock_build.return_value = _make_build_result(tmp_path)
+            mock_instance = MagicMock()
+            mock_get_class.return_value = lambda **kw: mock_instance
+
+            WinMLAutoModel.from_onnx(
+                fake_onnx,
+                task="image-classification",
+                device="cpu",
+                allow_unsupported_nodes=True,
+            )
+
+        assert mock_build.call_args.kwargs["allow_unsupported_nodes"] is True
+
     def test_returns_winml_pretrained_model(self, fake_onnx: Path, tmp_path: Path):
         """from_onnx() returns the inference wrapper from get_winml_class."""
         with (

--- a/tests/unit/models/auto/test_from_pretrained_ep.py
+++ b/tests/unit/models/auto/test_from_pretrained_ep.py
@@ -118,3 +118,54 @@ def test_both_absent_yields_none(monkeypatch: pytest.MonkeyPatch) -> None:
         WinMLAutoModel.from_pretrained("microsoft/resnet-50", device="cpu")
 
     assert received.get("ep") is None
+
+
+@pytest.mark.parametrize("flag", [True, False])
+def test_allow_unsupported_nodes_reaches_build(
+    monkeypatch: pytest.MonkeyPatch, flag: bool
+) -> None:
+    """``allow_unsupported_nodes`` propagates to build_hf_model (HF path)."""
+    from winml.modelkit.models import WinMLAutoModel
+
+    received = _install_stubs(monkeypatch, compile_provider=None)
+
+    with pytest.raises(_StopAfterEpCheckError):
+        WinMLAutoModel.from_pretrained(
+            "microsoft/resnet-50", device="cpu", allow_unsupported_nodes=flag
+        )
+
+    assert received.get("allow_unsupported_nodes") is flag
+
+
+def test_allow_unsupported_nodes_reaches_composite(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``allow_unsupported_nodes`` reaches the composite-model dispatch path."""
+    import transformers
+
+    from winml.modelkit.models import WinMLAutoModel
+    from winml.modelkit.models.winml import composite_model as cm_mod
+
+    # One fake composite registered for (model_type, task).
+    monkeypatch.setattr(cm_mod, "COMPOSITE_MODEL_REGISTRY", {("faketype", "faketask"): object})
+
+    fake_cfg = MagicMock()
+    fake_cfg.model_type = "faketype"
+    monkeypatch.setattr(
+        transformers, "AutoConfig", MagicMock(from_pretrained=lambda *a, **k: fake_cfg)
+    )
+
+    received: dict[str, Any] = {}
+
+    def _stub_composite(*_args: Any, **kwargs: Any) -> str:
+        received.update(kwargs)
+        return "COMPOSITE_SENTINEL"
+
+    monkeypatch.setattr(
+        cm_mod.WinMLCompositeModel, "from_pretrained", staticmethod(_stub_composite)
+    )
+
+    result = WinMLAutoModel.from_pretrained(
+        "some/composite", task="faketask", allow_unsupported_nodes=True
+    )
+
+    assert result == "COMPOSITE_SENTINEL"
+    assert received.get("allow_unsupported_nodes") is True


### PR DESCRIPTION
## Problem

`winml perf -m depth-anything/Depth-Anything-V2-Small-hf --task depth-estimation --ep openvino --device gpu` aborts at the optimize/analyze loop:

```
RuntimeError: Unsupported nodes persist after N analyze pass(es): ['OP/ai.onnx/Resize']
```

The static analyzer flags nodes the target EP doesn't fully support (e.g. `Resize` on OpenVINO GPU), so the build raises — even though the EP can still run the model (CPU fallback for those nodes).

## Change

Add an opt-in `--allow-unsupported-nodes` flag that turns the hard failure into a warning and lets the build proceed. The gate lives at the single `raise` in `build/common.py`:

```python
if analysis is not None and analysis.has_errors:
    message = f"Unsupported nodes persist after {analyze_iterations} analyze pass(es): ..."
    if allow_unsupported_nodes:
        logger.warning("%s. Continuing anyway ...", message)
    else:
        raise RuntimeError(message)
```

The flag is a **shared CLI option** (`cli_utils.allow_unsupported_nodes_option()`) applied to every command that builds a model via `WinMLAutoModel.from_*`:

| Command | Path | Status |
|---|---|---|
| `winml perf` | `BenchmarkConfig` → `from_pretrained`/`from_onnx`; `--module` → `build_hf_model` | ✅ verified e2e |
| `winml build` | `_run_optimize_stage` → `run_optimize_analyze_loop`; module mode → `build_hf_model` | ✅ verified e2e |
| `winml eval` | `WinMLEvaluationConfig.allow_unsupported_nodes` → `from_pretrained` | ✅ |
| `winml run` | `InferenceEngine.load` → `_load_from_hf` → `from_pretrained` | plumbed (command currently disabled) |

ONNX / `skip_build` load paths don't run the analyzer, so they're untouched. Default is `False` everywhere — strictly opt-in. Named `--allow-unsupported-nodes` (not a generic `--force`) since it gates exactly this analyzer check.

## Verification

- `winml perf ... --ep openvino --device gpu --allow-unsupported-nodes` → builds, compiles on OV GPU, benchmarks (~15.9 ms avg).
- `winml build ... --ep openvino --device gpu --allow-unsupported-nodes` → logs the warning (`['OP/ai.onnx/Resize']`) and completes.
- New/updated unit tests cover the gate (`build/test_common.py`), and flag passthrough for build/eval/run; full commands + inference + build + eval suites pass (871 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)