### PR TITLE
fix(sa-eval): run cleanup on SKIP_* / exception paths

### DIFF
--- a/scripts/e2e_eval/run_sa_eval.py
+++ b/scripts/e2e_eval/run_sa_eval.py
@@ -673,7 +673,6 @@ def evaluate_model(
     run_quantize: bool = True,
     quantize_precision: str = "int8",
     run_compile: bool = True,
-    cleanup: bool = False,
 ) -> dict | None:
     """Run the winml build + SA analysis pipeline for a single model."""
     hf_id = model_entry["hf_id"]
@@ -899,9 +898,6 @@ def evaluate_model(
     out_file = model_dir / "sa_eval_result.json"
     out_file.write_text(json.dumps(result, indent=2, ensure_ascii=False), encoding="utf-8")
     safe_print(f"  Written: {out_file}")
-
-    if cleanup:
-        cleanup_onnx_artifacts(model_dir)
 
     return result
 
@@ -1319,22 +1315,26 @@ def main() -> None:
                 pass  # Corrupted result file — re-run
 
         safe_print(f"\n[{i}/{len(models_to_run)}]")
-        result = evaluate_model(
-            entry,
-            output_dir,
-            use_cache=args.use_cache,
-            ep=args.ep,
-            device=args.device,
-            run_perf=not args.no_perf,
-            perf_iterations=args.perf_iterations,
-            perf_warmup=args.perf_warmup,
-            run_quantize=not args.no_quantize,
-            quantize_precision=args.quantize_precision,
-            run_compile=not args.no_compile,
-            cleanup=args.cleanup,
-        )
-        if result:
-            all_results.append(result)
+        try:
+            result = evaluate_model(
+                entry,
+                output_dir,
+                use_cache=args.use_cache,
+                ep=args.ep,
+                device=args.device,
+                run_perf=not args.no_perf,
+                perf_iterations=args.perf_iterations,
+                perf_warmup=args.perf_warmup,
+                run_quantize=not args.no_quantize,
+                quantize_precision=args.quantize_precision,
+                run_compile=not args.no_compile,
+            )
+            if result:
+                all_results.append(result)
+        finally:
+            # Cleanup must run on SKIP_* / exception paths too, not just success.
+            if args.cleanup:
+                cleanup_onnx_artifacts(model_dir)
 
     elapsed = time.monotonic() - t_start
     complete = [r for r in all_results if r.get("status") == "COMPLETE"]


### PR DESCRIPTION
## Summary

 + "valuate_model" +  in  + "scripts/e2e_eval/run_sa_eval.py" +  has 5 early-return paths via  + "_skip_result" +  (SKIP_BUILD / SKIP_EXPORT / SKIP_GRAPH_OPT / SKIP_SA_PRE / SKIP_SA_POST) that bypassed the trailing  + "cleanup_onnx_artifacts" +  call. Only the all-stages-succeed path cleaned up. So any model that failed mid-pipeline left its intermediate ONNX + external-data files on disk even when run with  + "--cleanup" + .

For LLMs whose  + "winml build" +  partially succeeded before the next stage aborted, this is multi-GB per model. Observed in practice: one  + "Qwen/Qwen2.5-1.5B-Instruct" +  SKIP_GRAPH_OPT folder leaked 22.9 GB ( + "xport.onnx.data" +  6.78GB ×2 +  + "graph_optimized.onnx.data" +  3.1GB + a lot of  + "onnx__MatMul_*" +  / weight external-data files).

## Fix

Move the  + "cleanup_onnx_artifacts" +  invocation out of  + "valuate_model" + 's success path and into a  + "	ry/finally" +  around the call site in the main loop. Now  + "--cleanup" +  runs regardless of which return path is taken (COMPLETE, any SKIP_*, or exception), matching the flag's documented semantics.
