### PR TITLE
Fix analyze e2e for invalid device

### DIFF
--- a/tests/e2e/test_analyze_e2e.py
+++ b/tests/e2e/test_analyze_e2e.py
@@ -201,7 +201,7 @@ class TestAnalyzeCliSurface:
     def test_invalid_device_choice_exits_two(self, onnx_model_path: Path) -> None:
         result = _invoke(["-m", str(onnx_model_path), "--device", "TPU"])
         assert result.exit_code == 2
-        assert "Invalid value for '--device'" in result.output
+        assert "Invalid value for '-d' / '--device'" in result.output
 
     def test_invalid_save_node_choice_exits_two(self, onnx_model_path: Path) -> None:
         result = _invoke(["-m", str(onnx_model_path), "--save-node", "supported"])


### PR DESCRIPTION
Updated todo list

## Fix outdated assertion in invalid device choice e2e test

### Summary
`test_invalid_device_choice_exits_two` was asserting the substring `"Invalid value for '--device'"`, but the `--device` flag exposes a short alias `-d` (via the shared `device_option`), so Click renders the error as `Invalid value for '-d' / '--device'`. The assertion no longer matched, causing the test to fail.

### Change
- Updated the assertion to the exact Click message: `"Invalid value for '-d' / '--device'"`.

### Notes
- Unrelated to `ep_options` / `device_options` behavior — purely a test assertion drift.
- The `-d` / `--device` pairing comes from the standard `device_option` decorator and is stable, so matching the exact string is safe.

### Verification
```
uv run pytest tests/e2e/test_analyze_e2e.py -k invalid_device -m e2e
1 passed, 49 deselected
```