### PR TITLE
fix(quantize): suppress ORT pre-processing warnings in quantize flow

### DIFF
--- a/src/winml/modelkit/commands/eval.py
+++ b/src/winml/modelkit/commands/eval.py
@@ -260,24 +260,16 @@ def eval(
     # The build-pipeline flags only take effect when eval rebuilds the model.
     # With a pre-built ONNX path and skip_build (the default), they are no-ops
     # forwarded to from_onnx, so warn the user that they were ignored — mirrors
-    # the --precision warning above.
-    if cfg.model_path is not None and cfg.skip_build:
-        ignored_build_flags = [
-            flag
-            for flag, ignored in (
-                ("--no-quant", not cfg.quant),
-                ("--no-optimize", not cfg.optimize),
-                ("--no-analyze", not cfg.analyze),
-                ("--max-optim-iterations", cfg.max_optim_iterations is not None),
-            )
-            if ignored
-        ]
-        if ignored_build_flags:
-            logger.warning(
-                "%s ignored for pre-built ONNX inputs (no build runs; "
-                "pass --no-skip-build to rebuild).",
-                ", ".join(ignored_build_flags),
-            )
+    # the --precision warning above. Shared with perf via utils/cli.py.
+    build_flags_warning = cli_utils.ignored_build_flags_warning(
+        skip_build_onnx=cfg.model_path is not None and cfg.skip_build,
+        quant=cfg.quant,
+        optimize=cfg.optimize,
+        analyze=cfg.analyze,
+        max_optim_iterations=cfg.max_optim_iterations,
+    )
+    if build_flags_warning:
+        logger.warning(build_flags_warning)
 
     logger.debug("Effective eval config: %s", cfg.to_dict())
 

--- a/src/winml/modelkit/commands/eval.py
+++ b/src/winml/modelkit/commands/eval.py
@@ -257,6 +257,28 @@ def eval(
             cfg.precision,
         )
 
+    # The build-pipeline flags only take effect when eval rebuilds the model.
+    # With a pre-built ONNX path and skip_build (the default), they are no-ops
+    # forwarded to from_onnx, so warn the user that they were ignored — mirrors
+    # the --precision warning above.
+    if cfg.model_path is not None and cfg.skip_build:
+        ignored_build_flags = [
+            flag
+            for flag, ignored in (
+                ("--no-quant", not cfg.quant),
+                ("--no-optimize", not cfg.optimize),
+                ("--no-analyze", not cfg.analyze),
+                ("--max-optim-iterations", cfg.max_optim_iterations is not None),
+            )
+            if ignored
+        ]
+        if ignored_build_flags:
+            logger.warning(
+                "%s ignored for pre-built ONNX inputs (no build runs; "
+                "pass --no-skip-build to rebuild).",
+                ", ".join(ignored_build_flags),
+            )
+
     logger.debug("Effective eval config: %s", cfg.to_dict())
 
     json_mode = output_format == "json"

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -1749,6 +1749,18 @@ def perf(
                     "pre-exported ONNX files (shapes are baked into the model)."
                 )
                 config.shape_config = None
+            # Build-pipeline flags are forwarded to from_onnx but no-op when the
+            # build is skipped (the default). Warn so the silent no-op is visible
+            # — shared detection with eval via utils/cli.py.
+            build_flags_warning = cli_utils.ignored_build_flags_warning(
+                skip_build_onnx=skip_build,
+                quant=quant,
+                optimize=optimize,
+                analyze=analyze,
+                max_optim_iterations=max_optim_iterations,
+            )
+            if build_flags_warning:
+                console.print(f"[yellow]Warning:[/yellow] {build_flags_warning}")
             console.print(f"[dim]Benchmarking ONNX:[/dim] {model_path}")
         else:
             if precision != "auto":

--- a/src/winml/modelkit/optim/api.py
+++ b/src/winml/modelkit/optim/api.py
@@ -160,19 +160,6 @@ def _convert_to_kwargs(config: dict[str, Any], all_caps: dict[str, Any]) -> dict
     return result
 
 
-def _hack_inject_quant_preprocess_metadata(model: onnx.ModelProto) -> None:
-    """Inject metadata that signals pre-processing was done.
-
-    Suppresses the ORT quantization warning:
-    'Please consider to run pre-processing before quantization.'
-    """
-    metadata = {"onnx.quant.pre_process": "onnxruntime.quant"}
-    if model.metadata_props:
-        for prop in model.metadata_props:
-            metadata[prop.key] = prop.value
-    onnx.helper.set_model_props(model, metadata)
-
-
 def optimize_onnx(
     model: str | Path | onnx.ModelProto,
     output: str | Path | None = None,
@@ -271,9 +258,6 @@ def optimize_onnx(
     # More than one "optimize" call is necessary for certain models for thorough optimization
     optimized_model = optimizer.optimize(loaded_model, **optimizer_kwargs)
     optimized_model = optimizer.optimize(optimized_model, **optimizer_kwargs)
-
-    # Step 9.5: Inject quant pre-processing metadata to suppress ORT warning
-    _hack_inject_quant_preprocess_metadata(optimized_model)
 
     # Step 10: Save if output path provided
     if output is not None:

--- a/src/winml/modelkit/quant/quantizer.py
+++ b/src/winml/modelkit/quant/quantizer.py
@@ -152,13 +152,20 @@ def quantize_onnx(
             extra_options=extra_options,
         )
 
-        # Step 2: Capture metadata before ORT quantization (it rebuilds the graph)
+        # Step 2: Load the input model, capture its metadata snapshot (ORT
+        # rebuilds the graph during quantization, so we restore afterwards),
+        # and tag it as pre-processed so quantize_static() does not emit the
+        # "run pre-processing before quantization" warning.  We hand this
+        # in-memory ModelProto to ORT directly rather than mutating the user's
+        # input file on disk.
+        from onnxruntime.quantization.quant_utils import add_pre_process_metadata
+
         from ..onnx import capture_metadata, load_onnx, restore_metadata, save_onnx
         from .qdq_fix import fix_qdq_dtype_info
 
-        pre_quant_model = load_onnx(model_path, load_weights=False, validate=False)
-        metadata_snapshot = capture_metadata(pre_quant_model)
-        del pre_quant_model
+        input_model = load_onnx(model_path, validate=False)
+        metadata_snapshot = capture_metadata(input_model)
+        add_pre_process_metadata(input_model)
 
         # Step 3: Apply quantization
         if use_external_data:
@@ -171,9 +178,8 @@ def quantize_onnx(
         # output directory rather than the process CWD.  Without this, a stale
         # .onnx.data sidecar in the process CWD from a previous build triggers
         # a false-positive FileExistsError even when the output dir is clean.
-        # Use absolute paths so the chdir does not break relative input/output
+        # Use an absolute output path so the chdir does not break its
         # resolution.  output_path.parent is guaranteed to exist (caller mkdir).
-        abs_model_input = str(Path(model_path).resolve())
         abs_model_output = str(Path(output_path).resolve())
         # Remove stale output artifacts from a previous build.  ORT/onnx refuse
         # to overwrite an existing external-data sidecar (e.g. quantized.onnx.data),
@@ -187,7 +193,7 @@ def quantize_onnx(
         try:
             os.chdir(output_path.parent)
             quantize(
-                model_input=abs_model_input,
+                model_input=input_model,
                 model_output=abs_model_output,
                 quant_config=qdq_config,
             )

--- a/src/winml/modelkit/utils/cli.py
+++ b/src/winml/modelkit/utils/cli.py
@@ -631,9 +631,9 @@ def max_optim_iterations_option(optional_message: str | None = None) -> Callable
     Returns:
         Decorator function.
     """
-    base_help = "Maximum autoconf re-optimization rounds (default: 3). --no-analyze sets this to 0."
+    base_help = "Maximum autoconf re-optimization rounds (default: 3). --no-analyze sets this to 0"
     if optional_message:
-        base_help = f"{base_help} {optional_message}"
+        base_help = f"{base_help}. {optional_message}"
     return click.option(
         "--max-optim-iterations",
         "max_optim_iterations",

--- a/src/winml/modelkit/utils/cli.py
+++ b/src/winml/modelkit/utils/cli.py
@@ -676,6 +676,54 @@ def build_pipeline_extra_kwargs(
     return extra
 
 
+def ignored_build_flags_warning(
+    *,
+    skip_build_onnx: bool,
+    quant: bool = True,
+    optimize: bool = True,
+    analyze: bool = True,
+    max_optim_iterations: int | None = None,
+) -> str | None:
+    """Build a warning for build-pipeline flags that are no-ops on a pre-built ONNX.
+
+    Commands that accept a pre-built ``.onnx`` input (``eval``, ``perf``) forward
+    ``--no-quant``/``--no-optimize``/``--no-analyze``/``--max-optim-iterations`` to
+    ``from_onnx``, but with ``skip_build`` (the default) no build runs, so those
+    toggles silently take no effect. This returns a message naming the flags the
+    user actually set (or ``None`` when nothing was set or a build will run), so
+    callers can surface it through their own logger/console — mirroring the
+    ``--precision``-ignored warning.
+
+    Args:
+        skip_build_onnx: True when the input is a pre-built ONNX *and* the build
+            is skipped (the precondition under which the flags are no-ops).
+        quant/optimize/analyze: Enabled-semantics toggles (False = user passed
+            the ``--no-*`` form).
+        max_optim_iterations: Explicit value, or ``None`` when left at default.
+
+    Returns:
+        Warning message, or ``None`` if no ignored flags apply.
+    """
+    if not skip_build_onnx:
+        return None
+    ignored = [
+        flag
+        for flag, was_set in (
+            ("--no-quant", not quant),
+            ("--no-optimize", not optimize),
+            ("--no-analyze", not analyze),
+            ("--max-optim-iterations", max_optim_iterations is not None),
+        )
+        if was_set
+    ]
+    if not ignored:
+        return None
+    return (
+        f"{', '.join(ignored)} ignored for pre-built ONNX inputs "
+        "(no build runs; pass --no-skip-build to rebuild)."
+    )
+
+
 def allow_unsupported_nodes_option(optional_message: str | None = None) -> Callable[[F], F]:
     """Add shared --allow-unsupported-nodes option to a Click command.
 

--- a/tests/unit/commands/test_eval.py
+++ b/tests/unit/commands/test_eval.py
@@ -717,6 +717,90 @@ class TestPerTaskDefaultDataset:
 
 
 # ---------------------------------------------------------------------------
+# Build-pipeline flags ignored for pre-built ONNX inputs
+# ---------------------------------------------------------------------------
+
+
+class TestPrebuiltOnnxIgnoredBuildFlags:
+    """A pre-built ONNX path with skip_build (the default) makes the build
+    flags (--no-quant/--no-optimize/--no-analyze/--max-optim-iterations)
+    no-ops, so the command warns they were ignored."""
+
+    @staticmethod
+    def _run(runner: CliRunner, args: list[str]):
+        """Invoke eval with ``evaluate`` stubbed so only the CLI front-half
+        (config resolution + warnings) runs. Returns the CliRunner result.
+
+        ``commands.eval`` imports ``evaluate`` lazily via ``from ..eval import
+        evaluate``, so the stub is installed on the ``winml.modelkit.eval``
+        package where that import resolves it."""
+        from winml.modelkit.commands.eval import eval as eval_cmd
+
+        with (
+            patch("winml.modelkit.eval.evaluate", return_value=object()),
+            patch("winml.modelkit.commands.eval._write_and_display", return_value=None),
+        ):
+            return runner.invoke(eval_cmd, args, obj={"debug": False})
+
+    def test_no_quant_warns_for_prebuilt_onnx(
+        self,
+        runner: CliRunner,
+        onnx_file,
+        caplog,
+    ):
+        import logging as _logging
+
+        with caplog.at_level(_logging.WARNING, logger="winml.modelkit.commands.eval"):
+            result = self._run(
+                runner,
+                [
+                    "-m",
+                    str(onnx_file),
+                    "--model-id",
+                    "some/model",
+                    "--task",
+                    "image-classification",
+                    "--no-quant",
+                    "--max-optim-iterations",
+                    "5",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        msgs = [r.getMessage() for r in caplog.records]
+        assert any(
+            "--no-quant" in m and "--max-optim-iterations" in m and "pre-built ONNX" in m
+            for m in msgs
+        ), f"expected ignored-build-flags warning not found in {msgs!r}"
+
+    def test_no_warning_when_flags_left_default(
+        self,
+        runner: CliRunner,
+        onnx_file,
+        caplog,
+    ):
+        """Default build flags emit no ignored-flags warning."""
+        import logging as _logging
+
+        with caplog.at_level(_logging.WARNING, logger="winml.modelkit.commands.eval"):
+            result = self._run(
+                runner,
+                [
+                    "-m",
+                    str(onnx_file),
+                    "--model-id",
+                    "some/model",
+                    "--task",
+                    "image-classification",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        msgs = [r.getMessage() for r in caplog.records]
+        assert not any("ignored for pre-built ONNX inputs (no build runs" in m for m in msgs), (
+            f"unexpected ignored-build-flags warning in {msgs!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
 # --format json
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/commands/test_perf_cli.py
+++ b/tests/unit/commands/test_perf_cli.py
@@ -374,6 +374,72 @@ class TestPerfUnifiedPipeline:
         assert "Benchmarking ONNX" in result.output
         assert captured["config"].shape_config is None
 
+    def test_cli_onnx_warns_ignored_build_flags(self, runner: CliRunner, tmp_path: Path) -> None:
+        """Build-pipeline flags are no-ops for a pre-built ONNX with skip_build,
+        so the CLI surfaces a warning naming the flags the user set."""
+        onnx_file = tmp_path / "model.onnx"
+        onnx_file.write_bytes(b"fake onnx")
+
+        def capture_config(_config: BenchmarkConfig) -> MagicMock:
+            mock = MagicMock()
+            mock.run.return_value = MagicMock()
+            return mock
+
+        with (
+            patch(
+                "winml.modelkit.commands.perf.PerfBenchmark",
+                side_effect=capture_config,
+            ),
+            patch("winml.modelkit.commands.perf.display_console_report"),
+            patch("winml.modelkit.commands.perf.write_json_report"),
+        ):
+            result = runner.invoke(
+                perf,
+                [
+                    "-m",
+                    str(onnx_file),
+                    "--no-quant",
+                    "--no-optimize",
+                    "-o",
+                    str(tmp_path / "out.json"),
+                ],
+                obj={},
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "--no-quant" in result.output
+        assert "--no-optimize" in result.output
+        assert "pre-built ONNX" in result.output
+
+    def test_cli_onnx_no_build_flag_warning_at_defaults(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """No ignored-build-flags warning when the flags are left at defaults."""
+        onnx_file = tmp_path / "model.onnx"
+        onnx_file.write_bytes(b"fake onnx")
+
+        def capture_config(_config: BenchmarkConfig) -> MagicMock:
+            mock = MagicMock()
+            mock.run.return_value = MagicMock()
+            return mock
+
+        with (
+            patch(
+                "winml.modelkit.commands.perf.PerfBenchmark",
+                side_effect=capture_config,
+            ),
+            patch("winml.modelkit.commands.perf.display_console_report"),
+            patch("winml.modelkit.commands.perf.write_json_report"),
+        ):
+            result = runner.invoke(
+                perf,
+                ["-m", str(onnx_file), "-o", str(tmp_path / "out.json")],
+                obj={},
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "ignored for pre-built ONNX inputs (no build runs" not in result.output
+
     def test_cli_onnx_not_found_error(self, runner: CliRunner, tmp_path: Path) -> None:
         """CLI with non-existent .onnx file should raise FileNotFoundError."""
         missing = tmp_path / "missing.onnx"

--- a/tests/unit/test_quantizer.py
+++ b/tests/unit/test_quantizer.py
@@ -39,6 +39,11 @@ class _FakeOrtQuantizationModule(ModuleType):
     QuantType: Any
     get_qdq_config: Any
     quantize: Any
+    quant_utils: ModuleType
+
+
+class _FakeOrtQuantUtilsModule(ModuleType):
+    add_pre_process_metadata: Any
 
 
 class _FakeOnnxModule(ModuleType):
@@ -74,9 +79,13 @@ def _install_fake_ort_quantization(monkeypatch: pytest.MonkeyPatch, *, quantize_
     )
     quant_module.get_qdq_config = lambda **_: SimpleNamespace(use_external_data_format=False)
     quant_module.quantize = quantize_impl
+    quant_utils_module = _FakeOrtQuantUtilsModule("onnxruntime.quantization.quant_utils")
+    quant_utils_module.add_pre_process_metadata = lambda _model: None
+    quant_module.quant_utils = quant_utils_module
     ort_module.quantization = quant_module
     monkeypatch.setitem(sys.modules, "onnxruntime", ort_module)
     monkeypatch.setitem(sys.modules, "onnxruntime.quantization", quant_module)
+    monkeypatch.setitem(sys.modules, "onnxruntime.quantization.quant_utils", quant_utils_module)
 
 
 def test_quantize_onnx_removes_only_exact_external_data_sidecar(
@@ -92,8 +101,12 @@ def test_quantize_onnx_removes_only_exact_external_data_sidecar(
     exact_sidecar.write_text("stale")
     extra_suffix_sidecar.write_text("keep")
 
-    def fake_quantize(*, model_input: str, model_output: str, quant_config) -> None:
-        assert model_input == str(model_path.resolve())
+    # The quantizer hands the in-memory input model (not the path) to ORT so it
+    # can tag it as pre-processed without mutating the user's input file.
+    input_model = SimpleNamespace()
+
+    def fake_quantize(*, model_input, model_output: str, quant_config) -> None:
+        assert model_input is input_model
         assert model_output == str(output_path.resolve())
         assert quant_config.use_external_data_format is True
         assert not exact_sidecar.exists()
@@ -106,7 +119,7 @@ def test_quantize_onnx_removes_only_exact_external_data_sidecar(
     quantized_model = SimpleNamespace(
         graph=SimpleNamespace(node=[SimpleNamespace(op_type="QuantizeLinear")])
     )
-    load_results = [SimpleNamespace(), quantized_model]
+    load_results = [input_model, quantized_model]
     fake_onnx_module.capture_metadata = lambda _model: SimpleNamespace(node_count=0)
     fake_onnx_module.load_onnx = lambda *_args, **_kwargs: load_results.pop(0)
     fake_onnx_module.restore_metadata = lambda *_args, **_kwargs: None

--- a/tests/unit/utils/test_cli.py
+++ b/tests/unit/utils/test_cli.py
@@ -212,9 +212,9 @@ class TestMaxOptimIterationsOption:
     """Tests for the shared max_optim_iterations_option() decorator."""
 
     @staticmethod
-    def _make_cmd() -> click.Command:
+    def _make_cmd(optional_message: str | None = None) -> click.Command:
         @click.command()
-        @max_optim_iterations_option()
+        @max_optim_iterations_option(optional_message=optional_message)
         def cmd(max_optim_iterations: int | None) -> None:
             click.echo(repr(max_optim_iterations))
 
@@ -229,6 +229,13 @@ class TestMaxOptimIterationsOption:
 
     def test_rejects_non_int(self) -> None:
         assert CliRunner().invoke(self._make_cmd(), ["--max-optim-iterations", "x"]).exit_code != 0
+
+    def test_optional_message_appended_with_period_separator(self) -> None:
+        """optional_message joins the base help with '. ', matching sibling helpers."""
+        result = CliRunner().invoke(self._make_cmd(optional_message="Extra note."), ["--help"])
+        # Click reflows --help text, so assert on the joined token rather than line layout.
+        joined = " ".join(result.output.split())
+        assert "to 0. Extra note." in joined
 
 
 class TestBuildPipelineExtraKwargs:

--- a/tests/unit/utils/test_cli.py
+++ b/tests/unit/utils/test_cli.py
@@ -13,6 +13,7 @@ from click.testing import CliRunner
 from winml.modelkit.utils.cli import (
     analyze_option,
     build_pipeline_extra_kwargs,
+    ignored_build_flags_warning,
     max_optim_iterations_option,
     optimize_option,
     parse_ep_options,
@@ -263,3 +264,53 @@ class TestBuildPipelineExtraKwargs:
     def test_combined_optimize_and_analyze(self) -> None:
         result = build_pipeline_extra_kwargs(optimize=False, analyze=False)
         assert result == {"skip_optimize": True, "hack_max_optim_iterations": 0}
+
+
+class TestIgnoredBuildFlagsWarning:
+    """Tests for the shared ignored_build_flags_warning() helper."""
+
+    def test_returns_none_when_build_runs(self) -> None:
+        """No warning when a build will run, even with flags set."""
+        assert (
+            ignored_build_flags_warning(
+                skip_build_onnx=False,
+                quant=False,
+                optimize=False,
+                analyze=False,
+                max_optim_iterations=5,
+            )
+            is None
+        )
+
+    def test_returns_none_when_no_flags_set(self) -> None:
+        """No warning when all flags are at their defaults."""
+        assert ignored_build_flags_warning(skip_build_onnx=True) is None
+
+    def test_names_each_set_flag(self) -> None:
+        msg = ignored_build_flags_warning(
+            skip_build_onnx=True,
+            quant=False,
+            optimize=False,
+            analyze=False,
+            max_optim_iterations=5,
+        )
+        assert msg is not None
+        for flag in ("--no-quant", "--no-optimize", "--no-analyze", "--max-optim-iterations"):
+            assert flag in msg
+        assert "pre-built ONNX" in msg
+        assert "--no-skip-build" in msg
+
+    def test_only_includes_set_flags(self) -> None:
+        """Unset flags are not named."""
+        msg = ignored_build_flags_warning(skip_build_onnx=True, quant=False)
+        assert msg is not None
+        assert "--no-quant" in msg
+        assert "--no-optimize" not in msg
+        assert "--no-analyze" not in msg
+        assert "--max-optim-iterations" not in msg
+
+    def test_max_optim_zero_counts_as_set(self) -> None:
+        """An explicit 0 is a user-set value (only None is the default)."""
+        msg = ignored_build_flags_warning(skip_build_onnx=True, max_optim_iterations=0)
+        assert msg is not None
+        assert "--max-optim-iterations" in msg


### PR DESCRIPTION
## Summary

Two related cleanups in the quantize/eval CLI surface.

### 1. Suppress duplicate ORT pre-processing warnings (fixes #557)

`winml quantize` emitted two near-duplicate ORT warnings per run:

```
WARNING: Please consider to run pre-processing before quantization. Refer to example: …
WARNING: Please consider pre-processing before quantization. See …
```

Both originate in ORT's `quantize_static`, gated on `model_has_pre_process_metadata()` of the model it reloads from the input path. Previously the pre-process metadata was injected in `optimize_onnx`, which only suppressed the warnings for models that went through optimize first — a standalone `winml quantize` on a raw model still warned twice.

Moved the tagging into the quantizer: load the input model, tag it via ORT's own `add_pre_process_metadata()`, and hand the in-memory `ModelProto` to `quantize()`. Passing the in-memory model (rather than the path) is required because ORT checks the flag on the copy it reloads from `model_input`, and it avoids mutating the user's pristine input file. ORT externalizes weights into its own temp dir, so external-data handling is unaffected.

### 2. Address deferred review comments from #923

- `max_optim_iterations_option`: use `. ` before `optional_message` to match the `optimize`/`analyze` sibling helpers (drop the redundant trailing period from the base help so the joined output stays clean).
- `eval`: warn when build-pipeline flags (`--no-quant`/`--no-optimize`/`--no-analyze`/`--max-optim-iterations`) are passed with a pre-built ONNX path and `skip_build`, where they're silently forwarded to `from_onnx` as no-ops — mirrors the existing `--precision`-ignored warning.

## Verification

- `tests/unit/test_quantizer.py` — passes
- `tests/integration/test_quantization.py` (3 tests, real ORT) — pass
- `tests/unit/commands/test_eval.py` + `tests/unit/utils/test_cli.py` (79 tests) — pass

Fixes #557