### PR TITLE
Fix torch.onnx.export writing .data files to cwd instead of output dir

### DIFF
--- a/src/winml/modelkit/export/htp/exporter.py
+++ b/src/winml/modelkit/export/htp/exporter.py
@@ -398,6 +398,9 @@ class HTPExporter:
         task: str | None = None,
     ) -> None:
         """Export to ONNX using WinMLExportConfig."""
+        # Resolve to absolute path so torch.onnx.export writes external data
+        # files (.data) next to the model, not in the current working directory.
+        output_path = str(Path(output_path).resolve())
         Path(output_path).parent.mkdir(parents=True, exist_ok=True)
 
         # Input names from config, fallback to inputs dict keys


### PR DESCRIPTION
## Summary

Fixes #852

When `torch.onnx.export` exports large models (>2GB), it writes UUID-named `.data` external data files relative to the path it receives. If that path is relative, the files land in the current working directory instead of the model output directory.

## Fix

Resolve `output_path` to an absolute path in `HTPExporter._convert_model_to_onnx` before passing it to `torch.onnx.export`. This ensures external data files are always written next to the ONNX model file regardless of the caller's cwd.

## Validation

All 21 existing unit tests in `tests/unit/export/test_pytorch_export.py` pass.