### PR TITLE
fix(perf): render live HW chart for --monitor in --module mode (#654)

### DIFF
--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -9,6 +9,7 @@ Benchmarks model inference performance using WinMLAutoModel and WinMLSession.
 Usage:
     winml perf -m microsoft/resnet-50
     winml perf -m microsoft/resnet-50 --device npu --iterations 100
+    winml perf -m microsoft/resnet-50 --module ResNetConvLayer
     winml perf -m bert-base-uncased --task text-classification
 """
 

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -890,6 +890,9 @@ def _perf_modules(
                             model_id=label,
                             device=resolved_device,
                         )
+                        # Collect inside the `with` block: hw_ctx.__exit__
+                        # stops the monitor, so to_dict() must read while it's
+                        # still live (mirrors the single-model path).
                         hw_metrics = hw.to_dict()
                 else:
                     with session.perf(warmup=warmup) as stats:

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -876,9 +876,20 @@ def _perf_modules(
                         )
 
                 if hw_ctx:
+                    # Drive the same live chart single-model mode uses so
+                    # --monitor renders a per-module HW utilization chart
+                    # instead of silently dumping metrics to JSON (issue #654).
                     with session.perf(warmup=warmup) as stats, hw_ctx as hw:
-                        for _ in range(total_iters):
-                            session.run(inputs)
+                        _run_monitored_loop(
+                            session,
+                            inputs,
+                            stats,
+                            hw,
+                            total_iterations=total_iters,
+                            warmup=warmup,
+                            model_id=label,
+                            device=resolved_device,
+                        )
                         hw_metrics = hw.to_dict()
                 else:
                     with session.perf(warmup=warmup) as stats:

--- a/tests/unit/commands/test_perf_module.py
+++ b/tests/unit/commands/test_perf_module.py
@@ -316,6 +316,108 @@ class TestPerfModuleParameterForwarding:
         assert instance["running_model_path"] == str(running_model_path)
 
 
+class TestPerfModuleMonitor:
+    """--monitor must drive the live HW utilization chart in --module mode.
+
+    Regression guard for #654: previously the module path created an
+    HWMonitor and dumped metrics to JSON but never rendered the live chart
+    (via _run_monitored_loop), so --monitor appeared to do nothing.
+    """
+
+    def test_monitor_drives_live_chart_per_module(self, tmp_path: Path) -> None:
+        fake_cfg = MagicMock()
+        fake_cfg.loader.model_type = "bert"
+        fake_cfg.loader.module_path = "encoder.layer.0"
+
+        fake_build_result = MagicMock()
+        fake_build_result.final_onnx_path = tmp_path / "model.onnx"
+
+        fake_stats = MagicMock()
+        for attr in ("mean_ms", "p50_ms", "p90_ms", "p95_ms", "p99_ms", "min_ms", "max_ms"):
+            setattr(fake_stats, attr, 1.0)
+        fake_stats.samples_ms = [1.0, 1.0]
+
+        fake_session = MagicMock()
+        fake_session.perf.return_value.__enter__.return_value = fake_stats
+        fake_session.running_model_path = tmp_path / "model_cpu_ctx.onnx"
+
+        fake_loader_cfg = MagicMock()
+        fake_loader_cfg.task = "fill-mask"
+
+        # HWMonitor instance: context-managed, with a JSON-serializable to_dict().
+        fake_hw = MagicMock()
+        fake_hw.__enter__.return_value = fake_hw
+        fake_hw.to_dict.return_value = {"monitor": "HWMonitor", "device_kind": None}
+        fake_hw_cls = MagicMock()
+        fake_hw_cls.is_available.return_value = True
+        fake_hw_cls.return_value = fake_hw
+
+        out_path = tmp_path / "out.json"
+
+        with (
+            patch(
+                "winml.modelkit.sysinfo.resolve_device",
+                return_value=("cpu", ["cpu"]),
+            ),
+            patch(
+                "winml.modelkit.config.generate_hf_build_config",
+                return_value=[fake_cfg],
+            ),
+            patch(
+                "winml.modelkit.loader.resolve_loader_config",
+                return_value=(fake_loader_cfg, MagicMock(), MagicMock(), MagicMock()),
+            ),
+            patch(
+                "winml.modelkit.commands.build._instantiate_parent_model",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "winml.modelkit.build.build_hf_model",
+                return_value=fake_build_result,
+            ),
+            patch(
+                "winml.modelkit.session.WinMLSession",
+                return_value=fake_session,
+            ),
+            patch(
+                "winml.modelkit.commands.perf.generate_random_inputs",
+                return_value={},
+            ),
+            patch(
+                "winml.modelkit.session.monitor.hw_monitor.HWMonitor",
+                fake_hw_cls,
+            ),
+            patch(
+                "winml.modelkit.commands.perf._run_monitored_loop",
+            ) as mock_loop,
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                [
+                    "perf",
+                    "-m",
+                    "fake/model",
+                    "--module",
+                    "BertLayer",
+                    "--monitor",
+                    "--iterations",
+                    "1",
+                    "--warmup",
+                    "0",
+                    "-o",
+                    str(out_path),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        # The live-chart loop must be driven once for the single module instance.
+        mock_loop.assert_called_once()
+        # And the collected HW metrics still land in the JSON report.
+        report = json.loads(out_path.read_text(encoding="utf-8"))
+        assert report["instances"][0]["hw_monitor"]["monitor"] == "HWMonitor"
+
+
 class TestPerfModuleQuantCompileToggles:
     """--no-quantize and --compile/--no-compile clear cfg.quant / cfg.compile
     independently in the per-module build (mirrors the single-model path)."""

--- a/tests/unit/commands/test_perf_module.py
+++ b/tests/unit/commands/test_perf_module.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import json
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 from click.testing import CliRunner
 
@@ -383,6 +383,9 @@ class TestPerfModuleMonitor:
                 "winml.modelkit.commands.perf.generate_random_inputs",
                 return_value={},
             ),
+            # Lazy import inside _perf_modules — patch the source module, not
+            # the call site (winml.modelkit.commands.perf has no HWMonitor name
+            # bound until the function runs).
             patch(
                 "winml.modelkit.session.monitor.hw_monitor.HWMonitor",
                 fake_hw_cls,
@@ -411,8 +414,19 @@ class TestPerfModuleMonitor:
             )
 
         assert result.exit_code == 0, result.output
-        # The live-chart loop must be driven once for the single module instance.
-        mock_loop.assert_called_once()
+        # The live-chart loop must be driven once for the single module
+        # instance, with the benchmark params forwarded intact (guards against
+        # e.g. dropping warmup or mislabeling the chart).
+        mock_loop.assert_called_once_with(
+            ANY,
+            ANY,
+            ANY,
+            ANY,
+            total_iterations=1,
+            warmup=0,
+            model_id=ANY,
+            device="cpu",
+        )
         # And the collected HW metrics still land in the JSON report.
         report = json.loads(out_path.read_text(encoding="utf-8"))
         assert report["instances"][0]["hw_monitor"]["monitor"] == "HWMonitor"


### PR DESCRIPTION
## Summary

Fixes #654 — `perf --monitor` did nothing visible in `--module` mode.

In single-model mode, `--monitor` drives a live hardware-utilization chart via `_run_monitored_loop()` → `LiveMonitorDisplay`, which is exactly what the flag's help promises (*"Show live hardware utilization chart"*).

In `--module` mode, the monitored branch created an `HWMonitor` and collected metrics into the JSON report, but **never instantiated the live chart** — it just spun the raw inference loop. So from the user's perspective `--monitor` appeared to do nothing for `--module`.

## Fix

Route the per-module monitored loop through the same shared `_run_monitored_loop()` helper that single-model mode already uses. Each module instance now renders the live chart, while `hw_monitor` metrics are still persisted to the JSON report (unchanged).

## Testing

- Added `TestPerfModuleMonitor::test_monitor_drives_live_chart_per_module`, which asserts `_run_monitored_loop` is invoked once per module instance under `--module --monitor` and that the HW metrics still land in the JSON report. Verified it **fails** without the source fix and **passes** with it.
- `uv run pytest tests/unit/commands/test_perf_module.py` — 12 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
