### PR TITLE
fix(ci): add --no-install-project to docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           python-version: "3.11"
 
-      - run: uv sync --group docs
+      - run: uv sync --only-group docs
 
       - name: Configure git for mike
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           python-version: "3.11"
 
-      - run: uv sync --extra dev
+      - run: uv sync --group docs
 
       - name: Configure git for mike
         run: |

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,7 +1,5 @@
 # Quickstart
 
-This guide walks you through verifying your install, inspecting a model from Hugging Face, running a full build pipeline to produce an optimized ONNX, and benchmarking the model on your device. Estimated time: 5 minutes.
-
 ## Verify the install
 
 Run the following command to enumerate available devices and execution providers
@@ -32,11 +30,6 @@ uv run winml inspect -m microsoft/resnet-50
 +---------------------------------------------------------------------------+
 ```
 
-!!! note "What just happened"
-    `winml inspect` read only the model's `config.json` from Hugging Face Hub —
-    no weights downloaded — and confirmed that `microsoft/resnet-50` maps to a
-    supported task, a known model class, and a compatible ONNX exporter.
-
 !!! tip
     Always inspect before build to catch unsupported architectures early.
 
@@ -46,7 +39,7 @@ uv run winml inspect -m microsoft/resnet-50
 uv run winml build -m microsoft/resnet-50 -o resnet_out/ --no-quant
 ```
 
-`winml build` runs all pipeline steps in sequence — export, optimize, quantize (when an NPU is detected on your device), and compile (disabled by default). You can start a model build without a config file, or provide one to configure each step in the sequence (see [`winml config`](../commands/config.md) to customize).
+`winml build` runs all pipeline steps in sequence — export, optimize, quantize. You can start a model build without a config file, or provide one to configure each step in the sequence (see [`winml config`](../commands/config.md) to customize).
 All intermediate artifacts land in `resnet_out/`, so you can reuse any stage independently.
 
 After a successful build, you will find the following outputs in `resnet_out/`:
@@ -54,15 +47,6 @@ After a successful build, you will find the following outputs in `resnet_out/`:
 - **A standard ONNX file for each completed stage** — load, inspect, or pass any of these to a downstream tool independently.
 - **`analyze_result.json`** — detailed model compatibility insights for each Windows ML EP, including supported, partially supported, and unsupported operators, detected optimization patterns, and recommended optimization workflows.
 - **A declarative `winml_build_config` file** — automatically generated after the build step to capture the full workflow end-to-end.
-
-!!! tip "CI/CD integration"
-    The declarative `winml_build_config` makes it easy to integrate the model build workflow into CI/CD pipelines — the same file drives reproducible, portable build workflows across environments.
-
-!!! note "--no-quant"
-    `--no-quant` tells the pipeline to skip the quantize stage. Quantization is a valuable step for NPU targets, but skipping it here for the output model run on any device.
-
-!!! note "Why compile is disabled by default"
-    Compilation embeds a pre-compiled binary optimized for your specific device. Skip this step to keep the ONNX output portable — it will run on any device using just-in-time (JIT) compilation.
 
 ## Benchmark the model
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,12 @@ dev = [
   "types-pyyaml>=6.0.12.20260518",
   "types-tqdm>=4.67.3.20260518",
 ]
+docs = [
+  "mkdocs-jupyter>=0.25",
+  "mkdocs-material>=9.5",
+  "mike>=2.1",
+  "pymdown-extensions>=10.7",
+]
 
 [tool.setuptools.packages.find]
 where = [ "src" ]


### PR DESCRIPTION
uv sync --group docs still installs the project itself (including onnxruntime-windowsml). Adding --no-install-project skips the project package and only installs the docs group dependencies.