### PR TITLE
feat: add --format json stdout output to eval, analyze, and perf commands

### DIFF
--- a/src/winml/modelkit/commands/analyze.py
+++ b/src/winml/modelkit/commands/analyze.py
@@ -13,6 +13,7 @@ Usage:
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 import sys
@@ -670,6 +671,14 @@ def _ep_name_device_display_name(ep_name: str, device_name: str) -> str:
     help="Path to HTP metadata JSON file for enhanced pattern extraction",
 )
 @click.option(
+    "-f",
+    "--format",
+    "output_format",
+    type=click.Choice(["text", "json"], case_sensitive=False),
+    default="text",
+    help="Output format (default: text). 'json' prints structured JSON to stdout.",
+)
+@click.option(
     "--run-unknown-op/--no-run-unknown-op",
     default=False,
     help="Run unknown operators on local machine if possible (default: disabled)",
@@ -695,6 +704,7 @@ def analyze(
     device: str | None,
     output: Path | None,
     information: bool,
+    output_format: str,
     verbose: int,
     quiet: bool,
     config_file: Path | None,
@@ -1169,8 +1179,6 @@ def analyze(
                 if len(analysis_results) == 1:
                     output.write_text(result.to_json(), encoding="utf-8")
                 else:
-                    import json
-
                     output.write_text(
                         json.dumps(
                             [json.loads(run_result.to_json()) for run_result in analysis_results]
@@ -1186,8 +1194,6 @@ def analyze(
 
         # Save optimization config if requested
         if optim_config:
-            import json
-
             try:
                 # Merge optimization configs from all execution pairs; warn on conflicts.
 
@@ -1228,6 +1234,19 @@ def analyze(
             except Exception as e:
                 logger.error("Failed to generate optimization config: %s", e)
                 logger.debug("Config generation traceback:", exc_info=True)
+
+        # Emit JSON to stdout if requested
+        json_mode = output_format.lower() == "json"
+        if json_mode:
+            if len(analysis_results) == 1:
+                click.echo(result.to_json())
+            else:
+                click.echo(
+                    json.dumps(
+                        [json.loads(run_result.to_json()) for run_result in analysis_results],
+                        indent=2,
+                    )
+                )
 
         # Exit code: 0 = fully supported, 1 = partial support
         overall_supported = all(run_result.is_fully_supported() for run_result in analysis_results)

--- a/src/winml/modelkit/commands/analyze.py
+++ b/src/winml/modelkit/commands/analyze.py
@@ -670,14 +670,7 @@ def _ep_name_device_display_name(ep_name: str, device_name: str) -> str:
     default=None,
     help="Path to HTP metadata JSON file for enhanced pattern extraction",
 )
-@click.option(
-    "-f",
-    "--format",
-    "output_format",
-    type=click.Choice(["text", "json"], case_sensitive=False),
-    default="text",
-    help="Output format (default: text). 'json' prints structured JSON to stdout.",
-)
+@cli_utils.format_option()
 @click.option(
     "--run-unknown-op/--no-run-unknown-op",
     default=False,
@@ -704,7 +697,7 @@ def analyze(
     device: str | None,
     output: Path | None,
     information: bool,
-    output_format: str,
+    output_format: cli_utils.OutputFormat,
     verbose: int,
     quiet: bool,
     config_file: Path | None,

--- a/src/winml/modelkit/commands/analyze.py
+++ b/src/winml/modelkit/commands/analyze.py
@@ -1229,7 +1229,7 @@ def analyze(
                 logger.debug("Config generation traceback:", exc_info=True)
 
         # Emit JSON to stdout if requested
-        json_mode = output_format.lower() == "json"
+        json_mode = output_format == "json"
         if json_mode:
             if len(analysis_results) == 1:
                 click.echo(result.to_json())

--- a/src/winml/modelkit/commands/catalog.py
+++ b/src/winml/modelkit/commands/catalog.py
@@ -352,7 +352,7 @@ def _save_json(data: Any, path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)
-    console.print(f"[green]Results saved to:[/green] {path}")
+    click.echo(f"Results saved to: {path}", err=True)
 
 
 # ---------------------------------------------------------------------------
@@ -384,18 +384,21 @@ def _save_json(data: Any, path: Path) -> None:
     optional_message="If not specified, shows all devices",
 )
 @cli_utils.output_option("Save results to a JSON file.")
+@cli_utils.format_option()
 def catalog(
     model_type: str | None,
     task: str | None,
     ep: EPNameOrAlias | None,
     device: str | None,
     output: Path | None,
+    output_format: cli_utils.OutputFormat,
 ) -> None:
     r"""Browse WinML CLI's curated built-in model catalog.
 
     Lists HuggingFace models that have been validated end-to-end
     (export -> quantise -> run on device) with confirmed accuracy results.
-    Use ``--output`` to save results to a JSON file.
+    Use ``--output`` to save results to a JSON file, or ``--format json``
+    to print structured JSON to stdout.
 
     \b
     Examples:
@@ -404,6 +407,7 @@ def catalog(
         winml catalog --task text-classification
         winml catalog --ep qnn
         winml catalog --device NPU
+        winml catalog --format json
         winml catalog --output results/catalog.json
     """
     try:
@@ -415,15 +419,20 @@ def catalog(
     models = _filter_by_ep(models, ep)
     models = _filter_by_device(models, device)
 
-    # Show the extra column only when exactly one of --ep / --device is given.
-    ep_col_header = None
-    ep_col_fn = None
-    if (ep is not None) ^ (device is not None):
-        if ep is not None:
-            ep_col_header, ep_col_fn = _make_ep_col_fn_for_ep(normalize_ep_name(ep) or "")
-        else:
-            ep_col_header, ep_col_fn = _make_ep_col_fn_for_device(device or "")
-    _output_list(models, ep_col_header=ep_col_header, ep_col_fn=ep_col_fn)
+    json_mode = output_format.lower() == "json"
+
+    if json_mode:
+        click.echo(json.dumps(models, indent=2))
+    else:
+        # Show the extra column only when exactly one of --ep / --device is given.
+        ep_col_header = None
+        ep_col_fn = None
+        if (ep is not None) ^ (device is not None):
+            if ep is not None:
+                ep_col_header, ep_col_fn = _make_ep_col_fn_for_ep(normalize_ep_name(ep) or "")
+            else:
+                ep_col_header, ep_col_fn = _make_ep_col_fn_for_device(device or "")
+        _output_list(models, ep_col_header=ep_col_header, ep_col_fn=ep_col_fn)
 
     if output is not None:
         _save_json(models, output)

--- a/src/winml/modelkit/commands/catalog.py
+++ b/src/winml/modelkit/commands/catalog.py
@@ -419,7 +419,7 @@ def catalog(
     models = _filter_by_ep(models, ep)
     models = _filter_by_device(models, device)
 
-    json_mode = output_format.lower() == "json"
+    json_mode = output_format == "json"
 
     if json_mode:
         click.echo(json.dumps(models, indent=2))

--- a/src/winml/modelkit/commands/eval.py
+++ b/src/winml/modelkit/commands/eval.py
@@ -163,6 +163,14 @@ logger = logging.getLogger(__name__)
     ),
 )
 @cli_utils.skip_build_option()
+@click.option(
+    "-f",
+    "--format",
+    "output_format",
+    type=click.Choice(["text", "json"], case_sensitive=False),
+    default="text",
+    help="Output format (default: text). 'json' prints structured JSON to stdout.",
+)
 @cli_utils.build_config_option()
 @cli_utils.verbosity_options()
 @click.pass_context
@@ -184,6 +192,7 @@ def eval(
     column: tuple[str, ...],
     label_mapping_path: Path | None,
     output: Path | None,
+    output_format: str,
     verbose: int,
     quiet: bool,
     dataset_script: str | None,
@@ -248,10 +257,12 @@ def eval(
 
     logger.debug("Effective eval config: %s", cfg.to_dict())
 
+    json_mode = output_format.lower() == "json"
+
     # ── 3. Evaluate ──
     try:
         result = evaluate(cfg)
-        _write_and_display(result, cfg.output_path)
+        _write_and_display(result, cfg.output_path, json_mode=json_mode)
     except Exception as e:
         if verbose:
             logger.exception("Evaluation failed")
@@ -349,7 +360,7 @@ def _resolve_device(cfg: WinMLEvaluationConfig) -> None:
 
     from ..sysinfo import resolve_device
 
-    console = Console()
+    console = Console(stderr=True)
     console.print("[bold]Detecting available devices...[/bold]")
     resolved, _ = resolve_device(cfg.device)
     cfg.device = resolved
@@ -390,7 +401,7 @@ def _run_dataset_script(cfg: WinMLEvaluationConfig, trust_remote_code: bool) -> 
 
     cmd = [sys.executable, str(script_path), "--output", str(Path(cfg.dataset.path).expanduser())]
 
-    Console().print(f"[bold]Building dataset via {script_path.name}...[/bold]")
+    Console(stderr=True).print(f"[bold]Building dataset via {script_path.name}...[/bold]")
     result = subprocess.run(  # noqa: S603
         cmd,
         capture_output=True,
@@ -404,16 +415,21 @@ def _run_dataset_script(cfg: WinMLEvaluationConfig, trust_remote_code: bool) -> 
         )
 
 
-def _write_and_display(result: EvalResult, output_path: Path | None) -> None:
+def _write_and_display(
+    result: EvalResult, output_path: Path | None, *, json_mode: bool = False
+) -> None:
     """Display evaluation results and optionally save to JSON."""
-    console = Console()
-    display_eval_report(result, console)
+    if json_mode:
+        click.echo(json.dumps(result.to_dict(), indent=2, default=_json_default))
+    else:
+        console = Console()
+        display_eval_report(result, console)
 
     if output_path is not None:
         output_path.parent.mkdir(parents=True, exist_ok=True)
         with output_path.open("w") as f:
             json.dump(result.to_dict(), f, indent=2, default=_json_default)
-        console.print(f"[green]Results saved to:[/green] {output_path}")
+        Console(stderr=True).print(f"[green]Results saved to:[/green] {output_path}")
 
 
 def _resolve_model_path(

--- a/src/winml/modelkit/commands/eval.py
+++ b/src/winml/modelkit/commands/eval.py
@@ -250,7 +250,7 @@ def eval(
 
     logger.debug("Effective eval config: %s", cfg.to_dict())
 
-    json_mode = output_format.lower() == "json"
+    json_mode = output_format == "json"
 
     # ── 3. Evaluate ──
     try:

--- a/src/winml/modelkit/commands/eval.py
+++ b/src/winml/modelkit/commands/eval.py
@@ -163,14 +163,7 @@ logger = logging.getLogger(__name__)
     ),
 )
 @cli_utils.skip_build_option()
-@click.option(
-    "-f",
-    "--format",
-    "output_format",
-    type=click.Choice(["text", "json"], case_sensitive=False),
-    default="text",
-    help="Output format (default: text). 'json' prints structured JSON to stdout.",
-)
+@cli_utils.format_option()
 @cli_utils.build_config_option()
 @cli_utils.verbosity_options()
 @click.pass_context
@@ -192,7 +185,7 @@ def eval(
     column: tuple[str, ...],
     label_mapping_path: Path | None,
     output: Path | None,
-    output_format: str,
+    output_format: cli_utils.OutputFormat,
     verbose: int,
     quiet: bool,
     dataset_script: str | None,

--- a/src/winml/modelkit/commands/inspect.py
+++ b/src/winml/modelkit/commands/inspect.py
@@ -89,14 +89,7 @@ def _looks_like_local_path(model_id: str) -> bool:
     default=None,
     help="HuggingFace model ID (e.g., microsoft/resnet-50)",
 )
-@click.option(
-    "-f",
-    "--format",
-    "output_format",
-    type=click.Choice(["table", "json"], case_sensitive=False),
-    default="table",
-    help="Output format (default: table)",
-)
+@cli_utils.format_option(choices=["table", "json"], default="table")
 @click.option(
     "-t",
     "--task",
@@ -135,7 +128,7 @@ def _looks_like_local_path(model_id: str) -> bool:
 def inspect(
     ctx: click.Context,
     model_id: str | None,
-    output_format: str,
+    output_format: cli_utils.OutputFormat,
     verbose: int,
     quiet: bool,
     task: str | None,

--- a/src/winml/modelkit/commands/inspect.py
+++ b/src/winml/modelkit/commands/inspect.py
@@ -206,7 +206,7 @@ def inspect(
     # json` consumers still get clean stdout. Suppressed in --quiet mode
     # and in JSON mode (Click 8.4 mixes stderr into CliRunner.result.output,
     # and JSON consumers expect clean stdout regardless).
-    json_mode = output_format.lower() == "json"
+    json_mode = output_format == "json"
     target = model_id or model_type or model_class
     if not quiet and not json_mode:
         _stderr_console.print(f"[dim]Inspecting [bold]{target}[/bold] …[/dim]")
@@ -238,7 +238,7 @@ def inspect(
                     include_hierarchy=hierarchy,
                 )
 
-        if output_format.lower() == "json":
+        if output_format == "json":
             click.echo(output_json(result, verbose=bool(verbose)))
         else:
             output_table(console, result, verbose=bool(verbose))

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -1111,6 +1111,14 @@ def _run_simple_loop(
     help="Enable operator-level profiling (requires onnxruntime-qnn)",
     hidden=True,  # Not ready, so hide from --help for now
 )
+@click.option(
+    "-f",
+    "--format",
+    "output_format",
+    type=click.Choice(["text", "json"], case_sensitive=False),
+    default="text",
+    help="Output format (default: text). 'json' prints structured JSON to stdout.",
+)
 @cli_utils.build_config_option()
 @cli_utils.verbosity_options()
 @click.pass_context
@@ -1134,6 +1142,7 @@ def perf(
     module_class: str | None,
     monitor: bool,
     op_tracing: str | None,
+    output_format: str,
     verbose: int,
     quiet: bool,
     config_file: Path | None,
@@ -1188,7 +1197,8 @@ def perf(
     verbose, quiet = cli_utils.resolve_verbosity(ctx, verbose, quiet)
     configure_logging(verbosity=verbose, quiet=quiet)
 
-    console = Console()
+    json_mode = output_format.lower() == "json"
+    console = Console(stderr=True) if json_mode else Console()
 
     # =========================================================================
     # MODULE MODE: per-module build + benchmark
@@ -1298,8 +1308,11 @@ def perf(
         benchmark = PerfBenchmark(config)
         result = benchmark.run()
 
-        # Display console report
-        display_console_report(result, console)
+        # Display results
+        if json_mode:
+            click.echo(json.dumps(result.to_dict(), indent=2))
+        else:
+            display_console_report(result, console)
 
         # Write JSON report
         write_json_report(result, output)

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -1190,7 +1190,7 @@ def perf(
     verbose, quiet = cli_utils.resolve_verbosity(ctx, verbose, quiet)
     configure_logging(verbosity=verbose, quiet=quiet)
 
-    json_mode = output_format.lower() == "json"
+    json_mode = output_format == "json"
     console = Console(stderr=True) if json_mode else Console()
 
     # =========================================================================

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -1111,14 +1111,7 @@ def _run_simple_loop(
     help="Enable operator-level profiling (requires onnxruntime-qnn)",
     hidden=True,  # Not ready, so hide from --help for now
 )
-@click.option(
-    "-f",
-    "--format",
-    "output_format",
-    type=click.Choice(["text", "json"], case_sensitive=False),
-    default="text",
-    help="Output format (default: text). 'json' prints structured JSON to stdout.",
-)
+@cli_utils.format_option()
 @cli_utils.build_config_option()
 @cli_utils.verbosity_options()
 @click.pass_context
@@ -1142,7 +1135,7 @@ def perf(
     module_class: str | None,
     monitor: bool,
     op_tracing: str | None,
-    output_format: str,
+    output_format: cli_utils.OutputFormat,
     verbose: int,
     quiet: bool,
     config_file: Path | None,

--- a/src/winml/modelkit/commands/run.py
+++ b/src/winml/modelkit/commands/run.py
@@ -468,14 +468,7 @@ def _print_input_hint(engine: Any) -> None:
     default=False,
     help="Print model schema (inputs + parameters) and exit",
 )
-@click.option(
-    "--format",
-    "output_format",
-    type=click.Choice(["text", "json"]),
-    default="text",
-    show_default=True,
-    help="Output format",
-)
+@cli_utils.format_option(short_flag=False)
 @cli_utils.output_option("Write output to file instead of stdout")
 @click.option(
     "--port",
@@ -511,7 +504,7 @@ def run(
     ep: EPNameOrAlias | None,
     params: tuple[str, ...],
     show_schema: bool,
-    output_format: str,
+    output_format: cli_utils.OutputFormat,
     output: Path | None,
     port: int,
     connect_host: str,
@@ -821,7 +814,7 @@ def _models_match(server_model: str, requested: str) -> bool:
 def _print_result(
     result: dict,
     *,
-    output_format: str,
+    output_format: cli_utils.OutputFormat,
     output_path: Path | None,
 ) -> None:
     if output_format == "json":

--- a/src/winml/modelkit/commands/sys.py
+++ b/src/winml/modelkit/commands/sys.py
@@ -666,14 +666,7 @@ def _output_ep_text(eps: list[dict[str, Any]]) -> None:
 
 
 @click.command()
-@click.option(
-    "--format",
-    "-f",
-    "output_format",
-    type=click.Choice(["text", "json", "compact"], case_sensitive=False),
-    default="text",
-    help="Output format: text (human-readable), json, or compact",
-)
+@cli_utils.format_option(choices=["text", "json", "compact"], default="text")
 @click.option(
     "--list-device",
     is_flag=True,
@@ -690,7 +683,7 @@ def _output_ep_text(eps: list[dict[str, Any]]) -> None:
 @click.pass_context
 def sysinfo(
     ctx: click.Context,
-    output_format: str,
+    output_format: cli_utils.OutputFormat,
     verbose: int,
     quiet: bool,
     list_device: bool,

--- a/src/winml/modelkit/commands/sys.py
+++ b/src/winml/modelkit/commands/sys.py
@@ -727,7 +727,7 @@ def sysinfo(
     # them.
     configure_logging(verbosity=verbose, quiet=quiet)
 
-    use_json = output_format.lower() == "json"
+    use_json = output_format == "json"
 
     # Logging is configured via the shared, idempotent configure_logging above;
     # no per-command logger snapshot/restore is needed (every other command
@@ -752,7 +752,7 @@ def sysinfo(
                     msg = f"Error detecting execution providers: {e}"
                     raise click.ClickException(msg) from e
             click.echo(json.dumps(result, indent=2))
-        elif output_format.lower() == "compact":
+        elif output_format == "compact":
             if list_device:
                 try:
                     devices = _gather_device_info()
@@ -807,7 +807,7 @@ def sysinfo(
             except Exception:
                 info["executionProviders"] = []
             _output_json(info)
-        elif output_format.lower() == "compact":
+        elif output_format == "compact":
             _output_compact(info)
         else:
             _output_text(info, verbose=bool(verbose))

--- a/src/winml/modelkit/utils/cli.py
+++ b/src/winml/modelkit/utils/cli.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 F = TypeVar("F", bound="Callable[..., Any]")
 
 # Allowed values for ``--format`` / ``-f``.
-OutputFormat: TypeAlias = Literal["text", "json"]
+OutputFormat: TypeAlias = Literal["text", "json", "table", "compact"]
 
 
 # Shared stderr console for security/diagnostic messages emitted from utils.
@@ -128,8 +128,8 @@ def output_option(help_text: str, required: bool = False) -> Callable[[F], F]:
 
 
 def format_option(
-    choices: list[str] | None = None,
-    default: str = "text",
+    choices: list[OutputFormat] | None = None,
+    default: OutputFormat = "text",
     short_flag: bool = True,
 ) -> Callable[[F], F]:
     """Add ``--format`` option to a Click command.

--- a/src/winml/modelkit/utils/cli.py
+++ b/src/winml/modelkit/utils/cli.py
@@ -127,19 +127,28 @@ def output_option(help_text: str, required: bool = False) -> Callable[[F], F]:
     return click.option("--output", "-o", **kwargs)
 
 
-def format_option() -> Callable[[F], F]:
-    """Add ``-f/--format`` option (text | json) to a Click command.
+def format_option(
+    choices: list[str] | None = None,
+    default: str = "text",
+) -> Callable[[F], F]:
+    """Add ``-f/--format`` option to a Click command.
 
     The option is exposed as the ``output_format`` parameter in the
     decorated function (type: :data:`OutputFormat`).
+
+    Args:
+        choices: Allowed format values. Defaults to ``["text", "json"]``.
+        default: Default format value. Defaults to ``"text"``.
     """
+    if choices is None:
+        choices = ["text", "json"]
     return click.option(
         "-f",
         "--format",
         "output_format",
-        type=click.Choice(["text", "json"], case_sensitive=False),
-        default="text",
-        help="Output format (default: text). 'json' prints structured JSON to stdout.",
+        type=click.Choice(choices, case_sensitive=False),
+        default=default,
+        help=f"Output format (default: {default}). 'json' prints structured JSON to stdout.",
     )
 
 

--- a/src/winml/modelkit/utils/cli.py
+++ b/src/winml/modelkit/utils/cli.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias, TypeVar
 
 import click
 from rich.console import Console
@@ -24,6 +24,9 @@ if TYPE_CHECKING:
 
 # TypeVar for signature-preserving Click decorators.
 F = TypeVar("F", bound="Callable[..., Any]")
+
+# Allowed values for ``--format`` / ``-f``.
+OutputFormat: TypeAlias = Literal["text", "json"]
 
 
 # Shared stderr console for security/diagnostic messages emitted from utils.
@@ -122,6 +125,22 @@ def output_option(help_text: str, required: bool = False) -> Callable[[F], F]:
     else:
         kwargs["default"] = None
     return click.option("--output", "-o", **kwargs)
+
+
+def format_option() -> Callable[[F], F]:
+    """Add ``-f/--format`` option (text | json) to a Click command.
+
+    The option is exposed as the ``output_format`` parameter in the
+    decorated function (type: :data:`OutputFormat`).
+    """
+    return click.option(
+        "-f",
+        "--format",
+        "output_format",
+        type=click.Choice(["text", "json"], case_sensitive=False),
+        default="text",
+        help="Output format (default: text). 'json' prints structured JSON to stdout.",
+    )
 
 
 def ep_option(required: bool = True, optional_message: str | None = None) -> Callable[[F], F]:

--- a/src/winml/modelkit/utils/cli.py
+++ b/src/winml/modelkit/utils/cli.py
@@ -130,8 +130,9 @@ def output_option(help_text: str, required: bool = False) -> Callable[[F], F]:
 def format_option(
     choices: list[str] | None = None,
     default: str = "text",
+    short_flag: bool = True,
 ) -> Callable[[F], F]:
-    """Add ``-f/--format`` option to a Click command.
+    """Add ``--format`` option to a Click command.
 
     The option is exposed as the ``output_format`` parameter in the
     decorated function (type: :data:`OutputFormat`).
@@ -139,12 +140,14 @@ def format_option(
     Args:
         choices: Allowed format values. Defaults to ``["text", "json"]``.
         default: Default format value. Defaults to ``"text"``.
+        short_flag: Whether to include ``-f`` short alias. Set to False
+            when another option already uses ``-f``.
     """
     if choices is None:
         choices = ["text", "json"]
+    args = ["-f", "--format"] if short_flag else ["--format"]
     return click.option(
-        "-f",
-        "--format",
+        *args,
         "output_format",
         type=click.Choice(choices, case_sensitive=False),
         default=default,

--- a/tests/unit/analyze/test_static_analyzer_cli.py
+++ b/tests/unit/analyze/test_static_analyzer_cli.py
@@ -1370,3 +1370,144 @@ class TestAnalyzeSummaryRendering:
         assert "DmlExecutionProvider (GPU)" in output
         assert "2/0/0" in output
         assert "Op check skipped" not in output
+
+
+# ---------------------------------------------------------------------------
+# --format json
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeFormatJson:
+    """Test --format json produces structured JSON to stdout."""
+
+    def test_help_shows_format_option(self, runner: CliRunner) -> None:
+        """--format flag must appear in --help output."""
+        result = runner.invoke(analyze, ["--help"])
+        assert result.exit_code == 0
+        assert "--format" in result.output
+        assert "json" in result.output
+
+    def test_invalid_format_rejected(self, runner: CliRunner, tmp_path: Path) -> None:
+        """An invalid --format value must be rejected by Click."""
+        model_file = tmp_path / "test.onnx"
+        model_file.write_bytes(b"dummy")
+
+        result = runner.invoke(
+            analyze,
+            ["--model", str(model_file), "--format", "xml"],
+        )
+        assert result.exit_code != 0
+
+    @patch("winml.modelkit.analyze.ONNXStaticAnalyzer")
+    def test_format_json_emits_valid_json(
+        self,
+        mock_analyzer_class: MagicMock,
+        runner: CliRunner,
+        tmp_path: Path,
+        mock_analyzer_result: Mock,
+    ) -> None:
+        """--format json output must contain parseable JSON."""
+        model_file = tmp_path / "test.onnx"
+        model_file.write_bytes(b"dummy")
+
+        mock_instance = Mock()
+        mock_instance.analyze.return_value = mock_analyzer_result
+        mock_analyzer_class.return_value = mock_instance
+
+        result = runner.invoke(
+            analyze,
+            [
+                "--model",
+                str(model_file),
+                "--ep",
+                "QNNExecutionProvider",
+                "--device",
+                "NPU",
+                "--format",
+                "json",
+                "--quiet",
+            ],
+        )
+
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert "metadata" in parsed
+        assert parsed["metadata"]["model_path"] == "test.onnx"
+
+    @patch("winml.modelkit.analyze.ONNXStaticAnalyzer")
+    def test_format_json_emits_on_partial_support(
+        self,
+        mock_analyzer_class: MagicMock,
+        runner: CliRunner,
+        tmp_path: Path,
+        mock_analyzer_partial_support: Mock,
+    ) -> None:
+        """--format json must still emit JSON when exit code is 1 (partial support)."""
+        model_file = tmp_path / "test.onnx"
+        model_file.write_bytes(b"dummy")
+
+        mock_instance = Mock()
+        mock_instance.analyze.return_value = mock_analyzer_partial_support
+        mock_analyzer_class.return_value = mock_instance
+
+        result = runner.invoke(
+            analyze,
+            [
+                "--model",
+                str(model_file),
+                "--ep",
+                "QNNExecutionProvider",
+                "--device",
+                "NPU",
+                "--format",
+                "json",
+                "--quiet",
+            ],
+        )
+
+        assert result.exit_code == 1
+        parsed = json.loads(result.output)
+        assert "metadata" in parsed
+
+    @patch("winml.modelkit.analyze.ONNXStaticAnalyzer")
+    def test_format_json_with_output_file(
+        self,
+        mock_analyzer_class: MagicMock,
+        runner: CliRunner,
+        tmp_path: Path,
+        mock_analyzer_result: Mock,
+    ) -> None:
+        """--format json + --output should emit JSON to stdout AND save file."""
+        model_file = tmp_path / "test.onnx"
+        model_file.write_bytes(b"dummy")
+        output_file = tmp_path / "result.json"
+
+        mock_instance = Mock()
+        mock_instance.analyze.return_value = mock_analyzer_result
+        mock_analyzer_class.return_value = mock_instance
+
+        result = runner.invoke(
+            analyze,
+            [
+                "--model",
+                str(model_file),
+                "--ep",
+                "QNNExecutionProvider",
+                "--device",
+                "NPU",
+                "--format",
+                "json",
+                "--output",
+                str(output_file),
+                "--quiet",
+            ],
+        )
+
+        assert result.exit_code == 0
+        # stdout has JSON
+        parsed = json.loads(result.output)
+        assert "metadata" in parsed
+        # File also has JSON
+        assert output_file.exists()
+        file_data = json.loads(output_file.read_text())
+        assert "metadata" in file_data

--- a/tests/unit/commands/test_catalog.py
+++ b/tests/unit/commands/test_catalog.py
@@ -610,3 +610,48 @@ def test_cli_device_npu_narrows_results(runner, patched_catalog, tmp_path):
     assert result.exit_code == 0
     data = json.loads(out.read_text())
     assert len(data) == 4
+
+
+# ---------------------------------------------------------------------------
+# --format json tests
+# ---------------------------------------------------------------------------
+
+
+class TestCatalogFormatJson:
+    """Tests for --format json output."""
+
+    def test_format_json_outputs_valid_json(self, runner, patched_catalog):
+        result = runner.invoke(catalog, ["--format", "json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output.strip())
+        assert isinstance(data, list)
+        assert len(data) == 4
+
+    def test_format_json_with_task_filter(self, runner, patched_catalog):
+        result = runner.invoke(catalog, ["--format", "json", "--task", "fill-mask"])
+        assert result.exit_code == 0
+        data = json.loads(result.output.strip())
+        assert len(data) == 1
+        assert data[0]["model_id"] == "google-bert/bert-base-uncased"
+
+    def test_format_json_with_ep_filter(self, runner, patched_catalog):
+        result = runner.invoke(catalog, ["--format", "json", "--ep", "qnn"])
+        assert result.exit_code == 0
+        data = json.loads(result.output.strip())
+        # Only models with QNN EP: bert-base-uncased, bert-base-NER
+        assert len(data) == 2
+
+    def test_format_json_with_device_filter(self, runner, patched_catalog):
+        result = runner.invoke(catalog, ["--format", "json", "--device", "NPU"])
+        assert result.exit_code == 0
+        data = json.loads(result.output.strip())
+        assert len(data) == 4
+
+    def test_format_json_contains_expected_keys(self, runner, patched_catalog):
+        result = runner.invoke(catalog, ["--format", "json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output.strip())
+        for model in data:
+            assert "model_id" in model
+            assert "model_type" in model
+            assert "supported_eps" in model

--- a/tests/unit/commands/test_eval.py
+++ b/tests/unit/commands/test_eval.py
@@ -76,20 +76,23 @@ class TestSinglePlain:
         """Passing both -m <hf_id> and --model-id is rejected as a conflict."""
         with pytest.raises(click.UsageError, match="Cannot pass both"):
             _resolve_model_path(
-                model=("microsoft/resnet-50",), model_id="Intel/bert-base-uncased-mrpc",
+                model=("microsoft/resnet-50",),
+                model_id="Intel/bert-base-uncased-mrpc",
             )
 
     def test_plain_hf_id_with_matching_model_id_ok(self):
         """Passing --model-id equal to -m <hf_id> is allowed (no-op duplicate)."""
         path, mid = _resolve_model_path(
-            model=("microsoft/resnet-50",), model_id="microsoft/resnet-50",
+            model=("microsoft/resnet-50",),
+            model_id="microsoft/resnet-50",
         )
         assert path is None
         assert mid == "microsoft/resnet-50"
 
     def test_plain_onnx_with_model_id(self, onnx_file):
         path, mid = _resolve_model_path(
-            model=(str(onnx_file),), model_id="microsoft/resnet-50",
+            model=(str(onnx_file),),
+            model_id="microsoft/resnet-50",
         )
         assert path == str(onnx_file)
         assert mid == "microsoft/resnet-50"
@@ -107,7 +110,8 @@ class TestSinglePlain:
         """Multiple plain -m values without role=path are ambiguous."""
         with pytest.raises(click.UsageError, match="role=path"):
             _resolve_model_path(
-                model=(str(onnx_file), str(onnx_file)), model_id="some/id",
+                model=(str(onnx_file), str(onnx_file)),
+                model_id="some/id",
             )
 
 
@@ -165,13 +169,15 @@ class TestComposite:
     def test_empty_role_raises(self, onnx_vision):
         with pytest.raises(click.BadParameter, match="role and path"):
             _resolve_model_path(
-                model=(f"={onnx_vision}",), model_id="some/id",
+                model=(f"={onnx_vision}",),
+                model_id="some/id",
             )
 
     def test_empty_path_raises(self):
         with pytest.raises(click.BadParameter, match="role and path"):
             _resolve_model_path(
-                model=("image-encoder=",), model_id="some/id",
+                model=("image-encoder=",),
+                model_id="some/id",
             )
 
     def test_whitespace_stripped(self, onnx_vision):
@@ -545,7 +551,9 @@ class TestPerTaskDefaultDataset:
         with (
             patch.object(evaluate_mod, "_load_model", return_value=object()),
             patch.object(
-                evaluate_mod, "get_evaluator_class", return_value=_FakeEvaluator,
+                evaluate_mod,
+                "get_evaluator_class",
+                return_value=_FakeEvaluator,
             ),
             patch("winml.modelkit.commands.eval._resolve_device", return_value=None),
             patch("winml.modelkit.commands.eval._write_and_display", return_value=None),
@@ -572,7 +580,8 @@ class TestPerTaskDefaultDataset:
         expected_split: str,
     ):
         cfg = self._run_and_capture(
-            runner, ["-m", "some/model", "--task", task],
+            runner,
+            ["-m", "some/model", "--task", task],
         )
         assert cfg.dataset.path == expected_path
         assert cfg.dataset.split == expected_split
@@ -587,9 +596,12 @@ class TestPerTaskDefaultDataset:
         cfg = self._run_and_capture(
             runner,
             [
-                "-m", "some/model",
-                "--task", "image-classification",
-                "--samples", "4",
+                "-m",
+                "some/model",
+                "--task",
+                "image-classification",
+                "--samples",
+                "4",
             ],
         )
         # Per-task default path filled in:
@@ -609,9 +621,12 @@ class TestPerTaskDefaultDataset:
         cfg = self._run_and_capture(
             runner,
             [
-                "-m", "some/model",
-                "--task", "image-classification",
-                "--split", "train",
+                "-m",
+                "some/model",
+                "--task",
+                "image-classification",
+                "--split",
+                "train",
             ],
         )
         assert cfg.dataset.split == "test"  # the default's split wins
@@ -627,9 +642,12 @@ class TestPerTaskDefaultDataset:
         cfg = self._run_and_capture(
             runner,
             [
-                "-m", "some/model",
-                "--task", "text-classification",
-                "--column", "input_column=my_text",
+                "-m",
+                "some/model",
+                "--task",
+                "text-classification",
+                "--column",
+                "input_column=my_text",
             ],
         )
         # Default's columns_mapping wins wholesale; user's --column dropped.
@@ -663,9 +681,12 @@ class TestPerTaskDefaultDataset:
         cfg = self._run_and_capture(
             runner,
             [
-                "-m", "some/model",
-                "--task", "text-classification",
-                "--dataset-name", "sst2",
+                "-m",
+                "some/model",
+                "--task",
+                "text-classification",
+                "--dataset-name",
+                "sst2",
             ],
         )
         # Default's name ("mrpc") wins; user's --dataset-name dropped.
@@ -693,3 +714,109 @@ class TestPerTaskDefaultDataset:
             and "timm/mini-imagenet" in m
             for m in msgs
         ), f"expected warning not found in {msgs!r}"
+
+
+# ---------------------------------------------------------------------------
+# --format json
+# ---------------------------------------------------------------------------
+
+
+class TestEvalFormatJson:
+    """Test --format json produces structured JSON to stdout."""
+
+    def test_format_json_produces_valid_json(self):
+        """_write_and_display with json_mode=True emits parseable JSON."""
+        from unittest.mock import MagicMock
+
+        from winml.modelkit.commands.eval import _write_and_display
+
+        mock_result = MagicMock()
+        mock_result.to_dict.return_value = {
+            "mode": "onnx",
+            "model_id": "microsoft/resnet-50",
+            "metrics": {"top1_accuracy": 0.741},
+        }
+
+        from click.testing import CliRunner
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            import io
+
+            buf = io.StringIO()
+            with patch(
+                "winml.modelkit.commands.eval.click.echo",
+                side_effect=lambda x: buf.write(x),
+            ):
+                _write_and_display(mock_result, None, json_mode=True)
+
+            output = buf.getvalue()
+            parsed = json.loads(output)
+            assert parsed["model_id"] == "microsoft/resnet-50"
+            assert parsed["metrics"]["top1_accuracy"] == 0.741
+
+    def test_format_json_with_output_file(self, tmp_path):
+        """--format json + --output should emit JSON to stdout AND save file."""
+        from unittest.mock import MagicMock
+
+        from winml.modelkit.commands.eval import _write_and_display
+
+        mock_result = MagicMock()
+        mock_result.to_dict.return_value = {
+            "mode": "onnx",
+            "model_id": "test/model",
+            "metrics": {"accuracy": 0.9},
+        }
+
+        output_file = tmp_path / "result.json"
+
+        import io
+
+        buf = io.StringIO()
+        with patch("winml.modelkit.commands.eval.click.echo", side_effect=lambda x: buf.write(x)):
+            _write_and_display(mock_result, output_file, json_mode=True)
+
+        # stdout has JSON
+        parsed = json.loads(buf.getvalue())
+        assert parsed["model_id"] == "test/model"
+
+        # File also has JSON
+        assert output_file.exists()
+        file_data = json.loads(output_file.read_text())
+        assert file_data["model_id"] == "test/model"
+
+    def test_format_text_shows_report(self):
+        """json_mode=False should call display_eval_report (default behavior)."""
+        from unittest.mock import MagicMock
+
+        from winml.modelkit.commands.eval import _write_and_display
+
+        mock_result = MagicMock()
+        mock_result.to_dict.return_value = {"metrics": {}}
+        mock_result.config.model_id = "test"
+        mock_result.config.task = "cls"
+        mock_result.config.device = "cpu"
+        mock_result.config.dataset.path = None
+        mock_result.config.dataset.samples = 100
+        mock_result.config.model_path = None
+        mock_result.metrics = {}
+
+        with patch("winml.modelkit.commands.eval.display_eval_report") as mock_display:
+            _write_and_display(mock_result, None, json_mode=False)
+            mock_display.assert_called_once()
+
+    def test_help_shows_format_option(self, runner: CliRunner):
+        """--format flag must appear in --help output."""
+        from winml.modelkit.commands.eval import eval as eval_cmd
+
+        result = runner.invoke(eval_cmd, ["--help"])
+        assert result.exit_code == 0
+        assert "--format" in result.output
+        assert "json" in result.output
+
+    def test_invalid_format_rejected(self, runner: CliRunner):
+        """An invalid --format value must be rejected by Click."""
+        from winml.modelkit.commands.eval import eval as eval_cmd
+
+        result = runner.invoke(eval_cmd, ["-m", "test", "--format", "xml"])
+        assert result.exit_code != 0

--- a/tests/unit/commands/test_perf_cli.py
+++ b/tests/unit/commands/test_perf_cli.py
@@ -395,3 +395,118 @@ class TestPerfUnifiedPipeline:
             benchmark._load_model()
 
         assert mock_from_onnx.call_args.kwargs["ep"] == "qnn"
+
+
+# =============================================================================
+# --FORMAT JSON TESTS
+# =============================================================================
+
+
+class TestPerfFormatJson:
+    """Test --format json produces structured JSON to stdout."""
+
+    def test_help_shows_format_option(self, runner: CliRunner) -> None:
+        """--format flag must appear in --help output."""
+        result = runner.invoke(perf, ["--help"])
+        assert result.exit_code == 0
+        assert "--format" in result.output
+        assert "json" in result.output
+
+    def test_invalid_format_rejected(self, runner: CliRunner) -> None:
+        """An invalid --format value must be rejected by Click."""
+        result = runner.invoke(perf, ["-m", "test", "--format", "xml"], obj={})
+        assert result.exit_code != 0
+
+    @patch("winml.modelkit.commands.perf.PerfBenchmark")
+    def test_format_json_emits_valid_json(
+        self, mock_benchmark_class: MagicMock, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """--format json must produce parseable JSON on stdout.
+
+        Note: CliRunner mixes stderr into result.output; in production the
+        Console(stderr=True) keeps stdout clean. Extract JSON from mixed output.
+        """
+        mock_result = MagicMock()
+        mock_result.to_dict.return_value = {
+            "benchmark_info": {
+                "model_id": "microsoft/resnet-50",
+                "task": "image-classification",
+                "device": "cpu",
+                "ep": None,
+            },
+            "latency_ms": {"mean": 18.3, "p50": 17.5, "p90": 21.7},
+            "throughput": {"samples_per_sec": 54.6},
+        }
+        mock_instance = MagicMock()
+        mock_instance.run.return_value = mock_result
+        mock_benchmark_class.return_value = mock_instance
+
+        output_file = tmp_path / "result.json"
+
+        result = runner.invoke(
+            perf,
+            [
+                "-m",
+                "microsoft/resnet-50",
+                "--format",
+                "json",
+                "--output",
+                str(output_file),
+            ],
+            obj={},
+        )
+
+        assert result.exit_code == 0
+        # Extract JSON object from mixed output (CliRunner mixes stderr)
+        output = result.output
+        json_start = output.index("{")
+        json_end = output.rindex("}") + 1
+        parsed = json.loads(output[json_start:json_end])
+        assert parsed["benchmark_info"]["model_id"] == "microsoft/resnet-50"
+        assert "latency_ms" in parsed
+
+    @patch("winml.modelkit.commands.perf.PerfBenchmark")
+    def test_format_text_shows_console_report(
+        self, mock_benchmark_class: MagicMock, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """Default --format text must not emit raw JSON."""
+        mock_result = MagicMock()
+        mock_result.to_dict.return_value = {"benchmark_info": {"model_id": "test"}}
+        mock_result.config = MagicMock()
+        mock_result.config.model_id = "test"
+        mock_result.actual_device = "cpu"
+        mock_result.actual_task = "cls"
+        mock_result.actual_ep = None
+        mock_result.mean_ms = 10.0
+        mock_result.min_ms = 9.0
+        mock_result.max_ms = 11.0
+        mock_result.p50_ms = 10.0
+        mock_result.p90_ms = 10.5
+        mock_result.p95_ms = 10.8
+        mock_result.p99_ms = 11.0
+        mock_result.std_ms = 0.5
+        mock_result.warmup_mean_ms = 12.0
+        mock_result.samples_per_sec = 100.0
+        mock_result.batches_per_sec = 100.0
+        mock_result.hw_monitor = None
+        mock_instance = MagicMock()
+        mock_instance.run.return_value = mock_result
+        mock_benchmark_class.return_value = mock_instance
+
+        output_file = tmp_path / "result.json"
+
+        result = runner.invoke(
+            perf,
+            [
+                "-m",
+                "test",
+                "--output",
+                str(output_file),
+            ],
+            obj={},
+        )
+
+        assert result.exit_code == 0
+        # Should NOT be parseable as JSON (it's console text)
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(result.output)


### PR DESCRIPTION
## Summary

Add and unify `-f`/`--format` option across **all** data-producing commands, enabling programmatic JSON output for Copilot agent skills and scripting workflows.

- **New**: `winml eval`, `winml analyze`, `winml perf`, `winml catalog` now support `--format json`
- **Unified**: `winml inspect`, `winml sys`, `winml run` migrated to shared `format_option()` decorator
- Shared `OutputFormat` type alias and `cli_utils.format_option()` decorator eliminates duplicate option definitions

Closes #847, closes #848, closes #849
Ref #858

## Changes

### New `--format json` support

| Command | `--format` choices | Default |
|---------|-------------------|---------|
| `eval` | `text`, `json` | `text` |
| `analyze` | `text`, `json` | `text` |
| `perf` | `text`, `json` | `text` |
| `catalog` | `text`, `json` | `text` |

### Unified to shared `format_option()` decorator

| Command | `--format` choices | Default | Notes |
|---------|-------------------|---------|-------|
| `inspect` | `table`, `json` | `table` | Was inline option |
| `sys` | `text`, `json`, `compact` | `text` | Was inline option |
| `run` | `text`, `json` | `text` | Was inline option; uses `--format` (no `-f` short flag, conflicts with `--file`) |

### Implementation details

- `cli_utils.format_option(choices, default, short_flag)` — shared Click decorator
- `OutputFormat` TypeAlias for static typing
- All banner/spinner/progress output routed to stderr in JSON mode
- JSON emitted via `click.echo(json.dumps(..., indent=2))` to stdout
- `analyze`: JSON emitted **before** `sys.exit()` so partial-support results (exit 1) still produce output

## Sample JSON output

### `winml eval --format json`
```json
{
  "mode": "onnx",
  "model_id": "microsoft/resnet-50",
  "task": "image-classification",
  "device": "npu",
  "ep": "QNNExecutionProvider",
  "precision": "w8a16",
  "dataset": {
    "path": "timm/mini-imagenet",
    "samples": 100,
    "split": "test"
  },
  "metrics": {
    "top1_accuracy": 0.741,
    "top5_accuracy": 0.912
  }
}
```

### `winml analyze --format json`
```json
{
  "analysis_timestamp": "2026-06-10T10:30:00",
  "metadata": {
    "model_path": "model.onnx",
    "opset_version": 13,
    "total_operators": 146,
    "operator_counts": {"Conv": 53, "Add": 50, "Relu": 43},
    "unique_operator_types": 3
  },
  "results": [
    {
      "ep": "QNNExecutionProvider",
      "device": "NPU",
      "supported": 142,
      "partial": 3,
      "unsupported": 1,
      "partial_ops": ["MultiHeadAttention", "LayerNorm", "Softmax"],
      "unsupported_ops": ["CustomRotaryEmbedding"]
    }
  ]
}
```

### `winml perf --format json`
```json
{
  "benchmark_info": {
    "model_id": "microsoft/resnet-50",
    "device": "npu",
    "ep": "QNNExecutionProvider",
    "iterations": 100,
    "warmup": 10,
    "batch_size": 1
  },
  "latency_ms": {
    "mean": 18.9,
    "min": 16.2,
    "max": 28.4,
    "p50": 18.3,
    "p90": 21.7,
    "p95": 23.1,
    "p99": 28.4,
    "std": 2.1
  },
  "throughput": {
    "samples_per_sec": 54.6,
    "batches_per_sec": 54.6
  }
}
```

### `winml catalog --format json`
```json
[
  {
    "model_id": "google-bert/bert-base-uncased",
    "model_type": "bert",
    "size_mb": 104.4,
    "task": "fill-mask",
    "supported_eps": {
      "cpu": ["CPU"],
      "dml": ["GPU"],
      "qnn": ["GPU", "NPU"],
      "openvino": ["CPU", "GPU", "NPU"]
    }
  },
  {
    "model_id": "microsoft/resnet-50",
    "model_type": "resnet",
    "size_mb": 97.8,
    "task": "image-classification",
    "supported_eps": {
      "cpu": ["CPU"],
      "dml": ["GPU"],
      "qnn": ["GPU", "NPU"]
    }
  }
]
```

### `winml inspect --format json`
```json
{
  "model_path": "model.onnx",
  "opset_version": 13,
  "ir_version": 8,
  "producer": "pytorch 2.1",
  "inputs": [
    {"name": "pixel_values", "shape": [1, 3, 224, 224], "dtype": "float32"}
  ],
  "outputs": [
    {"name": "logits", "shape": [1, 1000], "dtype": "float32"}
  ],
  "operators": {"Conv": 53, "Add": 50, "Relu": 43}
}
```

### `winml sys --format json`
```json
{
  "platform": "Windows-11-10.0.26100",
  "python": "3.11.14",
  "onnxruntime": "1.21.1",
  "execution_providers": [
    {"name": "QNNExecutionProvider", "available": true},
    {"name": "DmlExecutionProvider", "available": true},
    {"name": "CPUExecutionProvider", "available": true}
  ],
  "devices": {
    "cpu": "13th Gen Intel Core i7-1365U",
    "gpu": "Intel Iris Xe Graphics",
    "npu": "Intel AI Boost"
  }
}
```

### `winml run --format json`
```json
{
  "model_id": "microsoft/resnet-50",
  "task": "image-classification",
  "ep": "QNNExecutionProvider",
  "outputs": {
    "logits": [[0.02, 0.01, 0.95, "..."]]
  },
  "postprocessed": {
    "label": "golden retriever",
    "score": 0.95
  }
}
```

## Design decisions

- `--format json` and `--output` are independently combinable
- JSON uses `indent=2` for readability, consistent across all commands
- All banner/spinner/progress output goes to stderr in JSON mode
- `--format` defaults to `text` (or `table` for inspect) to preserve backward compatibility
- `format_option(short_flag=False)` for `run` to avoid conflict with `-f`/`--file`