### PR TITLE
docs: restore Privacy & Telemetry and Trademarks sections in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,24 @@ uv run winml perf -m resnet_out/model.onnx --device auto --iterations 50 --monit
 
 ---
 
+## 🔒 Privacy & Telemetry
+
+Official WinML CLI releases can collect **unlinked pseudonymized** usage telemetry
+to help improve the product. Telemetry is classified as **Optional**. A one-time
+prompt on your first run asks for consent (default: accept — press **Enter** to
+enable, type `n` to decline).
+
+**Control** — edit `%USERPROFILE%\.winml\config.json`:
+
+- Set `telemetry.consent` to `"disabled"` to opt out
+- Set `telemetry.consent` to `"enabled"` to opt in
+- Delete the file to re-show the first-run prompt on the next run
+
+See [docs/Privacy.md](docs/Privacy.md) for the full list of what is and is not
+collected, event schemas, CI auto-disable behavior, and storage locations.
+
+---
+
 ## 🤝 Contributing
 
 We welcome contributions! Please see the [contribution guidelines](CONTRIBUTING.md).
@@ -128,3 +146,11 @@ See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 ### License
 
 This project is licensed under the [MIT License](LICENSE.txt).
+
+### Trademarks
+
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft
+trademarks or logos is subject to and must follow
+[Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
+Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft
+sponsorship. Any use of third-party trademarks or logos are subject to those third-party's policies.


### PR DESCRIPTION
## Summary

Restores two sections that were dropped from the README in the last quickstart refresh (#893):

- **Privacy & Telemetry** — explains that official releases collect unlinked pseudonymized usage telemetry (Optional, accept-by-default first-run prompt), how to opt in/out via `%USERPROFILE%\.winml\config.json`, and links to [docs/Privacy.md](docs/Privacy.md).
- **Trademarks** — standard Microsoft trademark & brand guidance notice.

## Notes

- Text is restored verbatim from the prior version; the only change is the Privacy heading, updated from the old `:lock: Data / Telemetry` shortcode to `🔒 Privacy & Telemetry` to match the README's current emoji-heading style.
- Verified all consent details (config path, `telemetry.consent` values, accept-by-default prompt, delete-to-reprompt) still match `src/winml/modelkit/telemetry/consent.py`, and that `docs/Privacy.md` still exists.
