### PR TITLE
Populate last_hidden_state in the output of feature extraction model class

### DIFF
--- a/src/winml/modelkit/models/winml/feature_extraction.py
+++ b/src/winml/modelkit/models/winml/feature_extraction.py
@@ -59,4 +59,10 @@ class WinMLModelForFeatureExtraction(WinMLPreTrainedModel):
         pooling handles 1-D and 2-D after raw[0].
         """
         outputs = self._run_inference(self._format_inputs(**kwargs))
+        # WinMLEncoderDecoderModel expects its encoder sub-component to expose
+        # hidden states as "last_hidden_state". Alias the primary output when an
+        # encoder ONNX graph named it otherwise (e.g. "encoder_hidden_states").
+        # Appended last to preserve output[0] and the real ONNX output names.
+        if outputs and "last_hidden_state" not in outputs:
+            outputs["last_hidden_state"] = next(iter(outputs.values()))
         return FeatureExtractionModelOutput(outputs)


### PR DESCRIPTION
Fixes a regression introduced from #805

In #805, we removed the last_hidden_state output from the model class output and return whatever output provided by the underlying onnx model.

But this causes a regression. The composite model class `encoder_decoder` expects the encoder model to have `last_hidden_state` output. This output is treated as the encoded values. However, some models doesn't have this output name. Therefore, the encoder decoder loop will fail.

The fix is to provide last_hidden_state if the underlying onnx model uses a different output name.