### PR TITLE
Pipeline(E2E): move ModelKitArtifacts ref conditional into top-level …

### DIFF
--- a/.pipelines/Modelkit E2E Test.yml
+++ b/.pipelines/Modelkit E2E Test.yml
@@ -49,19 +49,28 @@ schedules:
 # check out the same-named release branch from ModelKitArtifacts so the
 # artifact content matches the modelkit release. For all other branches
 # (e.g. main scheduled runs, manual queue from main), fall back to main.
-# Build.SourceBranch is in the form 'refs/heads/release/<name>' which is a
-# valid ref value here.
+#
+# Azure Pipelines only allows template expressions in the *value* position of
+# a repository resource's `ref` (not as a YAML key inside `repositories`), so
+# the conditional is resolved here in a top-level compile-time variable and
+# the `ref` field simply references that variable.
+# Build.SourceBranch is in the form 'refs/heads/release/<name>', which is a
+# valid `ref` value for a GitHub repository resource.
 # See: https://learn.microsoft.com/azure/devops/release-notes/2022/sprint-212-update#template-expressions-in-repository-resource-definition
+variables:
+  - name: artifactsRef
+    ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/release/') }}:
+      value: ${{ variables['Build.SourceBranch'] }}
+    ${{ else }}:
+      value: main
+
 resources:
   repositories:
     - repository: ModelKitArtifacts
       type: github
       endpoint: github.com_yuesu_microsoft
       name: gim-home/ModelKitArtifacts
-      ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/release/') }}:
-        ref: ${{ variables['Build.SourceBranch'] }}
-      ${{ else }}:
-        ref: main
+      ref: ${{ variables.artifactsRef }}
 
 parameters:
   # --------------------------------------------------------------------


### PR DESCRIPTION
…variable

Azure Pipelines does not allow ${{ if }} / ${{ else }} template expressions in the YAML key position inside a 
esources.repositories entry. PR #823 used that pattern to switch the artifact repo's 
ef between Build.SourceBranch and main, which caused the pipeline parser to fail with:

  A template expression is not allowed in this context (Line 61/63)

Move the conditional into a top-level compile-time ariables block (which does support ${{ if }}: value: ... / ${{ else }}: value: ...) and reference the resulting rtifactsRef from 
esources.repositories.ModelKitArtifacts.ref as a plain value-position template expression — which is the pattern explicitly enabled by ADO Sprint 212.