### PR TITLE
fix(perf): generalize op-tracing availability check and align trace output path

### DIFF
--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -387,6 +387,16 @@ class PerfBenchmark:
         self._resolved_ep = resolved_ep
 
     @property
+    def resolved_device(self) -> str | None:
+        """Concrete device driving the build/inference (``None`` until resolved)."""
+        return self._resolved_device
+
+    @property
+    def resolved_ep(self) -> EPNameOrAlias | None:
+        """Concrete EP driving the build/inference (``None`` until resolved)."""
+        return self._resolved_ep
+
+    @property
     def _is_composite(self) -> bool:
         """Composite models orchestrate multiple sub-sessions (e.g. CLIP/SigLIP).
 
@@ -1810,11 +1820,17 @@ def perf(
         # Op-tracing (additive to existing benchmark)
         # =================================================================
         if op_tracing:
-            from ..optracing import is_qnn_profiling_available
+            from ..optracing import is_profiling_available
 
-            if not is_qnn_profiling_available():
-                console.print("[red]Error:[/red] Op-tracing requires onnxruntime-qnn")
-                console.print("Install with: [bold]pip install onnxruntime-qnn[/bold]")
+            if not is_profiling_available(
+                benchmark.resolved_ep, benchmark.resolved_device, op_tracing
+            ):
+                console.print(
+                    "[red]Error:[/red] Op-tracing is only supported for the QNN EP "
+                    "on NPU at the 'basic' level "
+                    f"(resolved EP={benchmark.resolved_ep}, "
+                    f"device={benchmark.resolved_device}, level={op_tracing})."
+                )
                 raise SystemExit(1)
 
             from ..optracing import (

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -1876,10 +1876,9 @@ def perf(
             # Display and save
             display_op_trace_report(trace_result, console)
 
-            model_slug = hf_model.replace("/", "_").replace("\\", "_")
-            if is_onnx:
-                model_slug = model_path.stem
-            trace_output = output_dir / f"{model_slug}_op_trace.json"
+            # Mirror the benchmark report path so the two files sit side by side:
+            # a/b.json -> a/b_op_trace.json.
+            trace_output = output.with_name(f"{output.stem}_op_trace{output.suffix}")
             write_op_trace_json(trace_result, trace_output)
             console.print(f"[green]Op-trace saved to:[/green] {trace_output}")
 

--- a/src/winml/modelkit/optracing/__init__.py
+++ b/src/winml/modelkit/optracing/__init__.py
@@ -6,20 +6,49 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from .base import OpTracer
 from .registry import get_tracer, register_tracer
 from .report import display_op_trace_report, write_op_trace_json
 from .result import OperatorMetrics, OpTraceResult
 
 
-def is_qnn_profiling_available() -> bool:
-    """Check if QNN EP is available for op-tracing."""
-    try:
-        import onnxruntime as ort
+if TYPE_CHECKING:
+    from ..utils.constants import EPNameOrAlias
 
-        return "QNNExecutionProvider" in ort.get_available_providers()
-    except (ImportError, AttributeError):
-        return False
+# The single EP / device / tracing-level combination op-tracing currently
+# supports. Expanded as more tracers land.
+_SUPPORTED_EP = "QNNExecutionProvider"
+_SUPPORTED_DEVICE = "npu"
+_SUPPORTED_LEVEL = "basic"
+
+
+def is_profiling_available(
+    resolved_ep: EPNameOrAlias | None,
+    resolved_device: str | None,
+    op_tracing: str | None,
+) -> bool:
+    """Check whether op-tracing is supported for a resolved EP/device/level.
+
+    Op-tracing is currently limited to the QNN EP on NPU at the ``"basic"``
+    level; every other combination is unsupported.
+
+    Args:
+        resolved_ep: Concrete EP the benchmark resolved to (full name or alias).
+        resolved_device: Concrete device the benchmark resolved to (e.g. ``"npu"``).
+        op_tracing: Requested tracing level (e.g. ``"basic"``), or ``None``.
+
+    Returns:
+        ``True`` only for the QNN + NPU + ``"basic"`` combination.
+    """
+    from ..utils.constants import normalize_ep_name
+
+    return (
+        normalize_ep_name(resolved_ep) == _SUPPORTED_EP
+        and (resolved_device or "").lower() == _SUPPORTED_DEVICE
+        and (op_tracing or "").lower() == _SUPPORTED_LEVEL
+    )
 
 
 __all__ = [
@@ -28,7 +57,7 @@ __all__ = [
     "OperatorMetrics",
     "display_op_trace_report",
     "get_tracer",
-    "is_qnn_profiling_available",
+    "is_profiling_available",
     "register_tracer",
     "write_op_trace_json",
 ]

--- a/src/winml/modelkit/optracing/qnn/profiler.py
+++ b/src/winml/modelkit/optracing/qnn/profiler.py
@@ -13,6 +13,7 @@ Orchestrates the end-to-end profiling workflow:
    (detail) post-processing.
 5. Return a structured ``OpTraceResult``.
 """
+
 from __future__ import annotations
 
 import contextlib
@@ -23,6 +24,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from ...winml import add_ep_for_device
 from ..base import OpTracer
 from ..result import OperatorMetrics, OpTraceResult
 from .csv_parser import parse_qnn_profiling_csv
@@ -125,14 +127,16 @@ class QNNProfiler(OpTracer):
         csv_path = self.output_dir / "profiling_output.csv"
         options = self._build_session_options(ort)
         provider_options = self._build_provider_options(csv_path)
+        if not add_ep_for_device(
+            options, "QNNExecutionProvider", ort.OrtHardwareDeviceType.NPU, provider_options
+        ):
+            raise RuntimeError("Failed to add QNNExecutionProvider for NPU device.")
 
         # CWD must be output_dir so schematic.bin lands there.
         with _working_directory(self.output_dir):
             session = ort.InferenceSession(
                 str(self.onnx_path),
                 sess_options=options,
-                providers=["QNNExecutionProvider"],
-                provider_options=provider_options,
             )
 
             inputs = self._generate_inputs(session)
@@ -158,16 +162,12 @@ class QNNProfiler(OpTracer):
     def _build_session_options(self, ort_module: Any) -> Any:
         """Create ``ort.SessionOptions`` with profiling config entries."""
         options = ort_module.SessionOptions()
-        options.add_session_config_entry(
-            "session.disable_cpu_ep_fallback", "1"
-        )
+        options.add_session_config_entry("session.disable_cpu_ep_fallback", "1")
         options.add_session_config_entry("ep.context_enable", "1")
         options.add_session_config_entry("ep.context_embed_mode", "0")
         return options
 
-    def _build_provider_options(
-        self, csv_path: Path
-    ) -> list[dict[str, str]]:
+    def _build_provider_options(self, csv_path: Path) -> dict[str, str]:
         """Build QNN EP provider options dict.
 
         - ``basic`` mode uses ``profiling_level=detailed`` (per-op cycles).
@@ -175,16 +175,13 @@ class QNNProfiler(OpTracer):
         """
         profiling_level = "optrace" if self.level == "detail" else "detailed"
 
-        return [
-            {
-                "backend_path": "QnnHtp.dll",
-                "htp_performance_mode": "high_performance",
-                "htp_graph_finalization_optimization_mode": "3",
-                "enable_htp_fp16_precision": "1",
-                "profiling_level": profiling_level,
-                "profiling_file_path": str(csv_path),
-            }
-        ]
+        return {
+            "htp_performance_mode": "high_performance",
+            "htp_graph_finalization_optimization_mode": "3",
+            "enable_htp_fp16_precision": "1",
+            "profiling_level": profiling_level,
+            "profiling_file_path": str(csv_path),
+        }
 
     # ------------------------------------------------------------------
     # Input generation
@@ -204,9 +201,7 @@ class QNNProfiler(OpTracer):
     # Result collection
     # ------------------------------------------------------------------
 
-    def _collect_results(
-        self, csv_path: Path, iterations: int
-    ) -> OpTraceResult:
+    def _collect_results(self, csv_path: Path, iterations: int) -> OpTraceResult:
         """Parse profiling artifacts into an ``OpTraceResult``."""
         artifacts: dict[str, str] = {}
         qnn_log = Path(str(csv_path) + "_qnn.log")
@@ -260,15 +255,11 @@ class QNNProfiler(OpTracer):
         import json as _json
 
         if schematic is None or not schematic.is_file():
-            logger.info(
-                "No schematic found; falling back to CSV for detail mode"
-            )
+            logger.info("No schematic found; falling back to CSV for detail mode")
             return None
 
         qhas_output = self.output_dir / "qhas_output.json"
-        result_path = run_qhas_viewer(
-            qnn_log, schematic, qhas_output, sdk_root=find_qnn_sdk()
-        )
+        result_path = run_qhas_viewer(qnn_log, schematic, qhas_output, sdk_root=find_qnn_sdk())
 
         if result_path is None or not result_path.is_file():
             logger.info("QHAS viewer did not produce output; falling back")
@@ -329,9 +320,7 @@ class QNNProfiler(OpTracer):
                 op_path=op["name"],
                 op_id=op["op_id"],
                 duration_us=op["cycles"] * cycle_to_us,
-                percent_of_total=(
-                    op["cycles"] / total_cycles * 100 if total_cycles > 0 else 0
-                ),
+                percent_of_total=(op["cycles"] / total_cycles * 100 if total_cycles > 0 else 0),
             )
             for op in parsed["operators"]
         ]

--- a/tests/unit/optracing/test_detection.py
+++ b/tests/unit/optracing/test_detection.py
@@ -2,11 +2,45 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-"""Test QNN EP detection for op-tracing."""
+"""Test op-tracing support detection for the resolved EP/device/level."""
 
-from winml.modelkit.optracing import is_qnn_profiling_available
+import pytest
+
+from winml.modelkit.optracing import is_profiling_available
 
 
-def test_is_qnn_profiling_available_returns_bool():
-    result = is_qnn_profiling_available()
+def test_is_profiling_available_returns_bool():
+    result = is_profiling_available("QNNExecutionProvider", "npu", "basic")
     assert isinstance(result, bool)
+
+
+def test_supported_combination():
+    assert is_profiling_available("QNNExecutionProvider", "npu", "basic") is True
+
+
+def test_qnn_alias_is_normalized():
+    # The benchmark may carry the user's EP alias verbatim; it must still match.
+    assert is_profiling_available("qnn", "npu", "basic") is True
+
+
+def test_device_is_case_insensitive():
+    assert is_profiling_available("QNNExecutionProvider", "NPU", "basic") is True
+
+
+def test_level_is_case_insensitive():
+    assert is_profiling_available("QNNExecutionProvider", "npu", "BASIC") is True
+
+
+@pytest.mark.parametrize(
+    ("ep", "device", "level"),
+    [
+        ("CPUExecutionProvider", "npu", "basic"),  # wrong EP
+        ("QNNExecutionProvider", "gpu", "basic"),  # wrong device
+        ("QNNExecutionProvider", "npu", "detail"),  # unsupported level
+        (None, "npu", "basic"),  # no EP
+        ("QNNExecutionProvider", None, "basic"),  # no device
+        ("QNNExecutionProvider", "npu", None),  # no level
+    ],
+)
+def test_unsupported_combinations(ep, device, level):
+    assert is_profiling_available(ep, device, level) is False

--- a/tests/unit/optracing/test_qnn_profiler.py
+++ b/tests/unit/optracing/test_qnn_profiler.py
@@ -52,13 +52,14 @@ def test_qnn_profiler_creates_session_options():
 
 
 def test_qnn_profiler_provider_options_basic():
-    """Verify provider options for basic mode (profiling_level=detailed)."""
-    profiler = QNNProfiler(Path("model.onnx"), output_dir=Path("out"), level="basic")
-    opts = profiler._build_provider_options(Path("out/profiling.csv"))
+    """Verify provider options for basic mode (profiling_level=detailed).
 
-    assert len(opts) == 1
-    po = opts[0]
-    assert po["backend_path"] == "QnnHtp.dll"
+    The QNN backend/device is now selected by ``add_ep_for_device``, so the
+    options dict no longer carries ``backend_path``.
+    """
+    profiler = QNNProfiler(Path("model.onnx"), output_dir=Path("out"), level="basic")
+    po = profiler._build_provider_options(Path("out/profiling.csv"))
+
     assert po["htp_performance_mode"] == "high_performance"
     assert po["htp_graph_finalization_optimization_mode"] == "3"
     assert po["enable_htp_fp16_precision"] == "1"
@@ -69,11 +70,9 @@ def test_qnn_profiler_provider_options_basic():
 def test_qnn_profiler_provider_options_detail():
     """Verify provider options for detail mode (profiling_level=optrace)."""
     profiler = QNNProfiler(Path("model.onnx"), output_dir=Path("out"), level="detail")
-    opts = profiler._build_provider_options(Path("out/profiling.csv"))
+    po = profiler._build_provider_options(Path("out/profiling.csv"))
 
-    po = opts[0]
     assert po["profiling_level"] == "optrace"
-    assert po["backend_path"] == "QnnHtp.dll"
 
 
 # =====================================================================
@@ -182,7 +181,7 @@ def test_qnn_profiler_run_basic(tmp_path):
         # Verify session creation was called correctly via builder methods.
         profiler._build_session_options(mock_ort)
         po = profiler._build_provider_options(output_dir / "profiling_output.csv")
-        assert po[0]["profiling_level"] == "detailed"
+        assert po["profiling_level"] == "detailed"
 
         # Now test the CSV parsing path directly.
         result = profiler._from_csv(


### PR DESCRIPTION
## Summary

Tightens and generalizes the `--op-tracing` path in `winml perf`, plus a QNN profiler session fix.

- **Rename `is_qnn_profiling_available()` → `is_profiling_available(resolved_ep, resolved_device, op_tracing)`.** Instead of only probing ORT for the QNN provider, it now validates the benchmark's *resolved* EP/device/level against the single combination op-tracing currently supports — **QNN EP + NPU + `basic`**. EP aliases (e.g. `qnn`) are normalized, and device/level comparisons are case-insensitive. Supported values live in module constants so they are easy to expand as more tracers land.
- **Expose `resolved_ep` / `resolved_device` properties** on `PerfBenchmark` so the CLI can gate op-tracing on what actually drove the build/inference, with an error message that reports the resolved values.
- **Align the op-trace output path with the benchmark report.** The trace JSON now mirrors `output`: `a/b.json` → `a/b_op_trace.json`, instead of being rebuilt from the model name.
- **QNN profiler session fix.** Build the QNN session via `add_ep_for_device(...)` for the NPU device (failing fast if it cannot be added) rather than passing `providers=[...]` directly, and switch provider options to a single dict.

## Tests

- Rewrote `tests/unit/optracing/test_detection.py` for the new signature: supported combo, alias normalization, case-insensitivity, and a parametrized table of unsupported combinations.
- `uv run pytest tests/unit/optracing/test_detection.py` — 11 passed.
