### PR TITLE
feat(perf): add --ep-options to pass runtime EP provider options (#865)

### DIFF
--- a/docs/commands/perf.md
+++ b/docs/commands/perf.md
@@ -23,6 +23,7 @@ $ winml perf [options]
 | `--device` | `-d` | `auto\|cpu\|gpu\|npu` | `auto` | Device to run the benchmark on. `auto` selects the highest-priority available device. |
 | `--precision` | | `TEXT` | `auto` | Precision mode applied during model build: `auto`, `fp32`, `fp16`, `int8`, `int16`, or compound forms such as `w8a16`. |
 | `--ep` | | `TEXT` | — | Force a specific execution provider (e.g., `qnn`, `dml`, `vitisai`, `openvino`, `cpu`). Overrides the device-to-provider mapping. |
+| `--ep-options` | | `KEY=VALUE` (multiple) | — | Runtime EP provider option forwarded to the inference session (e.g., `--ep-options htp_performance_mode=burst`). Repeatable. Applies to both HuggingFace model IDs and ONNX file inputs. Unlike build-time options set via `--config`, these tune the runtime session, not the compiled graph. |
 | `--output` | `-o` | `PATH` | `~/.cache/winml/perf/<slug>/<timestamp>.json` | Output JSON file path for the benchmark report. |
 | `--batch-size` | | `INTEGER` | `1` | Batch size used when generating synthetic input tensors. |
 | `--shape-config` | | `PATH` | — | Path to a JSON file containing shape overrides (e.g., `{"height": 480, "width": 480}`). Ignored for pre-exported ONNX files and in `--module` mode. |
@@ -76,6 +77,14 @@ Benchmark with live hardware monitoring enabled:
 
 ```bash
 $ winml perf -m microsoft/resnet-50 --device npu --monitor
+```
+
+Pass runtime EP provider options to tune the session (repeatable):
+
+```bash
+$ winml perf -m model.onnx --device npu \
+    --ep-options htp_performance_mode=burst \
+    --ep-options htp_graph_finalization_optimization_mode=3
 ```
 
 Per-module benchmarking to find latency hot-spots across all attention blocks:

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -84,6 +84,7 @@ class BenchmarkConfig:
     allow_unsupported_nodes: bool = False
     monitor: bool = False
     ep: EPNameOrAlias | None = None
+    ep_options: dict[str, str] | None = None
     shape_config: dict | None = None
 
 
@@ -368,6 +369,7 @@ class PerfBenchmark:
             "device": self.config.device,
             "precision": self.config.precision,
             "ep": self.config.ep,
+            "provider_options": self.config.ep_options,
             "use_cache": use_cache,
             "force_rebuild": force_rebuild,
             "shape_config": self.config.shape_config,
@@ -554,6 +556,7 @@ def _perf_modules(
     monitor: bool = False,
     device: str = "auto",
     ep: EPNameOrAlias | None = None,
+    ep_options: dict[str, str] | None = None,
     precision: str = "auto",
     allow_unsupported_nodes: bool = False,
 ) -> None:
@@ -578,6 +581,8 @@ def _perf_modules(
         device: Target device policy ("auto", "cpu", "gpu", "npu").
         ep: Explicit execution provider (e.g., "qnn", "dml"). Overrides
             device-to-provider mapping when set.
+        ep_options: Runtime EP provider options (e.g. QNN
+            ``htp_performance_mode``) forwarded to each per-module session.
         precision: Precision mode passed through to the build stage.
         allow_unsupported_nodes: If True, warn instead of failing the build when
             the analyzer reports unsupported nodes that persist.
@@ -687,6 +692,7 @@ def _perf_modules(
                     str(build_result.final_onnx_path),
                     device=resolved_device,
                     ep=ep,
+                    provider_options=ep_options,
                 )
                 io_cfg = session.io_config
                 inputs = generate_random_inputs(io_cfg, batch_size=batch_size)
@@ -1063,6 +1069,9 @@ def _run_simple_loop(
     required=False,
     optional_message="Overrides device-to-provider mapping.",
 )
+@cli_utils.ep_options_option(
+    optional_message="Applied to both HuggingFace model IDs and ONNX file inputs.",
+)
 @cli_utils.output_option(
     "Output JSON file path. Defaults to "
     "'~/.cache/winml/perf/<model_slug>[/<module_class>]/<timestamp>.json'."
@@ -1144,6 +1153,7 @@ def perf(
     device: str,
     precision: str,
     ep: EPNameOrAlias | None,
+    ep_options: tuple[str, ...],
     output: Path | None,
     batch_size: int,
     shape_config_path: Path | None,
@@ -1185,6 +1195,9 @@ def perf(
         # Text model with explicit task
         winml perf -m bert-base-uncased --task text-classification
 
+        # Pass runtime EP provider options (repeatable)
+        winml perf -m model.onnx --device npu --ep-options htp_performance_mode=burst
+
         # Per-module benchmarking
         winml perf -m bert-base-uncased --module BertAttention
 
@@ -1210,6 +1223,10 @@ def perf(
     # Merge top-level -v/-q with subcommand-level flags so either position works.
     verbose, quiet = cli_utils.resolve_verbosity(ctx, verbose, quiet)
     configure_logging(verbosity=verbose, quiet=quiet)
+
+    # Runtime EP provider options (e.g. QNN htp_performance_mode) forwarded to
+    # the inference session for both HF model IDs and ONNX file inputs.
+    ep_provider_options = cli_utils.parse_ep_options(ep_options)
 
     json_mode = output_format == "json"
     console = Console(stderr=True) if json_mode else Console()
@@ -1248,6 +1265,7 @@ def perf(
             monitor=monitor,
             device=device.lower(),
             ep=ep,
+            ep_options=ep_provider_options,
             precision=precision.lower(),
             allow_unsupported_nodes=allow_unsupported_nodes,
         )
@@ -1295,6 +1313,7 @@ def perf(
         allow_unsupported_nodes=allow_unsupported_nodes,
         monitor=monitor,
         ep=ep,
+        ep_options=ep_provider_options,
         shape_config=shape_config,
     )
 

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -148,6 +148,7 @@ class BenchmarkResult:
                 "task": self.actual_task,
                 "device": self.actual_device,
                 "ep": self.actual_ep,
+                "ep_options": self.config.ep_options,
                 "precision": self.config.precision,
                 "iterations": self.config.iterations,
                 "warmup": self.config.warmup,

--- a/src/winml/modelkit/models/auto.py
+++ b/src/winml/modelkit/models/auto.py
@@ -109,6 +109,7 @@ class WinMLAutoModel:
         device: str = "auto",
         precision: str = "auto",
         ep: EPNameOrAlias | None = None,
+        provider_options: dict[str, str] | None = None,
         cache_dir: str | Path | None = None,
         use_cache: bool = True,
         force_rebuild: bool = False,
@@ -131,6 +132,8 @@ class WinMLAutoModel:
             device: Target device ("auto", "npu", "gpu", "cpu").
             precision: Target precision ("auto", "fp32", "fp16", "int8").
             ep: Explicit execution provider.
+            provider_options: Runtime EP provider options (e.g. QNN
+                ``htp_performance_mode``) forwarded to the inference session.
             cache_dir: Override cache directory.
             use_cache: Whether to use persistent cache.
             force_rebuild: Force rebuild even if cached.
@@ -156,6 +159,7 @@ class WinMLAutoModel:
                 device=device,
                 precision=precision,
                 ep=ep,
+                provider_options=provider_options,
                 cache_dir=cache_dir,
                 use_cache=use_cache,
                 force_rebuild=force_rebuild,
@@ -203,6 +207,7 @@ class WinMLAutoModel:
                 device=device,
                 session_options=session_options,
                 ep=ep,
+                provider_options=provider_options,
             )
 
         # Resolve output directory
@@ -241,6 +246,7 @@ class WinMLAutoModel:
             device=device,
             session_options=session_options,
             ep=ep,
+            provider_options=provider_options,
         )
 
     @classmethod
@@ -252,6 +258,7 @@ class WinMLAutoModel:
         config: WinMLBuildConfig | None = None,
         device: str = "auto",
         precision: str = "auto",
+        provider_options: dict[str, str] | None = None,
         cache_dir: str | Path | None = None,
         use_cache: bool = True,
         force_rebuild: bool = False,
@@ -282,6 +289,8 @@ class WinMLAutoModel:
                 "auto" detects available hardware (NPU > GPU > CPU).
             precision: Target precision ("auto", "fp32", "fp16", "int8", "int16").
                 "auto" selects based on device (npu->int8, gpu->fp16, cpu->fp16).
+            provider_options: Runtime EP provider options (e.g. QNN
+                ``htp_performance_mode``) forwarded to the inference session.
             cache_dir: Directory for caching. If None, uses default cache dir.
             use_cache: If True (default), use persistent cache directory.
                 If False, build in a temp directory and always rebuild.
@@ -323,6 +332,7 @@ class WinMLAutoModel:
                 device=device,
                 precision=precision,
                 ep=kwargs.pop("ep", None),
+                provider_options=provider_options,
                 cache_dir=cache_dir,
                 use_cache=use_cache,
                 force_rebuild=force_rebuild,
@@ -362,6 +372,7 @@ class WinMLAutoModel:
                     trust_remote_code=trust_remote_code,
                     shape_config=shape_config,
                     precision=precision,
+                    provider_options=provider_options,
                     config=config,
                     cache_dir=cache_dir,
                     allow_unsupported_nodes=allow_unsupported_nodes,
@@ -463,6 +474,7 @@ class WinMLAutoModel:
             config=hf_config,  # HF PretrainedConfig for pipeline compatibility
             device=device,  # pass user's original device string; WinMLSession handles "auto"
             ep=resolved_ep,
+            provider_options=provider_options,
         )
         model._build_config = config  # resolved build config (task, quant, compile)
         return model

--- a/src/winml/modelkit/models/winml/base.py
+++ b/src/winml/modelkit/models/winml/base.py
@@ -68,6 +68,7 @@ class WinMLPreTrainedModel(PreTrainedModel, ABC):
         device: str = "auto",
         session_options: Any | None = None,
         ep: EPNameOrAlias | None = None,
+        provider_options: dict[str, str] | None = None,
     ) -> None:
         """Initialize inference model.
 
@@ -78,6 +79,9 @@ class WinMLPreTrainedModel(PreTrainedModel, ABC):
             session_options: Factory returning an ORT SessionOptions (e.g., for
                 graph_optimization_level). Called fresh per ORT session.
             ep: Explicit EP short name (e.g., "dml", "qnn"). Forwarded to WinMLSession.
+            provider_options: Runtime EP provider options (e.g. QNN
+                ``htp_performance_mode``). Forwarded to WinMLSession and on to
+                ``add_provider_for_devices``.
         """
         self._onnx_path = Path(onnx_path)
         self.config = config
@@ -92,6 +96,7 @@ class WinMLPreTrainedModel(PreTrainedModel, ABC):
             device=device,
             session_options=session_options,
             ep=ep,
+            provider_options=provider_options,
         )
 
     @property

--- a/src/winml/modelkit/session/session.py
+++ b/src/winml/modelkit/session/session.py
@@ -137,6 +137,7 @@ class WinMLSession:
         ep_config: EPConfig | None = None,
         *,
         ep: EPNameOrAlias | None = None,
+        provider_options: dict[str, str] | None = None,
         session_options: Callable[[], ort.SessionOptions] | None = None,
     ) -> None:
         """Initialize WinMLSession.
@@ -153,6 +154,11 @@ class WinMLSession:
             ep: Explicit EP short name (e.g., "migraphx", "nv_tensorrt_rtx").
                 When set, bypasses policy-based selection and uses
                 add_provider_for_devices to force the specific EP.
+            provider_options: Runtime EP provider options merged on top of any
+                ``ep_config.provider_options`` and forwarded to
+                ``add_provider_for_devices`` (e.g. QNN ``htp_performance_mode``).
+                Unlike ``ep_config``, this does not affect EPContext persistence —
+                it only tunes the runtime session.
             session_options: Factory returning an ``ort.SessionOptions``.
                 Called once per ``_build_session_options`` invocation so each
                 ORT session gets a fresh, un-poisoned options object
@@ -170,7 +176,11 @@ class WinMLSession:
         self._ep = ep
         self._persist_jit = ep_config.enable_ep_context if ep_config else False
         self._embed_context = ep_config.embed_context if ep_config else False
-        self._provider_options = ep_config.provider_options if ep_config else {}
+        self._provider_options = dict(ep_config.provider_options) if ep_config else {}
+        # Runtime provider options (e.g. from --ep-options) merge on top of and
+        # override any build-time options carried by ep_config.
+        if provider_options:
+            self._provider_options.update(provider_options)
 
         self._session_options_factory: Callable[[], ort.SessionOptions] = (
             session_options or ort.SessionOptions

--- a/src/winml/modelkit/session/session.py
+++ b/src/winml/modelkit/session/session.py
@@ -401,11 +401,12 @@ class WinMLSession:
         opts = self._session_options_factory()
         if add_ep_for_device(opts, resolved_ep, device_type, self._provider_options):
             logger.info(
-                "Built SessionOptions with EP: %s (%s) device=%s -> %s",
+                "Built SessionOptions with EP: %s (%s) device=%s -> %s provider_options=%s",
                 resolved_ep,
                 self._ep,
                 device,
                 resolved_device,
+                self._provider_options,
             )
             return opts, resolved_device, resolved_ep
 

--- a/src/winml/modelkit/utils/cli.py
+++ b/src/winml/modelkit/utils/cli.py
@@ -206,7 +206,8 @@ def ep_options_option(optional_message: str | None = None) -> Callable[[F], F]:
     help_text = (
         "Runtime EP provider option as KEY=VALUE (repeatable). Forwarded to the "
         "inference session's execution provider (e.g. "
-        "--ep-options htp_performance_mode=burst)."
+        "--ep-options htp_performance_mode=burst). Duplicate keys: later "
+        "occurrence wins."
     )
     if optional_message:
         help_text = f"{help_text} {optional_message}"
@@ -224,6 +225,9 @@ def parse_ep_options(values: tuple[str, ...]) -> dict[str, str] | None:
 
     Args:
         values: Raw values collected by a ``multiple=True`` Click option.
+
+    Surrounding whitespace is stripped from both key and value. Duplicate
+    keys follow last-write-wins semantics (the later occurrence wins).
 
     Returns:
         Mapping of option name to value, or ``None`` when nothing was provided
@@ -249,7 +253,7 @@ def parse_ep_options(values: tuple[str, ...]) -> dict[str, str] | None:
                 f"Invalid EP option format: '{item}'. Key cannot be empty.",
                 param_hint="--ep-options",
             )
-        options[key] = value
+        options[key] = value.strip()
     return options
 
 

--- a/src/winml/modelkit/utils/cli.py
+++ b/src/winml/modelkit/utils/cli.py
@@ -187,6 +187,72 @@ def ep_option(required: bool = True, optional_message: str | None = None) -> Cal
     )
 
 
+def ep_options_option(optional_message: str | None = None) -> Callable[[F], F]:
+    """Add a repeatable ``--ep-options KEY=VALUE`` option to a Click command.
+
+    Collects runtime EP provider options (e.g. QNN ``htp_performance_mode``)
+    that are forwarded to ``add_provider_for_devices`` when the inference
+    session is created. Distinct from build-time provider options set via
+    ``--config``: these affect the runtime session, not the compiled graph.
+
+    Use :func:`parse_ep_options` to turn the collected tuple into a dict.
+
+    Args:
+        optional_message: Extra command-specific guidance appended to help text.
+
+    Returns:
+        Decorator function.
+    """
+    help_text = (
+        "Runtime EP provider option as KEY=VALUE (repeatable). Forwarded to the "
+        "inference session's execution provider (e.g. "
+        "--ep-options htp_performance_mode=burst)."
+    )
+    if optional_message:
+        help_text = f"{help_text} {optional_message}"
+
+    return click.option(
+        "--ep-options",
+        "ep_options",
+        multiple=True,
+        help=help_text,
+    )
+
+
+def parse_ep_options(values: tuple[str, ...]) -> dict[str, str] | None:
+    """Parse ``--ep-options KEY=VALUE`` tuples into a provider-options dict.
+
+    Args:
+        values: Raw values collected by a ``multiple=True`` Click option.
+
+    Returns:
+        Mapping of option name to value, or ``None`` when nothing was provided
+        (so callers can leave the session default untouched).
+
+    Raises:
+        click.BadParameter: If any value is missing the ``=`` separator or has
+            an empty key.
+    """
+    if not values:
+        return None
+    options: dict[str, str] = {}
+    for item in values:
+        if "=" not in item:
+            raise click.BadParameter(
+                f"Invalid EP option format: '{item}'. Use KEY=VALUE.",
+                param_hint="--ep-options",
+            )
+        key, value = item.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise click.BadParameter(
+                f"Invalid EP option format: '{item}'. Key cannot be empty.",
+                param_hint="--ep-options",
+            )
+        options[key] = value
+    return options
+
+
 def device_option(
     required: bool = True,
     optional_message: str | None = None,

--- a/tests/unit/commands/test_perf_cli.py
+++ b/tests/unit/commands/test_perf_cli.py
@@ -20,6 +20,7 @@ from click.testing import CliRunner
 
 from winml.modelkit.commands.perf import (
     BenchmarkConfig,
+    BenchmarkResult,
     PerfBenchmark,
     generate_output_path,
     perf,
@@ -498,6 +499,21 @@ class TestPerfUnifiedPipeline:
         result = runner.invoke(perf, ["--help"])
         assert result.exit_code == 0
         assert "--ep-options" in result.output
+
+    def test_ep_options_captured_in_to_dict(self) -> None:
+        """ep_options must be written into benchmark_info so saved JSON is reproducible."""
+        ep_options = {"htp_performance_mode": "burst"}
+        config = BenchmarkConfig(model_id="m", ep_options=ep_options)
+        result = BenchmarkResult(config=config)
+
+        assert result.to_dict()["benchmark_info"]["ep_options"] == ep_options
+
+    def test_ep_options_none_when_not_set_in_to_dict(self) -> None:
+        """When no EP options are given, benchmark_info records None."""
+        config = BenchmarkConfig(model_id="m")
+        result = BenchmarkResult(config=config)
+
+        assert result.to_dict()["benchmark_info"]["ep_options"] is None
 
 
 # =============================================================================

--- a/tests/unit/commands/test_perf_cli.py
+++ b/tests/unit/commands/test_perf_cli.py
@@ -396,6 +396,109 @@ class TestPerfUnifiedPipeline:
 
         assert mock_from_onnx.call_args.kwargs["ep"] == "qnn"
 
+    def test_onnx_load_model_passes_ep_options(self, tmp_path: Path) -> None:
+        """--ep-options should reach from_onnx as provider_options (ONNX path)."""
+        onnx_file = tmp_path / "model.onnx"
+        onnx_file.write_bytes(b"fake onnx")
+
+        config = BenchmarkConfig(
+            model_id=str(onnx_file),
+            task="image-classification",
+            device="npu",
+            ep="qnn",
+            ep_options={"htp_performance_mode": "burst"},
+        )
+        benchmark = PerfBenchmark(config)
+
+        with patch(
+            "winml.modelkit.models.auto.WinMLAutoModel.from_onnx",
+            return_value=MagicMock(),
+        ) as mock_from_onnx:
+            benchmark._load_model()
+
+        assert mock_from_onnx.call_args.kwargs["provider_options"] == {
+            "htp_performance_mode": "burst"
+        }
+
+    def test_hf_load_model_passes_ep_options(self) -> None:
+        """--ep-options should reach from_pretrained as provider_options (HF path)."""
+        config = BenchmarkConfig(
+            model_id="microsoft/resnet-50",
+            task="image-classification",
+            device="npu",
+            ep="qnn",
+            ep_options={"htp_performance_mode": "burst"},
+        )
+        benchmark = PerfBenchmark(config)
+
+        with patch(
+            "winml.modelkit.models.auto.WinMLAutoModel.from_pretrained",
+            return_value=MagicMock(),
+        ) as mock_from_pretrained:
+            benchmark._load_model()
+
+        assert mock_from_pretrained.call_args.kwargs["provider_options"] == {
+            "htp_performance_mode": "burst"
+        }
+
+    def test_cli_ep_options_parsed_into_config(self, runner: CliRunner, tmp_path: Path) -> None:
+        """Repeated --ep-options KEY=VALUE are parsed into BenchmarkConfig.ep_options."""
+        onnx_file = tmp_path / "model.onnx"
+        onnx_file.write_bytes(b"fake onnx")
+
+        captured: dict[str, BenchmarkConfig] = {}
+
+        def capture_config(config: BenchmarkConfig) -> MagicMock:
+            captured["config"] = config
+            return MagicMock()
+
+        with (
+            patch("winml.modelkit.commands.perf.PerfBenchmark", side_effect=capture_config),
+            patch("winml.modelkit.commands.perf.display_console_report"),
+            patch("winml.modelkit.commands.perf.write_json_report"),
+        ):
+            result = runner.invoke(
+                perf,
+                [
+                    "-m",
+                    str(onnx_file),
+                    "--ep-options",
+                    "htp_performance_mode=burst",
+                    "--ep-options",
+                    "htp_graph_finalization_optimization_mode=3",
+                    "-o",
+                    str(tmp_path / "out.json"),
+                ],
+                obj={},
+            )
+
+        assert result.exit_code == 0, result.output
+        assert captured["config"].ep_options == {
+            "htp_performance_mode": "burst",
+            "htp_graph_finalization_optimization_mode": "3",
+        }
+
+    def test_cli_ep_options_invalid_format_rejected(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """An --ep-options value without '=' is rejected with a clear error."""
+        onnx_file = tmp_path / "model.onnx"
+        onnx_file.write_bytes(b"fake onnx")
+
+        result = runner.invoke(
+            perf,
+            ["-m", str(onnx_file), "--ep-options", "no_equals_sign"],
+            obj={},
+        )
+
+        assert result.exit_code != 0
+        assert "KEY=VALUE" in result.output
+
+    def test_help_shows_ep_options(self, runner: CliRunner) -> None:
+        result = runner.invoke(perf, ["--help"])
+        assert result.exit_code == 0
+        assert "--ep-options" in result.output
+
 
 # =============================================================================
 # --FORMAT JSON TESTS

--- a/tests/unit/session/test_winml_session.py
+++ b/tests/unit/session/test_winml_session.py
@@ -680,6 +680,57 @@ class TestWinMLSessionExplicitProviders:
         assert options in captured, f"provider_options not forwarded; got calls with: {captured}"
         assert "C" in outputs
 
+    def test_runtime_provider_options_forwarded(
+        self,
+        simple_matmul_onnx: Path,
+        sample_input: dict[str, np.ndarray],
+    ):
+        """Runtime ``provider_options`` kwarg is forwarded to add_provider_for_devices."""
+        from unittest.mock import patch
+
+        import onnxruntime as ort
+
+        options = {"runtime_only_key": "runtime_only_value"}
+        captured: list[dict[str, str]] = []
+        real_method = ort.SessionOptions.add_provider_for_devices
+
+        def spy(self_sess, ep_devices, provider_opts):
+            captured.append(dict(provider_opts))
+            return real_method(self_sess, ep_devices, provider_opts)
+
+        with patch.object(ort.SessionOptions, "add_provider_for_devices", spy):
+            session = WinMLSession(
+                onnx_path=simple_matmul_onnx,
+                device="cpu",
+                provider_options=options,
+            )
+            outputs = session.run(sample_input)
+
+        assert options in captured, f"provider_options not forwarded; got calls with: {captured}"
+        assert "C" in outputs
+
+    def test_runtime_provider_options_override_ep_config(
+        self,
+        simple_matmul_onnx: Path,
+    ):
+        """Runtime ``provider_options`` merge on top of and override ep_config options."""
+        session = WinMLSession(
+            onnx_path=simple_matmul_onnx,
+            device="cpu",
+            ep_config=EPConfig(
+                provider="cpu",
+                provider_options={"shared": "from_build", "build_only": "x"},
+            ),
+            provider_options={"shared": "from_runtime", "runtime_only": "y"},
+        )
+
+        # Runtime value wins for the shared key; both source-specific keys survive.
+        assert session._provider_options == {
+            "shared": "from_runtime",
+            "build_only": "x",
+            "runtime_only": "y",
+        }
+
     def test_explicit_ep_and_device_both_required(self, simple_matmul_onnx: Path):
         """Regression: ep=qnn + device=gpu must bind QNN-on-GPU, not QNN-on-NPU.
 

--- a/tests/unit/utils/test_cli.py
+++ b/tests/unit/utils/test_cli.py
@@ -40,6 +40,13 @@ class TestParseEpOptions:
     def test_last_wins_on_duplicate_key(self) -> None:
         assert parse_ep_options(("k=1", "k=2")) == {"k": "2"}
 
+    def test_whitespace_stripped_from_key_and_value(self) -> None:
+        """Surrounding whitespace (e.g. from shell quoting) is stripped."""
+        assert parse_ep_options(("htp_performance_mode= burst ",)) == {
+            "htp_performance_mode": "burst"
+        }
+        assert parse_ep_options(("  k  =  v  ",)) == {"k": "v"}
+
     def test_missing_equals_raises(self) -> None:
         with pytest.raises(click.BadParameter):
             parse_ep_options(("no_equals_sign",))

--- a/tests/unit/utils/test_cli.py
+++ b/tests/unit/utils/test_cli.py
@@ -1,0 +1,49 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Tests for shared CLI helpers in winml.modelkit.utils.cli."""
+
+from __future__ import annotations
+
+import click
+import pytest
+
+from winml.modelkit.utils.cli import parse_ep_options
+
+
+class TestParseEpOptions:
+    """Tests for parse_ep_options()."""
+
+    def test_empty_returns_none(self) -> None:
+        """No values -> None so callers leave the session default untouched."""
+        assert parse_ep_options(()) is None
+
+    def test_single_pair(self) -> None:
+        assert parse_ep_options(("htp_performance_mode=burst",)) == {
+            "htp_performance_mode": "burst"
+        }
+
+    def test_multiple_pairs(self) -> None:
+        result = parse_ep_options(
+            ("htp_performance_mode=burst", "htp_graph_finalization_optimization_mode=3")
+        )
+        assert result == {
+            "htp_performance_mode": "burst",
+            "htp_graph_finalization_optimization_mode": "3",
+        }
+
+    def test_value_may_contain_equals(self) -> None:
+        """Only the first '=' splits key from value."""
+        assert parse_ep_options(("key=a=b=c",)) == {"key": "a=b=c"}
+
+    def test_last_wins_on_duplicate_key(self) -> None:
+        assert parse_ep_options(("k=1", "k=2")) == {"k": "2"}
+
+    def test_missing_equals_raises(self) -> None:
+        with pytest.raises(click.BadParameter):
+            parse_ep_options(("no_equals_sign",))
+
+    def test_empty_key_raises(self) -> None:
+        with pytest.raises(click.BadParameter):
+            parse_ep_options(("=value",))


### PR DESCRIPTION
## Summary

Fixes #865.

Adds a repeatable `--ep-options KEY=VALUE` flag to `winml perf` that forwards runtime execution-provider options to the inference session. These options (e.g. QNN HTP `htp_performance_mode`) significantly affect runtime latency independently of the build-time quantization config, so being able to set them at benchmark time is essential for tuning.

The flag works for **both** input modes:
- HuggingFace model IDs (`winml perf -m microsoft/resnet-50 --ep-options htp_performance_mode=burst`)
- Pre-exported ONNX files (`winml perf -m model.onnx --ep-options htp_performance_mode=burst`)

It is also wired into per-module (`--module`) benchmarking.

## How it works

The options are threaded down to `session.py`''s `add_ep_for_device`, which already accepts an `ep_options` dict:

```
--ep-options (CLI, repeatable)
  -> parse_ep_options() -> dict
  -> BenchmarkConfig.ep_options
  -> WinMLAutoModel.from_pretrained / from_onnx (provider_options=)
  -> WinMLPreTrainedModel (provider_options=)
  -> WinMLSession (provider_options=)
  -> _build_session_options -> add_ep_for_device(opts, ep, device_type, provider_options)
```

`WinMLSession` gains a `provider_options` kwarg that **merges on top of and overrides** any build-time `ep_config.provider_options`, but — unlike passing a full `ep_config` — does **not** flip EPContext persistence (`persist_jit`). These options tune the runtime session, not the compiled graph.

## Changes

- `utils/cli.py`: new `ep_options_option()` decorator and `parse_ep_options()` helper (reusable by other commands).
- `session/session.py`: `WinMLSession` accepts `provider_options`, merged over `ep_config` options.
- `models/winml/base.py`, `models/auto.py`: thread `provider_options` through `from_pretrained` / `from_onnx` (including the composite-model and skip-build paths).
- `commands/perf.py`: add `--ep-options`, parse once, pass to both single-model and `--module` paths.
- `docs/commands/perf.md`: document the new flag with an example.

## Tests

- `tests/unit/utils/test_cli.py`: `parse_ep_options` (empty/single/multiple/`=`-in-value/duplicate-key/invalid/empty-key).
- `tests/unit/commands/test_perf_cli.py`: `--ep-options` forwarded as `provider_options` for both ONNX and HF paths; CLI parsing into `BenchmarkConfig`; invalid-format rejection; help text.
- `tests/unit/session/test_winml_session.py`: runtime `provider_options` forwarded to `add_provider_for_devices`; runtime options override `ep_config` options.

All affected suites pass (225 passed; 2 pre-existing OpenVINO-EP-dependent failures unrelated to this change, deselected on this machine where OpenVINO is not installed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)