### PR TITLE
feat(perf): cache per-module builds and honor --rebuild/--ignore-cache

### DIFF
--- a/src/winml/modelkit/cache/path.py
+++ b/src/winml/modelkit/cache/path.py
@@ -12,8 +12,19 @@ Dependencies: stdlib only (os, pathlib). ZERO internal imports.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import os
 from pathlib import Path
+from typing import Any
+
+
+# Build-control kwargs that change the produced artifact but are NOT part of
+# WinMLBuildConfig (they are forwarded to build_hf_model / build_onnx_model as
+# kwargs). Folding them into the cache key prevents --no-optimize / --no-analyze
+# / --max-optim-iterations from silently reusing an artifact built with
+# different settings. Keep in sync with utils.cli.build_pipeline_extra_kwargs.
+_CACHE_KEY_BUILD_CONTROLS = ("skip_optimize", "hack_max_optim_iterations")
 
 
 __all__ = [
@@ -63,7 +74,11 @@ def get_artifacts_dir(cache_dir: Path | None = None) -> Path:
     return cache_dir / "artifacts"
 
 
-def get_cache_key(task_abbrev: str, config_hash: str) -> str:
+def get_cache_key(
+    task_abbrev: str,
+    config_hash: str,
+    build_controls: dict[str, Any] | None = None,
+) -> str:
     """Assemble the cache key prefix from task abbreviation and config hash.
 
     Args:
@@ -71,11 +86,26 @@ def get_cache_key(task_abbrev: str, config_hash: str) -> str:
             Obtained from ``modelkit.loader.task.get_task_abbrev()``.
         config_hash: Deterministic config hash (e.g., ``"a1b2c3d4e5f67890"``).
             Obtained from ``WinMLBuildConfig.generate_cache_key()``.
+        build_controls: Optional mapping of build-pipeline kwargs (as produced
+            by ``utils.cli.build_pipeline_extra_kwargs``). Recognized
+            artifact-affecting keys (``skip_optimize``,
+            ``hack_max_optim_iterations``) are folded into the key so that
+            ``--no-optimize`` / ``--no-analyze`` / ``--max-optim-iterations``
+            do not silently reuse an artifact built with different settings.
+            Unrecognized keys are ignored, and a default (empty) mapping leaves
+            the key unchanged for backward compatibility.
 
     Returns:
-        Cache key string: ``"{task_abbrev}_{config_hash}"``
+        Cache key string: ``"{task_abbrev}_{config_hash}"``, optionally suffixed
+        with ``"_{controls_hash}"`` when non-default build controls are present.
     """
-    return f"{task_abbrev}_{config_hash}"
+    key = f"{task_abbrev}_{config_hash}"
+    if build_controls:
+        overrides = {k: build_controls[k] for k in _CACHE_KEY_BUILD_CONTROLS if k in build_controls}
+        if overrides:
+            blob = json.dumps(overrides, sort_keys=True)
+            key = f"{key}_{hashlib.sha256(blob.encode()).hexdigest()[:8]}"
+    return key
 
 
 def get_artifact_path(

--- a/src/winml/modelkit/commands/build.py
+++ b/src/winml/modelkit/commands/build.py
@@ -780,6 +780,7 @@ def build(
                 cache_key = get_cache_key(
                     get_task_abbrev(task),
                     config.generate_cache_key(),
+                    extra_kwargs,
                 )
             else:
                 # Guarded earlier (line ~381: `if not output_dir and not use_cache`).

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -831,6 +831,8 @@ def _perf_modules(
     ep_options: dict[str, str] | None = None,
     precision: str = "auto",
     allow_unsupported_nodes: bool = False,
+    rebuild: bool = False,
+    ignore_cache: bool = False,
 ) -> None:
     """Run per-module build and benchmark for matching submodules.
 
@@ -863,13 +865,21 @@ def _perf_modules(
         precision: Precision mode passed through to the build stage.
         allow_unsupported_nodes: If True, warn instead of failing the build when
             the analyzer reports unsupported nodes that persist.
+        rebuild: If True, overwrite cached per-module artifacts and re-run the
+            build (mirrors the single-model ``--rebuild``).
+        ignore_cache: If True, build each module in a throwaway temp dir and
+            always rebuild, discarding artifacts afterward (mirrors the
+            single-model ``--ignore-cache``).
     """
+    import contextlib
     import difflib
     import json as json_mod
     import tempfile
 
     from ..build import build_hf_model
+    from ..cache import get_cache_dir, get_cache_key, get_model_dir
     from ..config import SubmoduleClassNotFoundError, generate_hf_build_config
+    from ..loader.task import get_task_abbrev
     from ..sysinfo import resolve_device, resolve_eps
     from .build import _instantiate_parent_model
 
@@ -932,6 +942,18 @@ def _perf_modules(
     parent_loader_cfg, _, _, _resolution = resolve_loader_config(model_id=hf_model, task=task)
     parent_model = _instantiate_parent_model(model_type, task=parent_loader_cfg.task)
 
+    # Cache control mirrors auto.py / the single-model path:
+    #   --ignore-cache -> build each module in a throwaway temp dir, always
+    #                     rebuild, discard afterward
+    #   --rebuild      -> reuse the persistent model dir but overwrite artifacts
+    # Each module's cache_key folds in loader.module_path (and its I/O shapes),
+    # so sibling instances of the same class get distinct keys and coexist in
+    # the shared model dir without colliding.
+    use_cache = not ignore_cache
+    force_rebuild = rebuild or ignore_cache
+    task_abbrev = get_task_abbrev(parent_loader_cfg.task) if parent_loader_cfg.task else "module"
+    cache_model_dir = get_model_dir(hf_model, cache_dir=get_cache_dir()) if use_cache else None
+
     all_results: list[dict[str, Any]] = []
     for i, cfg in enumerate(module_configs):
         module_path = cfg.loader.module_path
@@ -960,12 +982,26 @@ def _perf_modules(
         if no_compile:
             cfg.compile = None
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        # Compute the cache key AFTER the quant/compile mutations above so it
+        # reflects what is actually built.
+        cache_key = get_cache_key(task_abbrev, cfg.generate_cache_key())
+
+        # Persistent model dir (reused across runs) when caching, else a
+        # throwaway temp dir that is removed when the with-block exits.
+        build_dir_ctx: Any = (
+            contextlib.nullcontext(cache_model_dir)
+            if use_cache
+            else tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        )
+        with build_dir_ctx as build_dir_raw:
+            build_dir = Path(build_dir_raw)
             try:
                 build_result = build_hf_model(
                     config=cfg,
-                    output_dir=Path(tmpdir),
+                    output_dir=build_dir,
                     pytorch_model=submodule,
+                    rebuild=force_rebuild,
+                    cache_key=cache_key,
                     ep=ep,
                     device=resolved_device,
                     allow_unsupported_nodes=allow_unsupported_nodes,
@@ -1681,6 +1717,8 @@ def perf(
             ep_options=ep_provider_options,
             precision=precision.lower(),
             allow_unsupported_nodes=allow_unsupported_nodes,
+            rebuild=rebuild,
+            ignore_cache=ignore_cache,
         )
         return
 

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -954,6 +954,15 @@ def _perf_modules(
     task_abbrev = get_task_abbrev(parent_loader_cfg.task) if parent_loader_cfg.task else "module"
     cache_model_dir = get_model_dir(hf_model, cache_dir=get_cache_dir()) if use_cache else None
 
+    # Optimize/analyze toggles aren't part of ``cfg``; fold them into the cache
+    # key so e.g. a later ``--no-optimize`` run doesn't silently reuse a cached
+    # optimized artifact (mirrors the single-model path in auto.py).
+    build_control_kwargs = cli_utils.build_pipeline_extra_kwargs(
+        optimize=not no_optimize,
+        analyze=not no_analyze,
+        max_optim_iterations=max_optim_iterations,
+    )
+
     all_results: list[dict[str, Any]] = []
     for i, cfg in enumerate(module_configs):
         module_path = cfg.loader.module_path
@@ -983,8 +992,9 @@ def _perf_modules(
             cfg.compile = None
 
         # Compute the cache key AFTER the quant/compile mutations above so it
-        # reflects what is actually built.
-        cache_key = get_cache_key(task_abbrev, cfg.generate_cache_key())
+        # reflects what is actually built. Build controls (optimize/analyze
+        # toggles) are folded in too since they aren't part of ``cfg``.
+        cache_key = get_cache_key(task_abbrev, cfg.generate_cache_key(), build_control_kwargs)
 
         # Persistent model dir (reused across runs) when caching, else a
         # throwaway temp dir that is removed when the with-block exits.
@@ -1005,11 +1015,7 @@ def _perf_modules(
                     ep=ep,
                     device=resolved_device,
                     allow_unsupported_nodes=allow_unsupported_nodes,
-                    **cli_utils.build_pipeline_extra_kwargs(
-                        optimize=not no_optimize,
-                        analyze=not no_analyze,
-                        max_optim_iterations=max_optim_iterations,
-                    ),
+                    **build_control_kwargs,
                 )
 
                 # Benchmark using WinMLSession

--- a/src/winml/modelkit/models/auto.py
+++ b/src/winml/modelkit/models/auto.py
@@ -213,7 +213,7 @@ class WinMLAutoModel:
 
         # Resolve output directory and cache key
         task_abbrev = get_task_abbrev(resolved_task) if resolved_task else "onnx"
-        cache_key = get_cache_key(task_abbrev, config.generate_cache_key())
+        cache_key = get_cache_key(task_abbrev, config.generate_cache_key(), kwargs)
         if use_cache:
             cache_dir_path = get_cache_dir(override=cache_dir)
             output_dir = get_model_dir(
@@ -438,7 +438,7 @@ class WinMLAutoModel:
             force_rebuild = True
             logger.info("Cache disabled -- using temp directory: %s", cache_dir_path)
 
-        cache_key = get_cache_key(get_task_abbrev(task), config.generate_cache_key())
+        cache_key = get_cache_key(get_task_abbrev(task), config.generate_cache_key(), kwargs)
         output_dir = get_model_dir(model_id, cache_dir=cache_dir_path)
 
         # =====================================================================

--- a/tests/unit/cache/test_path.py
+++ b/tests/unit/cache/test_path.py
@@ -88,6 +88,31 @@ class TestGetCacheKey:
         result = get_cache_key("txtcls", "deadbeef12345678")
         assert result == "txtcls_deadbeef12345678"
 
+    def test_empty_build_controls_unchanged(self) -> None:
+        # Default builds (no non-default toggles) keep the legacy key so
+        # existing caches remain valid.
+        base = get_cache_key("imgcls", "a1b2c3d4e5f67890")
+        assert get_cache_key("imgcls", "a1b2c3d4e5f67890", {}) == base
+        assert get_cache_key("imgcls", "a1b2c3d4e5f67890", None) == base
+
+    def test_unrecognized_build_controls_ignored(self) -> None:
+        base = get_cache_key("imgcls", "a1b2c3d4e5f67890")
+        assert get_cache_key("imgcls", "a1b2c3d4e5f67890", {"ep": "cpu"}) == base
+
+    def test_build_controls_change_key(self) -> None:
+        base = get_cache_key("imgcls", "a1b2c3d4e5f67890")
+        skip_opt = get_cache_key("imgcls", "a1b2c3d4e5f67890", {"skip_optimize": True})
+        no_analyze = get_cache_key("imgcls", "a1b2c3d4e5f67890", {"hack_max_optim_iterations": 0})
+        assert skip_opt != base
+        assert skip_opt.startswith(f"{base}_")
+        assert no_analyze != base
+        assert skip_opt != no_analyze
+
+    def test_build_controls_deterministic(self) -> None:
+        a = get_cache_key("imgcls", "a1b2c3d4e5f67890", {"skip_optimize": True})
+        b = get_cache_key("imgcls", "a1b2c3d4e5f67890", {"skip_optimize": True})
+        assert a == b
+
 
 # =============================================================================
 # get_artifact_path

--- a/tests/unit/commands/test_perf_module.py
+++ b/tests/unit/commands/test_perf_module.py
@@ -543,3 +543,113 @@ class TestPerfModuleQuantCompileToggles:
         cfg = self._run(tmp_path, ["--no-quantize", "--compile"])
         assert cfg.quant is None
         assert cfg.compile is not None
+
+
+class TestPerfModuleCache:
+    """--rebuild / --ignore-cache control the per-module build cache the same
+    way they do for the single-model path (mirrors auto.py).
+
+    Regression guard: per-module builds previously always used a throwaway
+    temp dir and never passed rebuild/cache_key, so artifacts were rebuilt
+    every run and the cache flags were silently ignored.
+    """
+
+    @staticmethod
+    def _run_build_kwargs(tmp_path: Path, extra_args: list[str]) -> dict:
+        """Invoke ``perf --module`` and return the build_hf_model call kwargs.
+
+        get_cache_dir is pinned to a known directory so the resolved
+        persistent build dir is deterministic. The benchmark is short-circuited
+        via a failing ``session.perf()`` — build_hf_model is already called by
+        then, so its kwargs are captured.
+        """
+        cache_root = tmp_path / "cache"
+
+        fake_cfg = MagicMock()
+        fake_cfg.loader.model_type = "bert"
+        fake_cfg.loader.module_path = "encoder.layer.0"
+        fake_cfg.generate_cache_key.return_value = "deadbeefdeadbeef"
+
+        fake_build_result = MagicMock()
+        fake_build_result.final_onnx_path = tmp_path / "model.onnx"
+
+        fake_session = MagicMock()
+        fake_session.perf.side_effect = RuntimeError("test-skip-benchmark")
+
+        fake_loader_cfg = MagicMock()
+        fake_loader_cfg.task = "fill-mask"
+
+        with (
+            patch(
+                "winml.modelkit.sysinfo.resolve_device",
+                return_value=("cpu", ["cpu"]),
+            ),
+            patch(
+                "winml.modelkit.config.generate_hf_build_config",
+                return_value=[fake_cfg],
+            ),
+            patch(
+                "winml.modelkit.loader.resolve_loader_config",
+                return_value=(fake_loader_cfg, MagicMock(), MagicMock(), MagicMock()),
+            ),
+            patch(
+                "winml.modelkit.commands.build._instantiate_parent_model",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "winml.modelkit.build.build_hf_model",
+                return_value=fake_build_result,
+            ) as mock_build,
+            patch(
+                "winml.modelkit.session.WinMLSession",
+                return_value=fake_session,
+            ),
+            # Pin the cache root so the resolved persistent build dir is
+            # deterministic. Patch the source attribute — _perf_modules binds
+            # the name via a function-local `from ..cache import get_cache_dir`.
+            patch(
+                "winml.modelkit.cache.get_cache_dir",
+                return_value=cache_root,
+            ),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                [
+                    "perf",
+                    "-m",
+                    "fake/model",
+                    "--module",
+                    "BertLayer",
+                    "--iterations",
+                    "1",
+                    "--warmup",
+                    "0",
+                    "-o",
+                    str(tmp_path / "out.json"),
+                    *extra_args,
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        return dict(mock_build.call_args.kwargs)
+
+    def test_default_uses_persistent_cache_no_rebuild(self, tmp_path: Path) -> None:
+        kwargs = self._run_build_kwargs(tmp_path, [])
+        # Builds into the model's persistent cache dir (under the pinned root),
+        # not a temp dir, and does not force a rebuild.
+        assert kwargs["rebuild"] is False
+        assert (tmp_path / "cache") in kwargs["output_dir"].parents
+        # cache_key disambiguates instances within the shared model dir.
+        assert kwargs["cache_key"]
+
+    def test_rebuild_forces_rebuild_in_cache_dir(self, tmp_path: Path) -> None:
+        kwargs = self._run_build_kwargs(tmp_path, ["--rebuild"])
+        # Reuses the persistent cache dir but overwrites artifacts.
+        assert kwargs["rebuild"] is True
+        assert (tmp_path / "cache") in kwargs["output_dir"].parents
+
+    def test_ignore_cache_uses_temp_dir_and_rebuilds(self, tmp_path: Path) -> None:
+        kwargs = self._run_build_kwargs(tmp_path, ["--ignore-cache"])
+        # Throwaway temp dir (outside the pinned cache root) + forced rebuild.
+        assert kwargs["rebuild"] is True
+        assert (tmp_path / "cache") not in kwargs["output_dir"].parents

--- a/tests/unit/commands/test_perf_module.py
+++ b/tests/unit/commands/test_perf_module.py
@@ -653,3 +653,96 @@ class TestPerfModuleCache:
         # Throwaway temp dir (outside the pinned cache root) + forced rebuild.
         assert kwargs["rebuild"] is True
         assert (tmp_path / "cache") not in kwargs["output_dir"].parents
+
+    def test_sibling_instances_get_distinct_cache_keys(self, tmp_path: Path) -> None:
+        """Two configs with distinct ``generate_cache_key()`` (as real sibling
+        instances have, since their ``loader.module_path`` differ) must reach
+        ``build_hf_model`` with distinct ``cache_key``s so their artifacts don't
+        collide in the shared model dir.
+
+        Guards the PR's central collision-free claim at this layer; the other
+        cache tests mock ``generate_cache_key`` to a constant and so can't.
+        """
+        cache_root = tmp_path / "cache"
+
+        cfg_a = MagicMock()
+        cfg_a.loader.model_type = "bert"
+        cfg_a.loader.module_path = "encoder.layer.0"
+        cfg_a.generate_cache_key.return_value = "aaaaaaaaaaaaaaaa"
+
+        cfg_b = MagicMock()
+        cfg_b.loader.model_type = "bert"
+        cfg_b.loader.module_path = "encoder.layer.1"
+        cfg_b.generate_cache_key.return_value = "bbbbbbbbbbbbbbbb"
+
+        fake_build_result = MagicMock()
+        fake_build_result.final_onnx_path = tmp_path / "model.onnx"
+
+        fake_session = MagicMock()
+        fake_session.perf.side_effect = RuntimeError("test-skip-benchmark")
+
+        fake_loader_cfg = MagicMock()
+        fake_loader_cfg.task = "fill-mask"
+
+        with (
+            patch(
+                "winml.modelkit.sysinfo.resolve_device",
+                return_value=("cpu", ["cpu"]),
+            ),
+            patch(
+                "winml.modelkit.config.generate_hf_build_config",
+                return_value=[cfg_a, cfg_b],
+            ),
+            patch(
+                "winml.modelkit.loader.resolve_loader_config",
+                return_value=(fake_loader_cfg, MagicMock(), MagicMock(), MagicMock()),
+            ),
+            patch(
+                "winml.modelkit.commands.build._instantiate_parent_model",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "winml.modelkit.build.build_hf_model",
+                return_value=fake_build_result,
+            ) as mock_build,
+            patch(
+                "winml.modelkit.session.WinMLSession",
+                return_value=fake_session,
+            ),
+            patch(
+                "winml.modelkit.cache.get_cache_dir",
+                return_value=cache_root,
+            ),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                [
+                    "perf",
+                    "-m",
+                    "fake/model",
+                    "--module",
+                    "BertLayer",
+                    "--iterations",
+                    "1",
+                    "--warmup",
+                    "0",
+                    "-o",
+                    str(tmp_path / "out.json"),
+                ],
+            )
+        assert result.exit_code == 0, result.output
+
+        cache_keys = [call.kwargs["cache_key"] for call in mock_build.call_args_list]
+        assert len(cache_keys) == 2
+        # Distinct config hashes -> distinct cache keys (collision-free).
+        assert cache_keys[0] != cache_keys[1]
+        assert "aaaaaaaaaaaaaaaa" in cache_keys[0]
+        assert "bbbbbbbbbbbbbbbb" in cache_keys[1]
+
+    def test_no_optimize_changes_cache_key(self, tmp_path: Path) -> None:
+        """``--no-optimize`` must alter the cache key so a prior optimized build
+        isn't silently reused (the optimize toggle isn't part of the config)."""
+        default_key = self._run_build_kwargs(tmp_path, [])["cache_key"]
+        no_opt_key = self._run_build_kwargs(tmp_path, ["--no-optimize"])["cache_key"]
+        assert default_key != no_opt_key


### PR DESCRIPTION
## Summary

`winml perf --module` built every submodule into a throwaway `tempfile.TemporaryDirectory` with no `cache_key` and no `rebuild` flag, so per-module artifacts were rebuilt on every run and `--rebuild` / `--ignore-cache` were silently ignored. The single-model path already honored these flags via `WinMLAutoModel` → `auto.py`.

This mirrors `auto.py`'s cache logic in `_perf_modules`:

- **Default**: each submodule builds into the model's persistent cache dir (`~/.cache/winml/artifacts/<model_slug>/`) and is reused on the next run.
- **`--rebuild`**: reuses the cache dir but overwrites artifacts.
- **`--ignore-cache`**: falls back to a temp dir + forced rebuild (prior behavior, now opt-in).

## Why per-module caching is collision-free

Each submodule config carries a unique `loader.module_path` (plus its traced I/O shapes). `cfg.generate_cache_key()` hashes the full config, so every instance gets a distinct key — even shape-identical siblings — and `build_hf_model`'s `cache_key` filename prefixing keeps each instance's `model.onnx` separate within one shared model dir.

## Behavior change worth noting

Per-module artifacts now **persist by default** (more disk use), which is the intended consequence of matching the single-model / `auto.py` behavior.

## Tests

Added `TestPerfModuleCache` (default → persistent dir + `rebuild=False`; `--rebuild` → `rebuild=True` in cache dir; `--ignore-cache` → temp dir + `rebuild=True`). Full `tests/unit/commands/test_perf_module.py`: 15 passed.

Closes #918

🤖 Generated with [Claude Code](https://claude.com/claude-code)
