### PR TITLE
fix(build): honor --ep; require explicit device+ep in resolve_device; support cross-compile

### DIFF
--- a/src/winml/modelkit/analyze/analyzer.py
+++ b/src/winml/modelkit/analyze/analyzer.py
@@ -795,7 +795,7 @@ class ONNXStaticAnalyzer:
         if device is not None and device.lower() == "auto":
             from ..sysinfo import resolve_device
 
-            resolved, _ = resolve_device("auto", ep=None)
+            resolved, _ = resolve_device("auto", ep=ep_normalized)
             device_to_use = resolved.upper()
             logger.info("Device 'auto' resolved to: %s", device_to_use)
         else:

--- a/src/winml/modelkit/analyze/analyzer.py
+++ b/src/winml/modelkit/analyze/analyzer.py
@@ -140,10 +140,7 @@ def _build_runtime_debug_details_summary(
                     level_bucket[node_stable_key] = candidate_entry
                     continue
 
-                if (
-                    existing_entry.case_indices is None
-                    and candidate_entry.case_indices is not None
-                ):
+                if existing_entry.case_indices is None and candidate_entry.case_indices is not None:
                     existing_entry.case_indices = candidate_entry.case_indices
 
                 if existing_entry.table_path is None and candidate_entry.table_path is not None:
@@ -798,7 +795,7 @@ class ONNXStaticAnalyzer:
         if device is not None and device.lower() == "auto":
             from ..sysinfo import resolve_device
 
-            resolved, _ = resolve_device("auto")
+            resolved, _ = resolve_device("auto", ep=None)
             device_to_use = resolved.upper()
             logger.info("Device 'auto' resolved to: %s", device_to_use)
         else:

--- a/src/winml/modelkit/commands/build.py
+++ b/src/winml/modelkit/commands/build.py
@@ -545,20 +545,19 @@ def build(
     # hardware -- analyzing for the wrong EP leaves black nodes that block a
     # later build targeting the actual device (#663).
     #
-    # resolve_device() either returns a device with >=1 available EP (auto-mode
-    # walks the priority list, falls back to cpu which is always valid), or
-    # raises ValueError for an explicit device with no compatible EP. So the
-    # following resolve_eps()[0] is safe whenever resolve_device returns.
+    # resolve_check_device_ep() either returns a device with >=1 available EP
+    # (auto-mode walks the priority list, falls back to cpu which is always
+    # valid), or raises ValueError for an explicit device with no compatible EP.
+    # So the following available_eps[0] is safe whenever it returns.
     if ep is None:
-        from ..sysinfo import resolve_device as _resolve_device
-        from ..sysinfo import resolve_eps as _resolve_eps
+        from ..sysinfo import resolve_check_device_ep
 
         try:
-            resolved_device, _ = _resolve_device(device=device, ep=None)
+            resolved_device, _, available_eps = resolve_check_device_ep(device=device, ep=None)
         except ValueError as e:
             raise click.UsageError(str(e)) from e
         device = resolved_device
-        ep = _resolve_eps(resolved_device)[0]
+        ep = available_eps[0]
         logger.info("Auto-resolved device=%s, EP=%s", resolved_device, ep)
 
     try:
@@ -1013,11 +1012,15 @@ def _run_optimize_stage(
             _header_shown[0] = False
 
         # Resolve "auto" to a concrete device once so that has_rule_data_for_ep
-        # doesn't search for non-existent "*_AUTO_*.parquet" files.
+        # doesn't search for non-existent "*_AUTO_*.parquet" files. Use
+        # resolve_check_device_ep so an explicit device+ep is validated
+        # statically (no availability cross-check): a --no-compile build may
+        # target a device absent on this machine (cross-compile), and this call
+        # only needs a concrete device name for the rule-data lookup.
         from ..analyze.utils.ep_utils import has_rule_data_for_ep
-        from ..sysinfo import resolve_device as _resolve_device
+        from ..sysinfo import resolve_check_device_ep
 
-        _resolved_device, _ = _resolve_device(device=device or "auto", ep=ep)
+        _resolved_device, _, _ = resolve_check_device_ep(device=device or "auto", ep=ep)
 
         def _on_ep_start(ep_name: EPName, operator_counts: dict) -> None:
             nonlocal _current_ep

--- a/src/winml/modelkit/commands/build.py
+++ b/src/winml/modelkit/commands/build.py
@@ -579,6 +579,7 @@ def build(
                 trust_remote_code=trust_remote_code,
                 device=device,
                 precision=precision,
+                ep=ep,
             )
             if not quant:
                 config_or_configs.quant = None
@@ -640,6 +641,24 @@ def build(
                 _cfg.validate()
         except ValueError as e:
             raise click.UsageError(f"Config validation failed: {e}") from e
+
+        # Fail fast for compile builds: compilation physically instantiates the
+        # EP (EPContext), so the target EP/device must be present on this
+        # machine. Catch an unavailable combo here -- before export/optimize --
+        # instead of surfacing deep in the compile stage. A no-compile build
+        # only produces a portable, analyzed ONNX and may legitimately target a
+        # device absent on this machine (cross-compile), so it is left to run.
+        for _cfg in _configs_to_validate:
+            _compile = _cfg.compile
+            if _compile is None or _compile.ep_config is None:
+                continue
+            from ..sysinfo import resolve_device as _resolve_device_check
+
+            try:
+                _resolve_device_check(device=device or "auto", ep=_compile.ep_config.provider)
+            except ValueError as e:
+                raise click.UsageError(str(e)) from e
+            break
 
         preloaded_hf_config = _validate_loader_tasks_for_model(
             model_id=model_id,
@@ -1012,11 +1031,18 @@ def _run_optimize_stage(
             _header_shown[0] = False
 
         # Resolve "auto" to a concrete device once so that has_rule_data_for_ep
-        # doesn't search for non-existent "*_AUTO_*.parquet" files.
+        # doesn't search for non-existent "*_AUTO_*.parquet" files. Only a device
+        # name is needed (the EP comes from each analyzer callback below), so
+        # don't pass ep or availability-fail here: a no-compile cross-compile
+        # build may target a device absent on this machine (compile builds are
+        # gated earlier, before export).
         from ..analyze.utils.ep_utils import has_rule_data_for_ep
         from ..sysinfo import resolve_device as _resolve_device
 
-        _resolved_device, _ = _resolve_device(device=device or "auto", ep=ep)
+        if device and device.lower() != "auto":
+            _resolved_device = device.lower()
+        else:
+            _resolved_device, _ = _resolve_device(device="auto")
 
         def _on_ep_start(ep_name: EPName, operator_counts: dict) -> None:
             nonlocal _current_ep

--- a/src/winml/modelkit/commands/build.py
+++ b/src/winml/modelkit/commands/build.py
@@ -554,7 +554,7 @@ def build(
         from ..sysinfo import resolve_eps as _resolve_eps
 
         try:
-            resolved_device, _ = _resolve_device(device=device)
+            resolved_device, _ = _resolve_device(device=device, ep=None)
         except ValueError as e:
             raise click.UsageError(str(e)) from e
         device = resolved_device
@@ -641,24 +641,6 @@ def build(
                 _cfg.validate()
         except ValueError as e:
             raise click.UsageError(f"Config validation failed: {e}") from e
-
-        # Fail fast for compile builds: compilation physically instantiates the
-        # EP (EPContext), so the target EP/device must be present on this
-        # machine. Catch an unavailable combo here -- before export/optimize --
-        # instead of surfacing deep in the compile stage. A no-compile build
-        # only produces a portable, analyzed ONNX and may legitimately target a
-        # device absent on this machine (cross-compile), so it is left to run.
-        for _cfg in _configs_to_validate:
-            _compile = _cfg.compile
-            if _compile is None or _compile.ep_config is None:
-                continue
-            from ..sysinfo import resolve_device as _resolve_device_check
-
-            try:
-                _resolve_device_check(device=device or "auto", ep=_compile.ep_config.provider)
-            except ValueError as e:
-                raise click.UsageError(str(e)) from e
-            break
 
         preloaded_hf_config = _validate_loader_tasks_for_model(
             model_id=model_id,
@@ -1031,18 +1013,11 @@ def _run_optimize_stage(
             _header_shown[0] = False
 
         # Resolve "auto" to a concrete device once so that has_rule_data_for_ep
-        # doesn't search for non-existent "*_AUTO_*.parquet" files. Only a device
-        # name is needed (the EP comes from each analyzer callback below), so
-        # don't pass ep or availability-fail here: a no-compile cross-compile
-        # build may target a device absent on this machine (compile builds are
-        # gated earlier, before export).
+        # doesn't search for non-existent "*_AUTO_*.parquet" files.
         from ..analyze.utils.ep_utils import has_rule_data_for_ep
         from ..sysinfo import resolve_device as _resolve_device
 
-        if device and device.lower() != "auto":
-            _resolved_device = device.lower()
-        else:
-            _resolved_device, _ = _resolve_device(device="auto")
+        _resolved_device, _ = _resolve_device(device=device or "auto", ep=ep)
 
         def _on_ep_start(ep_name: EPName, operator_counts: dict) -> None:
             nonlocal _current_ep

--- a/src/winml/modelkit/commands/build.py
+++ b/src/winml/modelkit/commands/build.py
@@ -553,7 +553,7 @@ def build(
         from ..sysinfo import resolve_check_device_ep
 
         try:
-            resolved_device, _, available_eps = resolve_check_device_ep(device=device, ep=None)
+            resolved_device, _, available_eps = resolve_check_device_ep(device=device, ep=ep)
         except ValueError as e:
             raise click.UsageError(str(e)) from e
         device = resolved_device

--- a/src/winml/modelkit/commands/eval.py
+++ b/src/winml/modelkit/commands/eval.py
@@ -364,7 +364,7 @@ def _resolve_device(cfg: WinMLEvaluationConfig) -> None:
 
     console = Console(stderr=True)
     console.print("[bold]Detecting available devices...[/bold]")
-    resolved, _ = resolve_device(cfg.device, ep=None)
+    resolved, _ = resolve_device(cfg.device, ep=cfg.ep)
     cfg.device = resolved
     console.print(f"[dim]Using device:[/dim] {resolved}")
 

--- a/src/winml/modelkit/commands/eval.py
+++ b/src/winml/modelkit/commands/eval.py
@@ -364,7 +364,7 @@ def _resolve_device(cfg: WinMLEvaluationConfig) -> None:
 
     console = Console(stderr=True)
     console.print("[bold]Detecting available devices...[/bold]")
-    resolved, _ = resolve_device(cfg.device)
+    resolved, _ = resolve_device(cfg.device, ep=None)
     cfg.device = resolved
     console.print(f"[dim]Using device:[/dim] {resolved}")
 

--- a/src/winml/modelkit/compiler/context.py
+++ b/src/winml/modelkit/compiler/context.py
@@ -37,6 +37,7 @@ class CompileContext:
 
     # Input
     model_path: Path
+    # From WinMLCompileConfig.to_dict()
     config: dict[str, Any]
     model: onnx.ModelProto | None = None
 

--- a/src/winml/modelkit/compiler/stages/compile.py
+++ b/src/winml/modelkit/compiler/stages/compile.py
@@ -176,7 +176,7 @@ class CompileStage(BaseStage):
         sess_options = context.shared_session_options
         if sess_options is None:
             register_execution_providers(ort=True)
-            resolved_device, _ = resolve_device(context.config.get("device", "auto"))
+            resolved_device, _ = resolve_device(context.config.get("device", "auto"), ep=None)
             ep = normalize_ep_name(ep_config.provider) or resolve_eps(resolved_device)[0]
             device_type = DEVICE_TO_DEVICE_TYPE.get(resolved_device.upper())
 

--- a/src/winml/modelkit/compiler/stages/compile.py
+++ b/src/winml/modelkit/compiler/stages/compile.py
@@ -176,7 +176,9 @@ class CompileStage(BaseStage):
         sess_options = context.shared_session_options
         if sess_options is None:
             register_execution_providers(ort=True)
-            resolved_device, _ = resolve_device(context.config.get("device", "auto"), ep=None)
+            resolved_device, _ = resolve_device(
+                context.get_config("device", "auto"), ep=context.execution_provider
+            )
             ep = normalize_ep_name(ep_config.provider) or resolve_eps(resolved_device)[0]
             device_type = DEVICE_TO_DEVICE_TYPE.get(resolved_device.upper())
 

--- a/src/winml/modelkit/sysinfo/device.py
+++ b/src/winml/modelkit/sysinfo/device.py
@@ -145,7 +145,7 @@ def _get_available_eps() -> frozenset[EPName]:
 
 
 def resolve_device(
-    device: str = "auto",
+    device: str,
     *,
     ep: EPNameOrAlias | None,
 ) -> tuple[str, list[str]]:

--- a/src/winml/modelkit/sysinfo/device.py
+++ b/src/winml/modelkit/sysinfo/device.py
@@ -147,7 +147,7 @@ def _get_available_eps() -> frozenset[EPName]:
 def resolve_device(
     device: str = "auto",
     *,
-    ep: EPNameOrAlias | None = None,
+    ep: EPNameOrAlias | None,
 ) -> tuple[str, list[str]]:
     """Resolve target device with EP availability cross-check.
 
@@ -233,7 +233,7 @@ def resolve_eps(resolved_device: str) -> list[EPName]:
 
 
 def resolve_check_device_ep(
-    *, device: str = "auto", ep: EPNameOrAlias | None = None
+    *, device: str, ep: EPNameOrAlias | None
 ) -> tuple[str, list[str], list[EPName]]:
     """Resolve or check that the requested device and/or EP combination is valid, raising if not.
 

--- a/tests/unit/commands/test_build.py
+++ b/tests/unit/commands/test_build.py
@@ -1742,38 +1742,3 @@ class TestBuildEpResolution:
             )
         assert result.exit_code == 0, result.output
         assert mock_gen.call_args.kwargs["ep"] == "openvino"
-
-    def test_compile_build_unavailable_ep_fails_before_build(
-        self, tmp_path: Path, mock_run_single_build: MagicMock
-    ):
-        """A compile build whose EP isn't present fails fast, before _run_single_build.
-
-        Compilation physically instantiates the EP, so an unavailable EP must be
-        caught up front rather than deep in the compile stage.
-        """
-        cfg = _make_minimal_config_file(tmp_path, compile_section={"execution_provider": "qnn"})
-        with patch(
-            "winml.modelkit.sysinfo.resolve_device",
-            side_effect=ValueError("Requested EP 'qnn' is not available on this system."),
-        ):
-            result = _invoke([*self._base_args(cfg, tmp_path), "--ep", "qnn", "--compile"])
-        assert result.exit_code == 2, result.output
-        assert "not available on this system" in result.output
-        mock_run_single_build.assert_not_called()
-
-    def test_no_compile_build_skips_ep_availability_gate(
-        self, tmp_path: Path, mock_run_single_build: MagicMock
-    ):
-        """A no-compile build proceeds even when the EP isn't present (cross-compile).
-
-        No-compile only produces a portable, analyzed ONNX, so it must not require
-        the target EP/device to exist on the build machine.
-        """
-        cfg = _make_minimal_config_file(tmp_path, compile_section={"execution_provider": "qnn"})
-        with patch(
-            "winml.modelkit.sysinfo.resolve_device",
-            side_effect=ValueError("Requested EP 'qnn' is not available on this system."),
-        ):
-            result = _invoke([*self._base_args(cfg, tmp_path), "--ep", "qnn", "--no-compile"])
-        assert result.exit_code == 0, result.output
-        mock_run_single_build.assert_called_once()

--- a/tests/unit/commands/test_build.py
+++ b/tests/unit/commands/test_build.py
@@ -1711,3 +1711,69 @@ class TestRunCompileStageNoOutput:
 
         # current_path should be updated to compiled_path
         assert result == compiled_path
+
+
+class TestBuildEpResolution:
+    """--ep forwarding into config generation + the compile EP-availability gate."""
+
+    def _base_args(self, cfg: str, tmp_path: Path) -> list[str]:
+        return ["-c", cfg, "-m", "microsoft/resnet-50", "-o", str(tmp_path / "out")]
+
+    def test_ep_forwarded_to_generate_build_config(
+        self, tmp_path: Path, mock_run_single_build: MagicMock
+    ):
+        """On the auto-config path (-m, no -c), --ep reaches generate_build_config.
+
+        Regression: the build command dropped --ep when auto-generating a config,
+        so the requested EP never influenced the generated config (it failed or
+        analyzed/compiled for the wrong EP).
+        """
+        fake_cfg = MagicMock()
+        fake_cfg.compile = None  # no compile -> EP-availability gate is skipped
+        with (
+            patch("winml.modelkit.config.generate_build_config", return_value=fake_cfg) as mock_gen,
+            patch(
+                "winml.modelkit.commands.build._validate_loader_tasks_for_model",
+                return_value=None,
+            ),
+        ):
+            result = _invoke(
+                ["-m", "microsoft/resnet-50", "--ep", "openvino", "-o", str(tmp_path / "out")]
+            )
+        assert result.exit_code == 0, result.output
+        assert mock_gen.call_args.kwargs["ep"] == "openvino"
+
+    def test_compile_build_unavailable_ep_fails_before_build(
+        self, tmp_path: Path, mock_run_single_build: MagicMock
+    ):
+        """A compile build whose EP isn't present fails fast, before _run_single_build.
+
+        Compilation physically instantiates the EP, so an unavailable EP must be
+        caught up front rather than deep in the compile stage.
+        """
+        cfg = _make_minimal_config_file(tmp_path, compile_section={"execution_provider": "qnn"})
+        with patch(
+            "winml.modelkit.sysinfo.resolve_device",
+            side_effect=ValueError("Requested EP 'qnn' is not available on this system."),
+        ):
+            result = _invoke([*self._base_args(cfg, tmp_path), "--ep", "qnn", "--compile"])
+        assert result.exit_code == 2, result.output
+        assert "not available on this system" in result.output
+        mock_run_single_build.assert_not_called()
+
+    def test_no_compile_build_skips_ep_availability_gate(
+        self, tmp_path: Path, mock_run_single_build: MagicMock
+    ):
+        """A no-compile build proceeds even when the EP isn't present (cross-compile).
+
+        No-compile only produces a portable, analyzed ONNX, so it must not require
+        the target EP/device to exist on the build machine.
+        """
+        cfg = _make_minimal_config_file(tmp_path, compile_section={"execution_provider": "qnn"})
+        with patch(
+            "winml.modelkit.sysinfo.resolve_device",
+            side_effect=ValueError("Requested EP 'qnn' is not available on this system."),
+        ):
+            result = _invoke([*self._base_args(cfg, tmp_path), "--ep", "qnn", "--no-compile"])
+        assert result.exit_code == 0, result.output
+        mock_run_single_build.assert_called_once()

--- a/tests/unit/commands/test_build.py
+++ b/tests/unit/commands/test_build.py
@@ -1212,17 +1212,17 @@ class TestBuildEpAutoSelection:
         mock_build_api: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """resolve_device raising (explicit device w/ no compatible EP) -> UsageError.
+        """resolve_check_device_ep raising (explicit device w/ no compatible EP) -> UsageError.
 
         Uses default ``--device auto`` (no CLI flag) so the downstream
-        device-patch path isn't triggered; the only resolve_device call is
-        the one inside the auto-select block.
+        device-patch path isn't triggered; the only resolution call is the
+        ``resolve_check_device_ep`` inside the auto-select block.
         """
         from winml.modelkit.commands.build import build
 
         with patch(
-            "winml.modelkit.sysinfo.resolve_device",
-            side_effect=ValueError("simulated resolve_device failure"),
+            "winml.modelkit.sysinfo.resolve_check_device_ep",
+            side_effect=ValueError("simulated resolve failure"),
         ):
             result = runner.invoke(
                 build,
@@ -1230,7 +1230,7 @@ class TestBuildEpAutoSelection:
                 obj={"debug": False},
             )
         assert result.exit_code != 0
-        assert "simulated resolve_device failure" in result.output
+        assert "simulated resolve failure" in result.output
         mock_build_api.assert_not_called()
 
     def test_auto_selection_respects_resolve_eps_priority(
@@ -1240,17 +1240,15 @@ class TestBuildEpAutoSelection:
         mock_build_api: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """First element of resolve_eps(resolved_device) is selected, not later ones."""
+        """First element of resolve_check_device_ep's available_eps is selected."""
         from winml.modelkit.commands.build import build
 
-        with (
-            patch(
-                "winml.modelkit.sysinfo.resolve_device",
-                return_value=("gpu", ["gpu", "cpu"]),
-            ),
-            patch(
-                "winml.modelkit.sysinfo.resolve_eps",
-                return_value=["DmlExecutionProvider", "OpenVINOExecutionProvider"],
+        with patch(
+            "winml.modelkit.sysinfo.resolve_check_device_ep",
+            return_value=(
+                "gpu",
+                ["gpu", "cpu"],
+                ["DmlExecutionProvider", "OpenVINOExecutionProvider"],
             ),
         ):
             result = runner.invoke(

--- a/tests/unit/sysinfo/test_device.py
+++ b/tests/unit/sysinfo/test_device.py
@@ -83,7 +83,7 @@ class TestGetAvailableDevices:
     def test_returns_empty_when_enumeration_fails(self) -> None:
         """If EP enumeration raises, return empty tuple (no devices visible).
 
-        ``resolve_device("auto")`` is responsible for the CPU fallback when no
+        ``resolve_device("auto", ep=None)`` is responsible for the CPU fallback when no
         devices are reachable; ``_get_available_devices`` only reports what is
         actually registered.
         """
@@ -214,7 +214,7 @@ class TestResolveDevice:
                 "cpu": ("CPUExecutionProvider",),
             }
         ):
-            device, available = resolve_device("auto")
+            device, available = resolve_device("auto", ep=None)
 
         assert device == "npu"
         assert available == ["npu", "gpu", "cpu"]
@@ -227,7 +227,7 @@ class TestResolveDevice:
                 "cpu": ("CPUExecutionProvider",),
             }
         ):
-            device, available = resolve_device("auto")
+            device, available = resolve_device("auto", ep=None)
 
         assert device == "gpu"
         assert available == ["gpu", "cpu"]
@@ -235,7 +235,7 @@ class TestResolveDevice:
     def test_resolve_device_auto_cpu_fallback(self) -> None:
         """Auto mode: only CPU EP registered -> returns "cpu"."""
         with _patch_device_ep_map({"cpu": ("CPUExecutionProvider",)}):
-            device, available = resolve_device("auto")
+            device, available = resolve_device("auto", ep=None)
 
         assert device == "cpu"
         assert available == ["cpu"]
@@ -248,7 +248,7 @@ class TestResolveDevice:
                 "cpu": ("CPUExecutionProvider",),
             }
         ):
-            device, available = resolve_device("gpu")
+            device, available = resolve_device("gpu", ep=None)
 
         assert device == "gpu"
         assert available == ["gpu", "cpu"]
@@ -256,7 +256,7 @@ class TestResolveDevice:
     def test_resolve_device_explicit_invalid(self) -> None:
         """Unrecognized device "tpu" -> raises ValueError."""
         with pytest.raises(ValueError, match="Unknown device 'tpu'"):
-            resolve_device("tpu")
+            resolve_device("tpu", ep=None)
 
     def test_resolve_device_explicit_no_ep_error_names_missing_eps(self) -> None:
         """Error message must name the compatible EPs so users know what to install."""
@@ -268,7 +268,7 @@ class TestResolveDevice:
             ),
             pytest.raises(ValueError) as exc_info,
         ):
-            resolve_device("npu")
+            resolve_device("npu", ep=None)
 
         message = str(exc_info.value)
         assert "no compatible EP" in message
@@ -278,7 +278,7 @@ class TestResolveDevice:
     def test_resolve_device_case_insensitive(self) -> None:
         """Device argument should be case-insensitive."""
         with _patch_device_ep_map({"cpu": ("CPUExecutionProvider",)}):
-            device, _ = resolve_device("CPU")
+            device, _ = resolve_device("CPU", ep=None)
 
         assert device == "cpu"
 
@@ -293,7 +293,7 @@ class TestResolveDevice:
             _patch_device_ep_map({}),
             pytest.raises(RuntimeError, match="No execution providers detected"),
         ):
-            resolve_device("auto")
+            resolve_device("auto", ep=None)
 
 
 class TestResolveDeviceWithEp:


### PR DESCRIPTION
## Summary

Several related EP/device-handling fixes in `winml build`, found after `winml build --ep openvino --device npu --compile` **silently ignored `--ep`**.

### 1. `winml build` now honors `--ep`
The command passed only `device`/`precision` to `generate_build_config` — never `ep` — so the requested EP was silently dropped (and, with an explicit absent `--device`, it failed for the wrong reason). Now `ep` is forwarded.

### 2. `resolve_device` requires explicit `device` + `ep`
Both are now required (no `device="auto"` default; `ep` was already required), so an omission is a **call error** instead of a silent `ep=None` / `device="auto"`. Several callers relied on the old defaults (latent `TypeError`s + 8 failing `test_device.py` tests) — fixed to pass both explicitly:
- analyzer auto-device resolution
- build's auto-EP (`ep is None`) block
- eval device resolution
- compile-stage device resolution

This closes the class of bug behind #931.

### 3. Cross-compile support via `resolve_check_device_ep`
`winml build` now resolves through `resolve_check_device_ep`, which validates an explicit device+ep **statically** (no availability cross-check). A build can target a device that isn't on the build machine; the outcome depends on whether compilation is actually needed:

| Scenario | Result |
|---|---|
| `--no-compile`, target device absent | ✅ builds — portable, analyzed/quantized ONNX (cross-compile) |
| `--compile`, EP has no EPContext (e.g. MIGraphX, DML) | ✅ builds — compile is a no-op |
| `--compile`, EP has EPContext, device absent (e.g. OpenVINO+NPU) | ⚠️ fails **at the compile stage** (late) — tracked in #950 |

## Verification

Empirical builds of `microsoft/resnet-50` on a machine without an NPU confirm all three rows (exit 0 / 0 / 1, failing only at the compile stage for row 3). Unit suites green: `tests/unit/{commands,sysinfo,compiler,analyze,config}` (2500+ passed); `test_build.py` + `test_device.py` updated for the new resolver contract.

## Follow-up

- #950 — make the `--compile`-on-absent-device case fail fast (before export) instead of at the compile stage. A gate was intentionally deferred so it can be conditioned correctly on `config.compile` (must not regress cross-compile / no-EPContext builds).

Related: #931 (fixed in #941).