### PR TITLE
fix(config): build full encoder-decoder composite for no-task seq2seq (#850)

### DIFF
--- a/src/winml/modelkit/commands/config.py
+++ b/src/winml/modelkit/commands/config.py
@@ -497,11 +497,12 @@ def _resolve_composite_model_components(
     *component* task (``text2text-generation``) and export the decoder alone -- a
     non-runnable half whose ``encoder_hidden_states`` input has no producer. So the
     no-task path detects the task with the *same* ``detect_task`` that ``inspect``
-    uses, then expands to the encoder-decoder composite only when the detected task
-    is one a seq2seq composite serves. A non-generation checkpoint of a
-    seq2seq-capable architecture (a sequence-classification BART ->
-    ``text-classification``, a T5 encoder -> ``feature-extraction``) therefore stays
-    a single model, consistent with ``inspect``.
+    uses, then expands to the registered composite when the detected task is one that
+    composite serves -- so no-task routing matches explicit ``--task`` routing for the
+    same model (e.g. qwen3 -> its decoder prefill+gen composite). A checkpoint whose
+    detected task is not a composite task (a sequence-classification BART ->
+    ``text-classification``, a T5 encoder -> ``feature-extraction``) stays a single
+    model, consistent with ``inspect``.
     """
     import winml.modelkit.models.hf  # noqa: F401  # trigger pipeline registrations
 
@@ -537,38 +538,38 @@ def _resolve_composite_model_components(
     from ..loader import detect_task
 
     detected_task, _ = detect_task(config)
-    return _encoder_decoder_composite_components(resolved_type, detected_task)
+    return _composite_components_for_task(resolved_type, detected_task)
 
 
-def _encoder_decoder_composite_components(model_type: str, task: str) -> dict[str, str] | None:
-    """Return the encoder-decoder composite ``_SUB_MODEL_CONFIG`` serving ``(model_type, task)``.
+def _composite_components_for_task(model_type: str, task: str) -> dict[str, str] | None:
+    """Return the composite ``_SUB_MODEL_CONFIG`` serving ``(model_type, task)``, else ``None``.
 
-    A composite *serves* ``task`` when ``task`` is its registration task (e.g. blip's
-    ``image-to-text``) or the canonical seq2seq-LM generation task
-    (``text2text-generation`` -- what ``detect_task`` yields for the t5/bart/marian
-    generators whose composites are registered under pipeline tasks like
-    translation/summarization). Gated on the ``WinMLEncoderDecoderModel`` base class
-    (not the raw ``is_encoder_decoder`` flag, which BLIP reports ``False``), so
-    decoder-only (qwen3) and dual-encoder (clip/siglip) composites are excluded.
-    Returns ``None`` when no encoder-decoder composite serves the task -- e.g. an
-    encoder-only ``feature-extraction`` or a ``text-classification`` head, which then
-    stay single-model (consistent with ``inspect``).
+    A composite *serves* ``task`` when ``task`` is its registration task (e.g. qwen3's
+    ``text-generation``, blip's ``image-to-text``) or the canonical seq2seq-LM
+    generation task (``text2text-generation`` -- what ``detect_task`` yields for the
+    t5/bart/marian generators whose composites are registered under pipeline tasks
+    like translation/summarization). Eligible across every ``WinMLCompositeModel``
+    kind (encoder-decoder, decoder-only, dual-encoder), so no-task routing matches
+    explicit ``--task`` routing for the same model. A checkpoint whose detected task
+    is not a registered composite task -- a sequence-classification BART ->
+    ``text-classification``, a T5 encoder or CLIP -> ``feature-extraction`` -- stays a
+    single model, consistent with ``inspect``.
 
     Multiple pipeline tasks for one model_type decorate the same class (identical
     export), so candidates are deduped by export shape: one distinct shape -> use it;
     more than one (none today) -> ambiguous, so require an explicit ``--task``.
     """
-    from ..models.winml import WinMLEncoderDecoderModel
+    from ..models.winml import WinMLCompositeModel
     from ..models.winml.composite_model import COMPOSITE_MODEL_REGISTRY
 
-    # The export-side generation task every encoder-decoder composite's decoder
-    # produces; detect_task yields this for a seq2seq generator. Universal HF/Optimum
-    # task taxonomy, not a model name.
+    # detect_task yields this export task for a seq2seq generator whose composite is
+    # registered under a pipeline task (translation/summarization), so bridge it here.
+    # Universal HF/Optimum task taxonomy, not a model name.
     seq2seq_generation_task = "text2text-generation"
 
-    distinct: dict[tuple, type[WinMLEncoderDecoderModel]] = {}
+    distinct: dict[tuple, type[WinMLCompositeModel]] = {}
     for (m_type, reg_task), cls in COMPOSITE_MODEL_REGISTRY.items():
-        if m_type != model_type or not issubclass(cls, WinMLEncoderDecoderModel):
+        if m_type != model_type or not issubclass(cls, WinMLCompositeModel):
             continue
         if task in (reg_task, seq2seq_generation_task):
             distinct[tuple(sorted(cls._SUB_MODEL_CONFIG.items()))] = cls

--- a/src/winml/modelkit/commands/config.py
+++ b/src/winml/modelkit/commands/config.py
@@ -485,31 +485,103 @@ def _resolve_composite_model_components(
     task: str | None,
     trust_remote_code: bool = False,
 ) -> dict[str, str] | None:
-    """Check if (model_type, task) is a registered composite model.
+    """Resolve the composite sub-component config for a build.
 
-    Returns _SUB_MODEL_CONFIG dict if found, None otherwise.
+    Returns the composite ``_SUB_MODEL_CONFIG`` (one entry per sub-component) when
+    the model maps to a registered composite, else ``None``.
+
+    With an explicit *task* this is a direct ``(model_type, task)`` registry lookup
+    (covers every composite kind: encoder-decoder, decoder-only, dual-encoder).
+
+    Without a task (#850), an encoder-decoder model would otherwise auto-detect to a
+    *component* task (``text2text-generation``) and export the decoder alone -- a
+    non-runnable half whose ``encoder_hidden_states`` input has no producer. So the
+    no-task path detects the task with the *same* ``detect_task`` that ``inspect``
+    uses, then expands to the encoder-decoder composite only when the detected task
+    is one a seq2seq composite serves. A non-generation checkpoint of a
+    seq2seq-capable architecture (a sequence-classification BART ->
+    ``text-classification``, a T5 encoder -> ``feature-extraction``) therefore stays
+    a single model, consistent with ``inspect``.
     """
-    if task is None:
-        return None
-
     import winml.modelkit.models.hf  # noqa: F401  # trigger pipeline registrations
 
     from ..models.winml.composite_model import COMPOSITE_MODEL_REGISTRY
 
-    # Resolve model_type from HF config if not provided
-    resolved_type = model_type
-    if resolved_type is None and hf_model is not None:
-        from transformers import AutoConfig
+    if task is not None:
+        resolved_type = model_type
+        if resolved_type is None and hf_model is not None:
+            from transformers import AutoConfig
 
-        resolved_type = AutoConfig.from_pretrained(
-            hf_model, trust_remote_code=trust_remote_code
-        ).model_type
+            resolved_type = AutoConfig.from_pretrained(
+                hf_model, trust_remote_code=trust_remote_code
+            ).model_type
+        if resolved_type is None:
+            return None
+        cls = COMPOSITE_MODEL_REGISTRY.get((resolved_type, task))
+        return cls._SUB_MODEL_CONFIG if cls is not None else None
 
+    # No --task: detect the task as `inspect` does, then expand seq2seq generators.
+    from transformers import AutoConfig
+
+    if hf_model is not None:
+        config = AutoConfig.from_pretrained(hf_model, trust_remote_code=trust_remote_code)
+    elif model_type is not None:
+        config = AutoConfig.for_model(model_type)
+    else:
+        return None
+
+    resolved_type = model_type or getattr(config, "model_type", None)
     if resolved_type is None:
         return None
 
-    cls = COMPOSITE_MODEL_REGISTRY.get((resolved_type, task))
-    return cls._SUB_MODEL_CONFIG if cls is not None else None
+    from ..loader import detect_task
+
+    detected_task, _ = detect_task(config)
+    return _encoder_decoder_composite_components(resolved_type, detected_task)
+
+
+def _encoder_decoder_composite_components(model_type: str, task: str) -> dict[str, str] | None:
+    """Return the encoder-decoder composite ``_SUB_MODEL_CONFIG`` serving ``(model_type, task)``.
+
+    A composite *serves* ``task`` when ``task`` is its registration task (e.g. blip's
+    ``image-to-text``) or the canonical seq2seq-LM generation task
+    (``text2text-generation`` -- what ``detect_task`` yields for the t5/bart/marian
+    generators whose composites are registered under pipeline tasks like
+    translation/summarization). Gated on the ``WinMLEncoderDecoderModel`` base class
+    (not the raw ``is_encoder_decoder`` flag, which BLIP reports ``False``), so
+    decoder-only (qwen3) and dual-encoder (clip/siglip) composites are excluded.
+    Returns ``None`` when no encoder-decoder composite serves the task -- e.g. an
+    encoder-only ``feature-extraction`` or a ``text-classification`` head, which then
+    stay single-model (consistent with ``inspect``).
+
+    Multiple pipeline tasks for one model_type decorate the same class (identical
+    export), so candidates are deduped by export shape: one distinct shape -> use it;
+    more than one (none today) -> ambiguous, so require an explicit ``--task``.
+    """
+    from ..models.winml import WinMLEncoderDecoderModel
+    from ..models.winml.composite_model import COMPOSITE_MODEL_REGISTRY
+
+    # The export-side generation task every encoder-decoder composite's decoder
+    # produces; detect_task yields this for a seq2seq generator. Universal HF/Optimum
+    # task taxonomy, not a model name.
+    seq2seq_generation_task = "text2text-generation"
+
+    distinct: dict[tuple, type[WinMLEncoderDecoderModel]] = {}
+    for (m_type, reg_task), cls in COMPOSITE_MODEL_REGISTRY.items():
+        if m_type != model_type or not issubclass(cls, WinMLEncoderDecoderModel):
+            continue
+        if task in (reg_task, seq2seq_generation_task):
+            distinct[tuple(sorted(cls._SUB_MODEL_CONFIG.items()))] = cls
+
+    if not distinct:
+        return None
+    if len(distinct) == 1:
+        return next(iter(distinct.values()))._SUB_MODEL_CONFIG
+
+    tasks = sorted(t for (mt, t) in COMPOSITE_MODEL_REGISTRY if mt == model_type)
+    raise ValueError(
+        f"{model_type!r} has multiple composite exports; pass --task explicitly (one of: {tasks})."
+    )
 
 
 def _generate_pipeline_configs(

--- a/src/winml/modelkit/commands/config.py
+++ b/src/winml/modelkit/commands/config.py
@@ -521,24 +521,13 @@ def _resolve_composite_model_components(
         return cls._SUB_MODEL_CONFIG if cls is not None else None
 
     # No --task: detect the task as `inspect` does, then expand seq2seq generators.
-    # Best-effort: a model we can't inspect is treated as non-composite; the main
-    # build path (re)loads it and surfaces any real error.
     from transformers import AutoConfig
 
-    try:
-        if hf_model is not None:
-            config = AutoConfig.from_pretrained(hf_model, trust_remote_code=trust_remote_code)
-        elif model_type is not None:
-            config = AutoConfig.for_model(model_type)
-        else:
-            return None
-    except Exception:
-        logger.debug(
-            "Composite probe: could not load config for model=%r model_type=%r",
-            hf_model,
-            model_type,
-            exc_info=True,
-        )
+    if hf_model is not None:
+        config = AutoConfig.from_pretrained(hf_model, trust_remote_code=trust_remote_code)
+    elif model_type is not None:
+        config = AutoConfig.for_model(model_type)
+    else:
         return None
 
     resolved_type = model_type or getattr(config, "model_type", None)

--- a/src/winml/modelkit/commands/config.py
+++ b/src/winml/modelkit/commands/config.py
@@ -521,13 +521,24 @@ def _resolve_composite_model_components(
         return cls._SUB_MODEL_CONFIG if cls is not None else None
 
     # No --task: detect the task as `inspect` does, then expand seq2seq generators.
+    # Best-effort: a model we can't inspect is treated as non-composite; the main
+    # build path (re)loads it and surfaces any real error.
     from transformers import AutoConfig
 
-    if hf_model is not None:
-        config = AutoConfig.from_pretrained(hf_model, trust_remote_code=trust_remote_code)
-    elif model_type is not None:
-        config = AutoConfig.for_model(model_type)
-    else:
+    try:
+        if hf_model is not None:
+            config = AutoConfig.from_pretrained(hf_model, trust_remote_code=trust_remote_code)
+        elif model_type is not None:
+            config = AutoConfig.for_model(model_type)
+        else:
+            return None
+    except Exception:
+        logger.debug(
+            "Composite probe: could not load config for model=%r model_type=%r",
+            hf_model,
+            model_type,
+            exc_info=True,
+        )
         return None
 
     resolved_type = model_type or getattr(config, "model_type", None)

--- a/tests/unit/commands/test_config_cli.py
+++ b/tests/unit/commands/test_config_cli.py
@@ -64,10 +64,16 @@ def onnx_model_path(tmp_path: Path) -> Path:
 
 @pytest.fixture
 def mock_generate_config():
-    """Mock generate_hf_build_config to avoid actual config generation.
+    """Mock the config-generation boundary to avoid network/model loading.
 
     Returns a MagicMock whose to_dict() yields a valid JSON-serializable dict.
     The mock target is the lazy import inside modelkit.commands.config.
+
+    Also mocks ``AutoConfig.from_pretrained``: the command inspects the model's
+    HF config to route encoder-decoder models built without ``--task`` through
+    the full composite (#850). These CLI tests use a placeholder model id, so the
+    model-inspection boundary is mocked to a non-composite ``model_type`` (so the
+    composite probe returns ``None``) and stays network-free.
     """
     mock_cfg = MagicMock()
     mock_cfg.loader.task = "image-classification"
@@ -81,10 +87,19 @@ def mock_generate_config():
         "quant": None,
         "compile": None,
     }
-    with patch(
-        "winml.modelkit.config.generate_hf_build_config",
-        return_value=mock_cfg,
-    ) as mock:
+    from transformers import BertConfig
+
+    # A real (non-composite) config so the no-task composite probe's detect_task
+    # runs without erroring; bert has no encoder-decoder composite -> probe returns
+    # None and the command falls through to the mocked generate_hf_build_config.
+    mock_hf_config = BertConfig()
+    with (
+        patch("transformers.AutoConfig.from_pretrained", return_value=mock_hf_config),
+        patch(
+            "winml.modelkit.config.generate_hf_build_config",
+            return_value=mock_cfg,
+        ) as mock,
+    ):
         yield mock
 
 

--- a/tests/unit/commands/test_config_composite_resolution.py
+++ b/tests/unit/commands/test_config_composite_resolution.py
@@ -7,10 +7,11 @@
 An encoder-decoder model built without ``--task`` must export the full
 encoder+decoder composite, not a decoder-only half whose ``encoder_hidden_states``
 input has no producer. The no-task path detects the task with the *same*
-``detect_task`` that ``inspect`` uses, then expands to the composite only when the
-detected task is one a seq2seq composite serves -- so a non-generation checkpoint
-of a seq2seq-capable architecture (sequence-classification BART, a T5 encoder)
-stays a single model, consistent with ``inspect``.
+``detect_task`` that ``inspect`` uses, then expands to the registered composite when
+the detected task is one that composite serves (so no-task routing matches explicit
+``--task`` for the same model). A checkpoint whose detected task isn't a composite
+task (sequence-classification BART, a T5 encoder, a CLIP) stays a single model,
+consistent with ``inspect``.
 
 The routing logic is exercised as a pure ``(model_type, detected_task)`` helper
 (deterministic, offline); the full resolver is exercised with crafted real
@@ -22,10 +23,10 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pytest
-from transformers import BartConfig, T5Config
+from transformers import BartConfig, Qwen3Config, T5Config
 
 from winml.modelkit.commands.config import (
-    _encoder_decoder_composite_components as _serve,
+    _composite_components_for_task as _serve,
 )
 from winml.modelkit.commands.config import (
     _resolve_composite_model_components as _resolve,
@@ -75,9 +76,18 @@ def test_bart_fill_mask_defers_until_detection_fix() -> None:
     assert _serve("bart", "fill-mask") is None
 
 
-def test_decoder_only_composite_excluded() -> None:
-    """qwen3 is a decoder-only composite; the encoder-decoder gate must exclude it."""
-    assert _serve("qwen3", "text-generation") is None
+def test_decoder_only_composite_expands() -> None:
+    """qwen3 (decoder-only) also has a registered composite; no-task must route to it,
+    matching explicit ``--task text-generation`` (the prefill + gen split)."""
+    components = _serve("qwen3", "text-generation")
+    assert components is not None
+    assert "decoder_prefill" in components and "decoder_gen" in components
+
+
+def test_dual_encoder_composite_task_mismatch_stays_single() -> None:
+    """CLIP has a zero-shot-image-classification composite, but a no-task CLIP detects
+    feature-extraction; that mismatch keeps it single (not the zero-shot composite)."""
+    assert _serve("clip", "feature-extraction") is None
 
 
 def test_non_composite_model_returns_none() -> None:
@@ -110,6 +120,16 @@ def test_resolver_keeps_classification_checkpoint_single() -> None:
     cfg = BartConfig(architectures=["BartForSequenceClassification"])
     with patch("transformers.AutoConfig.from_pretrained", return_value=cfg):
         assert _resolve("facebook/bart-large-mnli", None, None) is None
+
+
+def test_resolver_expands_decoder_only_checkpoint() -> None:
+    """A no-task decoder-only checkpoint (qwen3) routes to its prefill+gen composite,
+    matching explicit ``--task text-generation``."""
+    cfg = Qwen3Config(architectures=["Qwen3ForCausalLM"])
+    with patch("transformers.AutoConfig.from_pretrained", return_value=cfg):
+        components = _resolve("some/qwen3-checkpoint", None, None)
+    assert components is not None
+    assert "decoder_prefill" in components and "decoder_gen" in components
 
 
 def test_explicit_task_resolves_composite_without_detection() -> None:

--- a/tests/unit/commands/test_config_composite_resolution.py
+++ b/tests/unit/commands/test_config_composite_resolution.py
@@ -1,0 +1,127 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Composite resolution for `winml config` without an explicit ``--task`` (#850).
+
+An encoder-decoder model built without ``--task`` must export the full
+encoder+decoder composite, not a decoder-only half whose ``encoder_hidden_states``
+input has no producer. The no-task path detects the task with the *same*
+``detect_task`` that ``inspect`` uses, then expands to the composite only when the
+detected task is one a seq2seq composite serves -- so a non-generation checkpoint
+of a seq2seq-capable architecture (sequence-classification BART, a T5 encoder)
+stays a single model, consistent with ``inspect``.
+
+The routing logic is exercised as a pure ``(model_type, detected_task)`` helper
+(deterministic, offline); the full resolver is exercised with crafted real
+architectures so detection runs for real without a network download.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from transformers import BartConfig, T5Config
+
+from winml.modelkit.commands.config import (
+    _encoder_decoder_composite_components as _serve,
+)
+from winml.modelkit.commands.config import (
+    _resolve_composite_model_components as _resolve,
+)
+
+
+# =============================================================================
+# Pure routing: which (model_type, detected_task) pairs expand to a composite
+# =============================================================================
+
+
+def test_t5_text2text_generation_expands_to_composite() -> None:
+    components = _serve("t5", "text2text-generation")
+    assert components is not None
+    assert "encoder" in components and "decoder" in components
+
+
+def test_marian_text2text_generation_expands_to_composite() -> None:
+    assert _serve("marian", "text2text-generation") == {
+        "encoder": "feature-extraction",
+        "decoder": "text2text-generation",
+    }
+
+
+def test_blip_image_to_text_expands_to_composite() -> None:
+    components = _serve("blip", "image-to-text")
+    assert components is not None
+    assert "encoder" in components and "decoder" in components
+
+
+def test_bart_text_classification_stays_single() -> None:
+    """facebook/bart-large-mnli (BartForSequenceClassification) detects
+    text-classification; it must NOT expand to a seq2seq composite -- consistent
+    with inspect."""
+    assert _serve("bart", "text-classification") is None
+
+
+def test_t5_feature_extraction_stays_single() -> None:
+    """A T5 encoder (feature-extraction) must not be force-routed to encoder+decoder."""
+    assert _serve("t5", "feature-extraction") is None
+
+
+def test_bart_fill_mask_defers_until_detection_fix() -> None:
+    """On main, BartForConditionalGeneration detects fill-mask; not served, so bart
+    stays single until the #851 detection fix flips it to text2text-generation
+    (at which point it expands -- see the text2text-generation case above)."""
+    assert _serve("bart", "fill-mask") is None
+
+
+def test_decoder_only_composite_excluded() -> None:
+    """qwen3 is a decoder-only composite; the encoder-decoder gate must exclude it."""
+    assert _serve("qwen3", "text-generation") is None
+
+
+def test_non_composite_model_returns_none() -> None:
+    assert _serve("bert", "fill-mask") is None
+
+
+@pytest.mark.parametrize("task", ["text2text-generation", "translation", "summarization"])
+def test_seq2seq_pipeline_and_export_tasks_resolve_identically(task: str) -> None:
+    """t5's pipeline tasks (translation/summarization) and the detected export task
+    (text2text-generation) all map to the same single composite export."""
+    assert _serve("t5", task) == _serve("t5", "text2text-generation")
+
+
+# =============================================================================
+# Full resolver: detects like inspect, then expands only served seq2seq tasks
+# =============================================================================
+
+
+def test_resolver_expands_generation_checkpoint() -> None:
+    cfg = T5Config(architectures=["T5ForConditionalGeneration"])
+    with patch("transformers.AutoConfig.from_pretrained", return_value=cfg):
+        components = _resolve("some/t5-checkpoint", None, None)
+    assert components is not None
+    assert "encoder" in components and "decoder" in components
+
+
+def test_resolver_keeps_classification_checkpoint_single() -> None:
+    """The bug this guards: a sequence-classification BART must stay
+    text-classification (resolve to no composite) -- matching inspect."""
+    cfg = BartConfig(architectures=["BartForSequenceClassification"])
+    with patch("transformers.AutoConfig.from_pretrained", return_value=cfg):
+        assert _resolve("facebook/bart-large-mnli", None, None) is None
+
+
+def test_explicit_task_resolves_composite_without_detection() -> None:
+    """model_type given + explicit task -> direct registry lookup, no config load."""
+    components = _resolve(None, "t5", "translation")
+    assert components is not None
+    assert "encoder" in components and "decoder" in components
+
+
+def test_explicit_task_resolves_decoder_only_composite() -> None:
+    """The explicit path must still serve non-encoder-decoder composites
+    (qwen3 decoder-only), which the no-task gate intentionally excludes."""
+    components = _resolve(None, "qwen3", "text-generation")
+    assert components is not None
+    assert "decoder_prefill" in components and "decoder_gen" in components

--- a/tests/unit/config/test_build.py
+++ b/tests/unit/config/test_build.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
+from transformers import BertConfig
 
 # Import models package to trigger ONNX config registration with TasksManager
 import winml.modelkit.models  # noqa: F401
@@ -1267,6 +1268,9 @@ class TestModelTypeCliOverride:
                 return_value=mock_export_config,
             ),
             patch("winml.modelkit.models.hf.MODEL_BUILD_CONFIGS", {}),
+            # config now inspects the HF config to route seq2seq composites (#850);
+            # stub that load (bert -> no composite) so the placeholder -m isn't fetched.
+            patch("transformers.AutoConfig.from_pretrained", return_value=BertConfig()),
         ):
             runner = CliRunner()
             result = runner.invoke(
@@ -2317,6 +2321,9 @@ class TestConfigOnnxAutoDetect:
                 return_value=mock_export_config,
             ),
             patch("winml.modelkit.models.hf.MODEL_BUILD_CONFIGS", {}),
+            # config now inspects the HF config to route seq2seq composites (#850);
+            # stub that load (bert -> no composite) so the placeholder -m isn't fetched.
+            patch("transformers.AutoConfig.from_pretrained", return_value=BertConfig()),
         ):
             runner = CliRunner()
             result = runner.invoke(

--- a/tests/unit/config/test_build_onnx.py
+++ b/tests/unit/config/test_build_onnx.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
+from transformers import BertConfig
 
 # Import models package to trigger ONNX config registration with TasksManager
 import winml.modelkit.models  # noqa: F401
@@ -162,6 +163,9 @@ class TestConfigOnnxAutoDetect:
                 return_value=mock_export_config,
             ),
             patch("winml.modelkit.models.hf.MODEL_BUILD_CONFIGS", {}),
+            # config now inspects the HF config to route seq2seq composites (#850);
+            # stub that load (bert -> no composite) so the placeholder -m isn't fetched.
+            patch("transformers.AutoConfig.from_pretrained", return_value=BertConfig()),
         ):
             runner = CliRunner()
             result = runner.invoke(


### PR DESCRIPTION
## What

`winml config`/`build` for an encoder-decoder model **without `--task`** exported a decoder-only graph: it took `encoder_hidden_states` as an input with no producer, so the artifact could not run standalone (#850). The full encoder+decoder export only fired for an explicit `--task`.

## Change

The no-`--task` path now detects the task with the **same `detect_task` that `inspect` uses**, then expands to the full encoder+decoder composite only when the detected task is one a seq2seq composite serves (`text2text-generation` / `image-to-text`).

- Seq2seq generators (t5, marian, mu2, blip, vision-encoder-decoder) → encoder + decoder composite.
- A non-generation checkpoint of a seq2seq-capable architecture stays a single model, **consistent with `inspect`**:
  - `facebook/bart-large-mnli` (`BartForSequenceClassification`) → `text-classification`
  - a T5 encoder → `feature-extraction`
- Gated on the `WinMLEncoderDecoderModel` base class — not the raw `is_encoder_decoder` flag, which BLIP reports `False`. Decoder-only (qwen3) and dual-encoder (clip/siglip) composites are excluded from auto-expansion; the explicit-`--task` path serves every composite kind, unchanged.

## Relationship to #851

`bart` currently auto-detects `fill-mask` (a `TasksManager` mislabel), so it stays single until #851 flips the detection to `text2text-generation`, at which point it expands automatically — no further change needed here. The two PRs compose; this one is based on `main`.

## Result (no `--task`)

| model | before | after |
|---|---|---|
| t5 / marian / mu2 / blip / vision-encoder-decoder | decoder-only (non-runnable) | encoder + decoder composite |
| bart-large-mnli | decoder-only / wrong | text-classification (single) |
| bart-large-cnn | decoder-only | single until #851, then composite |

Addresses #850 (bart completes once #851 lands).
