### PR TITLE
test(e2e): retry transient dataset-download failures in e2e runs

### DIFF
--- a/tests/e2e/_retry.py
+++ b/tests/e2e/_retry.py
@@ -1,0 +1,137 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Retry helpers for flaky E2E dataset downloads.
+
+E2E tests invoke ``winml eval`` / ``winml perf`` in-process against real
+HuggingFace datasets. Streaming parquet fetches from the xet CDN intermittently
+fail with transient network errors (most commonly ``408 Request Time-out``),
+which turns the daily e2e pipeline red even though the code under test is fine.
+
+``RetryingCliRunner`` transparently retries an invocation when it fails with a
+*transient* network error, so flaky blips don't fail the suite. The retry lives
+entirely in the test harness — the shipped ``winml`` CLI behaviour is unchanged.
+
+Tunable via environment variables:
+    WINMLCLI_E2E_DATASET_RETRIES:     max attempts (default 4)
+    WINMLCLI_E2E_DATASET_RETRY_DELAY: base backoff seconds (default 3.0)
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import TYPE_CHECKING, Any
+
+from click.testing import CliRunner
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from click.testing import Result
+
+_DEFAULT_RETRIES = 4
+_DEFAULT_BASE_DELAY = 3.0
+
+# Substrings (lower-cased) that mark a transient/retryable dataset-download
+# failure in the captured CLI output. Kept narrow so genuine eval failures
+# (assertion errors, bad metrics, schema mismatches) are never retried.
+_TRANSIENT_MARKERS = (
+    "request time-out",
+    "time-out for url",
+    "timed out",
+    "read timed out",
+    "connection reset",
+    "connection aborted",
+    "connection error",
+    "temporarily unavailable",
+    "max retries exceeded",
+    "408 client error",
+    "429 client error",
+    "500 server error",
+    "502 server error",
+    "503 server error",
+    "504 server error",
+    "couldn't connect to",
+    "failed to fetch",
+)
+
+
+def _retries() -> int:
+    raw = os.environ.get("WINMLCLI_E2E_DATASET_RETRIES")
+    if raw:
+        try:
+            return max(1, int(raw))
+        except ValueError:
+            pass
+    return _DEFAULT_RETRIES
+
+
+def _base_delay() -> float:
+    raw = os.environ.get("WINMLCLI_E2E_DATASET_RETRY_DELAY")
+    if raw:
+        try:
+            return max(0.0, float(raw))
+        except ValueError:
+            pass
+    return _DEFAULT_BASE_DELAY
+
+
+def is_transient_output(output: str | None) -> bool:
+    """Return True if *output* looks like a transient dataset-download failure."""
+    if not output:
+        return False
+    lowered = output.lower()
+    return any(marker in lowered for marker in _TRANSIENT_MARKERS)
+
+
+def invoke_with_retry(
+    invoke: Callable[[], Result],
+    *,
+    retries: int | None = None,
+    base_delay: float | None = None,
+) -> Result:
+    """Call *invoke* (a zero-arg invocation), retrying transient failures.
+
+    A retry happens only when the returned ``Result`` has a non-zero exit code
+    *and* its output matches a known transient network-error marker. Any other
+    non-zero exit (real test failure) is returned immediately so genuine
+    regressions are never masked.
+
+    Args:
+        invoke: Zero-arg callable returning a click ``Result``.
+        retries: Max attempts (defaults to env/``_DEFAULT_RETRIES``).
+        base_delay: Base backoff seconds (defaults to env/``_DEFAULT_BASE_DELAY``).
+
+    Returns:
+        The last ``Result`` produced by *invoke*.
+    """
+    attempts = retries if retries is not None else _retries()
+    delay = base_delay if base_delay is not None else _base_delay()
+
+    result = invoke()
+    for attempt in range(1, attempts):
+        if result.exit_code == 0 or not is_transient_output(result.output):
+            return result
+        sleep_for = delay * (2 ** (attempt - 1))
+        print(
+            f"[e2e-retry] transient dataset error (attempt {attempt}/{attempts}); "
+            f"retrying in {sleep_for:.1f}s...",
+        )
+        time.sleep(sleep_for)
+        result = invoke()
+    return result
+
+
+class RetryingCliRunner(CliRunner):
+    """A ``CliRunner`` whose ``invoke`` retries transient dataset-download errors.
+
+    Drop-in replacement for ``CliRunner`` in E2E fixtures. Non-transient
+    failures behave exactly like the base runner (returned, not retried), so
+    error-path tests are unaffected.
+    """
+
+    def invoke(self, *args: Any, **kwargs: Any) -> Result:
+        return invoke_with_retry(lambda: super(RetryingCliRunner, self).invoke(*args, **kwargs))

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -18,6 +18,7 @@ E2E tests are auto-skipped unless explicitly selected with:
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -30,6 +31,17 @@ from PIL import Image
 
 if TYPE_CHECKING:
     from click.testing import CliRunner
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Raise the HF download timeout for E2E runs to reduce flaky 408 timeouts.
+
+    Test-only: this sets the env var for the pytest process so streaming parquet
+    fetches from the HF xet CDN get 60s (vs the 10s default) before timing out.
+    Uses ``setdefault`` so an explicit ``HF_HUB_DOWNLOAD_TIMEOUT`` still wins, and
+    it never affects the shipped CLI outside the test harness.
+    """
+    os.environ.setdefault("HF_HUB_DOWNLOAD_TIMEOUT", "60")
 
 
 # ---------------------------------------------------------------------------
@@ -132,9 +144,12 @@ def test_image(tmp_path_factory: pytest.TempPathFactory) -> str:
 
 @pytest.fixture
 def runner() -> CliRunner:
-    from click.testing import CliRunner
+    # RetryingCliRunner transparently retries invocations that fail with a
+    # transient dataset-download error (e.g. a 408 from the HF xet CDN) so
+    # network blips don't fail e2e runs. Non-transient failures are not retried.
+    from ._retry import RetryingCliRunner
 
-    return CliRunner()
+    return RetryingCliRunner()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_e2e_retry.py
+++ b/tests/unit/test_e2e_retry.py
@@ -1,0 +1,158 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Unit tests for the E2E transient-download retry helper (tests/e2e/_retry.py).
+
+Pure unit tests — no hardware or network required — so they live under
+``tests/unit`` and run in the normal suite (the helper itself lives under
+``tests/e2e`` because only the e2e harness uses it).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from tests.e2e import _retry
+
+
+@dataclass
+class _FakeResult:
+    """Minimal stand-in for click.testing.Result."""
+
+    exit_code: int
+    output: str
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_retry.time, "sleep", lambda _s: None)
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        "Error: Evaluation failed: 408 Client Error: Request Time-out for url: https://...",
+        "Read timed out.",
+        "Connection aborted",
+        "Max retries exceeded with url",
+        "503 Server Error: Service Unavailable",
+    ],
+)
+def test_is_transient_output_true(output: str) -> None:
+    assert _retry.is_transient_output(output)
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        "",
+        None,
+        "AssertionError: metric out of range",
+        "Dataset schema mismatch: missing column 'label'",
+        "404 Client Error: Not Found",
+    ],
+)
+def test_is_transient_output_false(output: str | None) -> None:
+    assert not _retry.is_transient_output(output)
+
+
+def test_success_first_try_no_retry() -> None:
+    calls = {"n": 0}
+
+    def invoke() -> _FakeResult:
+        calls["n"] += 1
+        return _FakeResult(exit_code=0, output="ok")
+
+    result = _retry.invoke_with_retry(invoke, retries=4, base_delay=0)
+    assert result.exit_code == 0
+    assert calls["n"] == 1
+
+
+def test_retries_transient_then_succeeds() -> None:
+    calls = {"n": 0}
+
+    def invoke() -> _FakeResult:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            return _FakeResult(exit_code=1, output="408 Client Error: Request Time-out")
+        return _FakeResult(exit_code=0, output="ok")
+
+    result = _retry.invoke_with_retry(invoke, retries=4, base_delay=0)
+    assert result.exit_code == 0
+    assert calls["n"] == 3
+
+
+def test_exhausts_retries_returns_last_transient() -> None:
+    calls = {"n": 0}
+
+    def invoke() -> _FakeResult:
+        calls["n"] += 1
+        return _FakeResult(exit_code=1, output="Request Time-out for url: https://...")
+
+    result = _retry.invoke_with_retry(invoke, retries=3, base_delay=0)
+    assert result.exit_code == 1
+    assert calls["n"] == 3
+
+
+def test_non_transient_failure_not_retried() -> None:
+    calls = {"n": 0}
+
+    def invoke() -> _FakeResult:
+        calls["n"] += 1
+        return _FakeResult(exit_code=1, output="AssertionError: metric out of range")
+
+    result = _retry.invoke_with_retry(invoke, retries=4, base_delay=0)
+    assert result.exit_code == 1
+    assert calls["n"] == 1
+
+
+def test_retry_count_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WINMLCLI_E2E_DATASET_RETRIES", "2")
+    calls = {"n": 0}
+
+    def invoke() -> _FakeResult:
+        calls["n"] += 1
+        return _FakeResult(exit_code=1, output="connection reset")
+
+    result = _retry.invoke_with_retry(invoke, base_delay=0)
+    assert result.exit_code == 1
+    assert calls["n"] == 2
+
+
+def test_retrying_cli_runner_retries_transient(monkeypatch: pytest.MonkeyPatch) -> None:
+    """RetryingCliRunner retries a real click command that flakes transiently."""
+    import click
+
+    monkeypatch.setattr(_retry.time, "sleep", lambda _s: None)
+    calls = {"n": 0}
+
+    @click.command()
+    def flaky() -> None:
+        calls["n"] += 1
+        if calls["n"] < 2:
+            raise click.ClickException("Evaluation failed: 408 Client Error: Request Time-out")
+
+    runner = _retry.RetryingCliRunner()
+    result = runner.invoke(flaky, [])
+    assert result.exit_code == 0
+    assert calls["n"] == 2
+
+
+def test_retrying_cli_runner_does_not_retry_real_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    import click
+
+    monkeypatch.setattr(_retry.time, "sleep", lambda _s: None)
+    calls = {"n": 0}
+
+    @click.command()
+    def broken() -> None:
+        calls["n"] += 1
+        raise click.ClickException("Dataset schema mismatch: missing column 'label'")
+
+    runner = _retry.RetryingCliRunner()
+    result = runner.invoke(broken, [])
+    assert result.exit_code != 0
+    assert calls["n"] == 1


### PR DESCRIPTION
The daily e2e pipeline intermittently fails when an in-process 'winml eval' streams HF dataset parquet files from the xet CDN and hits a transient '408 Request Time-out'. The failure is a network blip, not a code regression, but it repeatedly turns the pipeline red.

Keep the fix entirely in the test harness (no shipped CLI changes):
- tests/e2e/_retry.py: RetryingCliRunner + invoke_with_retry() + is_transient_output(). Only retries CliRunner invocations whose non-zero exit output matches a known transient marker (408/429/5xx, timeouts, connection resets). Real failures (assertions, schema/metric errors) are returned immediately, never masked. Tunable via WINMLCLI_E2E_DATASET_RETRIES and WINMLCLI_E2E_DATASET_RETRY_DELAY.
- tests/e2e/conftest.py: the shared 'runner' fixture now returns a RetryingCliRunner (covers eval + perf e2e with no churn elsewhere), and pytest_configure sets HF_HUB_DOWNLOAD_TIMEOUT=60 (setdefault) for the test process only, reducing 408s at the source.
- tests/unit/test_e2e_retry.py: unit tests for the retry helper.