### PR TITLE
fix(ci): use docs dependency group for docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           python-version: "3.11"
 
-      - run: uv sync --extra dev
+      - run: uv sync --group docs
 
       - name: Configure git for mike
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,12 @@ dev = [
   "types-pyyaml>=6.0.12.20260518",
   "types-tqdm>=4.67.3.20260518",
 ]
+docs = [
+  "mkdocs-jupyter>=0.25",
+  "mkdocs-material>=9.5",
+  "mike>=2.1",
+  "pymdown-extensions>=10.7",
+]
 
 [tool.setuptools.packages.find]
 where = [ "src" ]


### PR DESCRIPTION
The docs workflow fails on Ubuntu because uv sync --extra dev installs onnxruntime-windowsml which has no Linux wheel. Fix: Add a docs dependency group in pyproject.toml with only mkdocs/mike/pymdown packages, and change workflow to uv sync --group docs.