### PR TITLE
fix: declare psutil as a runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dependencies = [
   # non-functional but huge diffs across every generated rule artifact. If you
   # truly must bump this, regenerate ALL parquet artifacts in the same change.
   "pandas==2.3.3",
+  "psutil>=7",
   "pydantic>=2",
   "python-multipart>=0.0.22",
   "rapidfuzz>=3.9",


### PR DESCRIPTION
## Summary

`winml perf` crashes on a clean install with `No module named 'psutil'` because `src/winml/modelkit/session/monitor/memory_tracker.py` imports `psutil` at module level, and the perf flow imports that module unconditionally. `psutil` was never declared in `[project].dependencies` — only the dev type stub `types-psutil` is present — so the published wheel's `Requires-Dist` omits it, breaking `winml perf` (and `--monitor` / `--memory`) out-of-the-box for every user.

Regression from #861 (`feat: add --memory flag`); `memory_tracker.py` did not exist in v0.1.0, so `winml perf` was unaffected there. Installing `psutil` manually confirms perf/build/`--monitor` otherwise work correctly — the only defect is the missing dependency declaration.

## Change

Add `psutil>=7` to `[project].dependencies` (aligns with the existing `types-psutil>=7.2.2` stub).

Targeting `release/v0.2.0` directly as a release hotfix; `main` will pick it up via the post-release merge-back.

Closes #936