### PR TITLE
fix: relax NPU VRAM assertion in test_benchmark_npu_memory

### DIFF
--- a/tests/e2e/test_perf_e2e.py
+++ b/tests/e2e/test_perf_e2e.py
@@ -366,16 +366,13 @@ class _PerfBenchmarkSuite:
         assert mem["rss_after_inference_mb"] > 0
         assert "rss_model_load_delta_mb" in mem
 
-        # VRAM fields (NPU should have device memory)
+        # VRAM fields (NPU exposes device memory fields, but values depend on driver)
         assert "vram_local_after_inference_mb" in mem
         assert "vram_shared_after_inference_mb" in mem
         assert "vram_local_model_load_delta_mb" in mem
         assert "vram_shared_model_load_delta_mb" in mem
         assert "vram_local_inference_delta_mb" in mem
         assert "vram_shared_inference_delta_mb" in mem
-
-        # At least one VRAM metric should be > 0 on NPU
-        assert mem["vram_local_after_inference_mb"] > 0 or mem["vram_shared_after_inference_mb"] > 0
 
     def test_benchmark_cpu_monitor(self, tmp_path: Path, model_arg: str):
         """Benchmark on CPU with --monitor.


### PR DESCRIPTION
## Problem

On AMD Ryzen AI machines, the Windows PDH `GPU Process Memory` counters are not available for AMD NPUs — only NVIDIA/Intel WDDM discrete GPUs expose those counters. As a result, `get_vram_mb()` silently catches the PDH failure and returns `(0.0, 0.0)`, causing this assertion to fail:

```python
assert mem["vram_local_after_inference_mb"] > 0 or mem["vram_shared_after_inference_mb"] > 0
```

## Fix

Remove the `> 0` value check. The test docstring says it *"Verifies VRAM local/shared fields are present in JSON output"* — presence is now the only thing asserted, which is both correct and hardware-agnostic.