### PR TITLE
fix(build): honor loader.model_class on pretrained load path

### DIFF
--- a/src/winml/modelkit/build/hf.py
+++ b/src/winml/modelkit/build/hf.py
@@ -527,6 +527,7 @@ def _load_model(
         pytorch_model, _, _ = load_hf_model(
             model_name_or_path=model_id,
             task=task,
+            model_class=config.loader.model_class,
             trust_remote_code=effective_trust,
             hf_config=hf_config,
             model_type=model_type,

--- a/tests/unit/build/test_hf.py
+++ b/tests/unit/build/test_hf.py
@@ -322,6 +322,23 @@ class TestBuildHfModel:
         call_args = mock_pipeline["load"].call_args
         assert call_args[0][1] == "bert-base"  # model_id
 
+    def test_pretrained_load_threads_model_class(self, sample_config) -> None:
+        """Pretrained load path forwards ``loader.model_class`` to load_hf_model.
+
+        Regression (#836): the pretrained branch dropped the explicit
+        ``model_class``, so e.g. CLIP feature-extraction resolved to the full
+        CLIPModel (which requires ``pixel_values``) instead of the configured
+        CLIPTextModelWithProjection, failing export with text-only inputs.
+        """
+        from winml.modelkit.build.hf import _load_model
+
+        with patch("winml.modelkit.loader.load_hf_model") as m_load:
+            m_load.return_value = (MagicMock(), MagicMock(), "image-classification")
+            _load_model(sample_config, "test-model", trust_remote_code=False)
+
+        m_load.assert_called_once()
+        assert m_load.call_args.kwargs["model_class"] == "AutoModelForImageClassification"
+
     def test_pre_loaded_model_skips_load(
         self, tmp_path: Path, sample_config, mock_pipeline
     ) -> None:


### PR DESCRIPTION
## Problem

`winml build -c <build_config.json> -m openai/clip-vit-base-patch32 --device cpu` fails with:

```
Error: You have to specify pixel_values
```

even though the build config explicitly requests the text-only CLIP variant:

```json
"loader": {
  "task": "feature-extraction",
  "model_class": "CLIPTextModelWithProjection",
  "model_type": "clip_text_model"
}
```

## Root cause

Bisected to **#836** (`3946a01`, "Enable static quantization for Qwen3-0.6B decoder").

The pretrained branch of `_load_model` (`build/hf.py`) called `load_hf_model` **without** forwarding `config.loader.model_class`, so class resolution depended entirely on the `(model_type, task)` lookup in `MODEL_CLASS_MAPPING`.

#836 began threading `config.loader.model_type` into `load_hf_model` as a build-variant override. For CLIP this regresses resolution:

- The build config stores the **variant tag** `model_type = "clip_text_model"`.
- `MODEL_CLASS_MAPPING` is keyed on the **native** type: `("clip", "feature-extraction") -> CLIPTextModelWithProjection`.
- The override `"clip_text_model"` is not a key, so resolution falls through to `TasksManager` → `AutoModel` → the full `CLIPModel`, which requires `pixel_values`. Export with text-only inputs then fails.

The override scheme works for `qwen3_transformer_only` because that variant tag *is* a registered key; CLIP's is not, and the explicit `model_class` that would have saved it was dropped on the pretrained path (the random-init path already honors it).

## Fix

Forward `config.loader.model_class` to `load_hf_model` on the pretrained path. `resolve_task` then takes its Stage-0 user-class path, resolving `CLIPTextModelWithProjection` directly and ignoring the `model_type` override. Safe for the qwen3 transformer-only variant since Stage 0 only activates when `model_class` is set.

## Verification

- Repro command now completes (exit 0), loading `CLIPTextModelWithProjection` and exporting text-only inputs through optimize + fp16.
- Added regression test `test_pretrained_load_threads_model_class`.
- `tests/unit/build/`, `tests/unit/loader/test_load_hf_model.py`, `tests/unit/commands/test_build.py` all pass (192 + new test).