### PR TITLE
fix(task): detect encoder-decoder fill-mask heads as text2text-generation

### DIFF
--- a/src/winml/modelkit/loader/task.py
+++ b/src/winml/modelkit/loader/task.py
@@ -498,6 +498,11 @@ def _detect_task_and_class_from_config(config: PretrainedConfig) -> tuple[str, t
                 # default. If one ever exposes multiple, supported[0] is an
                 # arbitrary pick -- warn (listing the tasks) but still proceed;
                 # pass --task to choose a different one.
+                # No _upgrade_fill_mask_for_seq2seq here: this task comes from the
+                # wrapped library's ONNX export list (get_supported_tasks), not from
+                # class->task inference, so the optimum fill-mask mislabel cannot
+                # arise on this path; rewriting could also yield a task outside that
+                # list. The correction is intentionally scoped to the class->task paths.
                 task = supported[0]
                 if len(supported) > 1:
                     logger.warning(

--- a/src/winml/modelkit/loader/task.py
+++ b/src/winml/modelkit/loader/task.py
@@ -271,7 +271,24 @@ def _detect_task_from_config(config: PretrainedConfig) -> str:
     """
     model_class = _resolve_model_class_from_config(config)
     task = _detect_task_from_model_class(model_class)
+    task = _upgrade_fill_mask_for_seq2seq(task, config)
     logger.info("Detected task: %s (from %s)", task, model_class.__name__)
+    return task
+
+
+def _upgrade_fill_mask_for_seq2seq(task: str, config: PretrainedConfig) -> str:
+    """Correct Optimum's ``fill-mask`` mislabel for encoder-decoder generation heads.
+
+    ``TasksManager`` maps some encoder-decoder ``*ForConditionalGeneration`` classes
+    (e.g. ``BartForConditionalGeneration``) to ``fill-mask``. A real masked-LM is
+    encoder-only, so a config that is ``is_encoder_decoder`` yet reported as
+    ``fill-mask`` is actually a seq2seq generator -> ``text2text-generation``.
+    Architecture-agnostic: keyed on the ``is_encoder_decoder`` flag, not model names.
+    Requires the flag to be explicitly ``True`` (HF configs set a real bool) so a
+    partial/duck-typed config without the field is never silently upgraded.
+    """
+    if task == "fill-mask" and getattr(config, "is_encoder_decoder", False) is True:
+        return "text2text-generation"
     return task
 
 
@@ -508,6 +525,7 @@ def _detect_task_and_class_from_config(config: PretrainedConfig) -> tuple[str, t
 
     # [2] Infer task from model class
     task = _detect_task_from_model_class(arch_model_class)
+    task = _upgrade_fill_mask_for_seq2seq(task, config)
     logger.info("Detected task: %s (from %s)", task, arch_name)
 
     # [3] Get model_type - REQUIRED for specialization lookup

--- a/tests/integration/loader/test_detect_task_and_class.py
+++ b/tests/integration/loader/test_detect_task_and_class.py
@@ -114,6 +114,9 @@ class TestSeq2SeqFillMaskCorrection:
         task, resolved_class = _detect_task_and_class_from_config(config)
 
         assert task == "text2text-generation"
+        # BartDecoderWrapper is WinML's encoder-decoder decoder sub-component class
+        # registered for (bart, text2text-generation) — i.e. the seq2seq route,
+        # not the AutoModelForMaskedLM that the fill-mask mislabel would produce.
         assert resolved_class.__name__ == "BartDecoderWrapper"
 
     def test_bert_masked_lm_stays_fill_mask(self):

--- a/tests/integration/loader/test_detect_task_and_class.py
+++ b/tests/integration/loader/test_detect_task_and_class.py
@@ -100,3 +100,26 @@ class TestSupportedModelsIntegration:
 
         assert task == "image-classification"
         assert "ImageClassification" in resolved_class.__name__
+
+
+@pytest.mark.slow
+class TestSeq2SeqFillMaskCorrection:
+    """Encoder-decoder generation heads that Optimum mislabels as fill-mask must
+    resolve to text2text-generation, not the encoder-only masked-LM task."""
+
+    def test_bart_conditional_generation_is_text2text(self):
+        """BartForConditionalGeneration -> text2text-generation / BartDecoderWrapper."""
+        config = AutoConfig.from_pretrained("facebook/bart-large-cnn")
+
+        task, resolved_class = _detect_task_and_class_from_config(config)
+
+        assert task == "text2text-generation"
+        assert resolved_class.__name__ == "BartDecoderWrapper"
+
+    def test_bert_masked_lm_stays_fill_mask(self):
+        """Encoder-only masked-LM is untouched (is_encoder_decoder is False)."""
+        config = AutoConfig.from_pretrained("bert-base-uncased")
+
+        task, _ = _detect_task_and_class_from_config(config)
+
+        assert task == "fill-mask"

--- a/tests/integration/test_task_consistency.py
+++ b/tests/integration/test_task_consistency.py
@@ -40,6 +40,9 @@ CASES = [
     # sam has a (sam, None) default-class sentinel plus a single real task; the
     # sentinel must not make detection fall through — it resolves to mask-generation.
     ("facebook/sam-vit-base", "mask-generation"),
+    # optimum mislabels BartForConditionalGeneration as fill-mask; an encoder-decoder
+    # reported as fill-mask is a seq2seq generator -> text2text-generation.
+    ("facebook/bart-large-cnn", "text2text-generation"),
 ]
 
 

--- a/tests/unit/loader/test_detect_task.py
+++ b/tests/unit/loader/test_detect_task.py
@@ -69,6 +69,17 @@ def test_upgrade_fill_mask_for_seq2seq_only_touches_fill_mask() -> None:
     assert _upgrade_fill_mask_for_seq2seq("text-classification", cfg) == "text-classification"
 
 
+def test_upgrade_fill_mask_for_seq2seq_ignores_config_without_flag() -> None:
+    """A config that does not carry is_encoder_decoder at all is never upgraded
+    (getattr defaults to False), so a partial/duck-typed config is never silently
+    rewritten — as the docstring promises."""
+
+    class _NoFlagConfig:
+        pass
+
+    assert _upgrade_fill_mask_for_seq2seq("fill-mask", _NoFlagConfig()) == "fill-mask"
+
+
 def test_d2_upgrades_vision_feature_extraction_on_returned_task() -> None:
     """Top-level image_size/patch_size + feature-extraction -> image-feature-extraction."""
     cfg = _FakeConfig("faketype", image_size=518, patch_size=14)

--- a/tests/unit/loader/test_detect_task.py
+++ b/tests/unit/loader/test_detect_task.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from unittest.mock import patch
 
 from winml.modelkit.loader import detect_task, resolve_task_and_model_class
+from winml.modelkit.loader.task import _upgrade_fill_mask_for_seq2seq
 
 
 class _FakeConfig:
@@ -27,9 +28,11 @@ class _FakeConfig:
         image_size: int | None = None,
         patch_size: int | None = None,
         architectures: list[str] | None = None,
+        is_encoder_decoder: bool = False,
     ) -> None:
         self.model_type = model_type
         self.architectures = architectures or ["FakeModel"]
+        self.is_encoder_decoder = is_encoder_decoder
         if image_size is not None:
             self.image_size = image_size
         if patch_size is not None:
@@ -45,6 +48,25 @@ class _FakeConfig:
 
 
 _DETECT = "winml.modelkit.loader.task._detect_task_from_config"
+
+
+def test_upgrade_fill_mask_for_seq2seq_upgrades_encoder_decoder() -> None:
+    """Optimum mislabels encoder-decoder generation heads (e.g. BartForConditionalGeneration)
+    as fill-mask; an is_encoder_decoder config reported as fill-mask is a seq2seq generator."""
+    cfg = _FakeConfig("bart", is_encoder_decoder=True)
+    assert _upgrade_fill_mask_for_seq2seq("fill-mask", cfg) == "text2text-generation"
+
+
+def test_upgrade_fill_mask_for_seq2seq_leaves_encoder_only_masked_lm() -> None:
+    """A real masked-LM (BERT/RoBERTa) is encoder-only -> fill-mask stays fill-mask."""
+    cfg = _FakeConfig("bert", is_encoder_decoder=False)
+    assert _upgrade_fill_mask_for_seq2seq("fill-mask", cfg) == "fill-mask"
+
+
+def test_upgrade_fill_mask_for_seq2seq_only_touches_fill_mask() -> None:
+    """Tasks other than fill-mask are never rewritten, even for encoder-decoder configs."""
+    cfg = _FakeConfig("bart", is_encoder_decoder=True)
+    assert _upgrade_fill_mask_for_seq2seq("text-classification", cfg) == "text-classification"
 
 
 def test_d2_upgrades_vision_feature_extraction_on_returned_task() -> None:


### PR DESCRIPTION
## What

optimum's `TasksManager` maps some encoder-decoder `*ForConditionalGeneration` classes (e.g. `BartForConditionalGeneration`) to `fill-mask`, so `bart` auto-detected as `fill-mask` in `inspect` and `config` / `build`, while `t5` / `marian` correctly resolved to `text2text-generation`.

## Change

A universal correction (architecture-agnostic — keyed on the `is_encoder_decoder` flag, not model names): a config reported as `fill-mask` that is `is_encoder_decoder=True` is actually a seq2seq generator → `text2text-generation`. Applied at both detection sites:

- `_detect_task_from_config` → fixes `inspect` / `detect_task`.
- `_detect_task_and_class_from_config` → fixes `config` / `build` and makes the class resolve to `BartDecoderWrapper` (consistent with how t5 resolves to `T5DecoderWrapper`).

The flag must be explicitly `True` (HF configs set a real bool), so partial/duck-typed configs are never silently upgraded.

## Result

| model | before (inspect / config) | after |
|---|---|---|
| facebook/bart-large-cnn | fill-mask / AutoModelForMaskedLM | text2text-generation / BartDecoderWrapper |
| bert / roberta (real fill-mask) | fill-mask | unchanged |
| t5 / marian | text2text-generation | unchanged |

## Tests

- Unit: `_upgrade_fill_mask_for_seq2seq` — upgrades encoder-decoder fill-mask; leaves encoder-only fill-mask; only touches `fill-mask`.
- Integration: `bart-large-cnn → text2text-generation` (detect_task) and `→ (text2text-generation, BartDecoderWrapper)` (config/build); `bert → fill-mask` guard.

Fixes #838 (Step 2 of 2). The separate decoder-only no-`--task` seq2seq build issue is tracked in #850.
