### PR TITLE
chore(cli): convert boolean is_flag options to --flag/--no-flag pairs

### DIFF
--- a/src/winml/modelkit/commands/build.py
+++ b/src/winml/modelkit/commands/build.py
@@ -436,22 +436,23 @@ def _validate_loader_tasks_for_model(
     help="Output directory for all build artifacts",
 )
 @click.option(
-    "--use-cache",
-    is_flag=True,
+    "--use-cache/--no-use-cache",
     default=False,
+    show_default=True,
     help="Use WinML CLI global cache (~/.cache/winml/). Mutually exclusive with -o.",
 )
 @click.option(
-    "--rebuild",
-    is_flag=True,
+    "--rebuild/--no-rebuild",
     default=False,
+    show_default=True,
     help="Overwrite existing artifacts and rebuild",
 )
 @click.option(
-    "--no-quant",
-    is_flag=True,
-    default=False,
-    help="Skip quantization (overrides config)",
+    "--quant/--no-quant",
+    "quant",
+    default=True,
+    show_default=True,
+    help="Enable quantization (use --no-quant to skip, overrides config)",
 )
 @click.option(
     "--no-compile/--compile",
@@ -472,16 +473,18 @@ def _validate_loader_tasks_for_model(
     optional_message="Default: auto-detect.",
 )
 @click.option(
-    "--no-analyze",
-    is_flag=True,
-    default=False,
-    help="Skip analyzer loop during build",
+    "--analyze/--no-analyze",
+    "analyze",
+    default=True,
+    show_default=True,
+    help="Run analyzer loop during build (use --no-analyze to skip)",
 )
 @click.option(
-    "--no-optimize",
-    is_flag=True,
-    default=False,
-    help="Skip optimization (for pre-quantized ONNX models)",
+    "--optimize/--no-optimize",
+    "optimize",
+    default=True,
+    show_default=True,
+    help="Run optimization (use --no-optimize to skip for pre-quantized ONNX models)",
 )
 @click.option(
     "--max-optim-iterations",
@@ -503,12 +506,12 @@ def build(
     output_dir: str | None,
     use_cache: bool,
     rebuild: bool,
-    no_quant: bool,
+    quant: bool,
     no_compile: bool | None,
-    no_optimize: bool,
+    optimize: bool,
     ep: EPNameOrAlias | None,
     device: str,
-    no_analyze: bool,
+    analyze: bool,
     max_optim_iterations: int | None,
     allow_unsupported_nodes: bool,
     trust_remote_code: bool,
@@ -579,7 +582,7 @@ def build(
         if config_file is not None:
             config_or_configs = _load_config(
                 config_file,
-                no_quant=no_quant,
+                no_quant=not quant,
                 no_compile=no_compile,
             )
         else:
@@ -592,7 +595,7 @@ def build(
                 trust_remote_code=trust_remote_code,
                 device=device,
             )
-            if no_quant:
+            if not quant:
                 config_or_configs.quant = None
             # Auto-generated configs: compile disabled by default unless
             # --compile was explicitly passed (no_compile=False).
@@ -610,7 +613,7 @@ def build(
                 from ..config import resolve_quant_compile_config
 
                 resolved_quant, _ = resolve_quant_compile_config(device=device, ep=ep)
-                if no_quant or resolved_quant is None:
+                if not quant or resolved_quant is None:
                     cfg.quant = None
                 elif cfg.quant is None:
                     # Populate calibration identifiers from the loader/model
@@ -643,9 +646,7 @@ def build(
         # scratch state when the user passes the wrong file or a
         # hand-edited config (#P1 UX).
         _configs_to_validate: list[WinMLBuildConfig] = (
-            config_or_configs
-            if isinstance(config_or_configs, list)
-            else [config_or_configs]
+            config_or_configs if isinstance(config_or_configs, list) else [config_or_configs]
         )
         try:
             for _cfg in _configs_to_validate:
@@ -661,9 +662,9 @@ def build(
 
         # Build extra kwargs for pipeline control
         extra_kwargs: dict[str, Any] = {}
-        if no_optimize:
+        if not optimize:
             extra_kwargs["skip_optimize"] = True
-        if no_analyze:
+        if not analyze:
             extra_kwargs["hack_max_optim_iterations"] = 0
         elif max_optim_iterations is not None:
             extra_kwargs["hack_max_optim_iterations"] = max_optim_iterations

--- a/src/winml/modelkit/commands/compile.py
+++ b/src/winml/modelkit/commands/compile.py
@@ -85,9 +85,9 @@ console = Console()
     help="Path to QAIRT SDK root",
 )
 @click.option(
-    "--embed",
-    is_flag=True,
+    "--embed/--no-embed",
     default=False,
+    show_default=True,
     help="Embed EP context in ONNX file (default: external .bin file)",
 )
 @click.option(

--- a/src/winml/modelkit/commands/config.py
+++ b/src/winml/modelkit/commands/config.py
@@ -126,10 +126,11 @@ def _apply_stage_overrides(cfg: Any, *, no_quant: bool, no_compile: bool) -> Non
     help="Source library for TasksManager (default: transformers)",
 )
 @click.option(
-    "--no-quant",
-    is_flag=True,
-    default=False,
-    help="Exclude quantization from generated config (sets quant=None)",
+    "--quant/--no-quant",
+    "quant",
+    default=True,
+    show_default=True,
+    help="Include quantization in generated config (use --no-quant to exclude, sets quant=None)",
 )
 @click.option(
     "--no-compile/--compile",
@@ -156,7 +157,7 @@ def config(
     library_name: str,
     verbose: int,
     quiet: bool,
-    no_quant: bool,
+    quant: bool,
     no_compile: bool,
     trust_remote_code: bool,
 ) -> None:
@@ -289,7 +290,7 @@ def config(
             )
 
             # Apply --no-quant / --no-compile overrides
-            _apply_stage_overrides(config_obj, no_quant=no_quant, no_compile=no_compile)
+            _apply_stage_overrides(config_obj, no_quant=not quant, no_compile=no_compile)
 
             output_data = config_obj.to_dict()
             _is_onnx_mode = True
@@ -319,7 +320,7 @@ def config(
                     precision=precision,
                     trust_remote_code=trust_remote_code,
                     ep=ep,
-                    no_quant=no_quant,
+                    no_quant=not quant,
                     no_compile=no_compile,
                     output=output,
                     console=console,
@@ -347,7 +348,7 @@ def config(
             if module:
                 configs = generate_hf_build_config(module=module, **_shared_kwargs)
                 for cfg in configs:
-                    _apply_stage_overrides(cfg, no_quant=no_quant, no_compile=no_compile)
+                    _apply_stage_overrides(cfg, no_quant=not quant, no_compile=no_compile)
                 output_data = [cfg.to_dict() for cfg in configs]
                 _n_modules = len(configs)
                 # Use first config for display metadata
@@ -355,7 +356,7 @@ def config(
             else:
                 config_obj = generate_hf_build_config(**_shared_kwargs)
                 configs = []
-                _apply_stage_overrides(config_obj, no_quant=no_quant, no_compile=no_compile)
+                _apply_stage_overrides(config_obj, no_quant=not quant, no_compile=no_compile)
                 output_data = config_obj.to_dict()
                 _n_modules = 0
 

--- a/src/winml/modelkit/commands/eval.py
+++ b/src/winml/modelkit/commands/eval.py
@@ -112,9 +112,9 @@ logger = logging.getLogger(__name__)
     help="Shuffle dataset before sampling.",
 )
 @click.option(
-    "--streaming",
-    is_flag=True,
+    "--streaming/--no-streaming",
     default=False,
+    show_default=True,
     help="Stream dataset instead of downloading fully.",
 )
 @click.option(

--- a/src/winml/modelkit/commands/export.py
+++ b/src/winml/modelkit/commands/export.py
@@ -71,24 +71,31 @@ def _delete_onnx_with_external_data(onnx_path: Path) -> None:
 )
 @cli_utils.output_option("Output ONNX file path (e.g., model.onnx)", required=True)
 @click.option(
-    "--with-report",
-    is_flag=True,
+    "--with-report/--no-with-report",
     default=False,
+    show_default=True,
     help="Generate full export reports (markdown, JSON, console tree)",
 )
 @click.option(
-    "--clean-onnx",
-    "--no-hierarchy",
-    "no_hierarchy",
-    is_flag=True,
-    default=False,
-    help="Skip embedding hierarchy_tag metadata in ONNX (clean ONNX output)",
+    "--hierarchy/--no-hierarchy",
+    "hierarchy",
+    default=True,
+    show_default=True,
+    help="Embed hierarchy_tag metadata in ONNX output",
 )
 @click.option(
-    "--dynamo",
-    "dynamo",
+    "--clean-onnx",
+    "clean_onnx",
     is_flag=True,
     default=False,
+    hidden=True,
+    help="Deprecated alias for --no-hierarchy.",
+)
+@click.option(
+    "--dynamo/--no-dynamo",
+    "dynamo",
+    default=False,
+    show_default=True,
     help="Enable PyTorch 2.9+ dynamo export for rich node metadata",
 )
 @click.option(
@@ -132,7 +139,8 @@ def export(
     verbose: int,
     quiet: bool,
     with_report: bool,
-    no_hierarchy: bool,
+    hierarchy: bool,
+    clean_onnx: bool,
     dynamo: bool,
     torch_module: str | None,
     task: str | None,
@@ -195,14 +203,21 @@ def export(
         _build_export_dict = ec
         if not cli_utils.is_cli_provided(ctx, "task") and "task" in lc:
             task = lc["task"]
-        if not cli_utils.is_cli_provided(ctx, "no_hierarchy") and "enable_hierarchy_tags" in ec:
-            no_hierarchy = not ec["enable_hierarchy_tags"]
+        if (
+            not cli_utils.is_cli_provided(ctx, "hierarchy")
+            and not cli_utils.is_cli_provided(ctx, "clean_onnx")
+            and "enable_hierarchy_tags" in ec
+        ):
+            hierarchy = ec["enable_hierarchy_tags"]
         if not cli_utils.is_cli_provided(ctx, "dynamo") and "dynamo" in ec:
             dynamo = ec["dynamo"]
 
     from ..export import InputTensorSpec, OutputTensorSpec, WinMLExportConfig
     from ..export import export_pytorch as export_onnx
     from ..loader import load_hf_model
+
+    if clean_onnx and not cli_utils.is_cli_provided(ctx, "hierarchy"):
+        hierarchy = False
 
     # Configure logging — stderr only, shared format with the rest of the CLI.
     configure_logging(verbosity=verbose, quiet=quiet)
@@ -332,8 +347,8 @@ def export(
     # Layer 2: --export-config file overrides
     config_kwargs.update(export_config_dict)
     # Layer 3: explicit CLI options (highest precedence)
-    if cli_utils.is_cli_provided(ctx, "no_hierarchy"):
-        config_kwargs["enable_hierarchy_tags"] = not no_hierarchy
+    if cli_utils.is_cli_provided(ctx, "hierarchy") or cli_utils.is_cli_provided(ctx, "clean_onnx"):
+        config_kwargs["enable_hierarchy_tags"] = hierarchy
     if cli_utils.is_cli_provided(ctx, "verbose"):
         config_kwargs["verbose"] = bool(verbose)
     if cli_utils.is_cli_provided(ctx, "dynamo"):

--- a/src/winml/modelkit/commands/export.py
+++ b/src/winml/modelkit/commands/export.py
@@ -216,8 +216,13 @@ def export(
     from ..export import export_pytorch as export_onnx
     from ..loader import load_hf_model
 
-    if clean_onnx and not cli_utils.is_cli_provided(ctx, "hierarchy"):
-        hierarchy = False
+    if clean_onnx:
+        click.echo(
+            "warning: --clean-onnx is deprecated; use --no-hierarchy instead.",
+            err=True,
+        )
+        if not cli_utils.is_cli_provided(ctx, "hierarchy"):
+            hierarchy = False
 
     # Configure logging — stderr only, shared format with the rest of the CLI.
     configure_logging(verbosity=verbose, quiet=quiet)

--- a/src/winml/modelkit/commands/inspect.py
+++ b/src/winml/modelkit/commands/inspect.py
@@ -105,10 +105,10 @@ def _looks_like_local_path(model_id: str) -> bool:
     help="Override auto-detected task (e.g., image-classification, feature-extraction)",
 )
 @click.option(
-    "-H",
-    "--hierarchy",
-    is_flag=True,
+    "-H/-N",
+    "--hierarchy/--no-hierarchy",
     default=False,
+    show_default=True,
     help="Show HF module hierarchy (uses random weights, no weight download)",
 )
 @click.option(

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -1067,21 +1067,22 @@ def _run_simple_loop(
     help='JSON file with shape overrides (e.g., {"height": 480, "width": 480}).',
 )
 @click.option(
-    "--no-quantize",
-    is_flag=True,
-    default=False,
-    help="Skip quantization during model build",
+    "--quantize/--no-quantize",
+    "quantize",
+    default=True,
+    show_default=True,
+    help="Include quantization during model build (use --no-quantize to skip)",
 )
 @click.option(
-    "--rebuild",
-    is_flag=True,
+    "--rebuild/--no-rebuild",
     default=False,
+    show_default=True,
     help="Force rebuild even if cached artifacts exist",
 )
 @click.option(
-    "--ignore-cache",
-    is_flag=True,
+    "--ignore-cache/--no-ignore-cache",
     default=False,
+    show_default=True,
     help="Build from scratch in a temp folder (discard after benchmarking)",
 )
 @cli_utils.skip_build_option()
@@ -1097,9 +1098,9 @@ def _run_simple_loop(
     "not '--module encoder.layer.0.attention' (a path, will not match).",
 )
 @click.option(
-    "--monitor",
-    is_flag=True,
+    "--monitor/--no-monitor",
     default=False,
+    show_default=True,
     help="Show live hardware utilization chart for the benchmarked device (NPU, GPU, or CPU)",
 )
 @click.option(
@@ -1125,7 +1126,7 @@ def perf(
     output: Path | None,
     batch_size: int,
     shape_config_path: Path | None,
-    no_quantize: bool,
+    quantize: bool,
     rebuild: bool,
     ignore_cache: bool,
     skip_build: bool,
@@ -1216,7 +1217,7 @@ def perf(
             iterations=iterations,
             warmup=warmup,
             batch_size=batch_size,
-            no_quantize=no_quantize,
+            no_quantize=not quantize,
             output=output,
             verbose=bool(verbose),
             console=console,
@@ -1262,7 +1263,7 @@ def perf(
         warmup=warmup,
         batch_size=batch_size,
         output_path=output,
-        no_quantize=no_quantize,
+        no_quantize=not quantize,
         rebuild=rebuild,
         ignore_cache=ignore_cache,
         skip_build=skip_build,

--- a/src/winml/modelkit/commands/quantize.py
+++ b/src/winml/modelkit/commands/quantize.py
@@ -81,15 +81,15 @@ console = Console()
     help="Activation quantization type. Overrides --precision.",
 )
 @click.option(
-    "--per-channel",
-    is_flag=True,
+    "--per-channel/--no-per-channel",
     default=False,
+    show_default=True,
     help="Use per-channel quantization",
 )
 @click.option(
-    "--symmetric",
-    is_flag=True,
+    "--symmetric/--no-symmetric",
     default=False,
+    show_default=True,
     help="Use symmetric quantization",
 )
 @click.option(

--- a/src/winml/modelkit/commands/serve.py
+++ b/src/winml/modelkit/commands/serve.py
@@ -54,9 +54,9 @@ if TYPE_CHECKING:
     help="Unload session after N seconds idle (0 = never)",
 )
 @click.option(
-    "--multi",
-    is_flag=True,
+    "--multi/--no-multi",
     default=False,
+    show_default=True,
     help="Enable multi-model manager",
 )
 @click.option(
@@ -67,9 +67,9 @@ if TYPE_CHECKING:
     help="Memory budget in MB for multi-model manager",
 )
 @click.option(
-    "--auto-reload",
-    is_flag=True,
+    "--auto-reload/--no-auto-reload",
     default=False,
+    show_default=True,
     hidden=True,
     help="Dev mode: auto-reload on file changes",
 )

--- a/src/winml/modelkit/utils/cli.py
+++ b/src/winml/modelkit/utils/cli.py
@@ -329,9 +329,9 @@ def trust_remote_code_option(optional_message: str | None = None) -> Callable[[F
         return value
 
     return click.option(
-        "--trust-remote-code",
-        is_flag=True,
+        "--trust-remote-code/--no-trust-remote-code",
         default=False,
+        show_default=True,
         help=help_text,
         callback=_warn_callback,
     )
@@ -358,9 +358,9 @@ def allow_unsupported_nodes_option(optional_message: str | None = None) -> Calla
         help_text = f"{help_text} {optional_message}"
 
     return click.option(
-        "--allow-unsupported-nodes",
-        is_flag=True,
+        "--allow-unsupported-nodes/--no-allow-unsupported-nodes",
         default=False,
+        show_default=True,
         help=help_text,
     )
 

--- a/tests/unit/commands/test_boolean_flag_pairs.py
+++ b/tests/unit/commands/test_boolean_flag_pairs.py
@@ -151,14 +151,9 @@ class TestDefaultValues:
 class TestFlagValueParsing:
     """Verify that positive and negative flag forms set the correct values.
 
-    Uses a minimal Click invocation that captures ctx.params without running
-    the full command logic.
+    Uses Click's make_context with resilient_parsing to parse flags and inspect
+    ctx.params directly, without running the full command logic.
     """
-
-    @pytest.fixture
-    def _capture_params(self):
-        """Return a dict that will be populated with captured params."""
-        return {}
 
     @pytest.mark.parametrize(
         ("command", "flag", "param_name", "expected_value"),
@@ -212,30 +207,12 @@ class TestFlagValueParsing:
     def test_flag_sets_expected_value(
         self, command, flag: str, param_name: str, expected_value
     ) -> None:
-        """Verify each flag form correctly sets its parameter value."""
-        # Use --help trick: invoke with the flag + --help so the command
-        # doesn't actually run but Click still parses the flag.
-        # Instead, we inspect Click's param parsing directly.
-        runner = CliRunner()
-        # We only need to confirm Click accepts the flag without error.
-        # Invoke with --help after the flag to avoid missing required args.
-        result = runner.invoke(command, [flag, "--help"])
-        assert result.exit_code == 0, f"{flag} failed: {result.output}"
+        """Verify each flag form correctly sets its parameter value via make_context."""
+        import click as _click
 
-        # Also verify via Click's internal parameter resolution that the
-        # flag actually maps to the expected param.
-        found = False
-        for param in command.params:
-            if param.name == param_name:
-                found = True
-                # For boolean flag pairs, check that the flag string appears
-                # in either the primary or secondary opts
-                all_opts = list(param.opts) + list(param.secondary_opts)
-                # The flag or its bare form should be recognized
-                flag_bare = flag.lstrip("-")
-                assert (
-                    any(flag_bare in opt.lstrip("-") for opt in all_opts)
-                    or param.name == param_name
-                )
-                break
-        assert found, f"Param {param_name!r} not found on {command.name}"
+        ctx = _click.Context(command, info_name=command.name, resilient_parsing=True)
+        command.parse_args(ctx, [flag])
+        assert ctx.params[param_name] is expected_value, (
+            f"Expected {command.name} {flag} to set {param_name}={expected_value!r}, "
+            f"got {ctx.params[param_name]!r}"
+        )

--- a/tests/unit/commands/test_boolean_flag_pairs.py
+++ b/tests/unit/commands/test_boolean_flag_pairs.py
@@ -1,0 +1,94 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+from winml.modelkit.commands.build import build
+from winml.modelkit.commands.compile import compile
+from winml.modelkit.commands.config import config
+from winml.modelkit.commands.eval import eval as eval_cmd
+from winml.modelkit.commands.export import export
+from winml.modelkit.commands.inspect import inspect
+from winml.modelkit.commands.perf import perf
+from winml.modelkit.commands.quantize import quantize
+from winml.modelkit.commands.serve import serve
+
+
+@pytest.mark.parametrize(
+    ("command", "flags"),
+    [
+        (
+            build,
+            [
+                "--use-cache",
+                "--no-use-cache",
+                "--rebuild",
+                "--no-rebuild",
+                "--quant",
+                "--no-quant",
+                "--analyze",
+                "--no-analyze",
+                "--optimize",
+                "--no-optimize",
+                "--trust-remote-code",
+                "--no-trust-remote-code",
+                "--allow-unsupported-nodes",
+                "--no-allow-unsupported-nodes",
+            ],
+        ),
+        (compile, ["--embed", "--no-embed"]),
+        (
+            config,
+            ["--quant", "--no-quant", "--trust-remote-code", "--no-trust-remote-code"],
+        ),
+        (
+            eval_cmd,
+            [
+                "--streaming",
+                "--no-streaming",
+                "--allow-unsupported-nodes",
+                "--no-allow-unsupported-nodes",
+            ],
+        ),
+        (
+            export,
+            [
+                "--with-report",
+                "--no-with-report",
+                "--hierarchy",
+                "--no-hierarchy",
+                "--dynamo",
+                "--no-dynamo",
+            ],
+        ),
+        (inspect, ["--hierarchy", "--no-hierarchy", "-H", "-N"]),
+        (
+            perf,
+            [
+                "--quantize",
+                "--no-quantize",
+                "--rebuild",
+                "--no-rebuild",
+                "--ignore-cache",
+                "--no-ignore-cache",
+                "--monitor",
+                "--no-monitor",
+                "--allow-unsupported-nodes",
+                "--no-allow-unsupported-nodes",
+            ],
+        ),
+        (quantize, ["--per-channel", "--no-per-channel", "--symmetric", "--no-symmetric"]),
+        (serve, ["--multi", "--no-multi"]),
+    ],
+)
+def test_help_includes_boolean_flag_pairs(command, flags: list[str]) -> None:
+    result = CliRunner().invoke(command, ["--help"])
+
+    assert result.exit_code == 0, result.output
+    for flag in flags:
+        assert flag in result.output

--- a/tests/unit/commands/test_boolean_flag_pairs.py
+++ b/tests/unit/commands/test_boolean_flag_pairs.py
@@ -5,8 +5,14 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 from click.testing import CliRunner
+
+
+if TYPE_CHECKING:
+    import click
 
 from winml.modelkit.commands.build import build
 from winml.modelkit.commands.compile import compile
@@ -92,3 +98,144 @@ def test_help_includes_boolean_flag_pairs(command, flags: list[str]) -> None:
     assert result.exit_code == 0, result.output
     for flag in flags:
         assert flag in result.output
+
+
+# ---------------------------------------------------------------------------
+# Verify default values and that both positive/negative forms set correct values
+# ---------------------------------------------------------------------------
+
+
+def _get_param_default(command: click.Command, param_name: str) -> object:
+    """Get the default value of a Click parameter by its Python name."""
+    for param in command.params:
+        if param.name == param_name:
+            return param.default
+    msg = f"No param {param_name!r} on {command.name}"
+    raise ValueError(msg)
+
+
+class TestDefaultValues:
+    """Verify the default values for converted flags are correct."""
+
+    @pytest.mark.parametrize(
+        ("command", "param_name", "expected_default"),
+        [
+            # Group A: positive flags default False
+            (build, "use_cache", False),
+            (build, "rebuild", False),
+            (compile, "embed", False),
+            (eval_cmd, "streaming", False),
+            (export, "with_report", False),
+            (export, "dynamo", False),
+            (inspect, "hierarchy", False),
+            (perf, "rebuild", False),
+            (perf, "ignore_cache", False),
+            (perf, "monitor", False),
+            (quantize, "per_channel", False),
+            (quantize, "symmetric", False),
+            (serve, "multi", False),
+            (serve, "auto_reload", False),
+            # Group C: negative-to-positive flags default True
+            (build, "quant", True),
+            (build, "analyze", True),
+            (build, "optimize", True),
+            (config, "quant", True),
+            (perf, "quantize", True),
+            (export, "hierarchy", True),
+        ],
+    )
+    def test_default_value(self, command, param_name: str, expected_default) -> None:
+        assert _get_param_default(command, param_name) == expected_default
+
+
+class TestFlagValueParsing:
+    """Verify that positive and negative flag forms set the correct values.
+
+    Uses a minimal Click invocation that captures ctx.params without running
+    the full command logic.
+    """
+
+    @pytest.fixture
+    def _capture_params(self):
+        """Return a dict that will be populated with captured params."""
+        return {}
+
+    @pytest.mark.parametrize(
+        ("command", "flag", "param_name", "expected_value"),
+        [
+            # Positive form sets True
+            (build, "--use-cache", "use_cache", True),
+            (build, "--rebuild", "rebuild", True),
+            (build, "--quant", "quant", True),
+            (build, "--analyze", "analyze", True),
+            (build, "--optimize", "optimize", True),
+            (compile, "--embed", "embed", True),
+            (eval_cmd, "--streaming", "streaming", True),
+            (export, "--with-report", "with_report", True),
+            (export, "--hierarchy", "hierarchy", True),
+            (export, "--dynamo", "dynamo", True),
+            (inspect, "--hierarchy", "hierarchy", True),
+            (inspect, "-H", "hierarchy", True),
+            (perf, "--quantize", "quantize", True),
+            (perf, "--rebuild", "rebuild", True),
+            (perf, "--ignore-cache", "ignore_cache", True),
+            (perf, "--monitor", "monitor", True),
+            (quantize, "--per-channel", "per_channel", True),
+            (quantize, "--symmetric", "symmetric", True),
+            (serve, "--multi", "multi", True),
+            (serve, "--auto-reload", "auto_reload", True),
+            # Negative form sets False
+            (build, "--no-use-cache", "use_cache", False),
+            (build, "--no-rebuild", "rebuild", False),
+            (build, "--no-quant", "quant", False),
+            (build, "--no-analyze", "analyze", False),
+            (build, "--no-optimize", "optimize", False),
+            (compile, "--no-embed", "embed", False),
+            (eval_cmd, "--no-streaming", "streaming", False),
+            (export, "--no-with-report", "with_report", False),
+            (export, "--no-hierarchy", "hierarchy", False),
+            (export, "--no-dynamo", "dynamo", False),
+            (inspect, "--no-hierarchy", "hierarchy", False),
+            (inspect, "-N", "hierarchy", False),
+            (perf, "--no-quantize", "quantize", False),
+            (perf, "--no-rebuild", "rebuild", False),
+            (perf, "--no-ignore-cache", "ignore_cache", False),
+            (perf, "--no-monitor", "monitor", False),
+            (quantize, "--no-per-channel", "per_channel", False),
+            (quantize, "--no-symmetric", "symmetric", False),
+            (serve, "--no-multi", "multi", False),
+            (serve, "--no-auto-reload", "auto_reload", False),
+            # Backward compat: --clean-onnx (deprecated alias for --no-hierarchy)
+            (export, "--clean-onnx", "clean_onnx", True),
+        ],
+    )
+    def test_flag_sets_expected_value(
+        self, command, flag: str, param_name: str, expected_value
+    ) -> None:
+        """Verify each flag form correctly sets its parameter value."""
+        # Use --help trick: invoke with the flag + --help so the command
+        # doesn't actually run but Click still parses the flag.
+        # Instead, we inspect Click's param parsing directly.
+        runner = CliRunner()
+        # We only need to confirm Click accepts the flag without error.
+        # Invoke with --help after the flag to avoid missing required args.
+        result = runner.invoke(command, [flag, "--help"])
+        assert result.exit_code == 0, f"{flag} failed: {result.output}"
+
+        # Also verify via Click's internal parameter resolution that the
+        # flag actually maps to the expected param.
+        found = False
+        for param in command.params:
+            if param.name == param_name:
+                found = True
+                # For boolean flag pairs, check that the flag string appears
+                # in either the primary or secondary opts
+                all_opts = list(param.opts) + list(param.secondary_opts)
+                # The flag or its bare form should be recognized
+                flag_bare = flag.lstrip("-")
+                assert (
+                    any(flag_bare in opt.lstrip("-") for opt in all_opts)
+                    or param.name == param_name
+                )
+                break
+        assert found, f"Param {param_name!r} not found on {command.name}"

--- a/tests/unit/commands/test_export.py
+++ b/tests/unit/commands/test_export.py
@@ -277,11 +277,11 @@ class TestExportExportConfig:
         mock_load_hf_model: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """Test --clean-onnx sets enable_hierarchy_tags=False."""
+        """Test --clean-onnx sets enable_hierarchy_tags=False and emits deprecation warning."""
         from winml.modelkit.commands.export import export
 
         output_path = tmp_path / "model.onnx"
-        runner.invoke(
+        result = runner.invoke(
             export,
             ["--model", "test-model", "--output", str(output_path), "--clean-onnx"],
             obj={"debug": False},
@@ -290,6 +290,7 @@ class TestExportExportConfig:
         call_kwargs = mock_export_onnx.call_args.kwargs
         config = call_kwargs["export_config"]
         assert config.enable_hierarchy_tags is False
+        assert "--clean-onnx is deprecated" in result.output
 
     def test_export_no_hierarchy_disables_hierarchy_tags(
         self,

--- a/tests/unit/commands/test_export.py
+++ b/tests/unit/commands/test_export.py
@@ -66,8 +66,11 @@ class TestExportCLIInterface:
         assert "--verbose" in result.output
         assert "-v" in result.output
         assert "--with-report" in result.output
-        assert "--clean-onnx" in result.output
+        assert "--no-with-report" in result.output
+        assert "--hierarchy" in result.output
+        assert "--no-hierarchy" in result.output
         assert "--dynamo" in result.output
+        assert "--no-dynamo" in result.output
         assert "--torch-module" in result.output
         assert "--input-specs" in result.output
         assert "--export-config" in result.output
@@ -80,9 +83,7 @@ class TestExportCLIInterface:
 
         doc = getdoc(export) or ""
         examples = [
-            line.strip()
-            for line in doc.splitlines()
-            if line.strip().startswith("winml export")
+            line.strip() for line in doc.splitlines() if line.strip().startswith("winml export")
         ]
         assert examples, "Expected at least one winml export example in help docstring"
 
@@ -283,6 +284,27 @@ class TestExportExportConfig:
         runner.invoke(
             export,
             ["--model", "test-model", "--output", str(output_path), "--clean-onnx"],
+            obj={"debug": False},
+        )
+
+        call_kwargs = mock_export_onnx.call_args.kwargs
+        config = call_kwargs["export_config"]
+        assert config.enable_hierarchy_tags is False
+
+    def test_export_no_hierarchy_disables_hierarchy_tags(
+        self,
+        runner: CliRunner,
+        mock_export_onnx: MagicMock,
+        mock_load_hf_model: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Test --no-hierarchy sets enable_hierarchy_tags=False."""
+        from winml.modelkit.commands.export import export
+
+        output_path = tmp_path / "model.onnx"
+        runner.invoke(
+            export,
+            ["--model", "test-model", "--output", str(output_path), "--no-hierarchy"],
             obj={"debug": False},
         )
 


### PR DESCRIPTION
## Summary

Converts all `is_flag=True` Click boolean options to `--flag/--no-flag` pairs for consistency with the existing `--skip-build/--no-skip-build` pattern, as specified in #843.

## Changes

**Positive flags** (`--use-cache`, `--rebuild`, `--embed`, `--streaming`, `--with-report`, `--dynamo`, `--per-channel`, `--symmetric`, `--multi`, `--auto-reload`, `--ignore-cache`, `--monitor`, `--trust-remote-code`, `--allow-unsupported-nodes`) now accept an explicit `--no-xxx` counterpart.

**Negative flags** (`--no-quant`, `--no-analyze`, `--no-optimize`, `--no-quantize`, `--no-hierarchy`) are renamed to positive form (`--quant/--no-quant`, etc.) with `default=True`, so `--no-xxx` still works without breaking existing scripts.

**Export `--clean-onnx`** is preserved as a hidden deprecated flag that maps to `--no-hierarchy` behavior.

All `--help` output now shows both forms and the default value via `show_default=True`.

## Backward Compatibility

- All existing flag forms remain valid (e.g., `--no-quant` still works as the negative side of the pair)
- `--clean-onnx` preserved as hidden deprecated alias for `--no-hierarchy`
- No changes to internal helper function signatures or dataclass fields

Closes #843