### PR TITLE
Add e2e tests for perf memory measurement

### DIFF
--- a/tests/e2e/test_perf_e2e.py
+++ b/tests/e2e/test_perf_e2e.py
@@ -104,6 +104,7 @@ def _build_perf_args(
     ep: str | None = None,
     module: str | None = None,
     monitor: bool = False,
+    memory: bool | None = None,
     verbose: bool = False,
     no_skip_build: bool = False,
 ) -> list[str]:
@@ -132,6 +133,10 @@ def _build_perf_args(
         args += ["--module", module]
     if monitor:
         args.append("--monitor")
+    if memory is True:
+        args.append("--memory")
+    elif memory is False:
+        args.append("--no-memory")
     if verbose:
         args.append("--verbose")
     if no_skip_build:
@@ -266,6 +271,111 @@ class _PerfBenchmarkSuite:
         assert result.exit_code == 0, f"perf failed (exit {result.exit_code}):\n{result.output}"
         assert output_file.exists()
         assert "Results saved to" in result.output
+
+    def test_benchmark_cpu_memory(self, tmp_path: Path, model_arg: str):
+        """Benchmark with --memory produces memory profile in JSON output.
+
+        Verifies the JSON contains 'memory' section with RAM delta fields.
+        """
+        output_file = tmp_path / "perf_cpu_memory.json"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            perf,
+            _build_perf_args(
+                model_arg=model_arg, output_file=output_file, device="cpu", memory=True
+            ),
+            obj={},
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"perf failed (exit {result.exit_code}):\n{result.output}"
+
+        assert output_file.exists()
+        data = json.loads(output_file.read_text())
+
+        # Memory section must be present
+        assert "memory" in data, f"No 'memory' key in JSON output. Keys: {list(data.keys())}"
+        mem = data["memory"]
+
+        # Required RAM fields
+        assert "rss_baseline_mb" in mem
+        assert "rss_after_compile_mb" in mem
+        assert "rss_after_inference_mb" in mem
+        assert "rss_model_load_delta_mb" in mem
+        assert "rss_inference_delta_mb" in mem
+        assert "rss_total_delta_mb" in mem
+
+        # Values should be positive floats
+        assert mem["rss_after_inference_mb"] > 0
+        assert mem["rss_baseline_mb"] > 0
+
+        # Console output should contain Memory section
+        assert "Memory:" in result.output
+        assert "RAM:" in result.output
+
+    def test_benchmark_cpu_no_memory(self, tmp_path: Path, model_arg: str):
+        """Benchmark with --no-memory omits memory profile from JSON output."""
+        output_file = tmp_path / "perf_cpu_no_memory.json"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            perf,
+            _build_perf_args(
+                model_arg=model_arg, output_file=output_file, device="cpu", memory=False
+            ),
+            obj={},
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"perf failed (exit {result.exit_code}):\n{result.output}"
+
+        assert output_file.exists()
+        data = json.loads(output_file.read_text())
+
+        # Memory section must NOT be present
+        assert "memory" not in data
+
+        # Console output should NOT contain Memory section
+        assert "Memory:" not in result.output
+
+    def test_benchmark_npu_memory(self, tmp_path: Path, model_arg: str):
+        """Benchmark on NPU with --memory produces VRAM fields.
+
+        Verifies VRAM local/shared fields are present in JSON output.
+        """
+        _require_npu()
+        output_file = tmp_path / "perf_npu_memory.json"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            perf,
+            _build_perf_args(
+                model_arg=model_arg, output_file=output_file, device="npu", memory=True
+            ),
+            obj={},
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"perf failed (exit {result.exit_code}):\n{result.output}"
+
+        assert output_file.exists()
+        data = json.loads(output_file.read_text())
+
+        assert "memory" in data
+        mem = data["memory"]
+
+        # RAM fields
+        assert mem["rss_after_inference_mb"] > 0
+        assert "rss_model_load_delta_mb" in mem
+
+        # VRAM fields (NPU should have device memory)
+        assert "vram_local_after_inference_mb" in mem
+        assert "vram_shared_after_inference_mb" in mem
+        assert "vram_local_model_load_delta_mb" in mem
+        assert "vram_shared_model_load_delta_mb" in mem
+        assert "vram_local_inference_delta_mb" in mem
+        assert "vram_shared_inference_delta_mb" in mem
+
+        # At least one VRAM metric should be > 0 on NPU
+        assert mem["vram_local_after_inference_mb"] > 0 or mem["vram_shared_after_inference_mb"] > 0
 
     def test_benchmark_cpu_monitor(self, tmp_path: Path, model_arg: str):
         """Benchmark on CPU with --monitor.


### PR DESCRIPTION
## Summary

Adds end-to-end tests for the \--memory\/\--no-memory\ perf CLI flag introduced in #861.

## Changes

- Added \memory\ parameter to \_build_perf_args()\ test helper
- \	est_benchmark_cpu_memory\: Verifies \--memory\ produces JSON with \memory\ section containing RSS fields, and console output shows Memory/RAM sections
- \	est_benchmark_cpu_no_memory\: Verifies \--no-memory\ excludes memory from both JSON and console output
- \	est_benchmark_npu_memory\: Verifies VRAM local/shared fields are populated when running on NPU device

## Stacked on

- #861 (perf memory measurement implementation)