### PR TITLE
Pipeline(E2E): align ModelKitArtifacts with release branch at runtime

### DIFF
--- a/.pipelines/Modelkit E2E Test.yml
+++ b/.pipelines/Modelkit E2E Test.yml
@@ -24,10 +24,10 @@
 #     an automatic E2E run. (Subsequent pushes to a release branch will
 #     also trigger a run, which is acceptable since release branches
 #     typically see few commits.) When triggered from a release branch,
-#     the ModelKitArtifacts repo is also checked out from the same-named
-#     release branch (see `resources.repositories.ModelKitArtifacts.ref`
-#     below); main is used for all other triggers (scheduled, manual on
-#     main, etc.).
+#     the job switches the checked-out ModelKitArtifacts repo to the
+#     same-named release branch at runtime (see the "Align ModelKitArtifacts
+#     with release branch" step in templates/e2e-test-jobs.yml); main is used
+#     for all other triggers (scheduled, manual on main, feature branches).
 #   * No PR trigger. Failures do not block PR merges.
 
 trigger:
@@ -44,29 +44,31 @@ schedules:
         - main
     always: true
 
-# Check out ModelKitArtifacts from the same branch this pipeline is running on
-# so the artifact content matches the modelkit branch:
-#   * release/* run (CI trigger or manual queue) -> same-named release branch
-#   * main run (daily schedule or manual queue on main) -> main
-# Build.SourceBranch is 'refs/heads/<name>' (e.g. 'refs/heads/release/<x>' or
-# 'refs/heads/main'), which is a valid `ref` for a GitHub repository resource.
+# ModelKitArtifacts is pinned to `main` here, and the matching release branch
+# (when this pipeline runs on release/*) is selected at runtime instead.
 #
-# IMPORTANT: a repository resource's `ref` may only contain template
-# expressions over `parameters` and *system predefined* variables — it CANNOT
-# read YAML- or UI-defined `variables`. The previous indirection
-# (`ref: ${{ variables.artifactsRef }}` fed by a compile-time `variables`
-# block) silently violated this rule, so the expression was ignored and the
-# resource always checked out its default branch (main) — even on release/*.
-# Referencing the Build.SourceBranch system variable directly is the
-# documented, supported pattern for matching the pipeline's own branch.
-# See: https://learn.microsoft.com/azure/devops/release-notes/2022/sprint-212-update#template-expressions-in-repository-resource-definition
+# Why not select the branch on this resource directly? A repository resource's
+# `ref` is resolved before the pipeline starts and only accepts template
+# expressions over `parameters` and *system predefined* variables — not
+# YAML/UI variables, and not conditional `${{ if }}` keys (those fail with
+# "A template expression is not allowed in this context"). Referencing
+# Build.SourceBranch directly (`ref: ${{ variables['Build.SourceBranch'] }}`)
+# does compile, but it makes the resource check out *whatever* branch the
+# pipeline runs on, which fails outright when ModelKitArtifacts has no such
+# branch — e.g. on feature branches or manual ad-hoc runs:
+#   "No commit found for SHA: refs/heads/<branch>".
+#
+# So the resource always checks out main (which always exists), and the
+# e2e-test job switches it to the same-named release/* branch at runtime,
+# falling back to main when no matching branch exists. See the
+# "Align ModelKitArtifacts with release branch" step in e2e-test-jobs.yml.
 resources:
   repositories:
     - repository: ModelKitArtifacts
       type: github
       endpoint: github.com_yuesu_microsoft
       name: gim-home/ModelKitArtifacts
-      ref: ${{ variables['Build.SourceBranch'] }}
+      ref: main
 
 parameters:
   # --------------------------------------------------------------------

--- a/.pipelines/Modelkit E2E Test.yml
+++ b/.pipelines/Modelkit E2E Test.yml
@@ -44,32 +44,29 @@ schedules:
         - main
     always: true
 
-# When this pipeline runs on a release/* branch (CI trigger or manual queue),
-# check out the same-named release branch from ModelKitArtifacts so the
-# artifact content matches the modelkit release. For all other branches
-# (e.g. main scheduled runs, manual queue from main), fall back to main.
+# Check out ModelKitArtifacts from the same branch this pipeline is running on
+# so the artifact content matches the modelkit branch:
+#   * release/* run (CI trigger or manual queue) -> same-named release branch
+#   * main run (daily schedule or manual queue on main) -> main
+# Build.SourceBranch is 'refs/heads/<name>' (e.g. 'refs/heads/release/<x>' or
+# 'refs/heads/main'), which is a valid `ref` for a GitHub repository resource.
 #
-# Azure Pipelines only allows template expressions in the *value* position of
-# a repository resource's `ref` (not as a YAML key inside `repositories`), so
-# the conditional is resolved here in a top-level compile-time variable and
-# the `ref` field simply references that variable.
-# Build.SourceBranch is in the form 'refs/heads/release/<name>', which is a
-# valid `ref` value for a GitHub repository resource.
+# IMPORTANT: a repository resource's `ref` may only contain template
+# expressions over `parameters` and *system predefined* variables — it CANNOT
+# read YAML- or UI-defined `variables`. The previous indirection
+# (`ref: ${{ variables.artifactsRef }}` fed by a compile-time `variables`
+# block) silently violated this rule, so the expression was ignored and the
+# resource always checked out its default branch (main) — even on release/*.
+# Referencing the Build.SourceBranch system variable directly is the
+# documented, supported pattern for matching the pipeline's own branch.
 # See: https://learn.microsoft.com/azure/devops/release-notes/2022/sprint-212-update#template-expressions-in-repository-resource-definition
-variables:
-  - name: artifactsRef
-    ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/release/') }}:
-      value: ${{ variables['Build.SourceBranch'] }}
-    ${{ else }}:
-      value: main
-
 resources:
   repositories:
     - repository: ModelKitArtifacts
       type: github
       endpoint: github.com_yuesu_microsoft
       name: gim-home/ModelKitArtifacts
-      ref: ${{ variables.artifactsRef }}
+      ref: ${{ variables['Build.SourceBranch'] }}
 
 parameters:
   # --------------------------------------------------------------------

--- a/.pipelines/templates/e2e-test-jobs.yml
+++ b/.pipelines/templates/e2e-test-jobs.yml
@@ -63,6 +63,44 @@ jobs:
         fetchDepth: 1
         lfs: true
         path: artifacts
+        # Keep the GitHub auth token in the repo's git config so the runtime
+        # step below can fetch/checkout the matching release branch.
+        persistCredentials: true
+
+      # The ModelKitArtifacts resource is pinned to `main` (a repository
+      # resource `ref` cannot be conditionally chosen from the running branch).
+      # When this pipeline runs on a release/* branch, switch the already
+      # checked-out artifacts repo to the same-named release branch so its
+      # content matches the modelkit release. Fall back to main (with a
+      # warning) when no such branch exists — e.g. feature/ad-hoc branches.
+      - powershell: |
+          $srcBranch = "$(Build.SourceBranch)"
+          if ($srcBranch -notlike 'refs/heads/release/*') {
+            Write-Host "Source branch '$srcBranch' is not a release branch; using ModelKitArtifacts@main."
+            exit 0
+          }
+          $relBranch = $srcBranch -replace '^refs/heads/', ''
+          $repoDir = "$(Agent.BuildDirectory)/artifacts"
+          if (-not (Test-Path "$repoDir/.git")) {
+            $repoDir = "$(Agent.BuildDirectory)/ModelKitArtifacts"
+          }
+          Push-Location $repoDir
+          try {
+            Write-Host "Fetching ModelKitArtifacts branch '$relBranch'..."
+            git fetch --depth 1 origin "${relBranch}:${relBranch}"
+            if ($LASTEXITCODE -ne 0) {
+              Write-Warning "ModelKitArtifacts has no branch '$relBranch' (or fetch failed); staying on main."
+              exit 0
+            }
+            git checkout $relBranch
+            if ($LASTEXITCODE -ne 0) { Write-Error "Failed to checkout ModelKitArtifacts '$relBranch'."; exit 1 }
+            git lfs pull
+            if ($LASTEXITCODE -ne 0) { Write-Error "git lfs pull failed for ModelKitArtifacts '$relBranch'."; exit 1 }
+            Write-Host "Switched ModelKitArtifacts to '$relBranch'."
+          } finally {
+            Pop-Location
+          }
+        displayName: 'Align ModelKitArtifacts with release branch'
 
       - powershell: |
           Write-Host "Agent.BuildDirectory : $(Agent.BuildDirectory)"


### PR DESCRIPTION
## Problem

The E2E Test pipeline is supposed to check out the **same-named `release/*` branch**
of `ModelKitArtifacts` when it runs on a release branch, so the artifact content
matches the modelkit release. This never actually worked:

- The artifacts repo was selected via the repository resource's `ref`
  (`ref: ${{ variables.artifactsRef }}`, driven by a compile-time `variables`
  block). A repository resource `ref` is resolved **before** the pipeline starts
  and only accepts template expressions over `parameters` and **system predefined**
  variables — not YAML/UI-defined variables. So the expression was silently
  ignored and ModelKitArtifacts always checked out its default branch (`main`),
  even on `release/*` runs.
- Pointing `ref` directly at `Build.SourceBranch` does compile, but then the
  resource tries to check out *whatever* branch the pipeline runs on, which fails
  outright when ModelKitArtifacts has no matching branch (feature/ad-hoc runs):
  `No commit found for SHA: refs/heads/<branch>`.

In short, the branch of a repository resource cannot be conditionally chosen at
resource-resolution time.

## Fix

Select the artifacts branch **at runtime** instead:

- Pin the `ModelKitArtifacts` resource to `ref: main` (always exists), and remove
  the unusable `variables` indirection.
- Add a job step **"Align ModelKitArtifacts with release branch"** that, when
  `Build.SourceBranch` is `refs/heads/release/*`, switches the already-checked-out
  artifacts repo to the same-named release branch (`git fetch` + `git checkout` +
  `git lfs pull`). It falls back to `main` with a warning when no matching branch
  exists, so non-release runs (main schedule, manual, feature branches) keep
  working instead of failing at init.
- Enable `persistCredentials: true` on the artifacts checkout so the runtime
  fetch / lfs pull is authenticated.

## Result

- `release/*` run → ModelKitArtifacts switches to the same-named release branch ✓
- `main` / manual / feature run → stays on `main`, no init failure ✓

Verified on a live pipeline run.