### PR TITLE
analyze: optimize case_index encoding, persist model bytes for fast re-run, add --debug locator, and fix Pad/Gemm rule conflicts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,11 @@ dependencies = [
   "click>=8.4",
   "colorama>=0.4.6",
   "datasets>=4.1.1",
-  # pyarrow 24.0.0 crashes (0xC0000005) on Windows when its C extension is
-  # loaded after the WinML/ORT EP DLLs (see _preload_bundled_onnxruntime_dll
-  # in winml.modelkit.__init__). Cap to <24 until upstream is fixed; re-test
-  # 24.x patches / 25.x before relaxing.
-  "pyarrow>=21,<24",
+  # Pin pyarrow to keep generated parquet artifacts deterministic.
+  # Also avoid the Windows 24.0.0 crash (0xC0000005) when its C extension is
+  # loaded after WinML/ORT EP DLLs (see _preload_bundled_onnxruntime_dll in
+  # winml.modelkit.__init__). Re-evaluate after validating newer versions.
+  "pyarrow==23.0.1",
   "diffusers>=0.36",
   "evaluate>=0.4.6",
   "fastapi>=0.135.3",
@@ -47,6 +47,9 @@ dependencies = [
   "optimum>=2",
   "optimum-onnx>=0.1",
   "plotext>=5.3.2",
+  # Keep pandas pinned: version drift can change parquet string typing/metadata
+  # and create non-functional diffs in generated rules artifacts.
+  "pandas==2.3.3",
   "pydantic>=2",
   "python-multipart>=0.0.22",
   "rapidfuzz>=3.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,14 @@ dependencies = [
   "click>=8.4",
   "colorama>=0.4.6",
   "datasets>=4.1.1",
-  # Pin pyarrow to keep generated parquet artifacts deterministic.
-  # Also avoid the Windows 24.0.0 crash (0xC0000005) when its C extension is
-  # loaded after WinML/ORT EP DLLs (see _preload_bundled_onnxruntime_dll in
-  # winml.modelkit.__init__). Re-evaluate after validating newer versions.
+  # PINNED EXACTLY ON PURPOSE — do NOT relax to a range.
+  # pyarrow's writer emits parquet bytes that differ across versions, so any bump
+  # produces a huge, semantically-meaningless diff across EVERY generated rule
+  # .parquet artifact. If you truly must change this version, regenerate ALL
+  # parquet artifacts in the same change so the diff stays meaningful.
+  # (Also avoids the Windows 24.0.0 crash 0xC0000005 when pyarrow's C extension
+  # loads after the WinML/ORT EP DLLs — see _preload_bundled_onnxruntime_dll in
+  # winml.modelkit.__init__.)
   "pyarrow==23.0.1",
   "diffusers>=0.36",
   "evaluate>=0.4.6",
@@ -47,8 +51,10 @@ dependencies = [
   "optimum>=2",
   "optimum-onnx>=0.1",
   "plotext>=5.3.2",
-  # Keep pandas pinned: version drift can change parquet string typing/metadata
-  # and create non-functional diffs in generated rules artifacts.
+  # PINNED EXACTLY ON PURPOSE — do NOT relax to a range.
+  # pandas version drift changes parquet string typing/metadata, producing
+  # non-functional but huge diffs across every generated rule artifact. If you
+  # truly must bump this, regenerate ALL parquet artifacts in the same change.
   "pandas==2.3.3",
   "pydantic>=2",
   "python-multipart>=0.0.22",

--- a/src/winml/modelkit/analyze/analyzer.py
+++ b/src/winml/modelkit/analyze/analyzer.py
@@ -84,8 +84,7 @@ def _normalize_case_indices_for_summary(case_indices: Any) -> list[Any] | None:
 def _iter_runtime_test_results(pattern_runtime: PatternRuntime) -> list[RuntimeTestResult]:
     """Iterate all RuntimeTestResult objects reachable from PatternRuntime."""
     results = [pattern_runtime.result]
-    for alternative in pattern_runtime.alternatives:
-        results.append(alternative.result)
+    results.extend(alternative.result for alternative in pattern_runtime.alternatives)
     return results
 
 
@@ -822,7 +821,9 @@ class ONNXStaticAnalyzer:
         # Step 2: Check runtime support for each EP
         check_op_results: dict[EPName, list[PatternRuntime]] = {}
         information_list: dict[EPName, list[Information]] = {}
-        runtime_debug_details_summary: dict[str, dict[str, dict[str, RuntimeDebugSummaryEntry]]] = {}
+        runtime_debug_details_summary: dict[
+            str, dict[str, dict[str, RuntimeDebugSummaryEntry]]
+        ] = {}
         ep_runtime_timing: dict[str, int] = {}
         ep_info_timing: dict[str, int] = {}
         for current_ep in eps_to_analyze:

--- a/src/winml/modelkit/analyze/analyzer.py
+++ b/src/winml/modelkit/analyze/analyzer.py
@@ -90,23 +90,24 @@ def _iter_runtime_test_results(pattern_runtime: PatternRuntime) -> list[RuntimeT
 
 def _build_runtime_debug_details_summary(
     runtime_summary: dict[str, list[PatternRuntime]],
-) -> dict[str, dict[str, RuntimeDebugSummaryEntry]] | None:
+) -> dict[str, list[str] | dict[str, RuntimeDebugSummaryEntry]] | None:
     """Build debug_details summary grouped by support level and node stable key.
 
-    The returned dict always uses level keys ``unsupported``, ``partial``, and
-    ``supported`` (in this output order). ``unknown`` results are intentionally
-    filtered out.
+    The returned dict always starts with the ``unknown`` key (in output order),
+    followed by ``unsupported``, ``partial``, and ``supported``. ``unknown``
+    nodes have no matched rule case data, so they are recorded as a plain list
+    of ``node_stable_key`` values; the other levels map ``node_stable_key`` to a
+    :class:`RuntimeDebugSummaryEntry`.
     """
-    summary: dict[str, dict[str, RuntimeDebugSummaryEntry]] = {
+    leveled_summary: dict[str, dict[str, RuntimeDebugSummaryEntry]] = {
         level.value: {} for level in _RUNTIME_DEBUG_SUMMARY_LEVELS
     }
+    unknown_nodes: set[str] = set()
 
     for runtime_key in ("op_runtime_check_result", "subgraph_runtime_check_result"):
         for pattern_runtime in runtime_summary.get(runtime_key, []):
             for test_result in _iter_runtime_test_results(pattern_runtime):
                 level = test_result.classification
-                if level not in _RUNTIME_DEBUG_SUMMARY_LEVELS:
-                    continue
 
                 debug_details = test_result.debug_details
                 if not debug_details:
@@ -114,6 +115,15 @@ def _build_runtime_debug_details_summary(
 
                 node_stable_key = debug_details.get("node_stable_key")
                 if not node_stable_key:
+                    continue
+
+                if level == SupportLevel.UNKNOWN:
+                    # Unknown nodes carry no rule case data; record the
+                    # de-duplicated node key only.
+                    unknown_nodes.add(node_stable_key)
+                    continue
+
+                if level not in _RUNTIME_DEBUG_SUMMARY_LEVELS:
                     continue
 
                 candidate_entry = RuntimeDebugSummaryEntry(
@@ -124,7 +134,7 @@ def _build_runtime_debug_details_summary(
                     table_file=debug_details.get("table_file"),
                 )
 
-                level_bucket = summary[level.value]
+                level_bucket = leveled_summary[level.value]
                 existing_entry = level_bucket.get(node_stable_key)
                 if existing_entry is None:
                     level_bucket[node_stable_key] = candidate_entry
@@ -142,9 +152,17 @@ def _build_runtime_debug_details_summary(
                 if existing_entry.table_file is None and candidate_entry.table_file is not None:
                     existing_entry.table_file = candidate_entry.table_file
 
-    has_any_entry = any(summary[level.value] for level in _RUNTIME_DEBUG_SUMMARY_LEVELS)
+    has_any_entry = bool(unknown_nodes) or any(
+        leveled_summary[level.value] for level in _RUNTIME_DEBUG_SUMMARY_LEVELS
+    )
     if not has_any_entry:
         return None
+
+    # "unknown" is intentionally the first key in output order.
+    summary: dict[str, list[str] | dict[str, RuntimeDebugSummaryEntry]] = {
+        "unknown": sorted(unknown_nodes)
+    }
+    summary.update(leveled_summary)
     return summary
 
 
@@ -822,7 +840,7 @@ class ONNXStaticAnalyzer:
         check_op_results: dict[EPName, list[PatternRuntime]] = {}
         information_list: dict[EPName, list[Information]] = {}
         runtime_debug_details_summary: dict[
-            str, dict[str, dict[str, RuntimeDebugSummaryEntry]]
+            str, dict[str, list[str] | dict[str, RuntimeDebugSummaryEntry]]
         ] = {}
         ep_runtime_timing: dict[str, int] = {}
         ep_info_timing: dict[str, int] = {}

--- a/src/winml/modelkit/analyze/analyzer.py
+++ b/src/winml/modelkit/analyze/analyzer.py
@@ -15,11 +15,12 @@ import logging
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from ..optim.config import WinMLOptimizationConfig
 from ..utils.constants import EP_SUPPORTED_DEVICES, EPName, EPNameOrAlias, normalize_ep_name
 from .models.information import Information
+from .models.output import RuntimeDebugSummaryEntry
 from .models.support_level import SupportLevel
 from .utils.timing_utils import make_timing_logger
 
@@ -31,7 +32,7 @@ if TYPE_CHECKING:
 
     from .models.information import Action
     from .models.output import AnalysisOutput
-    from .models.runtime_checks import PatternRuntime
+    from .models.runtime_checks import PatternRuntime, RuntimeTestResult
 
 
 @dataclass
@@ -61,6 +62,91 @@ class LintResult:
 
 logger = logging.getLogger(__name__)
 _log_timing = make_timing_logger(logger)
+
+_RUNTIME_DEBUG_SUMMARY_LEVELS: tuple[SupportLevel, ...] = (
+    SupportLevel.UNSUPPORTED,
+    SupportLevel.PARTIAL,
+    SupportLevel.SUPPORTED,
+)
+
+
+def _normalize_case_indices_for_summary(case_indices: Any) -> list[Any] | None:
+    """Normalize case_indices to JSON-friendly list values."""
+    if case_indices is None:
+        return None
+    if isinstance(case_indices, list):
+        return case_indices
+    if isinstance(case_indices, tuple):
+        return list(case_indices)
+    return [case_indices]
+
+
+def _iter_runtime_test_results(pattern_runtime: PatternRuntime) -> list[RuntimeTestResult]:
+    """Iterate all RuntimeTestResult objects reachable from PatternRuntime."""
+    results = [pattern_runtime.result]
+    for alternative in pattern_runtime.alternatives:
+        results.append(alternative.result)
+    return results
+
+
+def _build_runtime_debug_details_summary(
+    runtime_summary: dict[str, list[PatternRuntime]],
+) -> dict[str, dict[str, RuntimeDebugSummaryEntry]] | None:
+    """Build debug_details summary grouped by support level and node stable key.
+
+    The returned dict always uses level keys ``unsupported``, ``partial``, and
+    ``supported`` (in this output order). ``unknown`` results are intentionally
+    filtered out.
+    """
+    summary: dict[str, dict[str, RuntimeDebugSummaryEntry]] = {
+        level.value: {} for level in _RUNTIME_DEBUG_SUMMARY_LEVELS
+    }
+
+    for runtime_key in ("op_runtime_check_result", "subgraph_runtime_check_result"):
+        for pattern_runtime in runtime_summary.get(runtime_key, []):
+            for test_result in _iter_runtime_test_results(pattern_runtime):
+                level = test_result.classification
+                if level not in _RUNTIME_DEBUG_SUMMARY_LEVELS:
+                    continue
+
+                debug_details = test_result.debug_details
+                if not debug_details:
+                    continue
+
+                node_stable_key = debug_details.get("node_stable_key")
+                if not node_stable_key:
+                    continue
+
+                candidate_entry = RuntimeDebugSummaryEntry(
+                    case_indices=_normalize_case_indices_for_summary(
+                        debug_details.get("case_indices")
+                    ),
+                    table_path=debug_details.get("table_path"),
+                    table_file=debug_details.get("table_file"),
+                )
+
+                level_bucket = summary[level.value]
+                existing_entry = level_bucket.get(node_stable_key)
+                if existing_entry is None:
+                    level_bucket[node_stable_key] = candidate_entry
+                    continue
+
+                if (
+                    existing_entry.case_indices is None
+                    and candidate_entry.case_indices is not None
+                ):
+                    existing_entry.case_indices = candidate_entry.case_indices
+
+                if existing_entry.table_path is None and candidate_entry.table_path is not None:
+                    existing_entry.table_path = candidate_entry.table_path
+
+                if existing_entry.table_file is None and candidate_entry.table_file is not None:
+                    existing_entry.table_file = candidate_entry.table_file
+
+    has_any_entry = any(summary[level.value] for level in _RUNTIME_DEBUG_SUMMARY_LEVELS)
+    if not has_any_entry:
+        return None
+    return summary
 
 
 class AnalysisResult:
@@ -498,6 +584,7 @@ class ONNXStaticAnalyzer:
         device: str | None = None,
         enable_information: bool = True,
         htp_metadata_path: str | None = None,
+        for_debug: bool = False,
         run_unknown_op: bool = False,
         save_node_types: set[str] | None = None,
         on_node_result: Callable | None = None,
@@ -523,6 +610,8 @@ class ONNXStaticAnalyzer:
                 Default: True
             htp_metadata_path: Optional path to HTP metadata JSON file
                 for pattern extraction from hierarchy traces
+            for_debug: Whether to include runtime debug payloads in check results.
+                Default: False
             run_unknown_op: Whether to run unknown operators on the local machine
                 if possible. Default: True
             save_node_types: Set of node types to save for further analysis
@@ -604,6 +693,7 @@ class ONNXStaticAnalyzer:
             enable_information=enable_information,
             model_path=str(model_file),
             htp_metadata_path=htp_metadata_path,
+            for_debug=for_debug,
             run_unknown_op=run_unknown_op,
             save_node_types=save_node_types,
             on_node_result=on_node_result,
@@ -629,6 +719,7 @@ class ONNXStaticAnalyzer:
         enable_information: bool = True,
         model_path: str | None = None,
         htp_metadata_path: str | None = None,
+        for_debug: bool = False,
         run_unknown_op: bool = False,
         save_node_types: set[str] | None = None,
         on_node_result: Callable | None = None,
@@ -651,6 +742,8 @@ class ONNXStaticAnalyzer:
             model_path: Optional path to model file (for metadata)
             htp_metadata_path: Optional path to HTP metadata JSON file
                 for pattern extraction from hierarchy traces
+            for_debug: Whether to include runtime debug payloads in check results.
+                Default: False
             run_unknown_op: Whether to run unknown operators on local machine
                 if possible. Default: True
             save_node_types: Set of node types to save for further analysis
@@ -729,6 +822,7 @@ class ONNXStaticAnalyzer:
         # Step 2: Check runtime support for each EP
         check_op_results: dict[EPName, list[PatternRuntime]] = {}
         information_list: dict[EPName, list[Information]] = {}
+        runtime_debug_details_summary: dict[str, dict[str, dict[str, RuntimeDebugSummaryEntry]]] = {}
         ep_runtime_timing: dict[str, int] = {}
         ep_info_timing: dict[str, int] = {}
         for current_ep in eps_to_analyze:
@@ -753,12 +847,18 @@ class ONNXStaticAnalyzer:
 
             runtime_summary = runtime_checker.summary(
                 patterns=pattern_matches,
+                for_debug=for_debug,
                 run_unknown_op=run_unknown_op_for_ep,
                 save_node_types=save_node_types,
                 on_node_result=on_node_result,
             )
             runtime_summary_ms = int((time.perf_counter() - runtime_summary_start) * 1000)
             ep_runtime_timing[current_ep] = runtime_summary_ms
+
+            if for_debug:
+                ep_debug_summary = _build_runtime_debug_details_summary(runtime_summary)
+                if ep_debug_summary is not None:
+                    runtime_debug_details_summary[current_ep] = ep_debug_summary
 
             # Convert runtime summary to expected format
             op_results_list = runtime_summary.get("op_runtime_check_result", [])
@@ -791,6 +891,13 @@ class ONNXStaticAnalyzer:
             information_list=information_list,
             device=device_to_use,
         )
+
+        if runtime_debug_details_summary:
+            for ep_support in output.results:
+                ep_debug_summary = runtime_debug_details_summary.get(ep_support.ep_type)
+                if ep_debug_summary is not None:
+                    ep_support.runtime_debug_details_summary = ep_debug_summary
+
         aggregate_ms = int((time.perf_counter() - aggregate_start) * 1000)
 
         _log_timing(

--- a/src/winml/modelkit/analyze/core/runtime_checker.py
+++ b/src/winml/modelkit/analyze/core/runtime_checker.py
@@ -157,6 +157,7 @@ class RuntimeChecker:
 
     def op_support(
         self,
+        for_debug: bool = False,
         run_unknown_op: bool = False,
         save_node_types: set[str] | None = None,
         on_node_result: Callable | None = None,
@@ -166,6 +167,7 @@ class RuntimeChecker:
         Returns operator-level runtime check results for each operator.
 
         Args:
+            for_debug: Whether to include runtime debug details for each node.
             on_node_result: Optional per-node progress callback.
                 When provided, tqdm progress bar is suppressed (caller
                 handles progress display via Rich Live).
@@ -230,6 +232,7 @@ class RuntimeChecker:
             node_start = time.perf_counter()
             result = query.run_for_node(
                 node,
+                for_debug=for_debug,
                 run_unknown_op=run_unknown_op,
                 save_node_types=save_node_types,
             )
@@ -272,6 +275,7 @@ class RuntimeChecker:
         Args:
             patterns: List of PatternMatchResult objects to check.
                       If None, uses patterns from initialization.
+            for_debug: Whether to include runtime debug details for operator checks.
 
         Returns:
             List[PatternRuntime]: Runtime results for each pattern with alternatives
@@ -387,6 +391,7 @@ class RuntimeChecker:
     def summary(
         self,
         patterns: list[PatternMatchResult] | None = None,
+        for_debug: bool = False,
         run_unknown_op: bool = False,
         save_node_types: set[str] | None = None,
         on_node_result: Callable | None = None,
@@ -416,6 +421,7 @@ class RuntimeChecker:
         if self._model is not None:
             op_start = time.perf_counter()
             op_results = self.op_support(
+                for_debug=for_debug,
                 run_unknown_op=run_unknown_op,
                 save_node_types=save_node_types,
                 on_node_result=on_node_result,

--- a/src/winml/modelkit/analyze/core/runtime_checker_query.py
+++ b/src/winml/modelkit/analyze/core/runtime_checker_query.py
@@ -2032,7 +2032,9 @@ class RuntimeCheckerQuery:
         )
         load_table_ms = _elapsed_ms(load_table_start)
         parquet_file = parquet_path.name if parquet_path is not None else None
-        parquet_path_norm = _normalize_table_path(parquet_path) if parquet_path is not None else None
+        parquet_path_norm = (
+            _normalize_table_path(parquet_path) if parquet_path is not None else None
+        )
 
         if table_df is None:
             if run_unknown_op:
@@ -2237,7 +2239,7 @@ class RuntimeCheckerQuery:
             matched_row.get("case_indices") if hasattr(matched_row, "get") else None
         )
 
-        debug_details: RuntimeDebugDetails | None = None
+        debug_details = None
         if for_debug:
             debug_details = {
                 "node_stable_key": node_stable_key,

--- a/src/winml/modelkit/analyze/core/runtime_checker_query.py
+++ b/src/winml/modelkit/analyze/core/runtime_checker_query.py
@@ -2410,6 +2410,13 @@ class RuntimeCheckerQuery:
         except ValueError:
             domain_resolve_ms = _elapsed_ms(domain_resolve_start)
             # Unknown domain (e.g., custom ops) — report as no_data
+            unsupported_domain_debug_details: RuntimeDebugDetails | None = None
+            if for_debug:
+                unsupported_domain_debug_details = {
+                    "op_type": node.op_type,
+                    "node_stable_key": node_key,
+                    "domain": node.domain,
+                }
             return _finish(
                 PatternRuntime(
                     pattern_id=pattern_match.pattern.pattern_id,
@@ -2418,7 +2425,7 @@ class RuntimeCheckerQuery:
                         compile=False,
                         no_data=True,
                         reason=f"unsupported_domain:{node.domain}",
-                        debug_details=None,
+                        debug_details=unsupported_domain_debug_details,
                     ),
                     alternatives=self.alternatives,
                     pattern_match=pattern_match,

--- a/src/winml/modelkit/analyze/core/runtime_checker_query.py
+++ b/src/winml/modelkit/analyze/core/runtime_checker_query.py
@@ -40,7 +40,13 @@ from ..exceptions import (
     OpOptionalInputSupportError,
     OpUnsupportedError,
 )
-from ..models.runtime_checks import NodeTag, PatternAlternative, PatternRuntime, RuntimeTestResult
+from ..models.runtime_checks import (
+    NodeTag,
+    PatternAlternative,
+    PatternRuntime,
+    RuntimeDebugDetails,
+    RuntimeTestResult,
+)
 from ..runtime_checker.ep_checker import EPChecker
 from ..runtime_checker.runner import ResilientRunner
 from ..utils.model_utils import (
@@ -138,6 +144,8 @@ def _extract_condition_columns(table_df: pd.DataFrame) -> list[str]:
         "compile_reason",
         "run_reason",
         "rule_row_count",
+        # Debug parquet may carry case index mappings; they are outputs, not conditions.
+        "case_indices",
     }
     return [col for col in table_df.columns if col not in output_cols]
 
@@ -1069,7 +1077,10 @@ class RuntimeCheckerQuery:
         # Cache of node results keyed by hashable table_filter_conditions
         self._node_result_cache: dict[Any, PatternRuntime] = {}
         # Per-op parquet rule table cache keyed by (op, domain, since, qdq)
-        self._parquet_rule_table_cache: dict[tuple[str, str, int, bool], pd.DataFrame | None] = {}
+        self._parquet_rule_table_cache: dict[
+            tuple[str, str, int, bool],
+            pd.DataFrame | None,
+        ] = {}
         self._parquet_condition_tree_cache: dict[
             tuple[str, str, int, bool],
             _ParquetConditionTree | None,
@@ -1587,6 +1598,8 @@ class RuntimeCheckerQuery:
         pattern_match: PatternMatchResult,
         node_tags: list[NodeTag],
         fallback_reason: str,
+        node_stable_key: str | None = None,
+        for_debug: bool = False,
         include_adjacent_qdq: bool = False,
         save_node_types: set[str] | None = None,
         conditions: Any | None = None,
@@ -1603,6 +1616,7 @@ class RuntimeCheckerQuery:
             pattern_match: Pattern match result for the node.
             node_tags: Collected tags for the node.
             fallback_reason: The original reason rules were not found.
+            for_debug: Whether to include debug_details in result payload.
             save_node_types: Set of node types to save (e.g., {"partial", "unsupported"}).
             conditions: Conditions for the local check.
 
@@ -1708,22 +1722,26 @@ class RuntimeCheckerQuery:
                     name_suffix="unsupported" if is_unsupported else "partial",
                 )
 
+        local_debug_details: RuntimeDebugDetails | None = None
+        if for_debug:
+            local_debug_details = {
+                "source": "local_ep_check",
+                "fallback_reason": fallback_reason,
+                "op_type": node.op_type,
+                "node_stable_key": node_stable_key,
+                "domain": str(op_domain),
+                "opset_version": opset_version,
+                "table_path": None,
+                "table_file": None,
+            }
+
         result = RuntimeTestResult(
             compile=compile_success,
             run=run_success,
             no_data=False,
             reason=reason_str,
             node_tags=node_tags,
-            debug_details={
-                "source": "local_ep_check",
-                "fallback_reason": fallback_reason,
-                "op_type": node.op_type,
-                "node_name": node.name,
-                "domain": str(op_domain),
-                "opset_version": opset_version,
-                "table_path": "",
-                "table_file": "",
-            },
+            debug_details=local_debug_details,
         )
 
         if conditions is not None:
@@ -1916,29 +1934,36 @@ class RuntimeCheckerQuery:
         op_domain: ONNXDomain,
         op_since_version: int,
         is_qdq: bool,
-    ) -> tuple[pd.DataFrame | None, Path, _ParquetConditionTree | None]:
+        for_debug: bool = False,
+    ) -> tuple[pd.DataFrame | None, Path | None, _ParquetConditionTree | None]:
         """Load per-op parquet rule table with cache.
 
         Returns:
-            tuple[pd.DataFrame | None, Path, _ParquetConditionTree | None]:
+            tuple[pd.DataFrame | None, Path | None, _ParquetConditionTree | None]:
                 Loaded dataframe when available, otherwise None,
-                the resolved parquet path used for lookup,
+                the resolved parquet path used for lookup when found,
                 and optional pre-built condition tree.
         """
         parquet_name = (
             f"{op_name}_{self.ep_name}_{self.device_type.upper()}_{op_domain.name}"
             f"_opset{op_since_version}{'_qdq' if is_qdq else ''}.parquet"
         )
-        parquet_path = resolve_rule_parquet_path(parquet_name)
+        parquet_path = resolve_rule_parquet_path(parquet_name, for_debug=for_debug)
 
         cache_key = (op_name, op_domain.value, op_since_version, is_qdq)
         if cache_key in self._parquet_rule_table_cache:
-            _log_parquet_cache_hit(parquet_path, scope="instance")
+            if parquet_path is not None:
+                _log_parquet_cache_hit(parquet_path, scope="instance")
             return (
                 self._parquet_rule_table_cache[cache_key],
                 parquet_path,
                 self._parquet_condition_tree_cache.get(cache_key),
             )
+
+        if parquet_path is None:
+            self._parquet_rule_table_cache[cache_key] = None
+            self._parquet_condition_tree_cache[cache_key] = None
+            return None, None, None
 
         table_df = _get_or_load_parquet_table_global(parquet_path)
         condition_tree = _build_condition_tree(table_df)
@@ -1957,6 +1982,7 @@ class RuntimeCheckerQuery:
         node_tags: list[NodeTag],
         pattern_match: PatternMatchResult,
         pattern_id: str,
+        node_stable_key: str,
         for_debug: bool,
         run_unknown_op: bool,
         save_node_types: set[str] | None,
@@ -2002,10 +2028,11 @@ class RuntimeCheckerQuery:
             op_domain,
             op_since_version,
             is_qdq,
+            for_debug=for_debug,
         )
         load_table_ms = _elapsed_ms(load_table_start)
-        parquet_file = parquet_path.name
-        parquet_path_norm = _normalize_table_path(parquet_path)
+        parquet_file = parquet_path.name if parquet_path is not None else None
+        parquet_path_norm = _normalize_table_path(parquet_path) if parquet_path is not None else None
 
         if table_df is None:
             if run_unknown_op:
@@ -2017,6 +2044,8 @@ class RuntimeCheckerQuery:
                     pattern_match,
                     node_tags,
                     "rules_not_found",
+                    node_stable_key=node_stable_key,
+                    for_debug=for_debug,
                     include_adjacent_qdq=is_qdq,
                     conditions=None,
                     save_node_types=save_node_types,
@@ -2033,6 +2062,18 @@ class RuntimeCheckerQuery:
                         no_data=local_result.result.no_data,
                     )
 
+            rules_not_found_debug_details: RuntimeDebugDetails | None = None
+            if for_debug:
+                rules_not_found_debug_details = {
+                    "op_type": node.op_type,
+                    "node_stable_key": node_stable_key,
+                    "domain": str(op_domain),
+                    "opset_version": opset_version,
+                    "table_path": parquet_path_norm,
+                    "table_file": parquet_file,
+                    "op_since_version": op_since_version,
+                }
+
             return _finish(
                 PatternRuntime(
                     pattern_id=pattern_id,
@@ -2042,18 +2083,7 @@ class RuntimeCheckerQuery:
                         no_data=True,
                         reason="rules_not_found",
                         node_tags=node_tags,
-                        debug_details=(
-                            {
-                                "op_type": node.op_type,
-                                "domain": str(op_domain),
-                                "opset_version": opset_version,
-                                "table_path": parquet_path_norm,
-                                "table_file": parquet_file,
-                                "op_since_version": op_since_version,
-                            }
-                            if for_debug
-                            else None
-                        ),
+                        debug_details=rules_not_found_debug_details,
                     ),
                     alternatives=self.alternatives,
                     pattern_match=pattern_match,
@@ -2117,7 +2147,7 @@ class RuntimeCheckerQuery:
         row_lookup_ms = _elapsed_ms(row_lookup_start)
 
         if matched_row is None:
-            debug_details = None
+            debug_details: RuntimeDebugDetails | None = None
             if for_debug:
                 debug_steps: list[dict[str, Any]] = []
                 current_df = table_df
@@ -2136,6 +2166,7 @@ class RuntimeCheckerQuery:
                     )
                 debug_details = {
                     "type": "properties_not_found",
+                    "node_stable_key": node_stable_key,
                     "total_rows": len(table_df),
                     "table_path": parquet_path_norm,
                     "table_file": parquet_file,
@@ -2154,6 +2185,8 @@ class RuntimeCheckerQuery:
                     pattern_match,
                     node_tags,
                     "properties_not_found",
+                    node_stable_key=node_stable_key,
+                    for_debug=for_debug,
                     include_adjacent_qdq=is_qdq,
                     conditions=cache_key,
                     save_node_types=save_node_types,
@@ -2197,10 +2230,24 @@ class RuntimeCheckerQuery:
                 query_signature_size=len(query_signature),
             )
 
-        row = matched_row
-        compile_run = row.get("compile_run_success", (False, False))
+        compile_run = matched_row.get("compile_run_success", (False, False))
         compile_result = bool(compile_run[0])
         run_result = bool(compile_run[1])
+        matched_case_indices = (
+            matched_row.get("case_indices") if hasattr(matched_row, "get") else None
+        )
+
+        debug_details: RuntimeDebugDetails | None = None
+        if for_debug:
+            debug_details = {
+                "node_stable_key": node_stable_key,
+                "table_path": parquet_path_norm,
+                "table_file": parquet_file,
+                "op_since_version": op_since_version,
+                "lookup_columns": op_columns,
+                "query_signature": query_signature,
+                "case_indices": matched_case_indices,
+            }
 
         result = RuntimeTestResult(
             compile=compile_result,
@@ -2208,17 +2255,7 @@ class RuntimeCheckerQuery:
             reason="",
             no_data=False,
             node_tags=node_tags,
-            debug_details=(
-                {
-                    "table_path": parquet_path_norm,
-                    "table_file": parquet_file,
-                    "op_since_version": op_since_version,
-                    "lookup_columns": op_columns,
-                    "query_signature": query_signature,
-                }
-                if for_debug
-                else None
-            ),
+            debug_details=debug_details,
         )
 
         maybe_save_start = time.perf_counter()
@@ -2448,6 +2485,16 @@ class RuntimeCheckerQuery:
                 node.name,
                 str(e),
             )
+            conditions_error_debug_details: RuntimeDebugDetails | None = None
+            if for_debug:
+                conditions_error_debug_details = {
+                    "op_type": node.op_type,
+                    "node_stable_key": node_key,
+                    "error_message": str(e),
+                    "table_path": None,
+                    "table_file": None,
+                }
+
             return _finish(
                 PatternRuntime(
                     pattern_id=get_pattern_id(is_qdq),
@@ -2457,13 +2504,7 @@ class RuntimeCheckerQuery:
                         no_data=True,
                         reason="optional_input_properties_not_found",
                         node_tags=node_tags,
-                        debug_details={
-                            "op_type": node.op_type,
-                            "node_name": node.name,
-                            "error_message": str(e),
-                            "table_path": "",
-                            "table_file": "",
-                        },
+                        debug_details=conditions_error_debug_details,
                     ),
                     alternatives=self.alternatives,
                     pattern_match=pattern_match,
@@ -2484,6 +2525,7 @@ class RuntimeCheckerQuery:
             node_tags,
             pattern_match,
             pattern_id,
+            node_key,
             for_debug,
             run_unknown_op,
             save_node_types,

--- a/src/winml/modelkit/analyze/models/output.py
+++ b/src/winml/modelkit/analyze/models/output.py
@@ -76,11 +76,15 @@ class EPSupport(BaseModel):
     information: list[Information] = Field(
         default_factory=list, description="Available information"
     )
-    runtime_debug_details_summary: dict[str, dict[str, RuntimeDebugSummaryEntry]] | None = Field(
+    runtime_debug_details_summary: (
+        dict[str, list[str] | dict[str, RuntimeDebugSummaryEntry]] | None
+    ) = Field(
         default=None,
         description=(
-            "Optional runtime debug summary grouped by support level "
-            "(supported/partial/unsupported) and node_stable_key."
+            "Optional runtime debug summary grouped by support level. "
+            "The 'unknown' level is a list of node_stable_key values (no case "
+            "data); 'supported'/'partial'/'unsupported' map node_stable_key to "
+            "detail entries."
         ),
     )
 

--- a/src/winml/modelkit/analyze/models/output.py
+++ b/src/winml/modelkit/analyze/models/output.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from collections import Counter
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -19,6 +19,23 @@ from .support_level import SupportLevel
 
 if TYPE_CHECKING:
     from .onnx_model import ONNXModel
+
+
+class RuntimeDebugSummaryEntry(BaseModel):
+    """Aggregated runtime debug details for a single node_stable_key."""
+
+    case_indices: list[Any] | None = Field(
+        default=None,
+        description="Matched case indices from rule table.",
+    )
+    table_path: str | None = Field(
+        default=None,
+        description="Absolute or normalized path to the source table.",
+    )
+    table_file: str | None = Field(
+        default=None,
+        description="Source table filename.",
+    )
 
 
 class EPSupport(BaseModel):
@@ -58,6 +75,13 @@ class EPSupport(BaseModel):
     )
     information: list[Information] = Field(
         default_factory=list, description="Available information"
+    )
+    runtime_debug_details_summary: dict[str, dict[str, RuntimeDebugSummaryEntry]] | None = Field(
+        default=None,
+        description=(
+            "Optional runtime debug summary grouped by support level "
+            "(supported/partial/unsupported) and node_stable_key."
+        ),
     )
 
 

--- a/src/winml/modelkit/analyze/models/runtime_checks.py
+++ b/src/winml/modelkit/analyze/models/runtime_checks.py
@@ -11,9 +11,45 @@ from typing import Any
 from uuid import uuid4
 
 from pydantic import BaseModel, Field
+from typing_extensions import NotRequired, TypedDict
 
 from .ihv_type import IHVType
 from .support_level import SupportLevel
+
+
+class RuntimeDebugStep(TypedDict):
+    """Single step in parquet debug filtering trace."""
+
+    column: str
+    value: Any
+    rows_before: int
+    rows_after: int
+
+
+class RuntimeDebugDetails(TypedDict):
+    """Typed payload for runtime debug details.
+
+    All fields are optional by design so producers can emit only applicable
+    diagnostics for each debug scenario.
+    """
+
+    table_path: NotRequired[str | None]
+    table_file: NotRequired[str | None]
+    case_indices: NotRequired[tuple[Any, ...] | list[Any] | None]
+
+    type: NotRequired[str]
+    source: NotRequired[str]
+    fallback_reason: NotRequired[str]
+    op_type: NotRequired[str]
+    node_stable_key: NotRequired[str | None]
+    domain: NotRequired[str]
+    opset_version: NotRequired[int]
+    op_since_version: NotRequired[int]
+    total_rows: NotRequired[int]
+    lookup_columns: NotRequired[list[str]]
+    query_signature: NotRequired[tuple[Any, ...]]
+    steps: NotRequired[list[dict[str, Any]]]
+    error_message: NotRequired[str]
 
 
 class NodeTag(str, Enum):
@@ -51,7 +87,7 @@ class RuntimeTestResult(BaseModel):
     node_tags: list[NodeTag] = Field(
         default_factory=list, description="List of NodeTag enums for classifying this node"
     )
-    debug_details: Any | None = Field(
+    debug_details: RuntimeDebugDetails | None = Field(
         default=None, description="Optional debug information for runtime checks"
     )
 

--- a/src/winml/modelkit/analyze/models/runtime_checks.py
+++ b/src/winml/modelkit/analyze/models/runtime_checks.py
@@ -17,15 +17,6 @@ from .ihv_type import IHVType
 from .support_level import SupportLevel
 
 
-class RuntimeDebugStep(TypedDict):
-    """Single step in parquet debug filtering trace."""
-
-    column: str
-    value: Any
-    rows_before: int
-    rows_after: int
-
-
 class RuntimeDebugDetails(TypedDict):
     """Typed payload for runtime debug details.
 

--- a/src/winml/modelkit/analyze/runtime_checker/result_processor.py
+++ b/src/winml/modelkit/analyze/runtime_checker/result_processor.py
@@ -682,6 +682,7 @@ def _deduplicate_rule_rows(
     output_cols: list[str],
     compare_output_cols: list[str] | None = None,
     case_index_col: str = "case_index",
+    aggregate_case_indices: bool = False,
 ) -> tuple[pd.DataFrame, pd.DataFrame | None]:
     """Deduplicate rows by condition columns and detect conflicts.
 
@@ -723,6 +724,18 @@ def _deduplicate_rule_rows(
             continue
 
         row = group_df.iloc[0].copy()
+        if aggregate_case_indices and case_index_col in group_df.columns:
+            case_indices: list[Any] = []
+            for case_index_value in group_df[case_index_col].tolist():
+                if case_index_value is None:
+                    continue
+                if isinstance(case_index_value, float) and pd.isna(case_index_value):
+                    continue
+                case_indices.append(case_index_value)
+
+            # Keep deterministic order so generated artifacts are stable.
+            row["case_indices"] = tuple(sorted(set(case_indices), key=lambda value: str(value)))
+
         row["rule_row_count"] = len(group_df)
         dedup_rows.append(row)
 
@@ -783,6 +796,26 @@ if __name__ == "__main__":
         ),
     )
     parser.add_argument(
+        "--debug",
+        action="store_true",
+        help=(
+            "Generate debug rule artifacts that include case_indices, "
+            "written to --rules-debug-dir and --rules-debug-json-dir."
+        ),
+    )
+    parser.add_argument(
+        "--rules-debug-dir",
+        type=str,
+        default=None,
+        help="Directory where debug parquet rule files are written.",
+    )
+    parser.add_argument(
+        "--rules-debug-json-dir",
+        type=str,
+        default=None,
+        help="Directory where debug JSON rule files are written.",
+    )
+    parser.add_argument(
         "--domains",
         type=str,
         default="ai.onnx,com.microsoft",
@@ -817,6 +850,21 @@ if __name__ == "__main__":
     parquet_dir = Path(args.rules_dir) if args.rules_dir else get_runtime_rules_search_dirs()[0]
     parquet_dir.mkdir(parents=True, exist_ok=True)
 
+    debug_parquet_dir: Path | None = None
+    debug_output_dir: Path | None = None
+    if args.debug:
+        if not args.rules_debug_dir:
+            print("--rules-debug-dir is required when --debug is enabled")
+            sys.exit(1)
+        if not args.rules_debug_json_dir:
+            print("--rules-debug-json-dir is required when --debug is enabled")
+            sys.exit(1)
+
+        debug_parquet_dir = Path(args.rules_debug_dir)
+        debug_output_dir = Path(args.rules_debug_json_dir)
+        debug_parquet_dir.mkdir(parents=True, exist_ok=True)
+        debug_output_dir.mkdir(parents=True, exist_ok=True)
+
     qdq_generator = None
     processed = 0
     skipped = 0
@@ -824,6 +872,7 @@ if __name__ == "__main__":
 
     output_cols = ["compile_run_success"]
     compare_output_cols = ["compile_run_success"]
+    debug_output_cols = ["compile_run_success", "case_indices"]
     internal_cols = ["has_not_run_placeholder_reason", "compile_reason", "run_reason"]
 
     for json_file in sorted(json_files):
@@ -896,12 +945,16 @@ if __name__ == "__main__":
                 for c in rule_df.columns
                 if c not in output_cols and c not in infinite_properties and c != "case_index"
             ]
+            # Keep artifact schema stable across runs/machines regardless of
+            # intermediate dict/set insertion ordering.
+            condition_cols = sorted(condition_cols)
 
             dedup_df, conflict_df = _deduplicate_rule_rows(
                 rule_df,
                 condition_cols,
                 output_cols,
                 compare_output_cols=compare_output_cols,
+                aggregate_case_indices=args.debug,
             )
 
             if conflict_df is not None and not conflict_df.empty:
@@ -922,32 +975,58 @@ if __name__ == "__main__":
 
             parquet_df = dedup_df.loc[:, [*condition_cols, *output_cols]].copy()
 
+            debug_parquet_df: pd.DataFrame | None = None
+            if args.debug:
+                debug_parquet_df = dedup_df.loc[:, [*condition_cols, *debug_output_cols]].copy()
+
             parquet_write_df = _encode_condition_columns_for_parquet(
                 parquet_df,
                 condition_cols,
             )
 
             json_payload = {
-                "format": "per_op_rules_v1",
-                "op_name": op_name,
-                "ep_name": ep_name,
-                "device": device,
-                "domain": domain_str,
-                "opset_version": opset_version,
-                "is_qdq": is_qdq,
-                "condition_columns": condition_cols,
                 "rows": _json_safe_records(parquet_df),
             }
+
+            debug_json_payload: dict[str, Any] | None = None
+            if args.debug and debug_parquet_df is not None:
+                debug_json_payload = {
+                    "rows": _json_safe_records(debug_parquet_df),
+                }
 
             with open(output_json, "w", encoding="utf-8", newline="\n") as f:  # noqa: PTH123
                 json.dump(json_payload, f, indent=2, ensure_ascii=False)
 
+            debug_parquet_file: Path | None = None
+            if args.debug and debug_output_dir is not None and debug_json_payload is not None:
+                debug_output_json = debug_output_dir / json_file.name
+                with open(debug_output_json, "w", encoding="utf-8", newline="\n") as f:  # noqa: PTH123
+                    json.dump(debug_json_payload, f, indent=2, ensure_ascii=False)
+
+                if debug_parquet_dir is not None:
+                    debug_parquet_file = debug_parquet_dir / f"{json_file.stem}.parquet"
+
             try:
                 parquet_write_df.to_parquet(parquet_file, index=False, compression="snappy")
+
+                if (
+                    args.debug
+                    and debug_parquet_df is not None
+                    and debug_parquet_file is not None
+                ):
+                    debug_parquet_write_df = _encode_condition_columns_for_parquet(
+                        debug_parquet_df,
+                        condition_cols,
+                    )
+                    debug_parquet_write_df.to_parquet(
+                        debug_parquet_file,
+                        index=False,
+                        compression="snappy",
+                    )
             except Exception as e:
                 raise RuntimeError(
                     "Failed to write parquet file. Ensure a parquet engine "
-                    "(for example pyarrow) is installed."
+                    "(e.g., pyarrow) is installed."
                 ) from e
 
             processed += 1
@@ -964,6 +1043,11 @@ if __name__ == "__main__":
         f"output_dir={output_dir}"
     )
     print(f"Parquet rule files written to: {parquet_dir}")
+    if args.debug:
+        assert debug_output_dir is not None
+        assert debug_parquet_dir is not None
+        print(f"Debug JSON rule files written to: {debug_output_dir}")
+        print(f"Debug parquet rule files written to: {debug_parquet_dir}")
 
     if conflict_skipped > 0:
         # Exit with a dedicated code so batch scripts can treat conflicts differently

--- a/src/winml/modelkit/analyze/runtime_checker/result_processor.py
+++ b/src/winml/modelkit/analyze/runtime_checker/result_processor.py
@@ -732,7 +732,7 @@ def _deduplicate_rule_rows(
                 case_indices.append(case_index_value)
 
             # Keep deterministic order so generated artifacts are stable.
-            row["case_indices"] = tuple(sorted(set(case_indices), key=lambda value: str(value)))
+            row["case_indices"] = tuple(sorted(set(case_indices), key=str))
 
         row["rule_row_count"] = len(group_df)
         dedup_rows.append(row)

--- a/src/winml/modelkit/analyze/runtime_checker/result_processor.py
+++ b/src/winml/modelkit/analyze/runtime_checker/result_processor.py
@@ -1042,8 +1042,8 @@ if __name__ == "__main__":
     )
     print(f"Parquet rule files written to: {parquet_dir}")
     if args.debug:
-        assert debug_output_dir is not None
-        assert debug_parquet_dir is not None
+        # debug_output_dir / debug_parquet_dir are guaranteed non-None here by the
+        # args.debug validation block above (no runtime assert needed).
         print(f"Debug JSON rule files written to: {debug_output_dir}")
         print(f"Debug parquet rule files written to: {debug_parquet_dir}")
 

--- a/src/winml/modelkit/analyze/runtime_checker/result_processor.py
+++ b/src/winml/modelkit/analyze/runtime_checker/result_processor.py
@@ -727,9 +727,7 @@ def _deduplicate_rule_rows(
         if aggregate_case_indices and case_index_col in group_df.columns:
             case_indices: list[Any] = []
             for case_index_value in group_df[case_index_col].tolist():
-                if case_index_value is None:
-                    continue
-                if isinstance(case_index_value, float) and pd.isna(case_index_value):
+                if case_index_value is None or pd.isna(case_index_value):
                     continue
                 case_indices.append(case_index_value)
 

--- a/src/winml/modelkit/analyze/utils/avalizble_ep_device_ops/available_ops_all.json
+++ b/src/winml/modelkit/analyze/utils/avalizble_ep_device_ops/available_ops_all.json
@@ -1,0 +1,1282 @@
+{
+  "total": 118,
+  "opset_range": [
+    12,
+    22
+  ],
+  "ops_ai_onnx": {
+    "Abs": {
+      "version_key_map": {
+        "6": "11",
+        "13": "12"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Acos": {
+      "version_key_map": {
+        "7": "13",
+        "22": "14"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Acosh": {
+      "version_key_map": {
+        "9": "15",
+        "22": "16"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Add": {
+      "version_key_map": {
+        "7": "17",
+        "13": "18",
+        "14": "19"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "And": {
+      "version_key_map": {
+        "7": "1a"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "ArgMax": {
+      "version_key_map": {
+        "12": "1b",
+        "13": "1c"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "ArgMin": {
+      "version_key_map": {
+        "12": "1d",
+        "13": "1e"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Asin": {
+      "version_key_map": {
+        "7": "1f",
+        "22": "1g"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Asinh": {
+      "version_key_map": {
+        "9": "1h",
+        "22": "1i"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Atan": {
+      "version_key_map": {
+        "7": "1j",
+        "22": "1k"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Atanh": {
+      "version_key_map": {
+        "9": "1l",
+        "22": "1m"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Attention": {
+      "version_key_map": {
+        "99999": "1n"
+      },
+      "start_version": 99999,
+      "valid_for_gene": false
+    },
+    "AveragePool": {
+      "version_key_map": {
+        "11": "1o",
+        "19": "1p",
+        "22": "1q"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "BatchNormalization": {
+      "version_key_map": {
+        "9": "1r",
+        "14": "1s",
+        "15": "1t"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Cast": {
+      "version_key_map": {
+        "9": "1u",
+        "13": "1v",
+        "19": "1w",
+        "21": "1x"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Ceil": {
+      "version_key_map": {
+        "6": "1y",
+        "13": "1z"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Celu": {
+      "version_key_map": {
+        "12": "21"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Clip": {
+      "version_key_map": {
+        "12": "22",
+        "13": "23"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Concat": {
+      "version_key_map": {
+        "11": "24",
+        "13": "25"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "ConstantOfShape": {
+      "version_key_map": {
+        "9": "26",
+        "20": "27",
+        "21": "28"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Conv": {
+      "version_key_map": {
+        "11": "29",
+        "22": "2a"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "ConvTranspose": {
+      "version_key_map": {
+        "11": "2b",
+        "22": "2c"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Cos": {
+      "version_key_map": {
+        "7": "2d",
+        "22": "2e"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Cosh": {
+      "version_key_map": {
+        "9": "2f",
+        "22": "2g"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "CumSum": {
+      "version_key_map": {
+        "11": "2h",
+        "14": "2i"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Div": {
+      "version_key_map": {
+        "7": "2j",
+        "13": "2k",
+        "14": "2l"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Dropout": {
+      "version_key_map": {
+        "12": "2m",
+        "13": "2n",
+        "22": "2o"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Elu": {
+      "version_key_map": {
+        "6": "2p",
+        "22": "2q"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Equal": {
+      "version_key_map": {
+        "11": "2r",
+        "13": "2s",
+        "19": "2t"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Erf": {
+      "version_key_map": {
+        "9": "2u",
+        "13": "2v"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Exp": {
+      "version_key_map": {
+        "6": "2w",
+        "13": "2x"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Expand": {
+      "version_key_map": {
+        "8": "2y",
+        "13": "2z"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Flatten": {
+      "version_key_map": {
+        "11": "31",
+        "13": "32",
+        "21": "33"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Floor": {
+      "version_key_map": {
+        "6": "34",
+        "13": "35"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Gather": {
+      "version_key_map": {
+        "11": "36",
+        "13": "37"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Gelu": {
+      "version_key_map": {
+        "20": "38"
+      },
+      "start_version": 20,
+      "valid_for_gene": true
+    },
+    "Gemm": {
+      "version_key_map": {
+        "11": "39",
+        "13": "3a"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "GlobalAveragePool": {
+      "version_key_map": {
+        "1": "3b",
+        "22": "3c"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "GlobalMaxPool": {
+      "version_key_map": {
+        "1": "3d",
+        "22": "3e"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Greater": {
+      "version_key_map": {
+        "9": "3f",
+        "13": "3g"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "GreaterOrEqual": {
+      "version_key_map": {
+        "12": "3h",
+        "16": "3i"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "HardSigmoid": {
+      "version_key_map": {
+        "6": "3j",
+        "22": "3k"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "HardSwish": {
+      "version_key_map": {
+        "14": "3l",
+        "22": "3m"
+      },
+      "start_version": 14,
+      "valid_for_gene": true
+    },
+    "Hardmax": {
+      "version_key_map": {
+        "11": "3n",
+        "13": "3o"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Identity": {
+      "version_key_map": {
+        "1": "3p",
+        "13": "3q",
+        "14": "3r",
+        "16": "3s",
+        "19": "3t",
+        "21": "3u"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "InstanceNormalization": {
+      "version_key_map": {
+        "6": "3v",
+        "22": "3w"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "IsInf": {
+      "version_key_map": {
+        "10": "3x",
+        "20": "3y"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "IsNaN": {
+      "version_key_map": {
+        "9": "3z",
+        "13": "41",
+        "20": "42"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "LRN": {
+      "version_key_map": {
+        "1": "43",
+        "13": "44"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "LayerNormalization": {
+      "version_key_map": {
+        "17": "45"
+      },
+      "start_version": 17,
+      "valid_for_gene": true
+    },
+    "LeakyRelu": {
+      "version_key_map": {
+        "6": "46",
+        "16": "47"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Less": {
+      "version_key_map": {
+        "9": "48",
+        "13": "49"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "LessOrEqual": {
+      "version_key_map": {
+        "12": "4a",
+        "16": "4b"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Log": {
+      "version_key_map": {
+        "6": "4c",
+        "13": "4d"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "LogSoftmax": {
+      "version_key_map": {
+        "11": "4e",
+        "13": "4f"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "LpNormalization": {
+      "version_key_map": {
+        "1": "4g",
+        "22": "4h"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "LpPool": {
+      "version_key_map": {
+        "11": "4i",
+        "18": "4j",
+        "22": "4k"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "MatMul": {
+      "version_key_map": {
+        "9": "4l",
+        "13": "4m"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "MaxPool": {
+      "version_key_map": {
+        "12": "4n",
+        "22": "4o"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "MeanVarianceNormalization": {
+      "version_key_map": {
+        "9": "4p",
+        "13": "4q"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Mod": {
+      "version_key_map": {
+        "10": "4r",
+        "13": "4s"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Mul": {
+      "version_key_map": {
+        "7": "4t",
+        "13": "4u",
+        "14": "4v"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Neg": {
+      "version_key_map": {
+        "6": "4w",
+        "13": "4x"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "NonZero": {
+      "version_key_map": {
+        "9": "4y",
+        "13": "4z"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Not": {
+      "version_key_map": {
+        "1": "51"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Or": {
+      "version_key_map": {
+        "7": "52"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "PRelu": {
+      "version_key_map": {
+        "9": "53",
+        "16": "54"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Pad": {
+      "version_key_map": {
+        "11": "55",
+        "13": "56",
+        "18": "57",
+        "19": "58",
+        "21": "59"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Pow": {
+      "version_key_map": {
+        "12": "5a",
+        "13": "5b",
+        "15": "5c"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Reciprocal": {
+      "version_key_map": {
+        "6": "5d",
+        "13": "5e"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "ReduceL1": {
+      "version_key_map": {
+        "11": "5f",
+        "13": "5g",
+        "18": "5h"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "ReduceL2": {
+      "version_key_map": {
+        "11": "5i",
+        "13": "5j",
+        "18": "5k"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "ReduceLogSum": {
+      "version_key_map": {
+        "11": "5l",
+        "13": "5m",
+        "18": "5n"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "ReduceLogSumExp": {
+      "version_key_map": {
+        "11": "5o",
+        "13": "5p",
+        "18": "5q"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "ReduceMax": {
+      "version_key_map": {
+        "12": "5r",
+        "13": "5s",
+        "18": "5t",
+        "20": "5u"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "ReduceMean": {
+      "version_key_map": {
+        "11": "5v",
+        "13": "5w",
+        "18": "5x"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "ReduceMin": {
+      "version_key_map": {
+        "12": "5y",
+        "13": "5z",
+        "18": "61",
+        "20": "62"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "ReduceProd": {
+      "version_key_map": {
+        "11": "63",
+        "13": "64",
+        "18": "65"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "ReduceSum": {
+      "version_key_map": {
+        "11": "66",
+        "13": "67"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "ReduceSumSquare": {
+      "version_key_map": {
+        "11": "68",
+        "13": "69",
+        "18": "6a"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Relu": {
+      "version_key_map": {
+        "6": "6b",
+        "13": "6c",
+        "14": "6d"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Reshape": {
+      "version_key_map": {
+        "5": "6e",
+        "13": "6f",
+        "14": "6g",
+        "19": "6h",
+        "21": "6i"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Resize": {
+      "version_key_map": {
+        "11": "6j",
+        "13": "6k",
+        "18": "6l",
+        "19": "6m"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Round": {
+      "version_key_map": {
+        "11": "6n",
+        "22": "6o"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "RMSNormalization": {
+      "version_key_map": {
+        "99999": "6p"
+      },
+      "start_version": 99999,
+      "valid_for_gene": false
+    },
+    "ScatterND": {
+      "version_key_map": {
+        "11": "6q",
+        "13": "6r",
+        "16": "6s",
+        "18": "6t"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Selu": {
+      "version_key_map": {
+        "6": "6u",
+        "22": "6v"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Shape": {
+      "version_key_map": {
+        "1": "6w",
+        "13": "6x",
+        "15": "6y",
+        "19": "6z",
+        "21": "71"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Shrink": {
+      "version_key_map": {
+        "9": "72"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Sigmoid": {
+      "version_key_map": {
+        "6": "73",
+        "13": "74"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Sign": {
+      "version_key_map": {
+        "9": "75",
+        "13": "76"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Sin": {
+      "version_key_map": {
+        "7": "77",
+        "22": "78"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Sinh": {
+      "version_key_map": {
+        "9": "79",
+        "22": "7a"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Softmax": {
+      "version_key_map": {
+        "11": "7b",
+        "13": "7c"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Softplus": {
+      "version_key_map": {
+        "1": "7d",
+        "22": "7e"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Softsign": {
+      "version_key_map": {
+        "1": "7f",
+        "22": "7g"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Split": {
+      "version_key_map": {
+        "11": "7h",
+        "13": "7i",
+        "18": "7j"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Sqrt": {
+      "version_key_map": {
+        "6": "7k",
+        "13": "7l"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Squeeze": {
+      "version_key_map": {
+        "11": "7m",
+        "13": "7n",
+        "21": "7o"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Sub": {
+      "version_key_map": {
+        "7": "7p",
+        "13": "7q",
+        "14": "7r"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Tan": {
+      "version_key_map": {
+        "7": "7s",
+        "22": "7t"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Tanh": {
+      "version_key_map": {
+        "6": "7u",
+        "13": "7v"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "ThresholdedRelu": {
+      "version_key_map": {
+        "10": "7w",
+        "22": "7x"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Transpose": {
+      "version_key_map": {
+        "1": "7y",
+        "13": "7z",
+        "21": "81"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Unsqueeze": {
+      "version_key_map": {
+        "11": "82",
+        "13": "83",
+        "21": "84"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Where": {
+      "version_key_map": {
+        "9": "85",
+        "16": "86"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "GatherElements": {
+      "version_key_map": {
+        "11": "87",
+        "13": "88"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "GatherND": {
+      "version_key_map": {
+        "12": "89",
+        "13": "8a"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "Slice": {
+      "version_key_map": {
+        "11": "8b",
+        "13": "8c"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "BitShift": {
+      "version_key_map": {
+        "11": "8d"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    },
+    "BitwiseAnd": {
+      "version_key_map": {
+        "18": "8e"
+      },
+      "start_version": 18,
+      "valid_for_gene": false
+    },
+    "BitwiseNot": {
+      "version_key_map": {
+        "18": "8f"
+      },
+      "start_version": 18,
+      "valid_for_gene": false
+    },
+    "BitwiseOr": {
+      "version_key_map": {
+        "18": "8g"
+      },
+      "start_version": 18,
+      "valid_for_gene": false
+    },
+    "BitwiseXor": {
+      "version_key_map": {
+        "18": "8h"
+      },
+      "start_version": 18,
+      "valid_for_gene": false
+    },
+    "CastLike": {
+      "version_key_map": {
+        "15": "8i",
+        "19": "8j",
+        "21": "8k"
+      },
+      "start_version": 15,
+      "valid_for_gene": true
+    },
+    "GroupNormalization": {
+      "version_key_map": {
+        "18": "8l",
+        "21": "8m"
+      },
+      "start_version": 18,
+      "valid_for_gene": false
+    },
+    "Mish": {
+      "version_key_map": {
+        "18": "8n",
+        "22": "8o"
+      },
+      "start_version": 18,
+      "valid_for_gene": false
+    },
+    "TopK": {
+      "version_key_map": {
+        "11": "8p"
+      },
+      "start_version": 12,
+      "valid_for_gene": true
+    }
+  },
+  "ops_com_microsoft": {
+    "Gelu": {
+      "version_key_map": {
+        "1": "8q"
+      },
+      "start_version": 1,
+      "valid_for_gene": true
+    }
+  },
+  "patterns": {
+    "ExpandedAttentionPattern": {
+      "ops": [
+        "Transpose",
+        "Mul",
+        "MatMul",
+        "Add",
+        "Softmax"
+      ],
+      "version_key_map": {
+        "11": "8r",
+        "13": "8s",
+        "14": "8t",
+        "21": "8u"
+      }
+    },
+    "TransposeAttentionPattern": {
+      "ops": [
+        "Transpose",
+        "Attention"
+      ],
+      "version_key_map": {
+        "99999": "8v"
+      }
+    },
+    "Conv2DInplaceLinear4DPattern": {
+      "ops": [
+        "Transpose",
+        "Reshape",
+        "Conv"
+      ],
+      "version_key_map": {
+        "11": "8w",
+        "13": "8x",
+        "14": "8y",
+        "19": "8z",
+        "21": "91",
+        "22": "92"
+      }
+    },
+    "Conv2DInplaceLinear3DPattern": {
+      "ops": [
+        "Transpose",
+        "Unsqueeze",
+        "Reshape",
+        "Conv",
+        "Squeeze"
+      ],
+      "version_key_map": {
+        "11": "93",
+        "13": "94",
+        "14": "95",
+        "19": "96",
+        "21": "97",
+        "22": "98"
+      }
+    },
+    "Conv2DInplaceLinear2DPattern": {
+      "ops": [
+        "Reshape",
+        "Transpose",
+        "Conv"
+      ],
+      "version_key_map": {
+        "11": "99",
+        "13": "9a",
+        "14": "9b",
+        "19": "9c",
+        "21": "9d",
+        "22": "9e"
+      }
+    },
+    "Gelu1Pattern": {
+      "ops": [
+        "Div",
+        "Erf",
+        "Add",
+        "Mul"
+      ],
+      "version_key_map": {
+        "9": "9f",
+        "13": "9g",
+        "14": "9h"
+      },
+      "check_for_eps": [
+        "qnn_npu"
+      ]
+    },
+    "Gelu2Pattern": {
+      "ops": [
+        "Div",
+        "Erf",
+        "Add",
+        "Mul"
+      ],
+      "version_key_map": {
+        "9": "9i",
+        "13": "9j",
+        "14": "9k"
+      },
+      "check_for_eps": [
+        "qnn_npu"
+      ]
+    },
+    "Gelu3Pattern": {
+      "ops": [
+        "Div",
+        "Erf",
+        "Add",
+        "Mul"
+      ],
+      "version_key_map": {
+        "9": "9l",
+        "13": "9m",
+        "14": "9n"
+      },
+      "check_for_eps": [
+        "qnn_npu"
+      ]
+    },
+    "Gelu4Pattern": {
+      "ops": [
+        "Mul",
+        "Erf",
+        "Add"
+      ],
+      "version_key_map": {
+        "9": "9o",
+        "13": "9p",
+        "14": "9q"
+      },
+      "check_for_eps": [
+        "qnn_npu"
+      ]
+    },
+    "MatMulAddPattern": {
+      "ops": [
+        "MatMul",
+        "Add"
+      ],
+      "version_key_map": {
+        "9": "9r",
+        "13": "9s",
+        "14": "9t"
+      },
+      "check_for_eps": [
+        "qnn_npu"
+      ]
+    },
+    "ReshapeGemmReshapePattern": {
+      "ops": [
+        "Reshape",
+        "Gemm"
+      ],
+      "version_key_map": {
+        "11": "9u",
+        "13": "9v",
+        "14": "9w",
+        "19": "9x",
+        "21": "9y"
+      },
+      "check_for_eps": [
+        "qnn_npu"
+      ]
+    },
+    "LayerNormalizationPowPattern": {
+      "ops": [
+        "ReduceMean",
+        "Sub",
+        "Pow",
+        "Add",
+        "Sqrt",
+        "Div",
+        "Mul"
+      ],
+      "version_key_map": {
+        "12": "9z",
+        "13": "a1",
+        "14": "a2",
+        "15": "a3",
+        "18": "a4"
+      }
+    },
+    "LayerNormalizationMulPattern": {
+      "ops": [
+        "ReduceMean",
+        "Sub",
+        "Mul",
+        "Add",
+        "Sqrt",
+        "Div"
+      ],
+      "version_key_map": {
+        "11": "a5",
+        "13": "a6",
+        "14": "a7",
+        "18": "a8"
+      }
+    },
+    "TransposedSingleLayerNormalizationPattern": {
+      "ops": [
+        "Transpose",
+        "Reshape",
+        "LayerNormalization"
+      ],
+      "version_key_map": {
+        "17": "a9",
+        "19": "aa",
+        "21": "ab"
+      }
+    },
+    "RMSNormalizationPowPattern": {
+      "ops": [
+        "Pow",
+        "ReduceMean",
+        "Add",
+        "Sqrt",
+        "Div",
+        "Mul"
+      ],
+      "version_key_map": {
+        "12": "ac",
+        "13": "ad",
+        "14": "ae",
+        "15": "af",
+        "18": "ag"
+      }
+    },
+    "RMSNormalizationMulPattern": {
+      "ops": [
+        "Mul",
+        "ReduceMean",
+        "Add",
+        "Sqrt",
+        "Div"
+      ],
+      "version_key_map": {
+        "11": "ah",
+        "13": "ai",
+        "14": "aj",
+        "18": "ak"
+      }
+    },
+    "TransposedSingleRMSNormalizationPattern": {
+      "ops": [
+        "Transpose",
+        "Reshape",
+        "RMSNormalization"
+      ],
+      "version_key_map": {
+        "99999": "al"
+      }
+    },
+    "ReshapeTransposeReshapeOverlyHighDimPattern": {
+      "ops": [
+        "Reshape",
+        "Transpose"
+      ],
+      "version_key_map": {
+        "5": "am",
+        "13": "an",
+        "14": "ao",
+        "19": "ap",
+        "21": "aq"
+      },
+      "check_for_eps": [
+        "ov_npu"
+      ]
+    },
+    "ReshapeTransposeReshapeLowDimPattern": {
+      "ops": [
+        "Reshape",
+        "Transpose"
+      ],
+      "version_key_map": {
+        "5": "ar",
+        "13": "as",
+        "14": "at",
+        "19": "au",
+        "21": "av"
+      },
+      "check_for_eps": [
+        "ov_npu"
+      ]
+    }
+  }
+}

--- a/src/winml/modelkit/analyze/utils/avalizble_ep_device_ops/avaliable_providers.json
+++ b/src/winml/modelkit/analyze/utils/avalizble_ep_device_ops/avaliable_providers.json
@@ -1,0 +1,66 @@
+{
+  "OpenVINOExecutionProvider": {
+    "devices": {
+      "CPU": {
+        "key": "1",
+        "valid": true
+      },
+      "GPU": {
+        "key": "2",
+        "valid": true
+      },
+      "NPU": {
+        "key": "3",
+        "valid": true
+      }
+    }
+  },
+  "QNNExecutionProvider": {
+    "devices": {
+      "CPU": {
+        "key": "4",
+        "valid": false
+      },
+      "GPU": {
+        "key": "5",
+        "valid": true
+      },
+      "NPU": {
+        "key": "6",
+        "valid": true
+      }
+    }
+  },
+  "NvTensorRTRTXExecutionProvider": {
+    "devices": {
+      "CPU": {
+        "key": "7",
+        "valid": false
+      },
+      "GPU": {
+        "key": "8",
+        "valid": true
+      },
+      "NPU": {
+        "key": "9",
+        "valid": false
+      }
+    }
+  },
+  "VitisAIExecutionProvider": {
+    "devices": {
+      "CPU": {
+        "key": "a",
+        "valid": false
+      },
+      "GPU": {
+        "key": "b",
+        "valid": false
+      },
+      "NPU": {
+        "key": "c",
+        "valid": false
+      }
+    }
+  }
+}

--- a/src/winml/modelkit/analyze/utils/avalizble_ep_device_ops/case_index_key_codec.py
+++ b/src/winml/modelkit/analyze/utils/avalizble_ep_device_ops/case_index_key_codec.py
@@ -1,3 +1,8 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
 from __future__ import annotations
 
 import json
@@ -6,12 +11,15 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+
 ALPHABET = set("123456789abcdefghijklmnopqrstuvwxyz")
 DEVICE_SET = {"CPU", "GPU", "NPU"}
 
 
 @dataclass(frozen=True)
 class DecodedLocation:
+    """Decoded folder/file location for a case_index key prefix."""
+
     folder_name: str
     file_name: str
 
@@ -38,7 +46,7 @@ def _load_json_object(path: Path) -> dict[str, Any]:
         raise FileNotFoundError(f"File not found: {path}")
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
-        raise ValueError(f"Invalid JSON root object: {path}")
+        raise TypeError(f"Invalid JSON root object: {path}")
     return payload
 
 
@@ -204,7 +212,7 @@ def _get_global_indexes(
         _GLOBAL_INDEXES_SOURCE = current_source
         return _GLOBAL_INDEXES
 
-    if _GLOBAL_INDEXES_SOURCE != current_source:
+    if current_source != _GLOBAL_INDEXES_SOURCE:
         raise ValueError(
             "Global index cache already initialized with different mapping files: "
             f"cached={_GLOBAL_INDEXES_SOURCE}, requested={current_source}"
@@ -218,7 +226,14 @@ def encode_file_name_to_4char_key(
     providers_json: str | Path | None = None,
     ops_json: str | Path | None = None,
 ) -> str:
-    ep_device_to_key, _key_to_ep_device, by_exact, by_name_version, _version_key_to_entry = _get_global_indexes(
+    """Encode a rule file name into its 4-char case_index key prefix."""
+    (
+        ep_device_to_key,
+        _key_to_ep_device,
+        by_exact,
+        by_name_version,
+        _version_key_to_entry,
+    ) = _get_global_indexes(
         providers_json,
         ops_json,
     )
@@ -237,9 +252,13 @@ def encode_file_name_to_4char_key(
         elif not candidates:
             raise KeyError(f"No version key found for {name} version {version} domain {domain}")
         else:
-            text = ", ".join(f"{candidate_domain}:{candidate_key}" for candidate_domain, candidate_key in candidates)
+            text = ", ".join(
+                f"{candidate_domain}:{candidate_key}"
+                for candidate_domain, candidate_key in candidates
+            )
             raise KeyError(
-                f"Ambiguous version key for {name} version {version} domain {domain}; candidates: {text}"
+                f"Ambiguous version key for {name} version {version} domain {domain}; "
+                f"candidates: {text}"
             )
 
     qdq_flag = "1" if is_qdq else "0"
@@ -251,7 +270,14 @@ def decode_4char_key_to_folder_and_file_name(
     providers_json: str | Path | None = None,
     ops_json: str | Path | None = None,
 ) -> DecodedLocation:
-    _ep_device_to_key, key_to_ep_device, _by_exact, _by_name_version, version_key_to_entry = _get_global_indexes(
+    """Decode a 4-char key (or case_index prefix) into its folder and file name."""
+    (
+        _ep_device_to_key,
+        key_to_ep_device,
+        _by_exact,
+        _by_name_version,
+        version_key_to_entry,
+    ) = _get_global_indexes(
         providers_json,
         ops_json,
     )

--- a/src/winml/modelkit/analyze/utils/avalizble_ep_device_ops/case_index_key_codec.py
+++ b/src/winml/modelkit/analyze/utils/avalizble_ep_device_ops/case_index_key_codec.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass
+from functools import cache
 from pathlib import Path
 from typing import Any
 
@@ -31,9 +32,6 @@ IndexBundle = tuple[
     dict[tuple[str, int], list[tuple[str, str]]],
     dict[str, tuple[str, int, str]],
 ]
-
-_GLOBAL_INDEXES: IndexBundle | None = None
-_GLOBAL_INDEXES_SOURCE: tuple[str, str] | None = None
 
 
 def _default_mapping_paths() -> tuple[Path, Path]:
@@ -186,46 +184,18 @@ def _compute_indexes(
     return ep_device_to_key, key_to_ep_device, by_exact, by_name_version, version_key_to_entry
 
 
-def _resolve_mapping_paths(
-    providers_json: str | Path | None,
-    ops_json: str | Path | None,
-) -> tuple[Path, Path]:
+@cache
+def _get_indexes() -> IndexBundle:
+    """Build (and cache) the index bundle from the bundled mapping files.
+
+    The mapping files are fixed and shipped alongside this module; the result is
+    parsed once per process and reused on every call.
+    """
     providers_path, ops_path = _default_mapping_paths()
-    if providers_json is not None:
-        providers_path = Path(providers_json)
-    if ops_json is not None:
-        ops_path = Path(ops_json)
-    return providers_path.resolve(), ops_path.resolve()
+    return _compute_indexes(str(providers_path), str(ops_path))
 
 
-def _get_global_indexes(
-    providers_json: str | Path | None,
-    ops_json: str | Path | None,
-) -> IndexBundle:
-    global _GLOBAL_INDEXES, _GLOBAL_INDEXES_SOURCE
-
-    providers_path, ops_path = _resolve_mapping_paths(providers_json, ops_json)
-    current_source = (str(providers_path), str(ops_path))
-
-    if _GLOBAL_INDEXES is None:
-        _GLOBAL_INDEXES = _compute_indexes(*current_source)
-        _GLOBAL_INDEXES_SOURCE = current_source
-        return _GLOBAL_INDEXES
-
-    if current_source != _GLOBAL_INDEXES_SOURCE:
-        raise ValueError(
-            "Global index cache already initialized with different mapping files: "
-            f"cached={_GLOBAL_INDEXES_SOURCE}, requested={current_source}"
-        )
-
-    return _GLOBAL_INDEXES
-
-
-def encode_file_name_to_4char_key(
-    file_name: str,
-    providers_json: str | Path | None = None,
-    ops_json: str | Path | None = None,
-) -> str:
+def encode_file_name_to_4char_key(file_name: str) -> str:
     """Encode a rule file name into its 4-char case_index key prefix."""
     (
         ep_device_to_key,
@@ -233,10 +203,7 @@ def encode_file_name_to_4char_key(
         by_exact,
         by_name_version,
         _version_key_to_entry,
-    ) = _get_global_indexes(
-        providers_json,
-        ops_json,
-    )
+    ) = _get_indexes()
 
     name, ep, device, domain, version, is_qdq = _parse_file_name(file_name)
 
@@ -265,11 +232,7 @@ def encode_file_name_to_4char_key(
     return f"{ep_device_key}{version_key}{qdq_flag}"
 
 
-def decode_4char_key_to_folder_and_file_name(
-    key_or_case_index: str,
-    providers_json: str | Path | None = None,
-    ops_json: str | Path | None = None,
-) -> DecodedLocation:
+def decode_4char_key_to_folder_and_file_name(key_or_case_index: str) -> DecodedLocation:
     """Decode a 4-char key (or case_index prefix) into its folder and file name."""
     (
         _ep_device_to_key,
@@ -277,10 +240,7 @@ def decode_4char_key_to_folder_and_file_name(
         _by_exact,
         _by_name_version,
         version_key_to_entry,
-    ) = _get_global_indexes(
-        providers_json,
-        ops_json,
-    )
+    ) = _get_indexes()
 
     trimmed = key_or_case_index.strip()
     if len(trimmed) < 4:

--- a/src/winml/modelkit/analyze/utils/avalizble_ep_device_ops/case_index_key_codec.py
+++ b/src/winml/modelkit/analyze/utils/avalizble_ep_device_ops/case_index_key_codec.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+ALPHABET = set("123456789abcdefghijklmnopqrstuvwxyz")
+DEVICE_SET = {"CPU", "GPU", "NPU"}
+
+
+@dataclass(frozen=True)
+class DecodedLocation:
+    folder_name: str
+    file_name: str
+
+
+IndexBundle = tuple[
+    dict[tuple[str, str], str],
+    dict[str, tuple[str, str]],
+    dict[tuple[str, int, str], str],
+    dict[tuple[str, int], list[tuple[str, str]]],
+    dict[str, tuple[str, int, str]],
+]
+
+_GLOBAL_INDEXES: IndexBundle | None = None
+_GLOBAL_INDEXES_SOURCE: tuple[str, str] | None = None
+
+
+def _default_mapping_paths() -> tuple[Path, Path]:
+    base_dir = Path(__file__).resolve().parent
+    return base_dir / "avaliable_providers.json", base_dir / "available_ops_all.json"
+
+
+def _load_json_object(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"File not found: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Invalid JSON root object: {path}")
+    return payload
+
+
+def _normalize_stem(file_name: str) -> tuple[str, bool]:
+    stem = Path(file_name).name
+    stem_lower = stem.lower()
+    if stem_lower.endswith(".json"):
+        stem = stem[:-5]
+    elif stem_lower.endswith(".parquet"):
+        stem = stem[:-8]
+    is_qdq = False
+    if stem.endswith("_qdq"):
+        stem = stem[:-4]
+        is_qdq = True
+    return stem, is_qdq
+
+
+def _parse_file_name(file_name: str) -> tuple[str, str, str, str, int, bool]:
+    stem, is_qdq = _normalize_stem(file_name)
+    opset_match = re.search(r"_opset(?P<version>\d+)$", stem)
+    if opset_match is None:
+        raise ValueError(f"Missing _opset<version> suffix in file name: {file_name}")
+
+    version = int(opset_match.group("version"))
+    prefix = stem[: opset_match.start()]
+    head, sep, domain = prefix.rpartition("_")
+    if not sep:
+        raise ValueError(f"Missing domain segment in file name: {file_name}")
+
+    parts = head.rsplit("_", 2)
+    if len(parts) != 3:
+        raise ValueError(f"Unable to parse <name>_<ep>_<device> from file name: {file_name}")
+
+    name, ep, device = parts
+    if device not in DEVICE_SET:
+        raise ValueError(f"Unsupported device '{device}' in file name: {file_name}")
+
+    return name, ep, device, domain, version, is_qdq
+
+
+def _section_domain(section_name: str) -> str:
+    if section_name == "ops_com_microsoft":
+        return "com.microsoft"
+    return "ai.onnx"
+
+
+def _compute_indexes(
+    providers_json_path: str,
+    ops_json_path: str,
+) -> IndexBundle:
+    providers_json = Path(providers_json_path)
+    ops_json = Path(ops_json_path)
+
+    providers_data = _load_json_object(providers_json)
+    ops_data = _load_json_object(ops_json)
+
+    ep_device_to_key: dict[tuple[str, str], str] = {}
+    key_to_ep_device: dict[str, tuple[str, str]] = {}
+
+    for ep_name, ep_payload in providers_data.items():
+        if not isinstance(ep_payload, dict):
+            continue
+        devices_payload = ep_payload.get("devices")
+        if not isinstance(devices_payload, dict):
+            continue
+
+        for device, device_payload in devices_payload.items():
+            if device not in DEVICE_SET:
+                continue
+            if not isinstance(device_payload, dict):
+                continue
+
+            ep_key = device_payload.get("key")
+            if not isinstance(ep_key, str) or len(ep_key) != 1 or ep_key not in ALPHABET:
+                raise ValueError(f"Invalid key for {ep_name}_{device}: {ep_key}")
+            if ep_key in key_to_ep_device:
+                raise ValueError(
+                    f"Duplicate EP/device key '{ep_key}' used by "
+                    f"{key_to_ep_device[ep_key]} and {(ep_name, device)}"
+                )
+
+            ep_device_to_key[(ep_name, device)] = ep_key
+            key_to_ep_device[ep_key] = (ep_name, device)
+
+    if not ep_device_to_key:
+        raise ValueError(f"No EP/device key mapping found in {providers_json}")
+
+    by_exact: dict[tuple[str, int, str], str] = {}
+    by_name_version: dict[tuple[str, int], list[tuple[str, str]]] = {}
+    version_key_to_entry: dict[str, tuple[str, int, str]] = {}
+
+    for section_name in ("ops_ai_onnx", "ops_com_microsoft", "patterns", "ops"):
+        section = ops_data.get(section_name)
+        if not isinstance(section, dict):
+            continue
+
+        domain = _section_domain(section_name)
+        for name, item in section.items():
+            if not isinstance(item, dict):
+                continue
+
+            version_key_map = item.get("version_key_map")
+            if not isinstance(version_key_map, dict):
+                continue
+
+            for raw_version, version_key in version_key_map.items():
+                try:
+                    version = int(raw_version)
+                except Exception as exc:
+                    raise ValueError(
+                        f"Invalid version key '{raw_version}' in {section_name}.{name}"
+                    ) from exc
+
+                if (
+                    not isinstance(version_key, str)
+                    or len(version_key) != 2
+                    or any(ch not in ALPHABET for ch in version_key)
+                ):
+                    raise ValueError(
+                        f"Invalid 2-char version key for {section_name}.{name} version {version}: "
+                        f"{version_key}"
+                    )
+
+                if version_key in version_key_to_entry:
+                    raise ValueError(
+                        f"Duplicate version key '{version_key}' used by "
+                        f"{version_key_to_entry[version_key]} and {(name, version, domain)}"
+                    )
+
+                by_exact[(name, version, domain)] = version_key
+                by_name_version.setdefault((name, version), []).append((domain, version_key))
+                version_key_to_entry[version_key] = (name, version, domain)
+
+    if not version_key_to_entry:
+        raise ValueError(f"No version key mapping found in {ops_json}")
+
+    return ep_device_to_key, key_to_ep_device, by_exact, by_name_version, version_key_to_entry
+
+
+def _resolve_mapping_paths(
+    providers_json: str | Path | None,
+    ops_json: str | Path | None,
+) -> tuple[Path, Path]:
+    providers_path, ops_path = _default_mapping_paths()
+    if providers_json is not None:
+        providers_path = Path(providers_json)
+    if ops_json is not None:
+        ops_path = Path(ops_json)
+    return providers_path.resolve(), ops_path.resolve()
+
+
+def _get_global_indexes(
+    providers_json: str | Path | None,
+    ops_json: str | Path | None,
+) -> IndexBundle:
+    global _GLOBAL_INDEXES, _GLOBAL_INDEXES_SOURCE
+
+    providers_path, ops_path = _resolve_mapping_paths(providers_json, ops_json)
+    current_source = (str(providers_path), str(ops_path))
+
+    if _GLOBAL_INDEXES is None:
+        _GLOBAL_INDEXES = _compute_indexes(*current_source)
+        _GLOBAL_INDEXES_SOURCE = current_source
+        return _GLOBAL_INDEXES
+
+    if _GLOBAL_INDEXES_SOURCE != current_source:
+        raise ValueError(
+            "Global index cache already initialized with different mapping files: "
+            f"cached={_GLOBAL_INDEXES_SOURCE}, requested={current_source}"
+        )
+
+    return _GLOBAL_INDEXES
+
+
+def encode_file_name_to_4char_key(
+    file_name: str,
+    providers_json: str | Path | None = None,
+    ops_json: str | Path | None = None,
+) -> str:
+    ep_device_to_key, _key_to_ep_device, by_exact, by_name_version, _version_key_to_entry = _get_global_indexes(
+        providers_json,
+        ops_json,
+    )
+
+    name, ep, device, domain, version, is_qdq = _parse_file_name(file_name)
+
+    ep_device_key = ep_device_to_key.get((ep, device))
+    if ep_device_key is None:
+        raise KeyError(f"No EP/device key found for {ep}_{device}")
+
+    version_key = by_exact.get((name, version, domain))
+    if version_key is None:
+        candidates = by_name_version.get((name, version), [])
+        if len(candidates) == 1:
+            version_key = candidates[0][1]
+        elif not candidates:
+            raise KeyError(f"No version key found for {name} version {version} domain {domain}")
+        else:
+            text = ", ".join(f"{candidate_domain}:{candidate_key}" for candidate_domain, candidate_key in candidates)
+            raise KeyError(
+                f"Ambiguous version key for {name} version {version} domain {domain}; candidates: {text}"
+            )
+
+    qdq_flag = "1" if is_qdq else "0"
+    return f"{ep_device_key}{version_key}{qdq_flag}"
+
+
+def decode_4char_key_to_folder_and_file_name(
+    key_or_case_index: str,
+    providers_json: str | Path | None = None,
+    ops_json: str | Path | None = None,
+) -> DecodedLocation:
+    _ep_device_to_key, key_to_ep_device, _by_exact, _by_name_version, version_key_to_entry = _get_global_indexes(
+        providers_json,
+        ops_json,
+    )
+
+    trimmed = key_or_case_index.strip()
+    if len(trimmed) < 4:
+        raise ValueError("key/case_index length must be >= 4")
+    prefix = trimmed[:4]
+
+    ep_device_key = prefix[0]
+    version_key = prefix[1:3]
+    qdq_flag = prefix[3]
+    if ep_device_key not in ALPHABET or any(ch not in ALPHABET for ch in version_key):
+        raise ValueError(f"Invalid key prefix: {prefix}")
+    if qdq_flag not in {"0", "1"}:
+        raise ValueError(f"Invalid qdq flag in key prefix: {prefix}")
+
+    ep_device = key_to_ep_device.get(ep_device_key)
+    if ep_device is None:
+        raise KeyError(f"No EP/device mapping for key '{ep_device_key}'")
+    ep, device = ep_device
+
+    version_entry = version_key_to_entry.get(version_key)
+    if version_entry is None:
+        raise KeyError(f"No version mapping for key '{version_key}'")
+    name, version, domain = version_entry
+
+    folder_name = f"{ep}_{device}"
+    qdq_suffix = "_qdq" if qdq_flag == "1" else ""
+    file_name = f"{name}_{ep}_{device}_{domain}_opset{version}{qdq_suffix}"
+    return DecodedLocation(folder_name=folder_name, file_name=file_name)
+
+

--- a/src/winml/modelkit/analyze/utils/ep_utils.py
+++ b/src/winml/modelkit/analyze/utils/ep_utils.py
@@ -106,26 +106,29 @@ def get_devices_with_rule_data(ep_name: EPName) -> list[str]:
 
 
 def has_any_rule_data() -> bool:
-    """Return True if any parquet rule file exists in any search directory.
+    """Return True if any parquet exists under one-level subdirectories.
 
     Used to distinguish "no data at all" (needs setup) from "data exists
     but not for this specific EP/device combination".
+
+    This intentionally uses a minimal filesystem probe pattern.
     """
     from .rule_loader import get_runtime_rules_search_dirs
 
     for search_dir in get_runtime_rules_search_dirs():
-        if search_dir.is_dir() and any(search_dir.rglob("*.parquet")):
+        if not search_dir.is_dir():
+            continue
+
+        if any(search_dir.glob("*/*.parquet")):
             return True
+
     return False
 
 
 def has_rule_data_for_ep(ep_name: EPName, device: str) -> bool:
     """Check whether runtime check rule data exists for a given EP and device.
 
-        Probes runtime-rule search directories for parquet files in either layout:
-        - flat files under search dir:
-            ``*_{ep_name}_{device}_*.parquet``
-        - provider subdirectory layout:
+        Probes runtime-rule search directories for provider subdirectory layout only:
             ``<search_dir>/{ep_name}_{device}/*.parquet``
 
         This is a fast filesystem check and does not parse parquet contents.
@@ -142,13 +145,7 @@ def has_rule_data_for_ep(ep_name: EPName, device: str) -> bool:
 
     def _has_parquet_in_search_dir(search_dir: Path, ep: EPName, device_upper: str) -> bool:
         provider_dir = search_dir / f"{ep}_{device_upper}"
-        if provider_dir.is_dir() and any(provider_dir.glob("*.parquet")):
-            return True
-
-        if any(search_dir.glob(f"*_{ep}_{device_upper}_*.parquet")):
-            return True
-
-        return any(search_dir.glob(f"{ep}_{device_upper}_*.parquet"))
+        return provider_dir.is_dir() and any(provider_dir.glob("*.parquet"))
 
     device_upper = device.upper()
     for search_dir in get_runtime_rules_search_dirs():

--- a/src/winml/modelkit/analyze/utils/op_utils.py
+++ b/src/winml/modelkit/analyze/utils/op_utils.py
@@ -16,6 +16,7 @@ import onnx
 from google.protobuf import json_format
 
 from ...pattern.op_input_gen import normalize_constraint_dict
+from .avalizble_ep_device_ops.case_index_key_codec import encode_file_name_to_4char_key
 
 
 def load_case_indices_from_conflict_file(conflict_file: str | Path) -> list[str]:
@@ -134,9 +135,21 @@ def compute_case_signature(case: dict, *, namespace: str) -> str:
     return "|".join(sig_parts)
 
 
-def hash_case_signature(signature: str) -> str:
-    """Return a stable hash value for a case signature."""
-    return hashlib.sha256(signature.encode("utf-8")).hexdigest()
+def _hash_case_signature(signature: str) -> str:
+    """Return a stable 32-char hash value for case content."""
+    return hashlib.md5(signature.encode("utf-8")).hexdigest()
+
+
+def _compute_case_index_with_namespace_key(case: dict, *, namespace_key: str) -> str:
+    """Compute unified 36-char case_index using 4-char namespace key + 32-char md5."""
+    signature = compute_case_signature(case, namespace="")
+    return f"{namespace_key}{_hash_case_signature(signature)}"
+
+
+def compute_case_index(case: dict, *, namespace: str) -> str:
+    """Compute unified 36-char case_index for a case under the given file namespace."""
+    namespace_key = encode_file_name_to_4char_key(namespace)
+    return _compute_case_index_with_namespace_key(case, namespace_key=namespace_key)
 
 
 class CheckResultWriter:
@@ -178,6 +191,7 @@ class CheckResultWriter:
         self.case_namespace = (
             self.file_path.stem
         )  # File name without extension for case_index namespace
+        self.case_namespace_key = encode_file_name_to_4char_key(self.case_namespace)
         if filter_case_index is None:
             self.filter_case_indices: list[str] | None = None
             self._filter_case_index_set: set[str] | None = None
@@ -233,9 +247,13 @@ class CheckResultWriter:
             True if the case should be skipped.
         """
         sig = compute_case_signature(case, namespace=self.case_namespace)
+        case_index = _compute_case_index_with_namespace_key(
+            case,
+            namespace_key=self.case_namespace_key,
+        )
         if self.filter_case_indices is not None:
             assert self._filter_case_index_set is not None
-            return hash_case_signature(sig) not in self._filter_case_index_set
+            return case_index not in self._filter_case_index_set
 
         if self.delta_only:
             # Only run brand-new cases; skip anything we already have
@@ -260,7 +278,7 @@ class CheckResultWriter:
             return
 
         self._assign_not_run_ids(case)
-        self._set_case_index_signature(case)
+        self._set_case_index_signatures(case)
         self.results.append(case)
         self.output_signatures.add(sig)
         self._increment_pending_and_maybe_save()
@@ -278,9 +296,13 @@ class CheckResultWriter:
             True if existing result was found and reused, False otherwise.
         """
         sig = compute_case_signature(case, namespace=self.case_namespace)
+        case_index = _compute_case_index_with_namespace_key(
+            case,
+            namespace_key=self.case_namespace_key,
+        )
         if self.filter_case_indices is not None:
             assert self._filter_case_index_set is not None
-            if hash_case_signature(sig) not in self._filter_case_index_set:
+            if case_index not in self._filter_case_index_set:
                 return False
 
         existing_case = self.existing_signatures.get(sig)
@@ -295,16 +317,22 @@ class CheckResultWriter:
             # via iter(), so its input_constraints is up-to-date.
             if "input_constraints" in case:
                 existing_case["input_constraints"] = case["input_constraints"]
-            self._set_case_index_signature(existing_case)
+            # Ensure reused cases keep the current model payload contract.
+            if isinstance(case.get("model_bytes_b64"), str):
+                existing_case["model_bytes_b64"] = case["model_bytes_b64"]
+            self._set_case_index_signatures(existing_case)
             self.results.append(existing_case)
             self.output_signatures.add(sig)
             return True
         return False
 
-    def _set_case_index_signature(self, case: dict[str, Any]) -> None:
-        """Set case_index to a stable hash derived from normalized signature."""
-        signature = compute_case_signature(case, namespace=self.case_namespace)
-        case["case_index"] = hash_case_signature(signature)
+    def _set_case_index_signatures(self, case: dict[str, Any]) -> None:
+        """Set unified 36-char case_index derived from namespace key and case content."""
+        case["case_index"] = _compute_case_index_with_namespace_key(
+            case,
+            namespace_key=self.case_namespace_key,
+        )
+        case.pop("case_index_ignore_ep_device", None)
 
     def _contains_not_run_reason(self, case: dict[str, Any]) -> bool:
         """Check whether compile/run reason contains a not_run placeholder."""
@@ -422,7 +450,7 @@ class CheckResultWriter:
 
         for item in output_data["check_results"]:
             if isinstance(item, dict):
-                self._set_case_index_signature(item)
+                self._set_case_index_signatures(item)
 
         # Sort results by case_index to keep deterministic ordering before writing
         output_data["check_results"] = sorted(

--- a/src/winml/modelkit/analyze/utils/op_utils.py
+++ b/src/winml/modelkit/analyze/utils/op_utils.py
@@ -137,7 +137,7 @@ def compute_case_signature(case: dict, *, namespace: str) -> str:
 
 def _hash_case_signature(signature: str) -> str:
     """Return a stable 32-char hash value for case content."""
-    return hashlib.md5(signature.encode("utf-8")).hexdigest()
+    return hashlib.md5(signature.encode("utf-8"), usedforsecurity=False).hexdigest()
 
 
 def _compute_case_index_with_namespace_key(case: dict, *, namespace_key: str) -> str:

--- a/src/winml/modelkit/analyze/utils/op_utils.py
+++ b/src/winml/modelkit/analyze/utils/op_utils.py
@@ -247,12 +247,12 @@ class CheckResultWriter:
             True if the case should be skipped.
         """
         sig = compute_case_signature(case, namespace=self.case_namespace)
-        case_index = _compute_case_index_with_namespace_key(
-            case,
-            namespace_key=self.case_namespace_key,
-        )
         if self.filter_case_indices is not None:
             assert self._filter_case_index_set is not None
+            case_index = _compute_case_index_with_namespace_key(
+                case,
+                namespace_key=self.case_namespace_key,
+            )
             return case_index not in self._filter_case_index_set
 
         if self.delta_only:
@@ -296,12 +296,12 @@ class CheckResultWriter:
             True if existing result was found and reused, False otherwise.
         """
         sig = compute_case_signature(case, namespace=self.case_namespace)
-        case_index = _compute_case_index_with_namespace_key(
-            case,
-            namespace_key=self.case_namespace_key,
-        )
         if self.filter_case_indices is not None:
             assert self._filter_case_index_set is not None
+            case_index = _compute_case_index_with_namespace_key(
+                case,
+                namespace_key=self.case_namespace_key,
+            )
             if case_index not in self._filter_case_index_set:
                 return False
 

--- a/src/winml/modelkit/analyze/utils/rule_loader.py
+++ b/src/winml/modelkit/analyze/utils/rule_loader.py
@@ -21,6 +21,10 @@ logger = logging.getLogger(__name__)
 #: Use ``os.pathsep`` (`;` on Windows, `:` on Unix) to separate multiple paths.
 WINMLCLI_RULES_DIR_ENV = "WINMLCLI_RULES_DIR"
 
+#: Environment variable for additional runtime debug rule directories.
+#: Use ``os.pathsep`` (`;` on Windows, `:` on Unix) to separate multiple paths.
+WINMLCLI_RULES_DIR_FOR_DEBUG_ENV = "WINMLCLI_RULES_DIR_FOR_DEBUG"
+
 # Directory containing this module file. Relative env-var entries are resolved from here.
 _RULE_LOADER_DIR: Path = Path(__file__).resolve().parent
 
@@ -42,6 +46,18 @@ def _resolve_env_rules_dir_entry(entry: str) -> Path:
     return (_RULE_LOADER_DIR / entry_path).resolve()
 
 
+def _get_env_rules_dirs(env_name: str) -> list[Path]:
+    """Parse ``os.pathsep``-separated env var values into absolute paths."""
+    dirs: list[Path] = []
+    env_val = os.environ.get(env_name, "").strip()
+    if env_val:
+        for entry in env_val.split(os.pathsep):
+            entry = entry.strip()
+            if entry:
+                dirs.append(_resolve_env_rules_dir_entry(entry))
+    return dirs
+
+
 def get_runtime_rules_search_dirs() -> list[Path]:
     """Return ordered list of directories to search for runtime rule artifacts.
 
@@ -54,27 +70,30 @@ def get_runtime_rules_search_dirs() -> list[Path]:
     Returns:
         List of directory Paths (may include non-existent ones; callers filter).
     """
-    dirs: list[Path] = []
-    env_val = os.environ.get(WINMLCLI_RULES_DIR_ENV, "").strip()
-    if env_val:
-        for entry in env_val.split(os.pathsep):
-            entry = entry.strip()
-            if entry:
-                dirs.append(_resolve_env_rules_dir_entry(entry))
+    dirs = _get_env_rules_dirs(WINMLCLI_RULES_DIR_ENV)
     dirs.append(_DEFAULT_RUNTIME_RULES_DIR)
     return dirs
 
 
-def resolve_rule_parquet_path(parquet_filename: str) -> Path:
-    """Resolve a parquet runtime-rule artifact by searching known directories.
+def get_runtime_rules_debug_search_dirs() -> list[Path]:
+    """Return ordered debug-rule directories from env var only.
+
+    Unlike :func:`get_runtime_rules_search_dirs`, this intentionally has no
+    embedded default fallback directory.
+    """
+    return _get_env_rules_dirs(WINMLCLI_RULES_DIR_FOR_DEBUG_ENV)
+
+
+def resolve_rule_parquet_path(parquet_filename: str, for_debug: bool = False) -> Path | None:
+    """Resolve a parquet runtime-rule artifact from ``<EP>_<DEVICE>/`` subdirs.
 
     Args:
         parquet_filename: Bare file name, e.g.
             ``Split_QNNExecutionProvider_NPU_ai.onnx_opset13.parquet``
 
     Returns:
-        Resolved Path to the parquet file if found. If not found, returns the
-        path under the first search directory to preserve deterministic debug output.
+        Resolved Path to the parquet file if found in provider subdirectories;
+        otherwise ``None``.
     """
 
     def _infer_ep_device_subdir(filename: str) -> str | None:
@@ -88,28 +107,22 @@ def resolve_rule_parquet_path(parquet_filename: str) -> Path:
             return None
         return f"{match.group('ep')}_{match.group('device')}"
 
-    search_dirs = get_runtime_rules_search_dirs()
     ep_device_subdir = _infer_ep_device_subdir(parquet_filename)
+    if ep_device_subdir is None:
+        return None
 
-    for search_dir in search_dirs:
-        candidate = search_dir / parquet_filename
-        if candidate.exists():
-            return candidate
-
-        if ep_device_subdir is not None:
-            candidate_in_subdir = search_dir / ep_device_subdir / parquet_filename
+    if for_debug:
+        for debug_dir in get_runtime_rules_debug_search_dirs():
+            candidate_in_subdir = debug_dir / ep_device_subdir / parquet_filename
             if candidate_in_subdir.exists():
                 return candidate_in_subdir
 
-        # Backward-compatible fallback for any one-level nested layout.
-        nested_matches = sorted(search_dir.glob(f"*/{parquet_filename}"))
-        if nested_matches:
-            return nested_matches[0]
+    for search_dir in get_runtime_rules_search_dirs():
+        candidate_in_subdir = search_dir / ep_device_subdir / parquet_filename
+        if candidate_in_subdir.exists():
+            return candidate_in_subdir
 
-    if search_dirs:
-        return search_dirs[0] / parquet_filename
-
-    return _DEFAULT_RUNTIME_RULES_DIR / parquet_filename
+    return None
 
 
 class RuleLoader:

--- a/src/winml/modelkit/commands/analyze.py
+++ b/src/winml/modelkit/commands/analyze.py
@@ -611,18 +611,31 @@ def _ep_name_device_display_name(ep_name: str, device_name: str) -> str:
     return f"{ep_name} ({device_name.upper()})"
 
 
-def _empty_runtime_debug_summary_payload() -> dict[str, dict[str, dict[str, object | None]]]:
-    """Create empty runtime debug summary payload with fixed top-level keys."""
-    return {level: {} for level in _RUNTIME_DEBUG_LEVELS}
+def _empty_runtime_debug_summary_payload() -> dict[str, Any]:
+    """Create empty runtime debug summary payload with fixed top-level keys.
+
+    ``unknown`` is intentionally the first key and holds a list of node keys
+    (no case_indices); the remaining levels map node keys to detail entries.
+    """
+    payload: dict[str, Any] = {"unknown": []}
+    payload.update({level: {} for level in _RUNTIME_DEBUG_LEVELS})
+    return payload
 
 
 def _normalize_runtime_debug_summary_payload(
     summary_payload: object,
-) -> dict[str, dict[str, dict[str, object | None]]]:
+) -> dict[str, Any]:
     """Normalize runtime debug summary payload to fixed JSON schema."""
     normalized = _empty_runtime_debug_summary_payload()
     if not isinstance(summary_payload, dict):
         return normalized
+
+    raw_unknown = summary_payload.get("unknown")
+    if isinstance(raw_unknown, list):
+        normalized["unknown"] = [str(node) for node in raw_unknown]
+    elif isinstance(raw_unknown, dict):
+        # Tolerate a dict-shaped unknown payload by keeping node keys only.
+        normalized["unknown"] = [str(node) for node in raw_unknown]
 
     for level in _RUNTIME_DEBUG_LEVELS:
         raw_level_entries = summary_payload.get(level)
@@ -649,7 +662,7 @@ def _extract_runtime_debug_summary_payload_for_pair(
     run_result: Any,
     ep_name: str,
     device_name: str,
-) -> dict[str, dict[str, dict[str, object | None]]]:
+) -> dict[str, Any]:
     """Extract runtime debug summary payload for one EP/device pair."""
     empty_payload = _empty_runtime_debug_summary_payload()
 

--- a/src/winml/modelkit/commands/analyze.py
+++ b/src/winml/modelkit/commands/analyze.py
@@ -918,8 +918,8 @@ def analyze(
             if candidate_ep is None or candidate_ep not in EP_SUPPORTED_DEVICES:
                 continue
             execution_pairs.extend(
-            (candidate_ep, candidate_device)
-            for candidate_device in devices
+                (candidate_ep, candidate_device)
+                for candidate_device in devices
                 if candidate_device.lower() in EP_SUPPORTED_DEVICES[candidate_ep]
             )
         execution_pairs = _sort_ep_device_pairs(execution_pairs)
@@ -1278,8 +1278,6 @@ def analyze(
                 run_unknown_op_for_ep = _resolve_run_unknown_op(
                     target_ep, target_device, run_unknown_op, local_pairs
                 )
-                current_device = target_device
-                current_ep_device_pair = None
 
                 result = analyzer.analyze(
                     model_path=str(model),

--- a/src/winml/modelkit/commands/analyze.py
+++ b/src/winml/modelkit/commands/analyze.py
@@ -19,7 +19,7 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import Any, TYPE_CHECKING, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import click
 from rich.console import Console
@@ -826,14 +826,14 @@ def analyze(
             logger.error("ONNX model file not found: %s", model)
             sys.exit(2)
 
+        from ..analyze.utils.ep_utils import (
+            has_any_rule_data,
+            has_rule_data_for_ep,
+        )
         from ..analyze.utils.rule_loader import (
             WINMLCLI_RULES_DIR_FOR_DEBUG_ENV,
             get_runtime_rules_debug_search_dirs,
             get_runtime_rules_search_dirs,
-        )
-        from ..analyze.utils.ep_utils import (
-            has_any_rule_data,
-            has_rule_data_for_ep,
         )
 
         for_debug = debug

--- a/src/winml/modelkit/commands/analyze.py
+++ b/src/winml/modelkit/commands/analyze.py
@@ -15,10 +15,11 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, cast
+from typing import Any, TYPE_CHECKING, Literal, cast
 
 import click
 from rich.console import Console
@@ -67,26 +68,8 @@ _COLORS = {
 }
 
 
-def _discover_runtime_rule_parquet_files() -> tuple[list[Path], list[Path]]:
-    """Return runtime-rule search directories and discovered parquet files.
-
-    The runtime checker supports both flat and one-level nested layouts.
-    """
-    from ..analyze.utils.rule_loader import get_runtime_rules_search_dirs
-
-    search_dirs = get_runtime_rules_search_dirs()
-    parquet_files: list[Path] = []
-
-    for search_dir in search_dirs:
-        if not search_dir.is_dir():
-            continue
-        parquet_files.extend(sorted(search_dir.glob("*.parquet")))
-        parquet_files.extend(sorted(search_dir.glob("*/*.parquet")))
-
-    return search_dirs, parquet_files
-
-
 _TRAILING_PAREN_RE = re.compile(r" \([^()]*\)$")
+_RUNTIME_DEBUG_LEVELS = ("unsupported", "partial", "supported")
 
 
 def _display_name(pattern_id: str) -> str:
@@ -628,6 +611,93 @@ def _ep_name_device_display_name(ep_name: str, device_name: str) -> str:
     return f"{ep_name} ({device_name.upper()})"
 
 
+def _empty_runtime_debug_summary_payload() -> dict[str, dict[str, dict[str, object | None]]]:
+    """Create empty runtime debug summary payload with fixed top-level keys."""
+    return {level: {} for level in _RUNTIME_DEBUG_LEVELS}
+
+
+def _normalize_runtime_debug_summary_payload(
+    summary_payload: object,
+) -> dict[str, dict[str, dict[str, object | None]]]:
+    """Normalize runtime debug summary payload to fixed JSON schema."""
+    normalized = _empty_runtime_debug_summary_payload()
+    if not isinstance(summary_payload, dict):
+        return normalized
+
+    for level in _RUNTIME_DEBUG_LEVELS:
+        raw_level_entries = summary_payload.get(level)
+        if not isinstance(raw_level_entries, dict):
+            continue
+
+        level_entries: dict[str, dict[str, object | None]] = {}
+        for node_stable_key, raw_entry in raw_level_entries.items():
+            if not isinstance(raw_entry, dict):
+                continue
+
+            level_entries[str(node_stable_key)] = {
+                "case_indices": raw_entry.get("case_indices"),
+                "table_path": raw_entry.get("table_path"),
+                "table_file": raw_entry.get("table_file"),
+            }
+
+        normalized[level] = level_entries
+
+    return normalized
+
+
+def _extract_runtime_debug_summary_payload_for_pair(
+    run_result: Any,
+    ep_name: str,
+    device_name: str,
+) -> dict[str, dict[str, dict[str, object | None]]]:
+    """Extract runtime debug summary payload for one EP/device pair."""
+    empty_payload = _empty_runtime_debug_summary_payload()
+
+    try:
+        result_json = json.loads(run_result.to_json())
+    except Exception:
+        logger.debug("Failed to deserialize run_result for runtime debug payload", exc_info=True)
+        return empty_payload
+
+    raw_results = result_json.get("results")
+    if not isinstance(raw_results, list):
+        return empty_payload
+
+    target_device = str(device_name).upper()
+
+    # Prefer exact EP/device match first.
+    for ep_result in raw_results:
+        if not isinstance(ep_result, dict):
+            continue
+        if ep_result.get("ep_type") != ep_name:
+            continue
+
+        result_device = str(ep_result.get("device_type") or "").upper()
+        if result_device and result_device != target_device:
+            continue
+
+        return _normalize_runtime_debug_summary_payload(
+            ep_result.get("runtime_debug_details_summary")
+        )
+
+    # Fallback: first available runtime_debug_details_summary in this run.
+    for ep_result in raw_results:
+        if not isinstance(ep_result, dict):
+            continue
+        if "runtime_debug_details_summary" in ep_result:
+            return _normalize_runtime_debug_summary_payload(
+                ep_result.get("runtime_debug_details_summary")
+            )
+
+    return empty_payload
+
+
+def _build_runtime_debug_output_path(model_path: Path, ep_name: str, device_name: str) -> Path:
+    """Build debug summary output path near the model file."""
+    filename = f"{model_path.stem}.analyze.{ep_name}.{str(device_name).upper()}.debug.json"
+    return model_path.parent / filename
+
+
 # ── Click command ─────────────────────────────────────────────────────────
 
 
@@ -677,6 +747,15 @@ def _ep_name_device_display_name(ep_name: str, device_name: str) -> str:
     help="Run unknown operators on local machine if possible (default: disabled)",
 )
 @click.option(
+    "--debug",
+    is_flag=True,
+    default=False,
+    help=(
+        "Enable runtime debug mode. Requires WINMLCLI_RULES_DIR_FOR_DEBUG "
+        "to point to a rules_debug directory containing */*.parquet files."
+    ),
+)
+@click.option(
     "--save-node",
     multiple=True,
     type=click.Choice(["partial", "unsupported"], case_sensitive=False),
@@ -703,6 +782,7 @@ def analyze(
     config_file: Path | None,
     htp_metadata: Path | None,
     run_unknown_op: bool,
+    debug: bool,
     save_node: tuple[str, ...],
     optim_config: Path | None,
 ) -> None:
@@ -746,17 +826,63 @@ def analyze(
             logger.error("ONNX model file not found: %s", model)
             sys.exit(2)
 
-        search_dirs, parquet_files = _discover_runtime_rule_parquet_files()
-        if not parquet_files:
+        from ..analyze.utils.rule_loader import (
+            WINMLCLI_RULES_DIR_FOR_DEBUG_ENV,
+            get_runtime_rules_debug_search_dirs,
+            get_runtime_rules_search_dirs,
+        )
+        from ..analyze.utils.ep_utils import (
+            has_any_rule_data,
+            has_rule_data_for_ep,
+        )
+
+        for_debug = debug
+        if for_debug:
+            debug_search_dirs = get_runtime_rules_debug_search_dirs()
+            has_debug_parquet = any(
+                debug_dir.is_dir() and any(debug_dir.glob("*/*.parquet"))
+                for debug_dir in debug_search_dirs
+            )
+            if not has_debug_parquet:
+                configured_debug_dir = os.environ.get(WINMLCLI_RULES_DIR_FOR_DEBUG_ENV, "").strip()
+                logger.error(
+                    "--debug requires %s to be configured and point to a rules_debug "
+                    "directory containing */*.parquet files; otherwise --debug cannot "
+                    "take effect.",
+                    WINMLCLI_RULES_DIR_FOR_DEBUG_ENV,
+                )
+                logger.error(
+                    "%s configured: %s",
+                    WINMLCLI_RULES_DIR_FOR_DEBUG_ENV,
+                    "yes" if configured_debug_dir else "no",
+                )
+                if configured_debug_dir:
+                    logger.error(
+                        "Configured %s raw value: %s",
+                        WINMLCLI_RULES_DIR_FOR_DEBUG_ENV,
+                        configured_debug_dir,
+                    )
+                    if debug_search_dirs:
+                        logger.error(
+                            "Resolved absolute path(s) from %s:",
+                            WINMLCLI_RULES_DIR_FOR_DEBUG_ENV,
+                        )
+                        for resolved_debug_dir in debug_search_dirs:
+                            logger.error("  - %s", resolved_debug_dir)
+                    else:
+                        logger.error(
+                            "Resolved absolute path(s) from %s: (none)",
+                            WINMLCLI_RULES_DIR_FOR_DEBUG_ENV,
+                        )
+                sys.exit(2)
+
+        search_dirs = get_runtime_rules_search_dirs()
+        if not has_any_rule_data():
             searched = ", ".join(str(p) for p in search_dirs) if search_dirs else "(none)"
             logger.error("No runtime rule parquet files were found.")
             logger.error("Please reinstall winml-cli, or manually download rule parquet files.")
             logger.error("Searched directories: %s", searched)
             sys.exit(2)
-
-        from ..analyze.utils.ep_utils import (
-            has_rule_data_for_ep,
-        )
 
         devices: list[str]
         if device == "auto":
@@ -792,8 +918,8 @@ def analyze(
             if candidate_ep is None or candidate_ep not in EP_SUPPORTED_DEVICES:
                 continue
             execution_pairs.extend(
-                (candidate_ep, candidate_device)
-                for candidate_device in devices
+            (candidate_ep, candidate_device)
+            for candidate_device in devices
                 if candidate_device.lower() in EP_SUPPORTED_DEVICES[candidate_ep]
             )
         execution_pairs = _sort_ep_device_pairs(execution_pairs)
@@ -1099,6 +1225,7 @@ def analyze(
                         device=target_device,
                         enable_information=information,
                         htp_metadata_path=str(htp_metadata) if htp_metadata else None,
+                        for_debug=for_debug,
                         run_unknown_op=run_unknown_op_for_ep,
                         save_node_types=save_node_types,
                         on_node_result=on_node_result,
@@ -1151,6 +1278,8 @@ def analyze(
                 run_unknown_op_for_ep = _resolve_run_unknown_op(
                     target_ep, target_device, run_unknown_op, local_pairs
                 )
+                current_device = target_device
+                current_ep_device_pair = None
 
                 result = analyzer.analyze(
                     model_path=str(model),
@@ -1158,6 +1287,7 @@ def analyze(
                     device=target_device,
                     enable_information=information,
                     htp_metadata_path=str(htp_metadata) if htp_metadata else None,
+                    for_debug=for_debug,
                     run_unknown_op=run_unknown_op_for_ep,
                     save_node_types=save_node_types,
                 )
@@ -1184,6 +1314,33 @@ def analyze(
             except Exception as e:
                 logger.error("Failed to serialize results to JSON: %s", e)
                 logger.debug("JSON serialization traceback:", exc_info=True)
+
+        # Save runtime debug summary JSON next to model when debug mode is enabled.
+        if for_debug:
+            try:
+                for (target_ep, target_device), run_result in zip(
+                    execution_pairs, analysis_results, strict=True
+                ):
+                    debug_payload = _extract_runtime_debug_summary_payload_for_pair(
+                        run_result=run_result,
+                        ep_name=target_ep,
+                        device_name=target_device,
+                    )
+                    debug_output = _build_runtime_debug_output_path(
+                        model_path=model,
+                        ep_name=target_ep,
+                        device_name=target_device,
+                    )
+                    debug_output.write_text(
+                        json.dumps(debug_payload, indent=2),
+                        encoding="utf-8",
+                    )
+                    logger.info("Runtime debug summary saved to: %s", debug_output)
+            except OSError as e:
+                logger.error("Failed to write runtime debug summary file: %s", e)
+            except Exception as e:
+                logger.error("Failed to prepare runtime debug summary JSON: %s", e)
+                logger.debug("Runtime debug summary traceback:", exc_info=True)
 
         # Save optimization config if requested
         if optim_config:

--- a/src/winml/modelkit/pattern/gemm_patterns.py
+++ b/src/winml/modelkit/pattern/gemm_patterns.py
@@ -445,6 +445,10 @@ class GemmPatternInputGenerator(PatternInputGenerator):
             item["C_dim"] = len(item["C_shape"])
         else:
             item["C_dim"] = 0
+
+        # Distinguish fixed-value bias constraints from shape-only constraints.
+        # This is finite (bool) and derives directly from existing row/query fields.
+        item["C_is_value_constraint"] = "C_value" in item and item["C_value"] is not None
         return item
 
     def get_infinite_property_names(self) -> list[str]:

--- a/src/winml/modelkit/pattern/op_input_gen/op_input_gen.py
+++ b/src/winml/modelkit/pattern/op_input_gen/op_input_gen.py
@@ -226,16 +226,19 @@ class InputValueConstraint(InputConstraint):
 
 
 def normalize_constraint_dict(c: dict) -> dict:
-    """Expand same_value/same_value_shape back to the canonical value list form.
+    """Expand same_value/same_value_shape back to the canonical value array form.
 
     Converts the compact representation produced by InputValueConstraint.to_dict()
-    when all values are equal, back to the full nested value list. Use this when
+    when all values are equal, back to the full nested value array. Use this when
     consuming serialized constraint dicts to ensure consistent handling regardless
     of which representation was saved.
     """
     if "same_value" in c and "same_value_shape" in c:
         normalized = {k: v for k, v in c.items() if k not in ("same_value", "same_value_shape")}
         dtype = np.dtype(c["dtype"]) if "dtype" in c else None
+        # Keep the ndarray (do NOT call .tolist()): .tolist() coerces numpy scalars
+        # to Python types (e.g. numpy bool_ -> bool), which loses the original dtype
+        # and breaks faithful restoration of the input value.
         normalized["value"] = np.full(c["same_value_shape"], c["same_value"], dtype=dtype)
 
         return normalized

--- a/src/winml/modelkit/pattern/op_input_gen/op_input_gen.py
+++ b/src/winml/modelkit/pattern/op_input_gen/op_input_gen.py
@@ -236,7 +236,7 @@ def normalize_constraint_dict(c: dict) -> dict:
     if "same_value" in c and "same_value_shape" in c:
         normalized = {k: v for k, v in c.items() if k not in ("same_value", "same_value_shape")}
         dtype = np.dtype(c["dtype"]) if "dtype" in c else None
-        normalized["value"] = np.full(c["same_value_shape"], c["same_value"], dtype=dtype).tolist()
+        normalized["value"] = np.full(c["same_value_shape"], c["same_value"], dtype=dtype)
 
         return normalized
     return c
@@ -1550,6 +1550,10 @@ class OpInputGenerator(ABC):
                 print("Running", kwargs_summary)
 
                 for onnx_model, final_tags in self.iter_const_and_dynamic_models(kwargs, tags):
+                    model_bytes = onnx_model.SerializeToString()
+                    # Keep model payload by default so every persisted case can be replayed.
+                    final_tags["model_bytes_b64"] = model_bytes_to_b64(model_bytes)
+
                     # Check if we should skip this case based on signature (delta/rerun mode)
                     if skip_signature_fn is not None:
                         if skip_signature_fn(final_tags):
@@ -1563,18 +1567,13 @@ class OpInputGenerator(ABC):
                         cases_skipped += 1
                         continue
 
-                    model_bytes = onnx_model.SerializeToString()
-                    if dry_run:
-                        # For dry_run, stash the model bytes in base64 for JSON output/replay.
-                        final_tags["model_bytes_b64"] = model_bytes_to_b64(model_bytes)
-
                     qdq_types = final_tags.get(self.qdq_types_key, None)
                     ep_checker_inputs = self.create_input_dict(kwargs, qdq_types=qdq_types)
 
                     def _dry_run_result() -> dict[str, Any]:
                         return {
                             "result": {
-                                "success": True,
+                                "success": False,
                                 "reason": "not_run",
                             },
                             "stdout": "not run",

--- a/src/winml/modelkit/pattern/op_input_gen/op_input_gen.py
+++ b/src/winml/modelkit/pattern/op_input_gen/op_input_gen.py
@@ -1550,15 +1550,16 @@ class OpInputGenerator(ABC):
                 print("Running", kwargs_summary)
 
                 for onnx_model, final_tags in self.iter_const_and_dynamic_models(kwargs, tags):
-                    model_bytes = onnx_model.SerializeToString()
-                    # Keep model payload by default so every persisted case can be replayed.
-                    final_tags["model_bytes_b64"] = model_bytes_to_b64(model_bytes)
-
-                    # Check if we should skip this case based on signature (delta/rerun mode)
+                    # Check if we should skip this case based on signature (delta/rerun mode).
+                    # The skip signature does not depend on model_bytes_b64, so serializing
+                    # the model is deferred until we know the case is not discarded.
                     if skip_signature_fn is not None:
                         if skip_signature_fn(final_tags):
                             if yield_skipped:
-                                # Yield skipped case with marker so caller can reuse existing result
+                                # Reused cases still need the model payload for replay.
+                                final_tags["model_bytes_b64"] = model_bytes_to_b64(
+                                    onnx_model.SerializeToString()
+                                )
                                 final_tags["_skipped"] = True
                                 yield final_tags
                             continue
@@ -1566,6 +1567,10 @@ class OpInputGenerator(ABC):
                     elif cases_skipped < skip_cases:
                         cases_skipped += 1
                         continue
+
+                    model_bytes = onnx_model.SerializeToString()
+                    # Keep model payload by default so every persisted case can be replayed.
+                    final_tags["model_bytes_b64"] = model_bytes_to_b64(model_bytes)
 
                     qdq_types = final_tags.get(self.qdq_types_key, None)
                     ep_checker_inputs = self.create_input_dict(kwargs, qdq_types=qdq_types)

--- a/src/winml/modelkit/pattern/op_input_gen/pad_input_generator.py
+++ b/src/winml/modelkit/pattern/op_input_gen/pad_input_generator.py
@@ -114,6 +114,12 @@ class PadInputGenerator(OpInputGenerator):
                 "pads": InputValueConstraint(np.array([2, 0, 0, 2], dtype=np.int64)),
                 "constant_value": InputValueConstraint(np.array(1.0, dtype=np.float32)),
             },
+            # ===== Asymmetric padding (second pattern for branch coverage) =====
+            {
+                "data": InputShapeConstraint((3, 4, 5)),
+                "pads": InputValueConstraint(np.array([0, 2, 1, 1, 0, 2], dtype=np.int64)),
+                "constant_value": InputValueConstraint(np.array(0.0, dtype=np.float32)),
+            },
         ]
 
     def derive_properties(self, properties: dict[str, Any]) -> dict[str, Any]:
@@ -138,10 +144,8 @@ class PadInputGenerator(OpInputGenerator):
 
         # need for NVidia TRT RTX execution provider tests
         item["pads_all_zeros"] = bool(np.all(pads_array == 0))
-        # item["pads_is_symmetric"] = bool(
-        #     np.array_equal(pads_array[: len(pads_array) // 2],
-        #                    pads_array[len(pads_array) // 2 :])
-        # )
+        half = len(pads_array) // 2
+        item["pads_is_symmetric"] = bool(np.array_equal(pads_array[:half], pads_array[half:]))
 
         return item
 

--- a/tests/unit/analyze/core/test_qdq.py
+++ b/tests/unit/analyze/core/test_qdq.py
@@ -1178,8 +1178,8 @@ class TestIterQDQCombinations:
             ),  # shape 3 * finite attributes 2 * 2 * 2 * optional combinations 2 * 2 * 2 * 4
             (
                 "Pad",
-                1024,
-            ),  # shape 8 * mode 4 * QDQ 4 * is_constant pads 2 * constant_value present/absent 2
+                1152,
+            ),  # shape 9 * mode 4 * QDQ 4 * is_constant pads 2 * constant_value present/absent 2
             # * Tind 2 (axes not used)
             # All Reduce* use this and it is enough
             (

--- a/tests/unit/analyze/core/test_runtime_checker_query_parquet.py
+++ b/tests/unit/analyze/core/test_runtime_checker_query_parquet.py
@@ -34,25 +34,38 @@ def _build_add_model(opset: int = 13):
     return helper.make_model(graph, opset_imports=[helper.make_opsetid("", opset)])
 
 
-def _write_parquet_rules(rules_dir: Path) -> Path:
+def _write_parquet_rules(
+    rules_dir: Path,
+    compile_run_success: tuple[bool, bool] = (True, False),
+    extra_columns: dict[str, object] | None = None,
+) -> Path:
     """Write parquet artifact equivalent to one Add rule row."""
-    parquet_path = rules_dir / "Add_QNNExecutionProvider_NPU_ai.onnx_opset13.parquet"
-    rule_df = pd.DataFrame(
-        [
-            {
-                "T_Add": encode_rule_condition_value_for_parquet("FLOAT"),
-                "input_dim": encode_rule_condition_value_for_parquet(4),
-                "compile_run_success": (True, False),
-            }
-        ]
+    parquet_path = (
+        rules_dir
+        / "QNNExecutionProvider_NPU"
+        / "Add_QNNExecutionProvider_NPU_ai.onnx_opset13.parquet"
     )
+    parquet_path.parent.mkdir(parents=True, exist_ok=True)
+    row: dict[str, object] = {
+        "T_Add": encode_rule_condition_value_for_parquet("FLOAT"),
+        "input_dim": encode_rule_condition_value_for_parquet(4),
+        "compile_run_success": compile_run_success,
+    }
+    if extra_columns:
+        row.update(extra_columns)
+    rule_df = pd.DataFrame([row])
     rule_df.to_parquet(parquet_path, index=False)
     return parquet_path
 
 
 def _write_legacy_parquet_rules_with_row_index(rules_dir: Path) -> Path:
     """Write legacy parquet artifact that still includes row_index column."""
-    parquet_path = rules_dir / "Add_QNNExecutionProvider_NPU_ai.onnx_opset13.parquet"
+    parquet_path = (
+        rules_dir
+        / "QNNExecutionProvider_NPU"
+        / "Add_QNNExecutionProvider_NPU_ai.onnx_opset13.parquet"
+    )
+    parquet_path.parent.mkdir(parents=True, exist_ok=True)
     rule_df = pd.DataFrame(
         [
             {
@@ -97,6 +110,12 @@ def clear_global_parquet_cache():
     runtime_checker_query_module._clear_global_parquet_table_cache()
 
 
+@pytest.fixture(autouse=True)
+def clear_debug_rules_env(monkeypatch: pytest.MonkeyPatch):
+    """Prevent host env debug rules dir from leaking into tests."""
+    monkeypatch.delenv("WINMLCLI_RULES_DIR_FOR_DEBUG", raising=False)
+
+
 class TestRuntimeCheckerQueryParquet:
     """Validate parquet runtime rule lookup."""
 
@@ -123,6 +142,69 @@ class TestRuntimeCheckerQueryParquet:
         assert result_parquet.result.compile is True
         assert result_parquet.result.run is False
         assert str(result_parquet.result.debug_details.get("table_file", "")).endswith(".parquet")
+
+    def test_parquet_lookup_omits_debug_details_without_for_debug(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        patched_query_conditions,
+    ):
+        """debug_details should be omitted unless for_debug is explicitly enabled."""
+        del patched_query_conditions
+
+        monkeypatch.setenv("WINMLCLI_RULES_DIR", str(tmp_path))
+        _write_parquet_rules(tmp_path)
+
+        model = _build_add_model()
+        node = model.graph.node[0]
+
+        query_parquet = RuntimeCheckerQuery(model, "QNNExecutionProvider", "NPU")
+        query_parquet.node_checkers = []
+        result_parquet = query_parquet.run_for_node(node, for_debug=False, run_unknown_op=False)
+
+        assert result_parquet.result.no_data is False
+        assert result_parquet.result.compile is True
+        assert result_parquet.result.run is False
+        assert result_parquet.result.debug_details is None
+
+    def test_parquet_lookup_prefers_debug_dir_when_for_debug(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        patched_query_conditions,
+    ):
+        """for_debug should resolve rules from WINMLCLI_RULES_DIR_FOR_DEBUG first."""
+        del patched_query_conditions
+
+        base_rules_dir = tmp_path / "rules"
+        debug_rules_dir = tmp_path / "rules_debug"
+        base_rules_dir.mkdir(parents=True, exist_ok=True)
+        debug_rules_dir.mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setenv("WINMLCLI_RULES_DIR", str(base_rules_dir))
+        monkeypatch.setenv("WINMLCLI_RULES_DIR_FOR_DEBUG", str(debug_rules_dir))
+
+        _write_parquet_rules(base_rules_dir, compile_run_success=(True, False))
+        _write_parquet_rules(
+            debug_rules_dir,
+            compile_run_success=(False, True),
+            extra_columns={"case_indices": ["case_42", "case_43"]},
+        )
+
+        model = _build_add_model()
+        node = model.graph.node[0]
+
+        query_parquet = RuntimeCheckerQuery(model, "QNNExecutionProvider", "NPU")
+        query_parquet.node_checkers = []
+        result_parquet = query_parquet.run_for_node(node, for_debug=True, run_unknown_op=False)
+
+        assert result_parquet.result.no_data is False
+        assert result_parquet.result.compile is False
+        assert result_parquet.result.run is True
+        debug_details = result_parquet.result.debug_details
+        assert isinstance(debug_details, dict)
+        assert "rules_debug" in str(debug_details.get("table_path", ""))
+        assert debug_details.get("case_indices") == ("case_42", "case_43")
 
     def test_parquet_global_cache_reused_across_instances(
         self,

--- a/tests/unit/analyze/models/test_rule_loader.py
+++ b/tests/unit/analyze/models/test_rule_loader.py
@@ -22,19 +22,19 @@ from pathlib import Path
 import pytest
 
 from winml.modelkit.analyze import IHVType, RuleLoader
-from winml.modelkit.analyze.utils.avalizble_ep_device_ops.case_index_key_codec import (
-    decode_4char_key_to_folder_and_file_name,
-    encode_file_name_to_4char_key,
-)
 from winml.modelkit.analyze.utils import (
     get_runtime_rules_search_dirs,
     resolve_rule_parquet_path,
 )
+from winml.modelkit.analyze.utils.avalizble_ep_device_ops.case_index_key_codec import (
+    decode_4char_key_to_folder_and_file_name,
+    encode_file_name_to_4char_key,
+)
 from winml.modelkit.analyze.utils.rule_loader import (
-    WINMLCLI_RULES_DIR_ENV,
-    WINMLCLI_RULES_DIR_FOR_DEBUG_ENV,
     _DEFAULT_RUNTIME_RULES_DIR,
     _RULE_LOADER_DIR,
+    WINMLCLI_RULES_DIR_ENV,
+    WINMLCLI_RULES_DIR_FOR_DEBUG_ENV,
     get_runtime_rules_debug_search_dirs,
 )
 
@@ -539,9 +539,9 @@ class TestRuntimeRules4CharKeyRoundTrip:
         for rules_dir in search_dirs:
             if not rules_dir.exists():
                 continue
-            for file_path in rules_dir.rglob("*"):
-                if file_path.is_file():
-                    discovered_files.append(file_path)
+            discovered_files.extend(
+                file_path for file_path in rules_dir.rglob("*") if file_path.is_file()
+            )
 
         assert discovered_files, "Expected at least one runtime-rule file to validate"
 

--- a/tests/unit/analyze/models/test_rule_loader.py
+++ b/tests/unit/analyze/models/test_rule_loader.py
@@ -22,11 +22,21 @@ from pathlib import Path
 import pytest
 
 from winml.modelkit.analyze import IHVType, RuleLoader
+from winml.modelkit.analyze.utils.avalizble_ep_device_ops.case_index_key_codec import (
+    decode_4char_key_to_folder_and_file_name,
+    encode_file_name_to_4char_key,
+)
 from winml.modelkit.analyze.utils import (
     get_runtime_rules_search_dirs,
     resolve_rule_parquet_path,
 )
-from winml.modelkit.analyze.utils.rule_loader import _DEFAULT_RUNTIME_RULES_DIR, _RULE_LOADER_DIR
+from winml.modelkit.analyze.utils.rule_loader import (
+    WINMLCLI_RULES_DIR_ENV,
+    WINMLCLI_RULES_DIR_FOR_DEBUG_ENV,
+    _DEFAULT_RUNTIME_RULES_DIR,
+    _RULE_LOADER_DIR,
+    get_runtime_rules_debug_search_dirs,
+)
 
 
 class TestRuleLoaderBasicLoading:
@@ -489,30 +499,95 @@ class TestRuntimeRulesSearchDirs:
         assert len(dirs) == 1
 
 
+class TestRuntimeRules4CharKeyRoundTrip:
+    """Test 4-char key round-trip for files discovered via runtime-rules search dirs."""
+
+    def test_round_trip_all_files_under_runtime_rules_search_dirs(self, monkeypatch, tmp_path):
+        """Each discovered runtime-rule file can encode/decode to folder and file stem."""
+        runtime_rules_root = tmp_path / "runtime_rules_env"
+        sample_files = {
+            "NvTensorRTRTXExecutionProvider_GPU": [
+                "Abs_NvTensorRTRTXExecutionProvider_GPU_ai.onnx_opset6.parquet",
+                "Gelu_NvTensorRTRTXExecutionProvider_GPU_com.microsoft_opset1.parquet",
+            ],
+            "QNNExecutionProvider_NPU": [
+                "Where_QNNExecutionProvider_NPU_ai.onnx_opset9_qdq.parquet",
+            ],
+            "OpenVINOExecutionProvider_NPU": [
+                "ExpandedAttentionPattern_OpenVINOExecutionProvider_NPU_ai.onnx_opset21.parquet",
+            ],
+        }
+
+        for folder_name, file_names in sample_files.items():
+            folder_path = runtime_rules_root / folder_name
+            folder_path.mkdir(parents=True, exist_ok=True)
+            for file_name in file_names:
+                (folder_path / file_name).write_bytes(b"PAR1")
+
+        # Keep default search dir controlled so this test traverses only files we create.
+        embedded_default = tmp_path / "embedded_runtime_rules"
+        embedded_default.mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setenv(WINMLCLI_RULES_DIR_ENV, str(runtime_rules_root))
+        monkeypatch.setattr(
+            "winml.modelkit.analyze.utils.rule_loader._DEFAULT_RUNTIME_RULES_DIR",
+            embedded_default,
+        )
+
+        search_dirs = get_runtime_rules_search_dirs()
+        discovered_files: list[Path] = []
+        for rules_dir in search_dirs:
+            if not rules_dir.exists():
+                continue
+            for file_path in rules_dir.rglob("*"):
+                if file_path.is_file():
+                    discovered_files.append(file_path)
+
+        assert discovered_files, "Expected at least one runtime-rule file to validate"
+
+        for file_path in discovered_files:
+            key4 = encode_file_name_to_4char_key(file_path.name)
+            decoded = decode_4char_key_to_folder_and_file_name(key4)
+            assert decoded.folder_name == file_path.parent.name
+            assert decoded.file_name == file_path.stem
+
+
+class TestRuntimeRulesDebugSearchDirs:
+    """Test get_runtime_rules_debug_search_dirs behavior."""
+
+    def test_debug_env_var_adds_dirs(self, monkeypatch):
+        """WINMLCLI_RULES_DIR_FOR_DEBUG adds extra debug search directories."""
+        monkeypatch.setenv(
+            WINMLCLI_RULES_DIR_FOR_DEBUG_ENV,
+            f"/debug/path1{os.pathsep}/debug/path2",
+        )
+        dirs = get_runtime_rules_debug_search_dirs()
+        assert len(dirs) == 2
+        assert dirs[0] == Path("/debug/path1").resolve()
+        assert dirs[1] == Path("/debug/path2").resolve()
+
+    def test_debug_env_var_relative_path_resolved_from_module_dir(self, monkeypatch):
+        """Relative WINMLCLI_RULES_DIR_FOR_DEBUG entries are module-dir relative."""
+        relative_entry = "debug/rules"
+        monkeypatch.setenv(WINMLCLI_RULES_DIR_FOR_DEBUG_ENV, relative_entry)
+
+        dirs = get_runtime_rules_debug_search_dirs()
+
+        assert len(dirs) == 1
+        assert dirs[0] == (_RULE_LOADER_DIR / relative_entry).resolve()
+
+    def test_debug_env_var_empty_ignored(self, monkeypatch):
+        """Empty WINMLCLI_RULES_DIR_FOR_DEBUG is treated as unset."""
+        monkeypatch.setenv(WINMLCLI_RULES_DIR_FOR_DEBUG_ENV, "  ")
+        dirs = get_runtime_rules_debug_search_dirs()
+        assert dirs == []
+
+
 class TestResolveRuleParquetPath:
     """Test resolve_rule_parquet_path behavior."""
 
-    def test_resolve_parquet_finds_file_in_env_dir(self, monkeypatch):
-        """resolve_rule_parquet_path finds parquet in an env-var search directory."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            parquet_name = "Split_QNNExecutionProvider_NPU_ai.onnx_opset13.parquet"
-            (Path(tmpdir) / parquet_name).write_bytes(b"PAR1")
-            monkeypatch.setenv("WINMLCLI_RULES_DIR", tmpdir)
-
-            result = resolve_rule_parquet_path(parquet_name)
-            assert result == Path(tmpdir).resolve() / parquet_name
-            assert result.exists()
-
-    def test_resolve_parquet_fallback_to_first_search_dir(self, monkeypatch):
-        """When parquet is missing everywhere, fallback path is under first search dir."""
-        monkeypatch.delenv("WINMLCLI_RULES_DIR", raising=False)
-        parquet_name = "missing_rule.parquet"
-
-        result = resolve_rule_parquet_path(parquet_name)
-        assert result == _DEFAULT_RUNTIME_RULES_DIR / parquet_name
-
-    def test_resolve_parquet_finds_file_in_ep_device_subdir(self, monkeypatch):
-        """resolve_rule_parquet_path finds parquet under rules_dir/<EP>_<DEVICE>/."""
+    def test_resolve_parquet_finds_file_in_env_dir_provider_subdir(self, monkeypatch):
+        """resolve_rule_parquet_path finds parquet in env-var EP_DEVICE subdirectory."""
         with tempfile.TemporaryDirectory() as tmpdir:
             parquet_name = "Split_QNNExecutionProvider_NPU_ai.onnx_opset13.parquet"
             nested_dir = Path(tmpdir) / "QNNExecutionProvider_NPU"
@@ -523,3 +598,52 @@ class TestResolveRuleParquetPath:
             result = resolve_rule_parquet_path(parquet_name)
             assert result == nested_dir.resolve() / parquet_name
             assert result.exists()
+
+    def test_resolve_parquet_returns_none_when_missing(self, monkeypatch):
+        """When parquet is missing everywhere, resolve returns None."""
+        monkeypatch.delenv("WINMLCLI_RULES_DIR", raising=False)
+        parquet_name = "missing_rule.parquet"
+
+        result = resolve_rule_parquet_path(parquet_name)
+        assert result is None
+
+    def test_resolve_parquet_ignores_flat_layout(self, monkeypatch):
+        """Flat parquet under search dir is ignored; provider subdir is required."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            parquet_name = "Split_QNNExecutionProvider_NPU_ai.onnx_opset13.parquet"
+            (Path(tmpdir) / parquet_name).write_bytes(b"PAR1")
+            monkeypatch.setenv("WINMLCLI_RULES_DIR", tmpdir)
+
+            result = resolve_rule_parquet_path(parquet_name)
+            assert result is None
+
+    def test_resolve_parquet_for_debug_prefers_debug_dir(self, monkeypatch):
+        """for_debug=True should prioritize WINMLCLI_RULES_DIR_FOR_DEBUG entries first."""
+        with tempfile.TemporaryDirectory() as rules_tmp, tempfile.TemporaryDirectory() as debug_tmp:
+            parquet_name = "Split_QNNExecutionProvider_NPU_ai.onnx_opset13.parquet"
+            rules_file = Path(rules_tmp) / "QNNExecutionProvider_NPU" / parquet_name
+            debug_file = Path(debug_tmp) / "QNNExecutionProvider_NPU" / parquet_name
+            rules_file.parent.mkdir(parents=True, exist_ok=True)
+            debug_file.parent.mkdir(parents=True, exist_ok=True)
+            rules_file.write_bytes(b"RULE")
+            debug_file.write_bytes(b"DEBUG")
+
+            monkeypatch.setenv("WINMLCLI_RULES_DIR", rules_tmp)
+            monkeypatch.setenv(WINMLCLI_RULES_DIR_FOR_DEBUG_ENV, debug_tmp)
+
+            result = resolve_rule_parquet_path(parquet_name, for_debug=True)
+            assert result == debug_file.resolve()
+
+    def test_resolve_parquet_for_debug_falls_back_to_rules_dir(self, monkeypatch):
+        """for_debug=True falls back to normal search dirs when debug file is missing."""
+        with tempfile.TemporaryDirectory() as rules_tmp, tempfile.TemporaryDirectory() as debug_tmp:
+            parquet_name = "Split_QNNExecutionProvider_NPU_ai.onnx_opset13.parquet"
+            rules_file = Path(rules_tmp) / "QNNExecutionProvider_NPU" / parquet_name
+            rules_file.parent.mkdir(parents=True, exist_ok=True)
+            rules_file.write_bytes(b"RULE")
+
+            monkeypatch.setenv("WINMLCLI_RULES_DIR", rules_tmp)
+            monkeypatch.setenv(WINMLCLI_RULES_DIR_FOR_DEBUG_ENV, debug_tmp)
+
+            result = resolve_rule_parquet_path(parquet_name, for_debug=True)
+            assert result == rules_file.resolve()

--- a/tests/unit/analyze/runtime_checker/test_ep_checker.py
+++ b/tests/unit/analyze/runtime_checker/test_ep_checker.py
@@ -32,8 +32,3 @@ def test_needs_case_isolation_for_openvino_cpu() -> None:
 def test_needs_case_isolation_for_non_isolated_ep() -> None:
     checker = _make_checker("QNNExecutionProvider")
     assert checker.needs_case_isolation() is False
-
-
-def test_needs_case_isolation_for_qnn_gpu() -> None:
-    checker = _make_checker("QNNExecutionProvider", device_type=ort.OrtHardwareDeviceType.GPU)
-    assert checker.needs_case_isolation() is True

--- a/tests/unit/analyze/runtime_checker/test_ep_checker.py
+++ b/tests/unit/analyze/runtime_checker/test_ep_checker.py
@@ -32,3 +32,8 @@ def test_needs_case_isolation_for_openvino_cpu() -> None:
 def test_needs_case_isolation_for_non_isolated_ep() -> None:
     checker = _make_checker("QNNExecutionProvider")
     assert checker.needs_case_isolation() is False
+
+
+def test_needs_case_isolation_for_qnn_gpu() -> None:
+    checker = _make_checker("QNNExecutionProvider", device_type=ort.OrtHardwareDeviceType.GPU)
+    assert checker.needs_case_isolation() is True

--- a/tests/unit/analyze/runtime_checker/test_result_processor_per_op.py
+++ b/tests/unit/analyze/runtime_checker/test_result_processor_per_op.py
@@ -131,6 +131,43 @@ class TestDeduplicateRuleRows:
         assert dedup_df.iloc[0]["compile_reason"] == "compile_error_1"
         assert dedup_df.iloc[0]["run_reason"] == "run_error_1"
 
+    def test_deduplicate_aggregates_case_indices_from_group(self):
+        df = pd.DataFrame(
+            [
+                {
+                    "case_index": "b_case",
+                    "T_Add": "FLOAT",
+                    "input_dim": 4,
+                    "compile_run_success": (True, True),
+                },
+                {
+                    "case_index": "a_case",
+                    "T_Add": "FLOAT",
+                    "input_dim": 4,
+                    "compile_run_success": (True, True),
+                },
+                {
+                    "case_index": "a_case",
+                    "T_Add": "FLOAT",
+                    "input_dim": 4,
+                    "compile_run_success": (True, True),
+                },
+            ]
+        )
+
+        dedup_df, conflict_df = _deduplicate_rule_rows(
+            df,
+            condition_cols=["T_Add", "input_dim"],
+            output_cols=["compile_run_success"],
+            compare_output_cols=["compile_run_success"],
+            aggregate_case_indices=True,
+        )
+
+        assert conflict_df is None
+        assert len(dedup_df) == 1
+        assert int(dedup_df.iloc[0]["rule_row_count"]) == 3
+        assert dedup_df.iloc[0]["case_indices"] == ("a_case", "b_case")
+
 
 class TestParquetConditionEncoding:
     """Validate parquet-safe condition encoding for mixed object values."""
@@ -158,5 +195,3 @@ class TestParquetConditionEncoding:
         assert all(isinstance(v, str) for v in encoded_df["attr_value"].tolist())
         # Output columns remain untouched.
         assert encoded_df.iloc[0]["compile_run_success"] == (False, True)
-
-

--- a/tests/unit/analyze/test_analyzer.py
+++ b/tests/unit/analyze/test_analyzer.py
@@ -11,7 +11,6 @@ from unittest.mock import MagicMock, Mock, patch
 import onnx
 import pytest
 
-from winml.modelkit.analyze.analyzer import _build_runtime_debug_details_summary
 from winml.modelkit.analyze import (
     Action,
     ActionItem,
@@ -26,6 +25,7 @@ from winml.modelkit.analyze import (
     SupportLevel,
     infer_ihv_from_ep_name,
 )
+from winml.modelkit.analyze.analyzer import _build_runtime_debug_details_summary
 from winml.modelkit.analyze.models.runtime_checks import PatternRuntime, RuntimeTestResult
 from winml.modelkit.optim import WinMLOptimizationConfig
 
@@ -733,7 +733,7 @@ class TestRuntimeDebugDetailsSummary:
                         debug_details={
                             "node_stable_key": "node_conv",
                             "case_indices": ("case_1", "case_2"),
-                            "table_path": "/tmp/conv.parquet",
+                            "table_path": "rules/conv.parquet",
                             "table_file": "conv.parquet",
                         },
                     ),
@@ -746,7 +746,7 @@ class TestRuntimeDebugDetailsSummary:
                         debug_details={
                             "node_stable_key": "node_resize",
                             "case_indices": ["case_3"],
-                            "table_path": "/tmp/resize.parquet",
+                            "table_path": "rules/resize.parquet",
                             "table_file": "resize.parquet",
                         },
                     ),
@@ -760,7 +760,7 @@ class TestRuntimeDebugDetailsSummary:
                         debug_details={
                             "node_stable_key": "node_unknown",
                             "case_indices": ["case_4"],
-                            "table_path": "/tmp/unknown.parquet",
+                            "table_path": "rules/unknown.parquet",
                             "table_file": "unknown.parquet",
                         },
                     ),
@@ -775,7 +775,7 @@ class TestRuntimeDebugDetailsSummary:
                         debug_details={
                             "node_stable_key": "node_subgraph",
                             "case_indices": ["case_5"],
-                            "table_path": "/tmp/subgraph.parquet",
+                            "table_path": "rules/subgraph.parquet",
                             "table_file": "subgraph.parquet",
                         },
                     ),
@@ -788,17 +788,17 @@ class TestRuntimeDebugDetailsSummary:
         assert summary is not None
         assert set(summary.keys()) == {"supported", "partial", "unsupported"}
 
-        assert summary["supported"]["node_conv"]["case_indices"] == ["case_1", "case_2"]
-        assert summary["supported"]["node_conv"]["table_path"] == "/tmp/conv.parquet"
-        assert summary["supported"]["node_conv"]["table_file"] == "conv.parquet"
+        assert summary["supported"]["node_conv"].case_indices == ["case_1", "case_2"]
+        assert summary["supported"]["node_conv"].table_path == "rules/conv.parquet"
+        assert summary["supported"]["node_conv"].table_file == "conv.parquet"
 
-        assert summary["partial"]["node_resize"]["case_indices"] == ["case_3"]
-        assert summary["partial"]["node_resize"]["table_path"] == "/tmp/resize.parquet"
-        assert summary["partial"]["node_resize"]["table_file"] == "resize.parquet"
+        assert summary["partial"]["node_resize"].case_indices == ["case_3"]
+        assert summary["partial"]["node_resize"].table_path == "rules/resize.parquet"
+        assert summary["partial"]["node_resize"].table_file == "resize.parquet"
 
-        assert summary["unsupported"]["node_subgraph"]["case_indices"] == ["case_5"]
-        assert summary["unsupported"]["node_subgraph"]["table_path"] == "/tmp/subgraph.parquet"
-        assert summary["unsupported"]["node_subgraph"]["table_file"] == "subgraph.parquet"
+        assert summary["unsupported"]["node_subgraph"].case_indices == ["case_5"]
+        assert summary["unsupported"]["node_subgraph"].table_path == "rules/subgraph.parquet"
+        assert summary["unsupported"]["node_subgraph"].table_file == "subgraph.parquet"
 
         assert "node_unknown" not in summary["supported"]
         assert "node_unknown" not in summary["partial"]
@@ -815,7 +815,7 @@ class TestRuntimeDebugDetailsSummary:
                         run=True,
                         debug_details={
                             "node_stable_key": "node_conv",
-                            "table_path": "/tmp/conv.parquet",
+                            "table_path": "rules/conv.parquet",
                         },
                     ),
                 ),
@@ -839,9 +839,9 @@ class TestRuntimeDebugDetailsSummary:
 
         assert summary is not None
         node_entry = summary["supported"]["node_conv"]
-        assert node_entry["table_path"] == "/tmp/conv.parquet"
-        assert node_entry["table_file"] == "conv.parquet"
-        assert node_entry["case_indices"] == ["case_42"]
+        assert node_entry.table_path == "rules/conv.parquet"
+        assert node_entry.table_file == "conv.parquet"
+        assert node_entry.case_indices == ["case_42"]
 
 
 class TestONNXStaticAnalyzer:
@@ -1014,7 +1014,7 @@ class TestONNXStaticAnalyzer:
                         debug_details={
                             "node_stable_key": "node_conv",
                             "case_indices": ("case_7",),
-                            "table_path": "/tmp/conv.parquet",
+                            "table_path": "rules/conv.parquet",
                             "table_file": "conv.parquet",
                         },
                     ),
@@ -1028,7 +1028,7 @@ class TestONNXStaticAnalyzer:
                         debug_details={
                             "node_stable_key": "node_unknown",
                             "case_indices": ["case_9"],
-                            "table_path": "/tmp/relu.parquet",
+                            "table_path": "rules/relu.parquet",
                             "table_file": "relu.parquet",
                         },
                     ),
@@ -1054,11 +1054,10 @@ class TestONNXStaticAnalyzer:
 
         ep_result = result.output.results[0]
         assert ep_result.runtime_debug_details_summary is not None
-        assert ep_result.runtime_debug_details_summary["supported"]["node_conv"] == {
-            "case_indices": ["case_7"],
-            "table_path": "/tmp/conv.parquet",
-            "table_file": "conv.parquet",
-        }
+        node_conv_entry = ep_result.runtime_debug_details_summary["supported"]["node_conv"]
+        assert node_conv_entry.case_indices == ["case_7"]
+        assert node_conv_entry.table_path == "rules/conv.parquet"
+        assert node_conv_entry.table_file == "conv.parquet"
         assert ep_result.runtime_debug_details_summary["partial"] == {}
         assert ep_result.runtime_debug_details_summary["unsupported"] == {}
         assert "node_unknown" not in ep_result.runtime_debug_details_summary["supported"]

--- a/tests/unit/analyze/test_analyzer.py
+++ b/tests/unit/analyze/test_analyzer.py
@@ -721,8 +721,8 @@ class TestAnalysisResult:
 class TestRuntimeDebugDetailsSummary:
     """Tests for runtime debug_details summary aggregation."""
 
-    def test_build_runtime_debug_details_summary_groups_and_filters_unknown(self) -> None:
-        """Should group by support level and filter unknown results."""
+    def test_build_runtime_debug_details_summary_groups_and_records_unknown(self) -> None:
+        """Should group by support level and record unknown nodes as a key list."""
         runtime_summary = {
             "op_runtime_check_result": [
                 PatternRuntime(
@@ -786,7 +786,9 @@ class TestRuntimeDebugDetailsSummary:
         summary = _build_runtime_debug_details_summary(runtime_summary)
 
         assert summary is not None
-        assert set(summary.keys()) == {"supported", "partial", "unsupported"}
+        assert set(summary.keys()) == {"unknown", "supported", "partial", "unsupported"}
+        # "unknown" must be the first key in output order.
+        assert next(iter(summary)) == "unknown"
 
         assert summary["supported"]["node_conv"].case_indices == ["case_1", "case_2"]
         assert summary["supported"]["node_conv"].table_path == "rules/conv.parquet"
@@ -800,6 +802,8 @@ class TestRuntimeDebugDetailsSummary:
         assert summary["unsupported"]["node_subgraph"].table_path == "rules/subgraph.parquet"
         assert summary["unsupported"]["node_subgraph"].table_file == "subgraph.parquet"
 
+        # Unknown nodes are recorded as a plain list of node keys (no case data).
+        assert summary["unknown"] == ["node_unknown"]
         assert "node_unknown" not in summary["supported"]
         assert "node_unknown" not in summary["partial"]
         assert "node_unknown" not in summary["unsupported"]
@@ -1060,6 +1064,7 @@ class TestONNXStaticAnalyzer:
         assert node_conv_entry.table_file == "conv.parquet"
         assert ep_result.runtime_debug_details_summary["partial"] == {}
         assert ep_result.runtime_debug_details_summary["unsupported"] == {}
+        assert ep_result.runtime_debug_details_summary["unknown"] == ["node_unknown"]
         assert "node_unknown" not in ep_result.runtime_debug_details_summary["supported"]
 
     @patch("winml.modelkit.analyze.utils.ep_utils.has_rule_data_for_ep", return_value=True)

--- a/tests/unit/analyze/test_analyzer.py
+++ b/tests/unit/analyze/test_analyzer.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, Mock, patch
 import onnx
 import pytest
 
+from winml.modelkit.analyze.analyzer import _build_runtime_debug_details_summary
 from winml.modelkit.analyze import (
     Action,
     ActionItem,
@@ -25,6 +26,7 @@ from winml.modelkit.analyze import (
     SupportLevel,
     infer_ihv_from_ep_name,
 )
+from winml.modelkit.analyze.models.runtime_checks import PatternRuntime, RuntimeTestResult
 from winml.modelkit.optim import WinMLOptimizationConfig
 
 
@@ -716,6 +718,132 @@ class TestAnalysisResult:
         assert config.get("kebab_style_key", False) is True
 
 
+class TestRuntimeDebugDetailsSummary:
+    """Tests for runtime debug_details summary aggregation."""
+
+    def test_build_runtime_debug_details_summary_groups_and_filters_unknown(self) -> None:
+        """Should group by support level and filter unknown results."""
+        runtime_summary = {
+            "op_runtime_check_result": [
+                PatternRuntime(
+                    pattern_id="OP/ai.onnx/Conv",
+                    result=RuntimeTestResult(
+                        compile=True,
+                        run=True,
+                        debug_details={
+                            "node_stable_key": "node_conv",
+                            "case_indices": ("case_1", "case_2"),
+                            "table_path": "/tmp/conv.parquet",
+                            "table_file": "conv.parquet",
+                        },
+                    ),
+                ),
+                PatternRuntime(
+                    pattern_id="OP/ai.onnx/Resize",
+                    result=RuntimeTestResult(
+                        compile=False,
+                        run=True,
+                        debug_details={
+                            "node_stable_key": "node_resize",
+                            "case_indices": ["case_3"],
+                            "table_path": "/tmp/resize.parquet",
+                            "table_file": "resize.parquet",
+                        },
+                    ),
+                ),
+                PatternRuntime(
+                    pattern_id="OP/ai.onnx/Unknown",
+                    result=RuntimeTestResult(
+                        compile=True,
+                        run=True,
+                        no_data=True,
+                        debug_details={
+                            "node_stable_key": "node_unknown",
+                            "case_indices": ["case_4"],
+                            "table_path": "/tmp/unknown.parquet",
+                            "table_file": "unknown.parquet",
+                        },
+                    ),
+                ),
+            ],
+            "subgraph_runtime_check_result": [
+                PatternRuntime(
+                    pattern_id="SUBGRAPH/TestPattern",
+                    result=RuntimeTestResult(
+                        compile=False,
+                        run=False,
+                        debug_details={
+                            "node_stable_key": "node_subgraph",
+                            "case_indices": ["case_5"],
+                            "table_path": "/tmp/subgraph.parquet",
+                            "table_file": "subgraph.parquet",
+                        },
+                    ),
+                )
+            ],
+        }
+
+        summary = _build_runtime_debug_details_summary(runtime_summary)
+
+        assert summary is not None
+        assert set(summary.keys()) == {"supported", "partial", "unsupported"}
+
+        assert summary["supported"]["node_conv"]["case_indices"] == ["case_1", "case_2"]
+        assert summary["supported"]["node_conv"]["table_path"] == "/tmp/conv.parquet"
+        assert summary["supported"]["node_conv"]["table_file"] == "conv.parquet"
+
+        assert summary["partial"]["node_resize"]["case_indices"] == ["case_3"]
+        assert summary["partial"]["node_resize"]["table_path"] == "/tmp/resize.parquet"
+        assert summary["partial"]["node_resize"]["table_file"] == "resize.parquet"
+
+        assert summary["unsupported"]["node_subgraph"]["case_indices"] == ["case_5"]
+        assert summary["unsupported"]["node_subgraph"]["table_path"] == "/tmp/subgraph.parquet"
+        assert summary["unsupported"]["node_subgraph"]["table_file"] == "subgraph.parquet"
+
+        assert "node_unknown" not in summary["supported"]
+        assert "node_unknown" not in summary["partial"]
+        assert "node_unknown" not in summary["unsupported"]
+
+    def test_build_runtime_debug_details_summary_merges_same_node(self) -> None:
+        """Should merge complementary debug fields for the same node key."""
+        runtime_summary = {
+            "op_runtime_check_result": [
+                PatternRuntime(
+                    pattern_id="OP/ai.onnx/Conv",
+                    result=RuntimeTestResult(
+                        compile=True,
+                        run=True,
+                        debug_details={
+                            "node_stable_key": "node_conv",
+                            "table_path": "/tmp/conv.parquet",
+                        },
+                    ),
+                ),
+                PatternRuntime(
+                    pattern_id="OP/ai.onnx/Conv",
+                    result=RuntimeTestResult(
+                        compile=True,
+                        run=True,
+                        debug_details={
+                            "node_stable_key": "node_conv",
+                            "case_indices": ("case_42",),
+                            "table_file": "conv.parquet",
+                        },
+                    ),
+                ),
+            ],
+            "subgraph_runtime_check_result": [],
+        }
+
+        summary = _build_runtime_debug_details_summary(runtime_summary)
+
+        assert summary is not None
+        node_entry = summary["supported"]["node_conv"]
+        assert node_entry["table_path"] == "/tmp/conv.parquet"
+        assert node_entry["table_file"] == "conv.parquet"
+        assert node_entry["case_indices"] == ["case_42"]
+
+
 class TestONNXStaticAnalyzer:
     """Tests for ONNXStaticAnalyzer."""
 
@@ -843,6 +971,97 @@ class TestONNXStaticAnalyzer:
 
         # Verify RuntimeChecker was called once
         assert mock_runtime_checker_cls.call_count == 1
+
+    @patch("winml.modelkit.analyze.utils.ep_utils.has_rule_data_for_ep", return_value=True)
+    @patch("winml.modelkit.analyze.core.onnx_loader.ONNXLoader")
+    @patch("winml.modelkit.analyze.core.pattern_extractor.PatternExtractor")
+    @patch("winml.modelkit.analyze.core.runtime_checker.RuntimeChecker")
+    def test_analyze_from_proto_includes_runtime_debug_summary_when_debug_enabled(
+        self,
+        mock_runtime_checker_cls: Mock,
+        mock_pattern_extractor_cls: Mock,
+        mock_onnx_loader_cls: Mock,
+        _mock_has_rule: Mock,
+    ) -> None:
+        """for_debug=True should add runtime_debug_details_summary to EP output."""
+        mock_model = MagicMock()
+        mock_loader = MagicMock()
+        mock_loader.load.return_value = mock_model
+        mock_onnx_loader_cls.return_value = mock_loader
+
+        mock_extractor = MagicMock()
+        mock_extractor.summary.return_value = {
+            "summary": ModelStats(
+                model_path="test.onnx",
+                opset_version=13,
+                total_operators=2,
+                operator_counts={"Conv": 1, "Relu": 1},
+                unique_operator_types=2,
+                detected_pattern_count={},
+            ),
+            "subgraph_patterns": [],
+        }
+        mock_pattern_extractor_cls.return_value = mock_extractor
+
+        mock_checker = MagicMock()
+        mock_checker.summary.return_value = {
+            "op_runtime_check_result": [
+                PatternRuntime(
+                    pattern_id="OP/ai.onnx/Conv",
+                    result=RuntimeTestResult(
+                        compile=True,
+                        run=True,
+                        debug_details={
+                            "node_stable_key": "node_conv",
+                            "case_indices": ("case_7",),
+                            "table_path": "/tmp/conv.parquet",
+                            "table_file": "conv.parquet",
+                        },
+                    ),
+                ),
+                PatternRuntime(
+                    pattern_id="OP/ai.onnx/Relu",
+                    result=RuntimeTestResult(
+                        compile=True,
+                        run=True,
+                        no_data=True,
+                        debug_details={
+                            "node_stable_key": "node_unknown",
+                            "case_indices": ["case_9"],
+                            "table_path": "/tmp/relu.parquet",
+                            "table_file": "relu.parquet",
+                        },
+                    ),
+                ),
+            ],
+            "subgraph_runtime_check_result": [],
+        }
+        mock_runtime_checker_cls.return_value = mock_checker
+
+        analyzer = ONNXStaticAnalyzer()
+        model_proto = MagicMock(spec=onnx.ModelProto)
+
+        result = analyzer.analyze_from_proto(
+            model_proto=model_proto,
+            ep="QNNExecutionProvider",
+            device="NPU",
+            enable_information=False,
+            for_debug=True,
+        )
+
+        assert isinstance(result, AnalysisResult)
+        assert len(result.output.results) == 1
+
+        ep_result = result.output.results[0]
+        assert ep_result.runtime_debug_details_summary is not None
+        assert ep_result.runtime_debug_details_summary["supported"]["node_conv"] == {
+            "case_indices": ["case_7"],
+            "table_path": "/tmp/conv.parquet",
+            "table_file": "conv.parquet",
+        }
+        assert ep_result.runtime_debug_details_summary["partial"] == {}
+        assert ep_result.runtime_debug_details_summary["unsupported"] == {}
+        assert "node_unknown" not in ep_result.runtime_debug_details_summary["supported"]
 
     @patch("winml.modelkit.analyze.utils.ep_utils.has_rule_data_for_ep", return_value=True)
     @patch("winml.modelkit.analyze.core.onnx_loader.ONNXLoader")

--- a/tests/unit/analyze/test_check_ops.py
+++ b/tests/unit/analyze/test_check_ops.py
@@ -328,7 +328,7 @@ class TestReuseExistingResultInputConstraints:
         assert saved["model_bytes_b64"] == "test_payload"
 
     def test_case_index_is_36_chars_and_ep_device_differs_by_first_char(self, tmp_path) -> None:
-        """跨 EP/device 的 case_index 应仅首字符不同，剩余 35 位保持一致。"""
+        """case_index should differ only in the first char across EP/device; last 35 stay equal."""
         case_template = {
             "type_vars": {"T": "FLOAT"},
             "input_constraints": {"X": {"type": "shape", "shape": [1], "min_max": None}},

--- a/tests/unit/analyze/test_check_ops.py
+++ b/tests/unit/analyze/test_check_ops.py
@@ -9,8 +9,11 @@ import json
 import numpy as np
 
 from winml.modelkit.analyze.utils import CheckResultWriter
+from winml.modelkit.analyze.utils.avalizble_ep_device_ops.case_index_key_codec import (
+    encode_file_name_to_4char_key,
+)
 from winml.modelkit.analyze.utils.op_utils import compute_case_signature
-from winml.modelkit.pattern.op_input_gen import InputValueConstraint
+from winml.modelkit.pattern.op_input_gen import InputValueConstraint, normalize_constraint_dict
 
 
 class TestComputeCaseSignature:
@@ -149,13 +152,66 @@ class TestComputeCaseSignature:
         )
 
 
+class TestConstraintRoundTrip:
+    """Tests for reversible serialization/deserialization of value constraints."""
+
+    def test_same_value_scalar_bool_roundtrip_preserves_ndarray(self) -> None:
+        """Scalar bool arrays should remain 0-D ndarray after normalization."""
+        original = np.asarray(True, dtype=np.bool_)
+        compact = InputValueConstraint(original).to_dict()
+
+        restored = normalize_constraint_dict(compact)["value"]
+
+        assert isinstance(restored, np.ndarray)
+        assert restored.shape == original.shape
+        assert restored.dtype == original.dtype
+        assert bool(restored.item()) is True
+
+    def test_same_value_dense_array_roundtrip_preserves_dtype_and_shape(self) -> None:
+        """Non-scalar arrays should restore with identical dtype and shape."""
+        original = np.full((2, 3), 7, dtype=np.int16)
+        compact = InputValueConstraint(original).to_dict()
+
+        restored = normalize_constraint_dict(compact)["value"]
+
+        assert isinstance(restored, np.ndarray)
+        assert restored.shape == original.shape
+        assert restored.dtype == original.dtype
+        assert np.array_equal(restored, original)
+
+    def test_scalar_bool_payload_preserves_ndarray(self) -> None:
+        """Scalar arrays keep ndarray payload instead of collapsing to Python scalars."""
+        scalar = np.asarray(True, dtype=np.bool_)
+        compact = InputValueConstraint(scalar).to_dict()
+
+        restored = normalize_constraint_dict(compact)["value"]
+
+        assert isinstance(restored, np.ndarray)
+        assert restored.shape == ()
+        assert restored.dtype == np.bool_
+        assert bool(restored.item()) is True
+
+    def test_dtype_with_scalar_value_keeps_original_payload(self) -> None:
+        """Non-compact value payloads keep their original scalar shape."""
+        serialized = {
+            "type": "value",
+            "value": 1,
+            "dtype": "int64",
+        }
+
+        restored = normalize_constraint_dict(serialized)["value"]
+
+        assert isinstance(restored, int)
+        assert restored == 1
+
+
 class TestReuseExistingResultInputConstraints:
     """Tests that reuse_existing_result upgrades input_constraints to current format."""
 
     @staticmethod
     def _make_writer(existing_cases: list[dict], tmp_path):
         """Create a CheckResultWriter with pre-loaded existing_signatures from cases."""
-        output_file = tmp_path / "test_op.json"
+        output_file = tmp_path / "Abs_QNNExecutionProvider_NPU_ai.onnx_opset13.json"
         output_file.write_text(json.dumps({"check_results": existing_cases}), encoding="utf-8")
         return CheckResultWriter(output_file, sys_info={}, delta_only=True)
 
@@ -243,3 +299,65 @@ class TestReuseExistingResultInputConstraints:
         saved = writer.results[0]
         assert saved["input_constraints"]["X"] == compact
         assert "same_value" in saved["input_constraints"]["X"]
+
+    def test_reuse_preserves_model_bytes_payload(self, tmp_path) -> None:
+        """Reused cases must retain model_bytes_b64 from the current generator payload."""
+        arr = np.ones((2,), dtype=np.float32)
+        compact = InputValueConstraint(arr).to_dict()
+
+        existing_case = {
+            "type_vars": {"T": "FLOAT"},
+            "input_constraints": {"X": compact},
+            "check_result": {
+                "compile": {"result": {"success": True}},
+                "run": {"result": {"success": True}},
+            },
+        }
+
+        with self._make_writer([existing_case], tmp_path) as writer:
+            skipped_case = {
+                "type_vars": {"T": "FLOAT"},
+                "input_constraints": {"X": compact},
+                "model_bytes_b64": "test_payload",
+                "_skipped": True,
+            }
+            reused = writer.reuse_existing_result(skipped_case)
+
+        assert reused
+        saved = writer.results[0]
+        assert saved["model_bytes_b64"] == "test_payload"
+
+    def test_case_index_is_36_chars_and_ep_device_differs_by_first_char(self, tmp_path) -> None:
+        """跨 EP/device 的 case_index 应仅首字符不同，剩余 35 位保持一致。"""
+        case_template = {
+            "type_vars": {"T": "FLOAT"},
+            "input_constraints": {"X": {"type": "shape", "shape": [1], "min_max": None}},
+            "check_result": {
+                "compile": {"result": {"success": True}},
+                "run": {"result": {"success": True}},
+            },
+        }
+
+        qnn_output = tmp_path / "Abs_QNNExecutionProvider_NPU_ai.onnx_opset13.json"
+        ov_output = tmp_path / "Abs_OpenVINOExecutionProvider_CPU_ai.onnx_opset13.json"
+
+        with CheckResultWriter(qnn_output, sys_info={}) as writer_qnn:
+            writer_qnn.append_result(dict(case_template))
+
+        with CheckResultWriter(ov_output, sys_info={}) as writer_ov:
+            writer_ov.append_result(dict(case_template))
+
+        qnn_case = writer_qnn.results[0]
+        ov_case = writer_ov.results[0]
+
+        qnn_case_index = qnn_case["case_index"]
+        ov_case_index = ov_case["case_index"]
+
+        assert len(qnn_case_index) == 36
+        assert len(ov_case_index) == 36
+        assert qnn_case_index[:4] == encode_file_name_to_4char_key(qnn_output.stem)
+        assert ov_case_index[:4] == encode_file_name_to_4char_key(ov_output.stem)
+        assert qnn_case_index[0] != ov_case_index[0]
+        assert qnn_case_index[1:] == ov_case_index[1:]
+        assert "case_index_ignore_ep_device" not in qnn_case
+        assert "case_index_ignore_ep_device" not in ov_case

--- a/tests/unit/analyze/test_has_rule_data.py
+++ b/tests/unit/analyze/test_has_rule_data.py
@@ -12,6 +12,7 @@ import pytest
 
 from winml.modelkit.analyze.utils import (
     get_devices_with_rule_data,
+    has_any_rule_data,
     has_rule_data_for_ep,
     infer_ihv_from_ep_name,
 )
@@ -96,7 +97,9 @@ class TestHasRuleDataForEP:
 
     def test_returns_false_for_unmatched_ep(self, tmp_path: Path) -> None:
         """Parquet files exist but none match the requested EP+device."""
-        (tmp_path / "Add_OtherEP_GPU_ai.onnx_opset13.parquet").touch()
+        other_dir = tmp_path / "OtherEP_GPU"
+        other_dir.mkdir()
+        (other_dir / "Add_OtherEP_GPU_ai.onnx_opset13.parquet").touch()
         with pytest.MonkeyPatch.context() as mp:
             mp.setattr(_PATCH_TARGET, lambda: [tmp_path])
             assert has_rule_data_for_ep("FakeEP", "NPU") is False
@@ -108,12 +111,12 @@ class TestHasRuleDataForEP:
             mp.setattr(_PATCH_TARGET, lambda: [missing])
             assert has_rule_data_for_ep("QNNExecutionProvider", "NPU") is False
 
-    def test_returns_true_when_parquet_exists_in_flat_layout(self, tmp_path: Path) -> None:
-        """Should return True when a matching parquet file is present in root layout."""
+    def test_returns_false_when_parquet_exists_in_flat_layout(self, tmp_path: Path) -> None:
+        """Flat parquet is ignored; provider subdirectory layout is required."""
         (tmp_path / "Add_FakeEP_NPU_ai.onnx_opset13.parquet").touch()
         with pytest.MonkeyPatch.context() as mp:
             mp.setattr(_PATCH_TARGET, lambda: [tmp_path])
-            assert has_rule_data_for_ep("FakeEP", "NPU") is True
+            assert has_rule_data_for_ep("FakeEP", "NPU") is False
 
     def test_returns_true_when_parquet_exists_in_provider_subdir(self, tmp_path: Path) -> None:
         """Should return True for rules_dir/<EP>_<DEVICE>/*.parquet layout."""
@@ -126,7 +129,9 @@ class TestHasRuleDataForEP:
 
     def test_device_is_case_insensitive(self, tmp_path: Path) -> None:
         """Device is uppercased internally, so 'npu' should match NPU parquet files."""
-        (tmp_path / "Add_FakeEP_NPU_ai.onnx_opset13.parquet").touch()
+        nested = tmp_path / "FakeEP_NPU"
+        nested.mkdir()
+        (nested / "Add_FakeEP_NPU_ai.onnx_opset13.parquet").touch()
         with pytest.MonkeyPatch.context() as mp:
             mp.setattr(_PATCH_TARGET, lambda: [tmp_path])
             assert has_rule_data_for_ep("FakeEP", "npu") is True
@@ -146,21 +151,64 @@ class TestHasRuleDataForEP:
             assert has_rule_data_for_ep("MyEP", "GPU") is True
 
 
+class TestHasAnyRuleData:
+    """Tests for has_any_rule_data()."""
+
+    def test_returns_false_for_empty_search_dir(self, tmp_path: Path) -> None:
+        """No parquet files in supported layouts should return False."""
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(_PATCH_TARGET, lambda: [tmp_path])
+            assert has_any_rule_data() is False
+
+    def test_returns_false_for_flat_layout(self, tmp_path: Path) -> None:
+        """Flat parquet under search dir should be ignored."""
+        (tmp_path / "AnyEP_NPU_dummy.parquet").touch()
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(_PATCH_TARGET, lambda: [tmp_path])
+            assert has_any_rule_data() is False
+
+    def test_returns_true_for_provider_subdir_layout(self, tmp_path: Path) -> None:
+        """Provider subdirectory parquet should return True."""
+        provider_dir = tmp_path / "AnyEP_NPU"
+        provider_dir.mkdir()
+        (provider_dir / "Add_AnyEP_NPU_ai.onnx_opset13.parquet").touch()
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(_PATCH_TARGET, lambda: [tmp_path])
+            assert has_any_rule_data() is True
+
+    def test_returns_true_for_non_ep_device_second_level_layout(self, tmp_path: Path) -> None:
+        """Any second-level parquet should count as available data."""
+        unrelated_dir = tmp_path / "nested"
+        unrelated_dir.mkdir()
+        (unrelated_dir / "Add_AnyEP_NPU_ai.onnx_opset13.parquet").touch()
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(_PATCH_TARGET, lambda: [tmp_path])
+            assert has_any_rule_data() is True
+
+
 class TestGetDevicesWithRuleData:
     """Tests for get_devices_with_rule_data()."""
 
     def test_returns_devices_from_rule_data(self, tmp_path: Path) -> None:
         """Should return all devices that have matching parquet rule files."""
-        (tmp_path / "Add_TestEP_NPU_ai.onnx_opset13.parquet").touch()
-        (tmp_path / "Add_TestEP_GPU_ai.onnx_opset13.parquet").touch()
+        npu_dir = tmp_path / "TestEP_NPU"
+        gpu_dir = tmp_path / "TestEP_GPU"
+        npu_dir.mkdir()
+        gpu_dir.mkdir()
+        (npu_dir / "Add_TestEP_NPU_ai.onnx_opset13.parquet").touch()
+        (gpu_dir / "Add_TestEP_GPU_ai.onnx_opset13.parquet").touch()
         with pytest.MonkeyPatch.context() as mp:
             mp.setattr(_PATCH_TARGET, lambda: [tmp_path])
             assert get_devices_with_rule_data("TestEP") == ["NPU", "GPU"]
 
     def test_preserves_priority_order(self, tmp_path: Path) -> None:
         """Devices should be returned in NPU > GPU > CPU order."""
-        (tmp_path / "Add_TestEP_CPU_ai.onnx_opset13.parquet").touch()
-        (tmp_path / "Add_TestEP_NPU_ai.onnx_opset13.parquet").touch()
+        cpu_dir = tmp_path / "TestEP_CPU"
+        npu_dir = tmp_path / "TestEP_NPU"
+        cpu_dir.mkdir()
+        npu_dir.mkdir()
+        (cpu_dir / "Add_TestEP_CPU_ai.onnx_opset13.parquet").touch()
+        (npu_dir / "Add_TestEP_NPU_ai.onnx_opset13.parquet").touch()
         with pytest.MonkeyPatch.context() as mp:
             mp.setattr(_PATCH_TARGET, lambda: [tmp_path])
             assert get_devices_with_rule_data("TestEP") == ["NPU", "CPU"]
@@ -200,7 +248,9 @@ class TestGetDevicesWithRuleData:
     def test_rule_data_takes_precedence_over_ep_device_map(self, tmp_path: Path) -> None:
         """If parquet rule data exists, EP device map should NOT be used."""
         # Imagine DML gets rule data for NPU in the future
-        (tmp_path / "Add_DmlExecutionProvider_NPU_ai.onnx_opset17.parquet").touch()
+        npu_dir = tmp_path / "DmlExecutionProvider_NPU"
+        npu_dir.mkdir()
+        (npu_dir / "Add_DmlExecutionProvider_NPU_ai.onnx_opset17.parquet").touch()
         with pytest.MonkeyPatch.context() as mp:
             mp.setattr(_PATCH_TARGET, lambda: [tmp_path])
             # Rule data says NPU, not the EP device map ["GPU"]

--- a/tests/unit/analyze/test_static_analyzer_cli.py
+++ b/tests/unit/analyze/test_static_analyzer_cli.py
@@ -478,6 +478,7 @@ class TestAnalyzeCommandOptions:
                         "ep_type": "QNNExecutionProvider",
                         "device_type": "NPU",
                         "runtime_debug_details_summary": {
+                            "unknown": ["node_customop"],
                             "supported": {
                                 "node_conv": {
                                     "case_indices": ["case_7"],
@@ -521,7 +522,10 @@ class TestAnalyzeCommandOptions:
         assert debug_file.exists()
 
         debug_content = json.loads(debug_file.read_text())
-        assert set(debug_content.keys()) == {"supported", "partial", "unsupported"}
+        assert set(debug_content.keys()) == {"unknown", "supported", "partial", "unsupported"}
+        # "unknown" must be the first key in the written debug.json.
+        assert next(iter(debug_content)) == "unknown"
+        assert debug_content["unknown"] == ["node_customop"]
         assert debug_content["supported"]["node_conv"] == {
             "case_indices": ["case_7"],
             "table_path": "rules/conv.parquet",

--- a/tests/unit/analyze/test_static_analyzer_cli.py
+++ b/tests/unit/analyze/test_static_analyzer_cli.py
@@ -63,15 +63,15 @@ def _mock_local_ep_device_pairs(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture(autouse=True)
-def _mock_runtime_rule_parquet_discovery(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Provide deterministic non-empty parquet discovery for CLI tests.
+def _mock_any_runtime_rule_data(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provide deterministic non-empty runtime-rule availability for CLI tests.
 
     Most tests validate EP/device selection logic and should not depend on
     machine/environment-specific parquet assets being present on disk.
     """
     monkeypatch.setattr(
-        "winml.modelkit.commands.analyze._discover_runtime_rule_parquet_files",
-        lambda: ([Path("runtime_check_rules")], [Path("runtime_check_rules/dummy.parquet")]),
+        "winml.modelkit.analyze.utils.ep_utils.has_any_rule_data",
+        lambda: True,
     )
 
 
@@ -253,8 +253,8 @@ class TestAnalyzeCommandArguments:
     ) -> None:
         """When no parquet is found in search dirs, analyze should fail fast."""
         monkeypatch.setattr(
-            "winml.modelkit.commands.analyze._discover_runtime_rule_parquet_files",
-            lambda: ([Path("runtime_check_rules")], []),
+            "winml.modelkit.analyze.utils.ep_utils.has_any_rule_data",
+            lambda: False,
         )
 
         model_file = tmp_path / "test.onnx"
@@ -441,16 +441,107 @@ class TestAnalyzeCommandOptions:
         assert call_kwargs["enable_information"] is False
 
     @patch("winml.modelkit.analyze.ONNXStaticAnalyzer")
-    def test_verbose_flag_enables_debug_logging(
+    def test_debug_flag_enables_runtime_debug(
         self,
         mock_analyzer_class: MagicMock,
         runner: CliRunner,
         tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
         mock_analyzer_result: Mock,
     ) -> None:
-        """Test that --verbose flag enables debug output."""
+        """Test that --debug writes runtime debug summary JSON near the model."""
         model_file = tmp_path / "test.onnx"
         model_file.write_bytes(b"dummy")
+        output_file = tmp_path / "results.json"
+        debug_rules_dir = tmp_path / "rules_debug"
+        debug_rules_subdir = debug_rules_dir / "QNNExecutionProvider_NPU"
+        debug_rules_subdir.mkdir(parents=True, exist_ok=True)
+        (debug_rules_subdir / "placeholder.parquet").write_bytes(b"dummy")
+        monkeypatch.setenv("WINMLCLI_RULES_DIR_FOR_DEBUG", str(debug_rules_dir))
+
+        mock_analyzer_result.to_json.return_value = json.dumps(
+            {
+                "analysis_timestamp": "2025-12-05T12:00:00",
+                "metadata": {
+                    "model_path": "test.onnx",
+                    "opset_version": 13,
+                    "total_operators": 1,
+                    "operator_counts": {"Conv": 1},
+                    "unique_operator_types": 1,
+                },
+                "results": [
+                    {
+                        "ep_type": "QNNExecutionProvider",
+                        "device_type": "NPU",
+                        "runtime_debug_details_summary": {
+                            "supported": {
+                                "node_conv": {
+                                    "case_indices": ["case_7"],
+                                    "table_path": "/tmp/conv.parquet",
+                                    "table_file": "conv.parquet",
+                                }
+                            },
+                            "partial": {},
+                            "unsupported": {},
+                        },
+                    }
+                ],
+            }
+        )
+
+        mock_instance = Mock()
+        mock_instance.analyze.return_value = mock_analyzer_result
+        mock_analyzer_class.return_value = mock_instance
+
+        result = runner.invoke(
+            analyze,
+            [
+                "--model",
+                str(model_file),
+                "--ep",
+                "QNNExecutionProvider",
+                "--device",
+                "NPU",
+                "--debug",
+                "--output",
+                str(output_file),
+            ],
+        )
+
+        # Should complete successfully
+        assert result.exit_code == 0
+        call_kwargs = mock_instance.analyze.call_args.kwargs
+        assert call_kwargs["for_debug"] is True
+
+        debug_file = tmp_path / "test.analyze.QNNExecutionProvider.NPU.debug.json"
+        assert debug_file.exists()
+
+        debug_content = json.loads(debug_file.read_text())
+        assert set(debug_content.keys()) == {"supported", "partial", "unsupported"}
+        assert debug_content["supported"]["node_conv"] == {
+            "case_indices": ["case_7"],
+            "table_path": "/tmp/conv.parquet",
+            "table_file": "conv.parquet",
+        }
+
+    @patch("winml.modelkit.analyze.ONNXStaticAnalyzer")
+    def test_verbose_flag_no_longer_enables_runtime_debug(
+        self,
+        mock_analyzer_class: MagicMock,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_analyzer_result: Mock,
+    ) -> None:
+        """--verbose should not enable runtime debug without --debug."""
+        model_file = tmp_path / "test.onnx"
+        model_file.write_bytes(b"dummy")
+        output_file = tmp_path / "results.json"
+        debug_rules_dir = tmp_path / "rules_debug"
+        debug_rules_subdir = debug_rules_dir / "QNNExecutionProvider_NPU"
+        debug_rules_subdir.mkdir(parents=True, exist_ok=True)
+        (debug_rules_subdir / "placeholder.parquet").write_bytes(b"dummy")
+        monkeypatch.setenv("WINMLCLI_RULES_DIR_FOR_DEBUG", str(debug_rules_dir))
 
         mock_instance = Mock()
         mock_instance.analyze.return_value = mock_analyzer_result
@@ -466,11 +557,84 @@ class TestAnalyzeCommandOptions:
                 "--device",
                 "NPU",
                 "--verbose",
+                "--output",
+                str(output_file),
             ],
         )
 
-        # Should complete successfully
         assert result.exit_code == 0
+        call_kwargs = mock_instance.analyze.call_args.kwargs
+        assert call_kwargs["for_debug"] is False
+
+        debug_file = tmp_path / "test.analyze.QNNExecutionProvider.NPU.debug.json"
+        assert not debug_file.exists()
+
+    @patch("winml.modelkit.analyze.ONNXStaticAnalyzer")
+    def test_debug_flag_requires_debug_env_with_parquet(
+        self,
+        mock_analyzer_class: MagicMock,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """--debug should fail fast when debug env var is missing."""
+        model_file = tmp_path / "test.onnx"
+        model_file.write_bytes(b"dummy")
+        monkeypatch.delenv("WINMLCLI_RULES_DIR_FOR_DEBUG", raising=False)
+
+        result = runner.invoke(
+            analyze,
+            [
+                "--model",
+                str(model_file),
+                "--ep",
+                "QNNExecutionProvider",
+                "--device",
+                "NPU",
+                "--debug",
+            ],
+        )
+
+        assert result.exit_code == 2
+        assert "--debug requires" in result.output.lower()
+        assert "winmlcli_rules_dir_for_debug" in result.output.lower()
+        assert not mock_analyzer_class.called
+
+    @patch("winml.modelkit.analyze.ONNXStaticAnalyzer")
+    def test_debug_flag_requires_second_level_parquet(
+        self,
+        mock_analyzer_class: MagicMock,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """--debug should fail when debug dir has no */*.parquet files."""
+        model_file = tmp_path / "test.onnx"
+        model_file.write_bytes(b"dummy")
+
+        debug_rules_dir = tmp_path / "rules_debug"
+        debug_rules_dir.mkdir(parents=True, exist_ok=True)
+        # Root-level parquet should not satisfy */*.parquet requirement.
+        (debug_rules_dir / "root.parquet").write_bytes(b"dummy")
+        monkeypatch.setenv("WINMLCLI_RULES_DIR_FOR_DEBUG", str(debug_rules_dir))
+
+        result = runner.invoke(
+            analyze,
+            [
+                "--model",
+                str(model_file),
+                "--ep",
+                "QNNExecutionProvider",
+                "--device",
+                "NPU",
+                "--debug",
+            ],
+        )
+
+        assert result.exit_code == 2
+        assert "--debug requires" in result.output.lower()
+        assert "winmlcli_rules_dir_for_debug" in result.output.lower()
+        assert not mock_analyzer_class.called
 
     @patch("winml.modelkit.analyze.ONNXStaticAnalyzer")
     def test_quiet_flag_suppresses_warnings(
@@ -836,6 +1000,7 @@ class TestAnalyzeCommandIntegration:
         assert call_kwargs["ep"] == "OpenVINOExecutionProvider"
         assert call_kwargs["device"] == "GPU"
         assert call_kwargs["enable_information"] is True
+        assert call_kwargs["for_debug"] is False
 
 
 class TestAnalyzeEPDeviceValidation:

--- a/tests/unit/analyze/test_static_analyzer_cli.py
+++ b/tests/unit/analyze/test_static_analyzer_cli.py
@@ -16,12 +16,16 @@ Tests verify:
 from __future__ import annotations
 
 import json
-from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from click.testing import CliRunner
 from rich.console import Console
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 from winml.modelkit.commands.analyze import analyze
 
@@ -477,7 +481,7 @@ class TestAnalyzeCommandOptions:
                             "supported": {
                                 "node_conv": {
                                     "case_indices": ["case_7"],
-                                    "table_path": "/tmp/conv.parquet",
+                                    "table_path": "rules/conv.parquet",
                                     "table_file": "conv.parquet",
                                 }
                             },
@@ -520,7 +524,7 @@ class TestAnalyzeCommandOptions:
         assert set(debug_content.keys()) == {"supported", "partial", "unsupported"}
         assert debug_content["supported"]["node_conv"] == {
             "case_indices": ["case_7"],
-            "table_path": "/tmp/conv.parquet",
+            "table_path": "rules/conv.parquet",
             "table_file": "conv.parquet",
         }
 

--- a/tests/unit/commands/test_config_value_priority.py
+++ b/tests/unit/commands/test_config_value_priority.py
@@ -369,11 +369,8 @@ def _run_analyze(
             return_value=True,
         ),
         patch(
-            "winml.modelkit.commands.analyze._discover_runtime_rule_parquet_files",
-            return_value=(
-                [Path("runtime_check_rules")],
-                [Path("runtime_check_rules/mock.parquet")],
-            ),
+            "winml.modelkit.analyze.utils.ep_utils.has_any_rule_data",
+            return_value=True,
         ),
         # Deterministic Tier-3 default: when ep stays "auto" through the
         # merge block, _get_available_eps -> QNN so target_ep is fixed.


### PR DESCRIPTION
## Summary

This PR groups four related improvements to the `analyze` runtime-checker pipeline: a more compact and efficient `case_index` encoding, durable persistence of model bytes for fast re-runs, a new `--debug` locator that maps models/nodes/rules back to `case_index` values, and fixes for the Pad and MatMul+Add (Gemm) rule conflicts. It also pins `pyarrow`/`pandas` to keep generated parquet rule artifacts deterministic.

## 1. `case_index` encoding optimization

Introduces a compact 4-character key prefix so that lookups into / writes from `case_index` are faster and self-describing.

- New codec `analyze/utils/avalizble_ep_device_ops/case_index_key_codec.py`:
  - **char 1** -> EP/device (1 char)
  - **chars 2-3** -> op / pattern + opset version (2 chars)
  - **char 4** -> is-QDQ flag (`0`/`1`)
- Backed by two mapping files: `avaliable_providers.json` (EP/device -> 1-char key) and `available_ops_all.json` (op/pattern + version -> 2-char key).
- `encode_file_name_to_4char_key()` and `decode_4char_key_to_folder_and_file_name()` provide a stable round-trip between rule file names and the 4-char prefix.
- Mapping indexes are built once and cached globally, with validation for the allowed alphabet, key length, and duplicate-key detection so collisions fail fast.

## 2. Persist model bytes in `op_check_result` for fast re-run

Every persisted case now carries its serialized model so it can be replayed without regeneration.

- `pattern/op_input_gen/op_input_gen.py`: serialize the model and store `model_bytes_b64` in `final_tags` by default for every case (previously only populated in `dry_run`). This makes any stored `op_check_result` directly re-runnable.
- `dry_run` placeholder result now reports `success=False` / `not_run` so dry-run rows are not mistaken for real passes.
- `normalize_constraint_dict` keeps the constructed numpy array instead of converting to a list, preserving dtype/shape fidelity.
- Pinned `pyarrow==23.0.1` and `pandas==2.3.3` (and `result_processor` now sorts condition columns) so generated parquet artifacts are byte-stable across runs/machines and avoid spurious diffs.

## 3. `analyze --debug`: directional `case_index` locator

Adds a `--debug` mode that uses the debug parquet artifacts in `rules_debug` (which carry `case_indices`) to locate `case_index` values from the model / node / rule direction.

- New `--debug` flag on the `analyze` command. It requires `WINMLCLI_RULES_DIR_FOR_DEBUG` to point at a `rules_debug` directory containing `*/*.parquet`; clear diagnostics are emitted when it is missing or misconfigured.
- Produces a runtime debug summary grouped by support level (`supported` / `partial` / `unsupported`) and `node_stable_key`, each entry carrying `case_indices`, `table_path`, and `table_file`.
- Writes `<model>.analyze.<EP>.<DEVICE>.debug.json` next to the model file.
- New typed payloads: `RuntimeDebugDetails` / `RuntimeDebugStep` (in `models/runtime_checks.py`) and `RuntimeDebugSummaryEntry` plus the `runtime_debug_details_summary` field on `EPSupport` (in `models/output.py`).
- `rule_loader.py`: new `WINMLCLI_RULES_DIR_FOR_DEBUG` env var and `get_runtime_rules_debug_search_dirs()`; `resolve_rule_parquet_path()` now resolves from `<EP>_<DEVICE>/` subdirs, supports `for_debug`, and returns `None` when not found instead of a guessed path.
- The offline rule generator (`result_processor` CLI) gains `--debug` / `--rules-debug-dir` / `--rules-debug-json-dir` and aggregates `case_indices` into the debug artifacts.

## 4. Fix Pad and MatMul+Add (Gemm) rule conflicts

Both fixes add finite, derived properties so previously-conflicting rule rows become distinguishable.

- `pattern/op_input_gen/pad_input_generator.py`: re-enable the `pads_is_symmetric` finite property and add an asymmetric-padding sample case for branch coverage -- resolves the Pad rule conflict.
- `pattern/gemm_patterns.py`: add the `C_is_value_constraint` finite property to distinguish a fixed-value bias constraint from a shape-only constraint -- resolves the MatMul+Add (Gemm) pattern conflict.

## Testing

Extensive unit-test additions and updates across the analyze pipeline, including `test_analyzer.py`, `test_check_ops.py`, `test_rule_loader.py`, `test_static_analyzer_cli.py`, `test_runtime_checker_query_parquet.py`, `test_result_processor_per_op.py`, and `test_has_rule_data.py`.
