### PR TITLE
refactoring: simplify compile ep selection logic

### DIFF
--- a/src/winml/modelkit/analyze/core/runtime_checker_query.py
+++ b/src/winml/modelkit/analyze/core/runtime_checker_query.py
@@ -253,7 +253,7 @@ def _colorize_log_text(text: str, color_code: str) -> str:
 
 def _log_parquet_cache_hit(parquet_path: Path, scope: str) -> None:
     """Emit a light-blue log entry for parquet cache hits."""
-    logger.info(
+    logger.debug(
         _colorize_log_text(
             f"[parquet-cache] {parquet_path.name} hit cache ({scope})",
             _LOG_COLOR_LIGHT_CYAN,
@@ -2498,7 +2498,7 @@ class RuntimeCheckerQuery:
     ) -> PatternRuntime:
         """Run runtime check for subgraph pattern via per-node checks."""
         pattern_name = pattern_match.pattern.__class__.__name__
-        logger.info(
+        logger.debug(
             "Pattern-level aggregated rules are removed; checking individual operators for '%s'",
             pattern_name,
         )

--- a/src/winml/modelkit/commands/compile.py
+++ b/src/winml/modelkit/commands/compile.py
@@ -264,5 +264,12 @@ def _resolve_compile_provider(resolved_device: str, ep: EPNameOrAlias | None) ->
 
     ``ep`` overrides the device mapping. Returns
     the canonical EP name (e.g., ``"QNNExecutionProvider"``).
+
+    Device/EP policy compatibility is enforced upstream by ``resolve_device``;
+    this helper trusts its inputs and only normalizes.
     """
-    return normalize_ep_name(ep) if ep else resolve_eps(resolved_device)[0]
+    if ep is not None:
+        normalized = normalize_ep_name(ep)
+        if normalized is not None:
+            return normalized
+    return resolve_eps(resolved_device)[0]

--- a/src/winml/modelkit/commands/compile.py
+++ b/src/winml/modelkit/commands/compile.py
@@ -28,7 +28,7 @@ from rich.console import Console
 from ..onnx import is_compiled_onnx
 from ..sysinfo import resolve_device, resolve_eps
 from ..utils import cli as cli_utils
-from ..utils.constants import EP_SUPPORTED_DEVICES, normalize_ep_name
+from ..utils.constants import normalize_ep_name
 
 
 if TYPE_CHECKING:
@@ -265,21 +265,4 @@ def _resolve_compile_provider(resolved_device: str, ep: EPNameOrAlias | None) ->
     ``ep`` overrides the device mapping. Returns
     the canonical EP name (e.g., ``"QNNExecutionProvider"``).
     """
-    if ep:
-        canonical = normalize_ep_name(ep)
-        if canonical is None:
-            raise click.UsageError(f"Unknown EP: {ep}")
-        supported = EP_SUPPORTED_DEVICES[canonical]
-        if resolved_device.lower() not in supported:
-            raise click.UsageError(
-                f"--ep {ep} cannot run on --device {resolved_device}. "
-                f"{canonical} supports: {', '.join(supported)}."
-            )
-        # EP host-availability is enforced by ``resolve_device`` upstream,
-        # no need for an extra check here
-        return canonical
-
-    eps = resolve_eps(resolved_device)
-    if not eps:
-        return "CPUExecutionProvider"
-    return eps[0]
+    return normalize_ep_name(ep) if ep else resolve_eps(resolved_device)[0]

--- a/src/winml/modelkit/session/ep_registry.py
+++ b/src/winml/modelkit/session/ep_registry.py
@@ -269,8 +269,12 @@ class WinMLEPRegistry:
         """Load EP catalog from WinML."""
         from windowsml import EpCatalog
 
+        checked_eps: set[EPName] = set()
         with EpCatalog() as catalog:
             for provider in catalog.find_all_providers():
+                if provider.name in checked_eps:
+                    continue
+                checked_eps.add(provider.name)
                 try:
                     _ensure_provider_ready(provider)
                 except OSError as e:

--- a/src/winml/modelkit/session/ep_registry.py
+++ b/src/winml/modelkit/session/ep_registry.py
@@ -289,7 +289,7 @@ class WinMLEPRegistry:
                 if provider.library_path == "":
                     continue
                 self._ep_paths[cast("EPName", provider.name)] = provider.library_path
-                logger.debug("Found EP: %s at %s", provider.name, provider.library_path)
+                logger.info("Found EP: %s at %s", provider.name, provider.library_path)
 
     def register_to_ort(self) -> list[EPName]:
         """Register discovered EPs to ONNX Runtime.

--- a/src/winml/modelkit/sysinfo/device.py
+++ b/src/winml/modelkit/sysinfo/device.py
@@ -177,10 +177,12 @@ def resolve_device(
         ep_full = normalize_ep_name(ep)
         if ep_full not in EP_SUPPORTED_DEVICES:
             raise ValueError(f"Unknown EP '{ep}'. Expected one of: {sorted(EP_SUPPORTED_DEVICES)}")
+        # Static policy gate (see issue #860): reject EP/device combos the EP
+        # architecture cannot support, before consulting runtime ORT availability.
         if device != "auto" and device not in EP_SUPPORTED_DEVICES[ep_full]:
             raise ValueError(
                 f"EP '{ep}' does not support device '{device}'. "
-                f"Supported devices for {ep_full}: {', '.join(EP_SUPPORTED_DEVICES[ep_full])}."
+                f"Supported devices: {', '.join(EP_SUPPORTED_DEVICES[ep_full])}."
             )
         device_ep_map = {dev: (ep_full,) for dev, eps in device_ep_map.items() if ep_full in eps}
         if not device_ep_map:

--- a/src/winml/modelkit/sysinfo/device.py
+++ b/src/winml/modelkit/sysinfo/device.py
@@ -177,6 +177,11 @@ def resolve_device(
         ep_full = normalize_ep_name(ep)
         if ep_full not in EP_SUPPORTED_DEVICES:
             raise ValueError(f"Unknown EP '{ep}'. Expected one of: {sorted(EP_SUPPORTED_DEVICES)}")
+        if device != "auto" and device not in EP_SUPPORTED_DEVICES[ep_full]:
+            raise ValueError(
+                f"EP '{ep}' does not support device '{device}'. "
+                f"Supported devices for {ep_full}: {', '.join(EP_SUPPORTED_DEVICES[ep_full])}."
+            )
         device_ep_map = {dev: (ep_full,) for dev, eps in device_ep_map.items() if ep_full in eps}
         if not device_ep_map:
             raise ValueError(

--- a/tests/e2e/test_compile_e2e.py
+++ b/tests/e2e/test_compile_e2e.py
@@ -180,8 +180,7 @@ def assert_by_run_inference(
 
 
 def _find_qairt_sdk_root() -> Path | None:
-    """Locate an installed QAIRT SDK on this host, or None.
-    """
+    """Locate an installed QAIRT SDK on this host, or None."""
     for env_var in ("QNN_SDK_ROOT", "QAIRT_SDK_ROOT"):
         value = os.environ.get(env_var)
         if value:
@@ -217,9 +216,18 @@ class TestCliSurface:
         result = _invoke("--help")
         assert result.exit_code == 0
         for opt in (
-            "--model", "--output", "--output-dir", "--device", "--ep",
-            "--validate", "--no-validate", "--verbose", "--compiler",
-            "--qnn-sdk-root", "--embed", "--list",
+            "--model",
+            "--output",
+            "--output-dir",
+            "--device",
+            "--ep",
+            "--validate",
+            "--no-validate",
+            "--verbose",
+            "--compiler",
+            "--qnn-sdk-root",
+            "--embed",
+            "--list",
         ):
             assert opt in result.output, f"--help missing {opt}"
 
@@ -241,9 +249,7 @@ class TestCliSurface:
         out = result.output.lower()
         assert "ort" in out and "qairt" in out
 
-    def test_reject_already_compiled_model(
-        self, simple_matmul_onnx: Path, tmp_path: Path
-    ) -> None:
+    def test_reject_already_compiled_model(self, simple_matmul_onnx: Path, tmp_path: Path) -> None:
         # Build an EPContext-looking ONNX by hand (no real compile needed).
         x = onnx.helper.make_tensor_value_info("input", onnx.TensorProto.FLOAT, [1, 4])
         y = onnx.helper.make_tensor_value_info("output", onnx.TensorProto.FLOAT, [1, 4])
@@ -256,10 +262,13 @@ class TestCliSurface:
             domain="com.microsoft",
         )
         graph = onnx.helper.make_graph([node], "fake_ctx", [x], [y])
-        model = onnx.helper.make_model(graph, opset_imports=[
-            onnx.helper.make_opsetid("", 17),
-            onnx.helper.make_opsetid("com.microsoft", 1),
-        ])
+        model = onnx.helper.make_model(
+            graph,
+            opset_imports=[
+                onnx.helper.make_opsetid("", 17),
+                onnx.helper.make_opsetid("com.microsoft", 1),
+            ],
+        )
         model.ir_version = 8
         ctx_path = tmp_path / "fake_ctx.onnx"
         onnx.save(model, str(ctx_path))
@@ -269,8 +278,7 @@ class TestCliSurface:
         assert result.exit_code != 0
         combined = (result.output or "") + (str(result.exception) if result.exception else "")
         assert (
-            "already a compiled" in combined.lower()
-            or "cannot be re-compiled" in combined.lower()
+            "already a compiled" in combined.lower() or "cannot be re-compiled" in combined.lower()
         )
 
 
@@ -308,9 +316,7 @@ def test_unsupported_ep_returns_error(ep: str, simple_matmul_onnx: Path) -> None
     src_hash = _sha256(simple_matmul_onnx)
     result = _invoke("-m", str(simple_matmul_onnx), "--ep", ep)
 
-    assert result.exit_code != 0, (
-        f"--ep {ep} should be rejected but exit was 0.\n{result.output}"
-    )
+    assert result.exit_code != 0, f"--ep {ep} should be rejected but exit was 0.\n{result.output}"
     combined = result.output.lower()
     assert "does not support epcontext compilation" in combined, (
         f"Expected unsupported-EP error message for {ep}.\n{result.output}"
@@ -327,9 +333,7 @@ def test_unsupported_ep_returns_error(ep: str, simple_matmul_onnx: Path) -> None
 @pytest.mark.e2e
 class TestOutputPaths:
     @pytest.mark.parametrize("ep", EPCONTEXT_EPS)
-    def test_explicit_output_file(
-        self, ep: str, simple_matmul_onnx: Path, tmp_path: Path
-    ) -> None:
+    def test_explicit_output_file(self, ep: str, simple_matmul_onnx: Path, tmp_path: Path) -> None:
         require_ep(ep)
         out = tmp_path / "custom_name.onnx"
         result = _invoke("-m", str(simple_matmul_onnx), "--ep", ep, "-o", str(out))
@@ -341,9 +345,7 @@ class TestOutputPaths:
         require_ep(ep)
         out_dir = tmp_path / "out"
         out_dir.mkdir()
-        result = _invoke(
-            "-m", str(simple_matmul_onnx), "--ep", ep, "--output-dir", str(out_dir)
-        )
+        result = _invoke("-m", str(simple_matmul_onnx), "--ep", ep, "--output-dir", str(out_dir))
         assert result.exit_code == 0, result.output
         produced = [p for p in out_dir.glob("*.onnx") if is_compiled_onnx(p)]
         assert len(produced) == 1, f"Expected exactly one EPContext .onnx, got {produced}"
@@ -403,8 +405,14 @@ class TestValidate:
         require_ep(ep)
         out = tmp_path / "no_validate.onnx"
         result = _invoke(
-            "-m", str(simple_matmul_onnx), "--ep", ep, "--no-validate", "--verbose",
-            "-o", str(out),
+            "-m",
+            str(simple_matmul_onnx),
+            "--ep",
+            ep,
+            "--no-validate",
+            "--verbose",
+            "-o",
+            str(out),
         )
         assert result.exit_code == 0, result.output
         assert out.is_file() and is_compiled_onnx(out)
@@ -420,7 +428,13 @@ class TestValidate:
         require_ep(ep)
         out = tmp_path / "validated.onnx"
         result = _invoke(
-            "-m", str(simple_matmul_onnx), "--ep", ep, "--verbose", "-o", str(out),
+            "-m",
+            str(simple_matmul_onnx),
+            "--ep",
+            ep,
+            "--verbose",
+            "-o",
+            str(out),
         )
         assert result.exit_code == 0, result.output
         assert out.is_file() and is_compiled_onnx(out)
@@ -459,9 +473,17 @@ class TestQairtBackend:
 
         out = tmp_path / "qairt.onnx"
         result = _invoke(
-            "-m", str(simple_matmul_onnx), "--ep", "qnn",
-            "--compiler", "qairt", "--qnn-sdk-root", str(sdk),
-            "-o", str(out), "--verbose",
+            "-m",
+            str(simple_matmul_onnx),
+            "--ep",
+            "qnn",
+            "--compiler",
+            "qairt",
+            "--qnn-sdk-root",
+            str(sdk),
+            "-o",
+            str(out),
+            "--verbose",
         )
         assert result.exit_code == 0, result.output
         lower = result.output.lower()
@@ -476,9 +498,7 @@ class TestQairtBackend:
         assert bin_path.is_file(), f"QAIRT intermediate .bin missing: {bin_path}"
         assert info_path.is_file(), f"QAIRT cache_info.json missing: {info_path}"
 
-    def test_qairt_backend_with_embed(
-        self, simple_matmul_onnx: Path, tmp_path: Path
-    ) -> None:
+    def test_qairt_backend_with_embed(self, simple_matmul_onnx: Path, tmp_path: Path) -> None:
         """``--compiler qairt --embed`` produces an inlined EPContext artifact.
 
         Strict: any failure here is either a QAIRT bug or a missing
@@ -490,9 +510,18 @@ class TestQairtBackend:
 
         out = tmp_path / "qairt_embed.onnx"
         result = _invoke(
-            "-m", str(simple_matmul_onnx), "--ep", "qnn",
-            "--compiler", "qairt", "--qnn-sdk-root", str(sdk),
-            "--embed", "-o", str(out), "--verbose",
+            "-m",
+            str(simple_matmul_onnx),
+            "--ep",
+            "qnn",
+            "--compiler",
+            "qairt",
+            "--qnn-sdk-root",
+            str(sdk),
+            "--embed",
+            "-o",
+            str(out),
+            "--verbose",
         )
         assert result.exit_code == 0, result.output
         assert_epcontext_artifact(out, simple_matmul_onnx, embed=True)
@@ -571,11 +600,15 @@ class TestConfigFile:
         out_dir.mkdir()
         out = out_dir / "cli_wins.onnx"
         result = _invoke(
-            "-m", str(simple_matmul_onnx), "-c", str(cfg),
-            "--embed",       # overrides config embed_context=false
-            "--validate",    # overrides config validate=false
-            "--verbose",     # so we can observe the validation log line
-            "-o", str(out),
+            "-m",
+            str(simple_matmul_onnx),
+            "-c",
+            str(cfg),
+            "--embed",  # overrides config embed_context=false
+            "--validate",  # overrides config validate=false
+            "--verbose",  # so we can observe the validation log line
+            "-o",
+            str(out),
         )
         assert result.exit_code == 0, result.output
         lower = result.output.lower()
@@ -630,12 +663,9 @@ def test_reject_recompile_of_real_compiled_output(
     # Second compile on that artifact must be rejected.
     second = _invoke("-m", str(out), "--ep", ep)
     assert second.exit_code != 0, second.output
-    combined = (second.output or "") + (
-        str(second.exception) if second.exception else ""
-    )
+    combined = (second.output or "") + (str(second.exception) if second.exception else "")
     assert (
-        "already a compiled" in combined.lower()
-        or "cannot be re-compiled" in combined.lower()
+        "already a compiled" in combined.lower() or "cannot be re-compiled" in combined.lower()
     ), combined
 
 
@@ -645,8 +675,7 @@ def test_reject_recompile_of_real_compiled_output(
 
 _EPCONTEXT_CAPABLE_EPS = ("qnn", "openvino", "vitisai", "nv_tensorrt_rtx")
 EP_DEVICE_SUPPORT: dict[str, tuple[str, ...]] = {
-    alias: EP_SUPPORTED_DEVICES[normalize_ep_name(alias)]
-    for alias in _EPCONTEXT_CAPABLE_EPS
+    alias: EP_SUPPORTED_DEVICES[normalize_ep_name(alias)] for alias in _EPCONTEXT_CAPABLE_EPS
 }
 
 
@@ -755,9 +784,7 @@ _BAD_INPUT_CONFLICT_PARAMS = _expand_conflict_inputs(EP_DEVICE_SUPPORT)
 
 @pytest.mark.e2e
 @pytest.mark.parametrize("device,ep", _BAD_INPUT_CONFLICT_PARAMS)
-def test_bad_input_device_ep_conflict(
-    device: str, ep: str, simple_matmul_onnx: Path
-) -> None:
+def test_bad_input_device_ep_conflict(device: str, ep: str, simple_matmul_onnx: Path) -> None:
     """``--device X --ep Y`` is rejected when Y does not support X.
 
     Gated on ``ep`` being registered on this host so the ``sysinfo``
@@ -768,15 +795,10 @@ def test_bad_input_device_ep_conflict(
     require_ep(ep)
     src_hash = _sha256(simple_matmul_onnx)
     result = _invoke("-m", str(simple_matmul_onnx), "--device", device, "--ep", ep)
-    # Two valid rejection paths depending on whether ORT enumerates ``ep``
-    # on ``device``:
-    #   * Yes (e.g. QNN on the cpu node) -> ``_resolve_compile_provider``
-    #     policy check raises ``--ep X cannot run on --device Y``.
-    #   * No (e.g. NvTensorRTRTX is GPU-only) -> ``resolve_device`` raises
-    #     ``Device 'X' requested but no compatible EP is available``.
+    # ``resolve_device`` raises `EP '{ep}' does not support device '{device}'``.
     _assert_rejected(
         result,
-        (f"cannot run on --device {device}", "no compatible EP is available"),
+        (f"does not support device '{device}'"),
         src_hash,
         simple_matmul_onnx,
     )
@@ -793,25 +815,19 @@ def test_bad_input_unsupported_ep(ep: str, simple_matmul_onnx: Path) -> None:
     require_ep(ep)
     src_hash = _sha256(simple_matmul_onnx)
     result = _invoke("-m", str(simple_matmul_onnx), "--ep", ep)
-    _assert_rejected(
-        result, "does not support EPContext compilation", src_hash, simple_matmul_onnx
-    )
+    _assert_rejected(result, "does not support EPContext compilation", src_hash, simple_matmul_onnx)
 
 
 # Pair each EP with a device it supports. With no ``--device``, ``sysinfo``
 # falls back to CPU when the requested EP isn't registered, which then
 # trips the policy check ("cannot run on --device cpu") instead of the
 # host-state rejection this test targets.
-_EP_NOT_REGISTERED_PARAMS = [
-    (ep, EP_DEVICE_SUPPORT[ep][0]) for ep in _EPCONTEXT_CAPABLE_EPS
-]
+_EP_NOT_REGISTERED_PARAMS = [(ep, EP_DEVICE_SUPPORT[ep][0]) for ep in _EPCONTEXT_CAPABLE_EPS]
 
 
 @pytest.mark.e2e
 @pytest.mark.parametrize("ep,device", _EP_NOT_REGISTERED_PARAMS)
-def test_bad_input_ep_not_registered(
-    ep: str, device: str, simple_matmul_onnx: Path
-) -> None:
+def test_bad_input_ep_not_registered(ep: str, device: str, simple_matmul_onnx: Path) -> None:
     """``--ep X`` on a host without X is rejected.
 
     With the EP unavailable on host, ``sysinfo``'s device-resolution
@@ -821,12 +837,8 @@ def test_bad_input_ep_not_registered(
     """
     require_not_ep(ep)
     src_hash = _sha256(simple_matmul_onnx)
-    result = _invoke(
-        "-m", str(simple_matmul_onnx), "--device", device, "--ep", ep
-    )
-    _assert_rejected(
-        result, "is not available on this system", src_hash, simple_matmul_onnx
-    )
+    result = _invoke("-m", str(simple_matmul_onnx), "--device", device, "--ep", ep)
+    _assert_rejected(result, "is not available on this system", src_hash, simple_matmul_onnx)
 
 
 @pytest.mark.e2e

--- a/tests/unit/commands/test_compile_quantize_flags.py
+++ b/tests/unit/commands/test_compile_quantize_flags.py
@@ -168,13 +168,25 @@ class TestCompileAutoDeviceEndToEnd:
             ("gpu", "vitisai"),
         ],
     )
-    def test_incompatible_pair_rejected(self, device, ep):
-        """Incompatible (device, ep) pairs raise ``click.UsageError`` instead
-        of silently overriding the user's intent (regression for #521)."""
-        import click
+    def test_incompatible_pair_rejected(self, device, ep, tmp_path):
+        """Incompatible (device, ep) pairs surface as ``click.UsageError`` from
+        the compile CLI (regression for #521).
 
-        with pytest.raises(click.UsageError):
-            _resolve_compile_provider(device, ep)
+        Policy enforcement lives in ``resolve_device`` (see
+        ``tests/unit/sysinfo/test_device.py::test_explicit_device_ep_policy_mismatch_raises``);
+        this test pins the CLI wrapping (``ValueError`` -> ``UsageError``).
+        """
+        from click.testing import CliRunner
+
+        from winml.modelkit.commands.compile import compile
+
+        model_file = tmp_path / "model.onnx"
+        model_file.write_bytes(b"fake")
+
+        result = CliRunner().invoke(compile, ["-m", str(model_file), "-d", device, "--ep", ep])
+
+        assert result.exit_code != 0
+        assert "does not support device" in result.output
 
 
 # Note: unknown / out-of-set devices are validated upstream by

--- a/tests/unit/commands/test_ep_device_pair.py
+++ b/tests/unit/commands/test_ep_device_pair.py
@@ -15,7 +15,6 @@ ordered tuple per EP whose first element is the canonical default device.
 
 from __future__ import annotations
 
-import click
 import pytest
 
 
@@ -72,8 +71,9 @@ class TestEpSupportedDevices:
 
 
 class TestCompileIncompatiblePair:
-    """``_resolve_compile_provider`` must reject (device, ep) combos that the
-    policy table marks as unsupported."""
+    """``winml compile`` must reject (device, ep) combos that the policy table
+    marks as unsupported. Enforcement lives in ``resolve_device`` (sysinfo);
+    these tests pin the CLI-surface behavior (regression for #521)."""
 
     @pytest.mark.parametrize(
         ("device", "ep"),
@@ -88,11 +88,18 @@ class TestCompileIncompatiblePair:
             ("npu", "migraphx"),
         ],
     )
-    def test_incompatible_pair_rejected(self, device: str, ep: str) -> None:
-        from winml.modelkit.commands.compile import _resolve_compile_provider
+    def test_incompatible_pair_rejected(self, device: str, ep: str, tmp_path) -> None:
+        from click.testing import CliRunner
 
-        with pytest.raises((click.UsageError, click.ClickException)):
-            _resolve_compile_provider(device, ep)
+        from winml.modelkit.commands.compile import compile
+
+        model_file = tmp_path / "model.onnx"
+        model_file.write_bytes(b"fake")
+
+        result = CliRunner().invoke(compile, ["-m", str(model_file), "-d", device, "--ep", ep])
+
+        assert result.exit_code != 0
+        assert "does not support device" in result.output
 
     @pytest.mark.parametrize(
         ("device", "ep", "expected"),

--- a/tests/unit/session/test_winml_session.py
+++ b/tests/unit/session/test_winml_session.py
@@ -681,12 +681,16 @@ class TestWinMLSessionExplicitProviders:
         assert "C" in outputs
 
     def test_explicit_ep_and_device_both_required(self, simple_matmul_onnx: Path):
-        """Regression: ep=qnn + device=cpu must bind QNN-on-CPU, not QNN-on-NPU.
+        """Regression: ep=qnn + device=gpu must bind QNN-on-GPU, not QNN-on-NPU.
 
         When both filters are set, ``add_ep_for_device`` must match ep_name
         AND device_type. Previously the explicit-EP path ignored device, so
         listing order in ``ort.get_ep_devices()`` decided the binding and
-        ``--ep qnn --device cpu`` could silently land on QNN-on-NPU.
+        ``--ep qnn --device gpu`` could silently land on QNN-on-NPU.
+
+        Both ``(npu, qnn)`` and ``(gpu, qnn)`` are policy-valid per
+        ``EP_SUPPORTED_DEVICES`` — that's what makes the disambiguation
+        ambiguous and the regression possible.
         """
         from types import SimpleNamespace
         from unittest.mock import patch
@@ -695,14 +699,14 @@ class TestWinMLSessionExplicitProviders:
 
         from winml.modelkit.sysinfo.device import _get_device_ep_map_from_ort
 
-        # NPU listed first (the trap); CPU second (the correct pick).
+        # NPU listed first (the trap); GPU second (the correct pick).
         npu_dev = SimpleNamespace(
             ep_name="QNNExecutionProvider",
             device=SimpleNamespace(type=ort.OrtHardwareDeviceType.NPU),
         )
-        cpu_dev = SimpleNamespace(
+        gpu_dev = SimpleNamespace(
             ep_name="QNNExecutionProvider",
-            device=SimpleNamespace(type=ort.OrtHardwareDeviceType.CPU),
+            device=SimpleNamespace(type=ort.OrtHardwareDeviceType.GPU),
         )
         captured: list = []
 
@@ -712,11 +716,11 @@ class TestWinMLSessionExplicitProviders:
         _get_device_ep_map_from_ort.cache_clear()
         try:
             with (
-                patch("onnxruntime.get_ep_devices", return_value=[npu_dev, cpu_dev]),
+                patch("onnxruntime.get_ep_devices", return_value=[npu_dev, gpu_dev]),
                 patch(
                     "winml.modelkit.sysinfo.device._get_device_ep_map_from_ort",
                     return_value={
-                        "cpu": ("QNNExecutionProvider",),
+                        "gpu": ("QNNExecutionProvider",),
                         "npu": ("QNNExecutionProvider",),
                     },
                 ),
@@ -724,16 +728,16 @@ class TestWinMLSessionExplicitProviders:
             ):
                 session = WinMLSession(
                     onnx_path=simple_matmul_onnx,
-                    device="cpu",
+                    device="gpu",
                     ep="qnn",
                 )
                 # Drive the binding without building a real InferenceSession,
                 # since the mock ep_devices would not load.
-                session._build_session_options("cpu")
+                session._build_session_options("gpu")
         finally:
             _get_device_ep_map_from_ort.cache_clear()
 
-        assert captured == [ort.OrtHardwareDeviceType.CPU], (
+        assert captured == [ort.OrtHardwareDeviceType.GPU], (
             f"binding picked the wrong device: {captured}"
         )
 

--- a/tests/unit/sysinfo/test_device.py
+++ b/tests/unit/sysinfo/test_device.py
@@ -386,7 +386,7 @@ class TestResolveDeviceWithEp:
         assert available == ["npu", "gpu"]
 
     def test_ep_explicit_device_filtered_out_raises(self) -> None:
-        """ep='qnn' + device='cpu' raises: cpu has no compatible EP within {QNN}."""
+        """ep='qnn' + device='cpu' raises the policy error before availability is checked."""
         with (
             _patch_device_ep_map(
                 {
@@ -401,9 +401,41 @@ class TestResolveDeviceWithEp:
                     {"QNNExecutionProvider", "CPUExecutionProvider"},
                 ),
             ),
-            pytest.raises(ValueError, match="no compatible EP"),
+            pytest.raises(ValueError, match="does not support device 'cpu'"),
         ):
             resolve_device("cpu", ep="qnn")
+
+    @pytest.mark.parametrize(
+        ("device", "ep"),
+        [
+            ("cpu", "qnn"),
+            ("cpu", "dml"),
+            ("cpu", "vitisai"),
+            ("cpu", "migraphx"),
+            ("npu", "cpu"),
+            ("npu", "dml"),
+            ("npu", "migraphx"),
+            ("gpu", "cpu"),
+            ("gpu", "vitisai"),
+        ],
+    )
+    def test_explicit_device_ep_policy_mismatch_raises(self, device: str, ep: str) -> None:
+        """Policy check rejects (device, ep) combos that ``EP_SUPPORTED_DEVICES`` forbids.
+
+        Independent of host EP availability — raises the policy error before
+        consulting the runtime device-EP map.
+        """
+        with (
+            _patch_device_ep_map(
+                {
+                    "npu": ("QNNExecutionProvider",),
+                    "gpu": ("QNNExecutionProvider", "DmlExecutionProvider"),
+                    "cpu": ("CPUExecutionProvider",),
+                }
+            ),
+            pytest.raises(ValueError, match=f"EP '{ep}' does not support device '{device}'"),
+        ):
+            resolve_device(device, ep=ep)
 
 
 class TestResolveEps:


### PR DESCRIPTION
Found when investigating https://github.com/microsoft/winml-cli/issues/829

# Change 1
When `resolve_device`, the returned device is already checked against ep, so use it directly.

So the previous code check is useless, simplified it and change test to check against `compile` directly

# Change 2
in `resolve_device` check against the hard code list first instead of into real ort ep device map, see issue #860

# Change 3
in `register_ep`, add a dup check for provider name