### PR TITLE
test(e2e): drive per-test timeout from --timeout CLI option

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -141,11 +141,26 @@ def runner() -> CliRunner:
 # Auto-skip E2E
 # ---------------------------------------------------------------------------
 
+# Default per-test timeout (seconds) for E2E tests when --timeout is not passed
+# on the command line. Higher than the global 300 s ini default because cold
+# E2E runs build the model end-to-end (export -> optimize -> quantize ->
+# compile). Precedence (highest first): a per-test ``@pytest.mark.timeout``
+# marker, then ``--timeout`` on the CLI, then this default. An explicit
+# ``--timeout`` therefore always wins over this fallback.
+E2E_DEFAULT_TIMEOUT = 900
+
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
-    """Auto-skip E2E tests unless '-m e2e' is explicitly passed."""
+    """Auto-skip E2E tests unless '-m e2e' is passed; else apply the e2e timeout default."""
     marker_expr = config.getoption("-m", default="")
     if "e2e" in str(marker_expr):
+        # E2E tests are running. Inject the default timeout only when neither a
+        # per-test marker nor --timeout is given, so an explicit --timeout on the
+        # CLI always takes effect (pytest-timeout precedence: marker > CLI > ini).
+        if config.getoption("timeout", default=None) is None:
+            for item in items:
+                if "e2e" in item.keywords and item.get_closest_marker("timeout") is None:
+                    item.add_marker(pytest.mark.timeout(E2E_DEFAULT_TIMEOUT))
         return  # User explicitly requested E2E tests
     skip_e2e = pytest.mark.skip(reason="E2E tests require -m e2e (skipped by default)")
     for item in items:

--- a/tests/e2e/test_eval_e2e.py
+++ b/tests/e2e/test_eval_e2e.py
@@ -43,10 +43,12 @@ if TYPE_CHECKING:
     from click.testing import CliRunner
 
 
-# 900 s per-test timeout (overrides the global 300 s in pyproject.toml).
-# Cold runs build the model end-to-end (export -> optimize -> quantize ->
-# compile), which can exceed 300 s for larger composite models (e.g. BLIP).
-pytestmark = [pytest.mark.e2e, pytest.mark.timeout(900)]
+# Per-test timeout is driven by the --timeout CLI option, falling back to the
+# e2e default in tests/e2e/conftest.py when none is passed (an explicit
+# --timeout always wins). Cold runs build the model end-to-end (export ->
+# optimize -> quantize -> compile), which can exceed the global 300 s ini
+# default for larger composite models (e.g. BLIP) or cold NPU compiles.
+pytestmark = [pytest.mark.e2e]
 
 # 10 samples keeps each e2e run short while giving enough signal for
 # range-based assertions. Shuffle uses a fixed seed=42 (see


### PR DESCRIPTION
The module-level pytest.mark.timeout(900) in test_eval_e2e.py overrode the command-line --timeout (pytest-timeout precedence: marker > CLI > ini), so passing --timeout had no effect and cold VitisAI compiles in test_compare_mode hit the 900s cap on CI.

Remove the hardcoded marker and inject an E2E_DEFAULT_TIMEOUT (900s) fallback in conftest only when --timeout is absent, so an explicit --timeout always wins.