### PR TITLE
feat(cli): add --precision to build; share precision_option helper

### DIFF
--- a/src/winml/modelkit/commands/build.py
+++ b/src/winml/modelkit/commands/build.py
@@ -470,6 +470,9 @@ def _validate_loader_tasks_for_model(
     include_auto=True,
     optional_message="Default: auto-detect.",
 )
+@cli_utils.precision_option(
+    optional_message="With -c, applied only when --device or --precision is passed.",
+)
 @click.option(
     "--analyze/--no-analyze",
     "analyze",
@@ -509,6 +512,7 @@ def build(
     optimize: bool,
     ep: EPNameOrAlias | None,
     device: str,
+    precision: str,
     analyze: bool,
     max_optim_iterations: int | None,
     allow_unsupported_nodes: bool,
@@ -531,6 +535,12 @@ def build(
 
         # Full pipeline with explicit config
         winml build -c config.json -m microsoft/resnet-50 -o output/
+
+        # Device-aware auto precision (npu->w8a16, gpu/cpu->fp16)
+        winml build -m microsoft/resnet-50 -o output/ --device npu --precision auto
+
+        # Force fp16 (skips quantization)
+        winml build -m bert-base-uncased -o output/ --device gpu --precision fp16
 
         # Build from pre-exported ONNX file
         winml build -c config.json -m model.onnx -o output/
@@ -592,6 +602,7 @@ def build(
                 model_id,
                 trust_remote_code=trust_remote_code,
                 device=device,
+                precision=precision,
             )
             if not quant:
                 config_or_configs.quant = None
@@ -602,15 +613,19 @@ def build(
             if no_compile:
                 config_or_configs.compile = None
 
-        # If --device was explicitly provided, patch compile config and clear
-        # quant for CPU/GPU (neither device uses quantization by default).
-        if cli_utils.is_cli_provided(ctx, "device") and device:
+        # If --device or --precision was explicitly provided, patch quant/compile
+        # to honor the requested policy. fp16/fp32 clear quant; npu/int8 etc set it.
+        if (
+            cli_utils.is_cli_provided(ctx, "device") or cli_utils.is_cli_provided(ctx, "precision")
+        ) and device:
             from ..compiler.configs import WinMLCompileConfig
 
             def _patch_device(cfg: WinMLBuildConfig) -> None:
                 from ..config import resolve_quant_compile_config
 
-                resolved_quant, _ = resolve_quant_compile_config(device=device, ep=ep)
+                resolved_quant, _ = resolve_quant_compile_config(
+                    device=device, precision=precision, ep=ep
+                )
                 if not quant or resolved_quant is None:
                     cfg.quant = None
                 elif cfg.quant is None:

--- a/src/winml/modelkit/commands/build.py
+++ b/src/winml/modelkit/commands/build.py
@@ -615,9 +615,7 @@ def build(
 
         # If --device or --precision was explicitly provided, patch quant/compile
         # to honor the requested policy. fp16/fp32 clear quant; npu/int8 etc set it.
-        if (
-            cli_utils.is_cli_provided(ctx, "device") or cli_utils.is_cli_provided(ctx, "precision")
-        ) and device:
+        if cli_utils.is_cli_provided(ctx, "device") or cli_utils.is_cli_provided(ctx, "precision"):
             from ..compiler.configs import WinMLCompileConfig
 
             def _patch_device(cfg: WinMLBuildConfig) -> None:

--- a/src/winml/modelkit/commands/config.py
+++ b/src/winml/modelkit/commands/config.py
@@ -109,15 +109,7 @@ def _apply_stage_overrides(cfg: Any, *, no_quant: bool, no_compile: bool) -> Non
     optional_message="Overrides device-to-provider mapping. "
     "When used without --device, device is inferred from EP.",
 )
-@click.option(
-    "-p",
-    "--precision",
-    "precision",
-    type=str,
-    default="auto",
-    help="Precision: auto, fp32, fp16, int8, int16, or w{x}a{y} (e.g., w8a16). "
-    "Default: auto (based on device when device is specified).",
-)
+@cli_utils.precision_option()
 @cli_utils.output_option("Output JSON file path (default: stdout)")
 @click.option(
     "--library",

--- a/src/winml/modelkit/commands/eval.py
+++ b/src/winml/modelkit/commands/eval.py
@@ -82,14 +82,8 @@ logger = logging.getLogger(__name__)
     help="Device to run on. 'auto' detects the best available device.",
 )
 @cli_utils.ep_option(required=False)
-@click.option(
-    "--precision",
-    type=str,
-    default="auto",
-    show_default=True,
-    help="Precision: auto, fp32, fp16, int8, int16, or w{x}a{y} (e.g., w8a16). "
-    "Applied during model build (fp16/fp32 skip quantization). "
-    "Ignored for pre-built ONNX inputs (precision is already baked in).",
+@cli_utils.precision_option(
+    optional_message="Ignored for pre-built ONNX inputs (precision is already baked in).",
 )
 @click.option(
     "--samples",

--- a/src/winml/modelkit/commands/eval.py
+++ b/src/winml/modelkit/commands/eval.py
@@ -83,7 +83,8 @@ logger = logging.getLogger(__name__)
 )
 @cli_utils.ep_option(required=False)
 @cli_utils.precision_option(
-    optional_message="Ignored for pre-built ONNX inputs (precision is already baked in).",
+    optional_message="Applied during model build. Ignored for pre-built ONNX inputs "
+    "(precision is already baked in).",
 )
 @click.option(
     "--samples",

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -1305,13 +1305,7 @@ def _run_simple_loop(
     help="Number of warmup iterations (excluded from statistics; must be >= 0)",
 )
 @cli_utils.device_option(required=False, default="auto", include_auto=True)
-@click.option(
-    "--precision",
-    type=str,
-    default="auto",
-    show_default=True,
-    help="Precision mode: auto, fp32, fp16, int8, int16, or w{x}a{y} (e.g., w8a16).",
-)
+@cli_utils.precision_option()
 @cli_utils.ep_option(
     required=False,
     optional_message="Overrides device-to-provider mapping.",

--- a/src/winml/modelkit/commands/quantize.py
+++ b/src/winml/modelkit/commands/quantize.py
@@ -47,14 +47,11 @@ console = Console()
     help="Input ONNX model file",
 )
 @cli_utils.output_option("Output path (default: {input}_qdq.onnx)")
-@click.option(
-    "--precision",
-    "-p",
-    type=str,
+@cli_utils.precision_option(
     default=None,
-    help="Quantization precision. Accepted: auto, int8, int16, or w{x}a{y} "
-    "where x,y in {8,16} (e.g., w8a8, w8a16, w16a16). "
-    "Overridden by explicit --weight-type/--activation-type.",
+    help_text="Quantization precision: auto, int8, int16, or w{x}a{y} where "
+    "x,y in {8,16} (e.g., w8a8, w8a16, w16a16)",
+    optional_message="Overridden by explicit --weight-type/--activation-type",
 )
 @click.option(
     "--samples",

--- a/src/winml/modelkit/models/auto.py
+++ b/src/winml/modelkit/models/auto.py
@@ -289,7 +289,7 @@ class WinMLAutoModel:
             device: Target device ("auto", "npu", "gpu", "cpu").
                 "auto" detects available hardware (NPU > GPU > CPU).
             precision: Target precision ("auto", "fp32", "fp16", "int8", "int16").
-                "auto" selects based on device (npu->int8, gpu->fp16, cpu->fp16).
+                "auto" selects based on device (npu->w8a16, gpu->fp16, cpu->fp16).
             provider_options: Runtime EP provider options (e.g. QNN
                 ``htp_performance_mode``) forwarded to the inference session.
             cache_dir: Directory for caching. If None, uses default cache dir.

--- a/src/winml/modelkit/utils/cli.py
+++ b/src/winml/modelkit/utils/cli.py
@@ -294,6 +294,48 @@ def device_option(
     )
 
 
+def precision_option(
+    default: str = "auto",
+    optional_message: str | None = None,
+    include_short: bool = True,
+) -> Callable[[F], F]:
+    """Add --precision option to a Click command.
+
+    Shared across ``build``, ``config``, ``eval``, and ``perf`` so the accepted
+    values and help text stay consistent. Uses ``type=str`` (not
+    ``click.Choice``) so the ``w{x}a{y}`` mixed-precision format (e.g. ``w8a16``)
+    is accepted; invalid values are rejected downstream by ``resolve_precision``.
+
+    Args:
+        default: Default precision value (default: "auto").
+        optional_message: Command-specific note appended after the base help
+            text (e.g., "Ignored for pre-built ONNX inputs.").
+        include_short: Whether to also register the ``-p`` short alias
+            (default: True).
+
+    Returns:
+        Decorator function.
+    """
+    help_text = (
+        "Precision: auto, fp32, fp16, int8, int16, or w{x}a{y} (e.g., w8a16). "
+        "auto resolves from --device (npu->w8a16, gpu/cpu->fp16); "
+        "fp16/fp32 skip quantization"
+    )
+    if optional_message:
+        help_text = f"{help_text}. {optional_message}"
+
+    param_decls = ["--precision", "precision"]
+    if include_short:
+        param_decls.insert(0, "-p")
+    return click.option(
+        *param_decls,
+        type=str,
+        default=default,
+        show_default=True,
+        help=help_text,
+    )
+
+
 def verbosity_options() -> Callable[[F], F]:
     """Add verbose and quiet logging options to a Click command.
 

--- a/src/winml/modelkit/utils/cli.py
+++ b/src/winml/modelkit/utils/cli.py
@@ -295,34 +295,42 @@ def device_option(
 
 
 def precision_option(
-    default: str = "auto",
+    default: str | None = "auto",
     optional_message: str | None = None,
     include_short: bool = True,
+    help_text: str | None = None,
 ) -> Callable[[F], F]:
     """Add --precision option to a Click command.
 
-    Shared across ``build``, ``config``, ``eval``, and ``perf`` so the accepted
-    values and help text stay consistent. Uses ``type=str`` (not
-    ``click.Choice``) so the ``w{x}a{y}`` mixed-precision format (e.g. ``w8a16``)
-    is accepted; invalid values are rejected downstream by ``resolve_precision``.
+    Shared across ``build``, ``config``, ``eval``, ``perf``, and ``quantize`` so
+    the flag spelling (``-p``/``--precision``) and parsing stay consistent. Uses
+    ``type=str`` (not ``click.Choice``) so the ``w{x}a{y}`` mixed-precision
+    format (e.g. ``w8a16``) is accepted; invalid values are rejected downstream
+    (``resolve_precision`` for build-path commands, ``_resolve_quant_types`` for
+    ``quantize``).
 
     Args:
-        default: Default precision value (default: "auto").
-        optional_message: Command-specific note appended after the base help
-            text (e.g., "Ignored for pre-built ONNX inputs.").
+        default: Default precision value (default: "auto"). Pass ``None`` for
+            commands like ``quantize`` that treat "no precision" distinctly.
+        optional_message: Command-specific note appended after the help text
+            (e.g., "Ignored for pre-built ONNX inputs.").
         include_short: Whether to also register the ``-p`` short alias
             (default: True).
+        help_text: Override for the base help text. Commands whose accepted
+            values differ from the default float+int set (e.g. ``quantize``,
+            which has no fp16/fp32) supply their own; ``optional_message`` is
+            still appended to it.
 
     Returns:
         Decorator function.
     """
-    help_text = (
+    base_help = help_text or (
         "Precision: auto, fp32, fp16, int8, int16, or w{x}a{y} (e.g., w8a16). "
         "auto resolves from --device (npu->w8a16, gpu/cpu->fp16); "
         "fp16/fp32 skip quantization"
     )
     if optional_message:
-        help_text = f"{help_text}. {optional_message}"
+        base_help = f"{base_help}. {optional_message}"
 
     param_decls = ["--precision", "precision"]
     if include_short:
@@ -332,7 +340,7 @@ def precision_option(
         type=str,
         default=default,
         show_default=True,
-        help=help_text,
+        help=base_help,
     )
 
 

--- a/tests/unit/commands/test_build.py
+++ b/tests/unit/commands/test_build.py
@@ -578,6 +578,61 @@ class TestBuildFlagPassthrough:
         assert result.exit_code == 0, result.output
         assert mock_run_single_build.call_args.kwargs["device"] == "npu"
 
+    def test_precision_flag_sets_quant(self, tmp_path: Path, mock_run_single_build: MagicMock):
+        """``--precision int8`` populates the quant config for the target device."""
+        cfg = _make_minimal_config_file(tmp_path)  # quant=None
+        result = _invoke(
+            [*self._base_args(cfg, tmp_path), "--device", "gpu", "--precision", "int8"]
+        )
+        assert result.exit_code == 0, result.output
+        passed = mock_run_single_build.call_args.kwargs["config"]
+        assert passed.quant is not None
+        assert passed.quant.weight_type == "uint8"
+
+    def test_precision_fp16_clears_quant(self, tmp_path: Path, mock_run_single_build: MagicMock):
+        """``--precision fp16`` skips quantization even on a quantizing device."""
+        cfg = _make_minimal_config_file(tmp_path)
+        result = _invoke(
+            [*self._base_args(cfg, tmp_path), "--device", "npu", "--precision", "fp16"]
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_run_single_build.call_args.kwargs["config"].quant is None
+
+    def test_precision_alone_triggers_quant_patch(
+        self, tmp_path: Path, mock_run_single_build: MagicMock
+    ):
+        """``--precision`` without ``--device`` still patches quant (here, clears it)."""
+        # Config ships an explicit quant section; fp16 must clear it even though
+        # --device was not passed (precision alone triggers the patch path).
+        config = {
+            "loader": {"task": "image-classification"},
+            "export": {"opset_version": 17, "batch_size": 1},
+            "optim": {},
+            "quant": {
+                "mode": "qdq",
+                "samples": 10,
+                "task": "image-classification",
+                "model_name": "test",
+            },
+            "compile": None,
+        }
+        cfg = tmp_path / "withquant.json"
+        cfg.write_text(json.dumps(config))
+        result = _invoke(
+            [
+                "-c",
+                str(cfg),
+                "-m",
+                "microsoft/resnet-50",
+                "-o",
+                str(tmp_path / "out"),
+                "--precision",
+                "fp16",
+            ]
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_run_single_build.call_args.kwargs["config"].quant is None
+
     def test_trust_remote_code_forwarded(self, tmp_path: Path, mock_run_single_build: MagicMock):
         """``--trust-remote-code`` is forwarded via ``extra_kwargs``."""
         cfg = _make_minimal_config_file(tmp_path)

--- a/tests/unit/utils/test_cli.py
+++ b/tests/unit/utils/test_cli.py
@@ -109,3 +109,22 @@ class TestPrecisionOption:
         result = CliRunner().invoke(self._make_cmd(), ["--precision", "bf16"])
         assert result.exit_code == 0
         assert result.output.strip() == "bf16"
+
+    def test_default_none(self) -> None:
+        """default=None (e.g. quantize) yields no value when the flag is omitted."""
+        result = CliRunner().invoke(self._make_cmd(default=None), [])
+        assert result.exit_code == 0
+        assert result.output.strip() == ""
+
+    def test_help_text_override_replaces_base(self) -> None:
+        """help_text replaces the default float+int help; optional_message still appends."""
+        cmd = self._make_cmd(
+            help_text="Quantization precision: int8, int16",
+            optional_message="Overridden by --weight-type",
+        )
+        result = CliRunner().invoke(cmd, ["--help"])
+        # Collapse whitespace so wrapped help lines compare as one string.
+        flat = " ".join(result.output.split())
+        assert "Quantization precision: int8, int16" in flat
+        assert "Overridden by --weight-type" in flat
+        assert "fp16" not in flat  # base float help is gone

--- a/tests/unit/utils/test_cli.py
+++ b/tests/unit/utils/test_cli.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 
 import click
 import pytest
+from click.testing import CliRunner
 
-from winml.modelkit.utils.cli import parse_ep_options
+from winml.modelkit.utils.cli import parse_ep_options, precision_option
 
 
 class TestParseEpOptions:
@@ -54,3 +55,57 @@ class TestParseEpOptions:
     def test_empty_key_raises(self) -> None:
         with pytest.raises(click.BadParameter):
             parse_ep_options(("=value",))
+
+
+class TestPrecisionOption:
+    """Tests for the shared precision_option() decorator."""
+
+    @staticmethod
+    def _make_cmd(**kwargs: object) -> click.Command:
+        @click.command()
+        @precision_option(**kwargs)  # type: ignore[arg-type]
+        def cmd(precision: str) -> None:
+            click.echo(precision)
+
+        return cmd
+
+    def test_default_is_auto(self) -> None:
+        """No --precision yields the default 'auto'."""
+        result = CliRunner().invoke(self._make_cmd(), [])
+        assert result.exit_code == 0
+        assert result.output.strip() == "auto"
+
+    def test_short_flag_p(self) -> None:
+        """-p is registered by default and maps to the precision param."""
+        result = CliRunner().invoke(self._make_cmd(), ["-p", "fp16"])
+        assert result.exit_code == 0
+        assert result.output.strip() == "fp16"
+
+    def test_long_flag(self) -> None:
+        """--precision sets the value."""
+        result = CliRunner().invoke(self._make_cmd(), ["--precision", "w8a16"])
+        assert result.exit_code == 0
+        assert result.output.strip() == "w8a16"
+
+    def test_include_short_false_drops_p(self) -> None:
+        """include_short=False removes the -p alias but keeps --precision."""
+        cmd = self._make_cmd(include_short=False)
+        assert CliRunner().invoke(cmd, ["-p", "fp16"]).exit_code != 0
+        assert CliRunner().invoke(cmd, ["--precision", "fp16"]).exit_code == 0
+
+    def test_custom_default(self) -> None:
+        """default overrides the resolved value when flag is omitted."""
+        result = CliRunner().invoke(self._make_cmd(default="int8"), [])
+        assert result.output.strip() == "int8"
+
+    def test_optional_message_appended_to_help(self) -> None:
+        """optional_message is appended after the base help text."""
+        result = CliRunner().invoke(self._make_cmd(optional_message="Extra note."), ["--help"])
+        assert "w8a16" in result.output  # base help present
+        assert "Extra note." in result.output
+
+    def test_accepts_arbitrary_string(self) -> None:
+        """type=str: validation is deferred downstream, so any string parses."""
+        result = CliRunner().invoke(self._make_cmd(), ["--precision", "bf16"])
+        assert result.exit_code == 0
+        assert result.output.strip() == "bf16"


### PR DESCRIPTION
## Summary

Wires `--precision` into `winml build` and removes the duplicated `--precision`
option across commands by extracting a shared `cli_utils.precision_option()`
helper. Part of #64 (device-aware auto precision).

### `winml build` gains `--precision`
`winml build` previously had no `--precision` flag despite issue #64's
documented CLI (`wmk build … --precision auto`). It now accepts `-p/--precision`
and threads it through:
- the auto-generated config path (`generate_build_config(..., precision=...)`), and
- the device-patch path, which now also fires when only `--precision` is passed
  (not just `--device`), so `fp16`/`fp32` clear the quant config and
  `int8`/`w8a16` populate it.

The precision **engine** (`config/precision.py`, `resolve_precision`) already
existed and was fully tested — this is CLI wiring only. No new precision
semantics, no fp16-conversion stage (deferred).

### Shared `precision_option` helper
`--precision` was copy-pasted across `build`, `config`, `eval`, `perf`, and
`quantize` with drifting help text. Extracted into `cli_utils.precision_option()`:
- `type=str` (not `click.Choice`) so the `w{x}a{y}` mixed-precision format
  parses; invalid values are still rejected downstream (`resolve_precision`
  for build-path commands, `_resolve_quant_types` for `quantize`).
- consistent base help, with an optional command-specific note appended.
- registers `-p` by default (`eval`/`perf` gain the alias for consistency).
- `default` accepts `None` and a `help_text` override, so `quantize` — whose
  accepted set excludes `fp16`/`fp32` and whose default is `None` — shares the
  same helper without a misleading help string.

All five commands now use the helper; zero inline `--precision` definitions remain.

### Misc
- Fixed a stale `npu->int8` docstring in `models/auto.py` to `npu->w8a16`
  (matches the actual engine default).

## Tests
- `tests/unit/commands/test_build.py`: 3 new cases — `--precision int8` sets
  quant, `--precision fp16` clears quant on NPU, `--precision` alone (no
  `--device`) still patches quant.
- `tests/unit/utils/test_cli.py`: new `TestPrecisionOption` (default, `-p`,
  `--precision`, `include_short=False`, custom default, `default=None`,
  `help_text` override, help-text append, arbitrary-string acceptance).
- 389 affected unit tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
