### PR TITLE
Fix rich Live thread crashes.

### DIFF
--- a/src/winml/modelkit/utils/console.py
+++ b/src/winml/modelkit/utils/console.py
@@ -266,6 +266,48 @@ def get_onnx_total_size(onnx_path: Path) -> int:
 # ══════════════════════════════════════════════════════════════════════════
 
 
+class _SafeLive(Live):
+    """A :class:`rich.live.Live` that survives Windows console hiccups.
+
+    Some native dependencies (e.g. OpenVINO / ONNX Runtime EPs) can put
+    the Windows console handle into a state where ANSI/control writes
+    fail with ``OSError: [WinError 1]`` ("Incorrect function").  That
+    error is raised from Rich's daemon refresh thread, which then dies
+    and dumps an ugly traceback into the middle of build output even
+    though the build itself succeeds.
+
+    This subclass catches :class:`OSError` in :meth:`refresh` and, after
+    the first failure, disables further refreshes for the lifetime of
+    this Live instance.  The visible effect is that the final frame may
+    not animate further, but no traceback escapes and the surrounding
+    pipeline continues normally.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._refresh_disabled: bool = False
+
+    def refresh(self) -> None:  # type: ignore[override]
+        if self._refresh_disabled:
+            return
+        try:
+            super().refresh()
+        except OSError:
+            # Console handle is unusable (typically VT/handle state damaged
+            # by a native library).  Disable further refreshes so the
+            # daemon thread does not spam tracebacks.
+            self._refresh_disabled = True
+            logger.debug("Disabling Live refresh after OSError", exc_info=True)
+
+
+def _safe_call(func: Any, *args: Any, **kwargs: Any) -> None:
+    """Invoke a Rich Live operation, swallowing console OSErrors."""
+    try:
+        func(*args, **kwargs)
+    except OSError:
+        logger.debug("Ignoring OSError from Live operation", exc_info=True)
+
+
 class StageLive:
     """Live region for a single build stage.
 
@@ -287,25 +329,25 @@ class StageLive:
         self._name = name
         self._console = console
         self._lines: list[RenderableType] = []
-        self._live: Live | None = None
+        self._live: _SafeLive | None = None
         self._status_idx: int = 0
 
     def __enter__(self) -> StageLive:
         self._lines = [self._make_running_line()]
         self._status_idx = 0
-        self._live = Live(
+        self._live = _SafeLive(
             self._render(),
             console=self._console,
             refresh_per_second=15,
             transient=False,
         )
-        self._live.start()
+        _safe_call(self._live.start)
         return self
 
     def __exit__(self, *_: object) -> None:
         if self._live:
-            self._live.update(self._render())
-            self._live.stop()
+            _safe_call(self._live.update, self._render())
+            _safe_call(self._live.stop)
             self._live = None
 
     def _render(self) -> Group:
@@ -313,7 +355,7 @@ class StageLive:
 
     def _update(self) -> None:
         if self._live:
-            self._live.update(self._render())
+            _safe_call(self._live.update, self._render())
 
     # ── Status line management ────────────────────────────────────
 

--- a/src/winml/modelkit/utils/console.py
+++ b/src/winml/modelkit/utils/console.py
@@ -15,13 +15,18 @@ for machine-readable output (JSON configs, build manifests).
 
 from __future__ import annotations
 
+import functools
 import logging
+from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from rich.console import Console, Group, RenderableType
 from rich.live import Live
 from rich.text import Text
+
+
+F = TypeVar("F", bound=Callable[..., Any])
 
 
 if TYPE_CHECKING:
@@ -278,10 +283,25 @@ class _SafeLive(Live):
 
     This subclass catches :class:`OSError` in :meth:`refresh` and, after
     the first failure, disables further refreshes for the lifetime of
-    this Live instance.  The visible effect is that the final frame may
-    not animate further, but no traceback escapes and the surrounding
-    pipeline continues normally.
+    this Live instance.  ``start``/``stop``/``update`` are also wrapped
+    so callers can use ``_SafeLive`` exactly like :class:`Live`.  The
+    visible effect is that the final frame may not animate further, but
+    no traceback escapes and the surrounding pipeline continues normally.
     """
+
+    @staticmethod
+    def _swallow_oserror(method: F) -> F:
+        """Decorator: invoke ``method`` and swallow console ``OSError``."""
+
+        @functools.wraps(method)
+        def wrapper(self: _SafeLive, *args: Any, **kwargs: Any) -> Any:
+            try:
+                return method(self, *args, **kwargs)
+            except OSError:
+                logger.debug("Ignoring OSError from Live.%s", method.__name__, exc_info=True)
+                return None
+
+        return wrapper  # type: ignore[return-value]
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -299,13 +319,17 @@ class _SafeLive(Live):
             self._refresh_disabled = True
             logger.debug("Disabling Live refresh after OSError", exc_info=True)
 
+    @_swallow_oserror
+    def start(self, refresh: bool = False) -> None:  # type: ignore[override]
+        super().start(refresh=refresh)
 
-def _safe_call(func: Any, *args: Any, **kwargs: Any) -> None:
-    """Invoke a Rich Live operation, swallowing console OSErrors."""
-    try:
-        func(*args, **kwargs)
-    except OSError:
-        logger.debug("Ignoring OSError from Live operation", exc_info=True)
+    @_swallow_oserror
+    def stop(self) -> None:  # type: ignore[override]
+        super().stop()
+
+    @_swallow_oserror
+    def update(self, renderable: RenderableType, *, refresh: bool = False) -> None:  # type: ignore[override]
+        super().update(renderable, refresh=refresh)
 
 
 class StageLive:
@@ -341,13 +365,13 @@ class StageLive:
             refresh_per_second=15,
             transient=False,
         )
-        _safe_call(self._live.start)
+        self._live.start()
         return self
 
     def __exit__(self, *_: object) -> None:
         if self._live:
-            _safe_call(self._live.update, self._render())
-            _safe_call(self._live.stop)
+            self._live.update(self._render())
+            self._live.stop()
             self._live = None
 
     def _render(self) -> Group:
@@ -355,7 +379,7 @@ class StageLive:
 
     def _update(self) -> None:
         if self._live:
-            _safe_call(self._live.update, self._render())
+            self._live.update(self._render())
 
     # ── Status line management ────────────────────────────────────
 


### PR DESCRIPTION
Issue:
https://github.com/microsoft/winml-cli/issues/795

**Root cause:** Inside the Rich `Live` refresh thread, a stderr write fails with `OSError: [WinError 1]` ("Incorrect function"). On Windows this typically happens when a native EP dependency (here OpenVINO inside `compile_onnx`'s `session.run` validation) puts the console handle into a state where ANSI/control writes no longer work. Rich's daemon refresh thread doesn't catch this, dies, and Python dumps its traceback into the middle of build output. The build itself completes — the visible log lines after the traceback are proof of that.

**Fix:** console.py

- Added `_SafeLive`, a `rich.live.Live` subclass that catches `OSError` inside `refresh()`. After the first failure it disables further refreshes for that Live (logged at DEBUG), so the daemon thread can't die or spam tracebacks.
- Added a tiny `_safe_call` helper and wrapped `StageLive.__enter__` / `__exit__` / `_update` Live operations with it, so any console hiccup on `start`/`update`/`stop` is also swallowed.
- Net effect: the stage may stop animating its final frame after such an event, but the surrounding pipeline continues cleanly with no traceback noise.