### PR TITLE
Disable run/serve E2E tests by default (#892)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -392,6 +392,10 @@ markers = [
   "requires_network: Tests requiring network access (alias for network)",
   "memory_intensive: Tests requiring >2GB memory",
 
+  # Command Capability Markers
+  "e2e_run: E2E tests for 'winml run' (disabled by default — command not yet enabled)",
+  "e2e_serve: E2E tests for 'winml serve' (disabled by default — command not yet enabled)",
+
   # Hardware Markers
   "npu: Tests requiring NPU hardware",
   "gpu: Tests requiring GPU hardware",

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -151,9 +151,14 @@ E2E_DEFAULT_TIMEOUT = 900
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
-    """Auto-skip E2E tests unless '-m e2e' is passed; else apply the e2e timeout default."""
-    marker_expr = config.getoption("-m", default="")
-    if "e2e" in str(marker_expr):
+    """Auto-skip E2E tests unless '-m e2e' is passed; else apply the e2e timeout default.
+
+    Additionally, tests marked ``e2e_run`` or ``e2e_serve`` are always skipped
+    unless their marker name appears in the ``-m`` expression (the commands are
+    not yet enabled — see https://github.com/microsoft/winml-cli/issues/892).
+    """
+    marker_expr = str(config.getoption("-m", default=""))
+    if "e2e" in marker_expr:
         # E2E tests are running. Inject the default timeout only when neither a
         # per-test marker nor --timeout is given, so an explicit --timeout on the
         # CLI always takes effect (pytest-timeout precedence: marker > CLI > ini).
@@ -161,6 +166,19 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
             for item in items:
                 if "e2e" in item.keywords and item.get_closest_marker("timeout") is None:
                     item.add_marker(pytest.mark.timeout(E2E_DEFAULT_TIMEOUT))
+
+        # Skip e2e_run / e2e_serve unless explicitly opted-in via -m
+        _disabled_commands = {
+            "e2e_run": "winml run is not yet enabled (see #892)",
+            "e2e_serve": "winml serve is not yet enabled (see #892)",
+        }
+        for marker_name, reason in _disabled_commands.items():
+            if marker_name not in marker_expr:
+                skip_marker = pytest.mark.skip(reason=reason)
+                for item in items:
+                    if marker_name in item.keywords:
+                        item.add_marker(skip_marker)
+
         return  # User explicitly requested E2E tests
     skip_e2e = pytest.mark.skip(reason="E2E tests require -m e2e (skipped by default)")
     for item in items:

--- a/tests/e2e/test_run_e2e.py
+++ b/tests/e2e/test_run_e2e.py
@@ -65,7 +65,13 @@ if TYPE_CHECKING:
 
     from click.testing import CliRunner
 
-pytestmark = [pytest.mark.e2e, pytest.mark.slow, pytest.mark.network, pytest.mark.timeout(3600)]
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.e2e_run,
+    pytest.mark.slow,
+    pytest.mark.network,
+    pytest.mark.timeout(3600),
+]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/test_serve_e2e.py
+++ b/tests/e2e/test_serve_e2e.py
@@ -66,7 +66,13 @@ from .conftest import hub_test_id as _pytest_id
 from .conftest import resolve_model_arg as _resolve_model_arg
 
 
-pytestmark = [pytest.mark.e2e, pytest.mark.slow, pytest.mark.network, pytest.mark.timeout(3600)]
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.e2e_serve,
+    pytest.mark.slow,
+    pytest.mark.network,
+    pytest.mark.timeout(3600),
+]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`winml run` and `winml serve` are not yet enabled. This PR adds `e2e_run` / `e2e_serve` capability markers and auto-skips them during `-m e2e` runs unless explicitly opted-in.

## Changes

- **`pyproject.toml`** — register `e2e_run` and `e2e_serve` markers
- **`tests/e2e/conftest.py`** — update `pytest_collection_modifyitems` to skip tests with these markers by default
- **`tests/e2e/test_run_e2e.py`** — add `pytest.mark.e2e_run`
- **`tests/e2e/test_serve_e2e.py`** — add `pytest.mark.e2e_serve`

## Opt-in usage (when commands are enabled)

```bash
uv run pytest -m "e2e and e2e_run" tests/e2e/test_run_e2e.py
uv run pytest -m "e2e and e2e_serve" tests/e2e/test_serve_e2e.py
```

Closes #892