### PR TITLE
Add standalone Qwen3 embeddings (fp32) and lm_head (int4 RTN) 

### DIFF
--- a/scripts/export_qwen3_embeddings_lm_head.py
+++ b/scripts/export_qwen3_embeddings_lm_head.py
@@ -1,0 +1,185 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""One-shot export of the Qwen3 embeddings + lm_head sub-models.
+
+Companion to ``export_qwen3_transformer_only.py``. That script builds the
+transformer (prefill + decode). This one builds the two remaining pieces of the
+split Qwen3 graph:
+
+  - ``embeddings`` — input embedding table (``input_ids`` -> ``input_hidden_states``).
+    Built FLOAT (``precision="fp32"``); NOT quantized. Produces a ``Gather``.
+  - ``lm_head``    — vocab projection (``output_hidden_states`` -> ``logits``).
+    Quantized weight-only to int4 via MatMulNBits/RTN (``precision="w4a32"``).
+    Produces a ``MatMulNBits`` node (no float ``MatMul``).
+
+Both are standalone ``model_type`` builds, invoked separately.
+
+Usage::
+
+    # Build (or reuse cached) both ONNX, print their paths + node summary:
+    uv run python scripts/export_qwen3_embeddings_lm_head.py
+
+    # Build only one of them:
+    uv run python scripts/export_qwen3_embeddings_lm_head.py --only embeddings
+    uv run python scripts/export_qwen3_embeddings_lm_head.py --only lm_head
+
+    # Copy the ONNX (with external data) into a folder:
+    uv run python scripts/export_qwen3_embeddings_lm_head.py --output-dir out/qwen3
+    #   -> writes embeddings_fp32.onnx and lm_head_w4a32.onnx
+
+    # Different model / device / seq geometry, force a rebuild:
+    uv run python scripts/export_qwen3_embeddings_lm_head.py \
+        --model-id Qwen/Qwen3-0.6B --device npu --seq-len 64 --force-rebuild
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import sys
+import time
+from pathlib import Path
+
+import onnx
+
+from winml.modelkit.models.auto import WinMLAutoModel
+from winml.modelkit.onnx import copy_onnx_model
+
+
+# Per-component build settings: which model_type to register against and the
+# precision that drives its quant policy. Embeddings stay float (``fp32``); the
+# lm_head is weight-only int4 with fp32 activations (``w4a32`` — the activations
+# are NOT quantized, this is RTN/MatMulNBits).
+_COMPONENTS = {
+    "embeddings": {"model_type": "qwen3_embeddings_only", "precision": "fp32"},
+    "lm_head": {"model_type": "qwen3_lm_head_only", "precision": "w4a32"},
+}
+
+# Component -> output file stem (when --output-dir is given). The precision
+# suffix is carried in the filename so the two pieces self-document their scheme.
+_OUTPUT_STEMS = {
+    "embeddings": f"embeddings_{_COMPONENTS['embeddings']['precision']}",
+    "lm_head": f"lm_head_{_COMPONENTS['lm_head']['precision']}",
+}
+
+# Default EP per device; CPU/NPU/GPU map to their canonical providers.
+_DEVICE_TO_EP = {
+    "cpu": "CPUExecutionProvider",
+    "npu": "QNNExecutionProvider",
+    "gpu": "DmlExecutionProvider",
+}
+
+
+def node_summary(path: str | Path) -> str:
+    """Return a one-line structural summary of the graph's key ops.
+
+    The interesting markers for these two sub-models are:
+      - embeddings: ``Gather`` present, no ``MatMulNBits`` / no QDQ (stays float).
+      - lm_head:    ``MatMulNBits`` present, float ``MatMul`` gone (int4 weight-only).
+    """
+    model = onnx.load(str(path), load_external_data=False)
+    counts = collections.Counter(n.op_type for n in model.graph.node)
+    return (
+        f"Gather={counts['Gather']} MatMul={counts['MatMul']} "
+        f"MatMulNBits={counts['MatMulNBits']} "
+        f"Q={counts['QuantizeLinear']} DQ={counts['DequantizeLinear']}"
+    )
+
+
+def build_component(name: str, args: argparse.Namespace):
+    """Build (or reuse cached) one standalone sub-model and return it."""
+    spec = _COMPONENTS[name]
+    print(f"\n=== building {name} (model_type={spec['model_type']}, "
+          f"precision={spec['precision']}) ===")
+    return WinMLAutoModel.from_pretrained(
+        args.model_id,
+        task="feature-extraction",
+        model_type=spec["model_type"],
+        precision=spec["precision"],
+        device=args.device,
+        ep=_DEVICE_TO_EP[args.device],
+        no_compile=args.no_compile,
+        use_cache=True,
+        force_rebuild=args.force_rebuild,
+        shape_config={"seq_len": args.seq_len},
+    )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--model-id", default="Qwen/Qwen3-0.6B", help="HF model id or local path.")
+    p.add_argument(
+        "--device",
+        default="cpu",
+        choices=sorted(_DEVICE_TO_EP),
+        help="Target device (selects the canonical EP). Default: cpu.",
+    )
+    p.add_argument(
+        "--only",
+        choices=sorted(_COMPONENTS),
+        default=None,
+        help="Build only this component. Default: build both.",
+    )
+    p.add_argument(
+        "--seq-len",
+        type=int,
+        default=64,
+        help="Static sequence length baked into both sub-models. Default: 64.",
+    )
+    p.add_argument(
+        "--no-compile",
+        dest="no_compile",
+        action="store_true",
+        default=True,
+        help="Skip EPContext compilation (default; these are consumed pre-compile).",
+    )
+    p.add_argument(
+        "--compile",
+        dest="no_compile",
+        action="store_false",
+        help="Enable EPContext compilation (requires the device's compiler/SDK).",
+    )
+    p.add_argument("--force-rebuild", action="store_true", help="Rebuild even if cached.")
+    p.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="If set, copy the ONNX (with external data) here as "
+             "embeddings_fp32.onnx / lm_head_w4a32.onnx.",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Build (or reuse) the requested sub-models and report/copy them."""
+    args = parse_args(argv)
+
+    names = [args.only] if args.only else ["embeddings", "lm_head"]
+
+    output_dir: Path | None = args.output_dir
+    if output_dir is not None:
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+    t0 = time.monotonic()
+    for name in names:
+        model = build_component(name, args)
+        src = Path(model.onnx_path)
+        print(f"[{name}] {src}")
+        print(f"   {node_summary(src)}")
+        if output_dir is not None:
+            dst = output_dir / f"{_OUTPUT_STEMS[name]}.onnx"
+            copy_onnx_model(src, dst)
+            print(f"   -> copied to {dst}")
+
+    print(f"\n=== done in {time.monotonic() - t0:.1f}s ===")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/winml/modelkit/loader/resolution.py
+++ b/src/winml/modelkit/loader/resolution.py
@@ -413,15 +413,29 @@ def resolve_task(
             # image-feature-extraction rather than the modality-blind feature-extraction.
             opt_task = _infer_task_from_architecture(config)
             surfaced = _resolve_task_modality(config, opt_task)
-        try:
-            resolved = TasksManager.get_model_class_for_task(
-                opt_task, framework="pt", model_class_name=model_class
-            )
-        except (KeyError, AttributeError) as e:
-            raise ValueError(
-                f"Model class '{model_class}' not found for task '{opt_task}'. "
-                f"Check that the class name is correct and available in transformers."
-            ) from e
+        # A WinML build variant (model_type_override) may name a custom wrapper
+        # registered in MODEL_CLASS_MAPPING rather than a transformers class —
+        # e.g. the single-model qwen3_embeddings_only / qwen3_lm_head_only
+        # builds, whose loader config carries the wrapper's __name__ as
+        # model_class. TasksManager can't resolve those, so when the requested
+        # class name IS that custom wrapper, resolve it directly. Guarded on the
+        # class name so a genuine transformers class still falls through (e.g. a
+        # CLIP --model-class override).
+        resolved = None
+        if model_type_norm:
+            custom = _get_custom_model_class(model_type_norm, opt_task)
+            if custom is not None and custom.__name__ == model_class:
+                resolved = custom
+        if resolved is None:
+            try:
+                resolved = TasksManager.get_model_class_for_task(
+                    opt_task, framework="pt", model_class_name=model_class
+                )
+            except (KeyError, AttributeError) as e:
+                raise ValueError(
+                    f"Model class '{model_class}' not found for task '{opt_task}'. "
+                    f"Check that the class name is correct and available in transformers."
+                ) from e
         return TaskResolution(
             surfaced, to_optimum_task(surfaced), resolved, TaskSource.USER_CLASS, None
         )

--- a/src/winml/modelkit/models/hf/__init__.py
+++ b/src/winml/modelkit/models/hf/__init__.py
@@ -56,6 +56,16 @@ from .qwen import MODEL_CLASS_MAPPING as _QWEN_CLASS_MAPPING
 from .qwen import QWEN_CONFIG
 from .qwen import QwenGenIOConfig as _QwenGenIOConfig
 from .qwen import QwenPrefillIOConfig as _QwenPrefillIOConfig
+from .qwen3.qwen_embeddings_only import MODEL_CLASS_MAPPING as _QWEN_EMB_CLASS_MAPPING
+from .qwen3.qwen_embeddings_only import QWEN_EMBEDDINGS_ONLY_CONFIG
+from .qwen3.qwen_embeddings_only import (
+    QwenEmbeddingsOnlyIOConfig as _QwenEmbeddingsOnlyIOConfig,  # triggers registration
+)
+from .qwen3.qwen_lm_head_only import MODEL_CLASS_MAPPING as _QWEN_LMH_CLASS_MAPPING
+from .qwen3.qwen_lm_head_only import QWEN_LM_HEAD_ONLY_CONFIG
+from .qwen3.qwen_lm_head_only import (
+    QwenLMHeadOnlyIOConfig as _QwenLMHeadOnlyIOConfig,  # triggers registration
+)
 from .qwen3.qwen_transformer_only import MODEL_CLASS_MAPPING as _QWEN_TO_CLASS_MAPPING
 from .qwen3.qwen_transformer_only import QWEN_TRANSFORMER_ONLY_CONFIG
 from .qwen3.qwen_transformer_only import (
@@ -110,6 +120,8 @@ MODEL_CLASS_MAPPING: dict[tuple[str, str | None], type] = {
         _MU2_CLASS_MAPPING,
         _QWEN_CLASS_MAPPING,
         _QWEN_TO_CLASS_MAPPING,
+        _QWEN_EMB_CLASS_MAPPING,
+        _QWEN_LMH_CLASS_MAPPING,
         _SAM2_CLASS_MAPPING,
         _SEGFORMER_CLASS_MAPPING,
         _SIGLIP_CLASS_MAPPING,
@@ -137,6 +149,8 @@ MODEL_BUILD_CONFIGS = {
     "mu2": MU2_CONFIG,
     "qwen3": QWEN_CONFIG,
     "qwen3-transformer-only": QWEN_TRANSFORMER_ONLY_CONFIG,
+    "qwen3-embeddings-only": QWEN_EMBEDDINGS_ONLY_CONFIG,
+    "qwen3-lm-head-only": QWEN_LM_HEAD_ONLY_CONFIG,
     "siglip": SIGLIP_CONFIG,
     "siglip-text-model": SIGLIP_CONFIG,
     "siglip-vision-model": SIGLIP_CONFIG,

--- a/src/winml/modelkit/models/hf/qwen3/qwen_embeddings_only.py
+++ b/src/winml/modelkit/models/hf/qwen3/qwen_embeddings_only.py
@@ -69,9 +69,7 @@ class QwenEmbeddingsOnlyWrapper(nn.Module):
         self.config.model_type = EMBEDDINGS_ONLY_MODEL_TYPE
 
     @classmethod
-    def from_pretrained(
-        cls, model_name_or_path: str, **kwargs: Any
-    ) -> QwenEmbeddingsOnlyWrapper:
+    def from_pretrained(cls, model_name_or_path: str, **kwargs: Any) -> QwenEmbeddingsOnlyWrapper:
         """Load the HF model and wrap its input embedding for export."""
         kwargs.setdefault("torch_dtype", torch.float32)
         model = AutoModelForCausalLM.from_pretrained(model_name_or_path, **kwargs)
@@ -124,7 +122,9 @@ class _EmbeddingsInputIdsGenerator(DummyInputGenerator):
         float_dtype: str = "fp32",
     ) -> torch.Tensor:
         if input_name == "input_ids":
-            return torch.randint(0, self.vocab_size, (self.batch_size, self.seq_len), dtype=torch.int64)
+            return torch.randint(
+                0, self.vocab_size, (self.batch_size, self.seq_len), dtype=torch.int64
+            )
         raise ValueError(f"Unknown input: {input_name}")
 
 

--- a/src/winml/modelkit/models/hf/qwen3/qwen_embeddings_only.py
+++ b/src/winml/modelkit/models/hf/qwen3/qwen_embeddings_only.py
@@ -1,0 +1,198 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Embeddings-only ``qwen3`` build variant, registered as a distinct model_type.
+
+This module registers a self-contained build path under the model_type
+``"qwen3_embeddings_only"`` (a sibling of ``"qwen3_transformer_only"`` and
+``"qwen3_lm_head_only"``). Selecting it is explicit — pass
+``model_type="qwen3_embeddings_only"`` to ``WinMLAutoModel.from_pretrained(...)``.
+
+The variant exports the input-embedding lookup as a standalone ONNX file:
+
+  Inputs : input_ids (INT, ``[1, seq_len]``)
+  Outputs: input_hidden_states (FP32, ``[1, seq_len, hidden]``)
+  Ops    : ``onnx::Gather`` (embedding table lookup).
+
+Embeddings are deliberately left in float — they are **not** quantized. Build
+it with a float precision (e.g. ``precision="fp32"``) so the device/precision
+policy leaves ``config.quant=None`` and no QDQ / RTN pass runs.
+
+The output name ``input_hidden_states`` matches the transformer-only graph's
+``input_hidden_states`` input, so the two ONNX chain together at runtime.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+import torch
+import torch.nn as nn
+from optimum.exporters.onnx import OnnxConfig
+from optimum.utils import NormalizedConfig
+from optimum.utils.input_generators import DummyInputGenerator
+from transformers import AutoModelForCausalLM
+
+from ....config import WinMLBuildConfig
+from ....export import register_onnx_overwrite
+from ....export.config import WinMLExportConfig
+from ...winml import register_specialization
+
+
+# Distinct model_type for this variant. The underscore form is what the
+# exporter sees on ``model.config.model_type``; the hyphenated form is used for
+# the ``MODEL_CLASS_MAPPING`` / ``MODEL_BUILD_CONFIGS`` lookups (those callers
+# normalize ``_`` -> ``-``).
+EMBEDDINGS_ONLY_MODEL_TYPE = "qwen3_embeddings_only"
+
+
+# =============================================================================
+# Wrapper module
+# =============================================================================
+
+
+class QwenEmbeddingsOnlyWrapper(nn.Module):
+    """Wraps the ``Qwen3ForCausalLM`` input embedding for standalone export.
+
+    Only ``get_input_embeddings()`` (the embedding table) is exported; the
+    transformer stack and ``lm_head`` stay out of the graph.
+    """
+
+    def __init__(self, embed_tokens: nn.Module, config: Any) -> None:
+        super().__init__()
+        self.embed_tokens = embed_tokens
+        # The embedding submodule has no ``config``; carry the parent's so the
+        # exporter resolves this variant's OnnxConfig and the build pipeline can
+        # read ``model.config.model_type`` for quant-policy dispatch.
+        self.config = config
+        self.config.model_type = EMBEDDINGS_ONLY_MODEL_TYPE
+
+    @classmethod
+    def from_pretrained(
+        cls, model_name_or_path: str, **kwargs: Any
+    ) -> QwenEmbeddingsOnlyWrapper:
+        """Load the HF model and wrap its input embedding for export."""
+        kwargs.setdefault("torch_dtype", torch.float32)
+        model = AutoModelForCausalLM.from_pretrained(model_name_or_path, **kwargs)
+        wrapper = cls(model.get_input_embeddings(), model.config)
+        wrapper.eval()
+        return wrapper
+
+    def get_export_args(self, inputs: dict[str, torch.Tensor]) -> tuple[torch.Tensor, ...]:
+        """Flatten the dummy-input dict into positional export args."""
+        return (inputs["input_ids"],)
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        """Embed ``input_ids`` -> ``input_hidden_states`` (FP32).
+
+        The embedding table is loaded in float32, so its output is already
+        FP32 — no explicit cast is added (keeps the graph a single ``Gather``).
+        """
+        return self.embed_tokens(input_ids)
+
+
+# =============================================================================
+# Dummy input generator (embeddings I/O)
+# =============================================================================
+
+
+class _EmbeddingsInputIdsGenerator(DummyInputGenerator):
+    """Generates ``input_ids`` (INT, ``[1, seq_len]``)."""
+
+    SUPPORTED_INPUT_NAMES = ("input_ids",)
+
+    _default_seq_len: ClassVar[int] = 1
+
+    def __init__(
+        self,
+        task: str,
+        normalized_config: Any,
+        batch_size: int = 1,
+        seq_len: int | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.batch_size = batch_size
+        self.vocab_size = normalized_config.vocab_size
+        self.seq_len = seq_len or getattr(normalized_config, "seq_len", self._default_seq_len)
+
+    def generate(
+        self,
+        input_name: str,
+        framework: str = "pt",
+        int_dtype: str = "int64",
+        float_dtype: str = "fp32",
+    ) -> torch.Tensor:
+        if input_name == "input_ids":
+            return torch.randint(0, self.vocab_size, (self.batch_size, self.seq_len), dtype=torch.int64)
+        raise ValueError(f"Unknown input: {input_name}")
+
+
+# =============================================================================
+# OnnxConfig — embeddings I/O layout
+# =============================================================================
+
+
+_QWEN_EMBEDDINGS_NORMALIZED = NormalizedConfig.with_args(
+    hidden_size="hidden_size",
+    vocab_size="vocab_size",
+    allow_new=True,
+)
+
+
+@register_onnx_overwrite(
+    EMBEDDINGS_ONLY_MODEL_TYPE, "feature-extraction", library_name="transformers"
+)
+class QwenEmbeddingsOnlyIOConfig(OnnxConfig):
+    """Embeddings lookup — ``input_ids`` -> ``input_hidden_states``."""
+
+    NORMALIZED_CONFIG_CLASS = _QWEN_EMBEDDINGS_NORMALIZED
+    DUMMY_INPUT_GENERATOR_CLASSES = (_EmbeddingsInputIdsGenerator,)
+
+    @property
+    def inputs(self) -> dict[str, dict[int, str]]:
+        """ONNX input axes (token ids)."""
+        return {"input_ids": {1: "seq_len"}}
+
+    @property
+    def outputs(self) -> dict[str, dict[int, str]]:
+        """ONNX output axes (hidden states)."""
+        return {"input_hidden_states": {1: "seq_len"}}
+
+
+# =============================================================================
+# Build config — TorchScript exporter (matches the transformer-only variant).
+# =============================================================================
+
+
+QWEN_EMBEDDINGS_ONLY_CONFIG = WinMLBuildConfig(
+    export=WinMLExportConfig(dynamo=False, opset_version=18),
+    # Pure graph (no post-export fusion).
+    optim=None,
+)
+
+
+# =============================================================================
+# Declarative registration (import-time)
+# =============================================================================
+
+# Wrapper-class lookup keyed by (model_type, task). Keys use the hyphenated
+# model_type form because ``_get_custom_model_class`` normalizes ``_`` -> ``-``
+# before lookup. Merged into the aggregate mapping by ``models.hf.__init__``.
+MODEL_CLASS_MAPPING: dict[tuple[str, str], type] = {
+    ("qwen3-embeddings-only", "feature-extraction"): QwenEmbeddingsOnlyWrapper,
+}
+
+# Inference specialization (GenericTask — the wrapper returns raw hidden states).
+register_specialization(
+    EMBEDDINGS_ONLY_MODEL_TYPE, "feature-extraction", "WinMLModelForGenericTask"
+)
+
+
+__all__ = [
+    "EMBEDDINGS_ONLY_MODEL_TYPE",
+    "MODEL_CLASS_MAPPING",
+    "QWEN_EMBEDDINGS_ONLY_CONFIG",
+    "QwenEmbeddingsOnlyIOConfig",
+    "QwenEmbeddingsOnlyWrapper",
+]

--- a/src/winml/modelkit/models/hf/qwen3/qwen_embeddings_only.py
+++ b/src/winml/modelkit/models/hf/qwen3/qwen_embeddings_only.py
@@ -37,6 +37,7 @@ from transformers import AutoModelForCausalLM
 from ....config import WinMLBuildConfig
 from ....export import register_onnx_overwrite
 from ....export.config import WinMLExportConfig
+from ....optim.config import WinMLOptimizationConfig
 from ...winml import register_specialization
 
 
@@ -87,7 +88,7 @@ class QwenEmbeddingsOnlyWrapper(nn.Module):
         The embedding table is loaded in float32, so its output is already
         FP32 — no explicit cast is added (keeps the graph a single ``Gather``).
         """
-        return self.embed_tokens(input_ids)
+        return self.embed_tokens(input_ids)  # type: ignore[no-any-return]
 
 
 # =============================================================================
@@ -95,7 +96,7 @@ class QwenEmbeddingsOnlyWrapper(nn.Module):
 # =============================================================================
 
 
-class _EmbeddingsInputIdsGenerator(DummyInputGenerator):
+class _EmbeddingsInputIdsGenerator(DummyInputGenerator):  # type: ignore[misc]  # optimum base is untyped
     """Generates ``input_ids`` (INT, ``[1, seq_len]``)."""
 
     SUPPORTED_INPUT_NAMES = ("input_ids",)
@@ -112,7 +113,11 @@ class _EmbeddingsInputIdsGenerator(DummyInputGenerator):
     ) -> None:
         self.batch_size = batch_size
         self.vocab_size = normalized_config.vocab_size
-        self.seq_len = seq_len or getattr(normalized_config, "seq_len", self._default_seq_len)
+        self.seq_len = (
+            int(seq_len)
+            if seq_len
+            else int(getattr(normalized_config, "seq_len", self._default_seq_len))
+        )
 
     def generate(
         self,
@@ -143,7 +148,7 @@ _QWEN_EMBEDDINGS_NORMALIZED = NormalizedConfig.with_args(
 @register_onnx_overwrite(
     EMBEDDINGS_ONLY_MODEL_TYPE, "feature-extraction", library_name="transformers"
 )
-class QwenEmbeddingsOnlyIOConfig(OnnxConfig):
+class QwenEmbeddingsOnlyIOConfig(OnnxConfig):  # type: ignore[misc]  # optimum base is untyped
     """Embeddings lookup — ``input_ids`` -> ``input_hidden_states``."""
 
     NORMALIZED_CONFIG_CLASS = _QWEN_EMBEDDINGS_NORMALIZED
@@ -168,7 +173,7 @@ class QwenEmbeddingsOnlyIOConfig(OnnxConfig):
 QWEN_EMBEDDINGS_ONLY_CONFIG = WinMLBuildConfig(
     export=WinMLExportConfig(dynamo=False, opset_version=18),
     # Pure graph (no post-export fusion).
-    optim=None,
+    optim=WinMLOptimizationConfig(),
 )
 
 

--- a/src/winml/modelkit/models/hf/qwen3/qwen_lm_head_only.py
+++ b/src/winml/modelkit/models/hf/qwen3/qwen_lm_head_only.py
@@ -1,0 +1,198 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""LM-head-only ``qwen3`` build variant, registered as a distinct model_type.
+
+This module registers a self-contained build path under the model_type
+``"qwen3_lm_head_only"`` (a sibling of ``"qwen3_transformer_only"`` and
+``"qwen3_embeddings_only"``). Selecting it is explicit — pass
+``model_type="qwen3_lm_head_only"`` to ``WinMLAutoModel.from_pretrained(...)``.
+
+The variant exports the final projection (``lm_head``) as a standalone ONNX file:
+
+  Inputs : output_hidden_states (FP32, ``[1, seq_len, hidden]``)
+  Outputs: logits (FP32, ``[1, seq_len, vocab]``)
+  Ops    : ``onnx::MatMul`` (vocab projection).
+
+The LM head is quantized weight-only to 4 bits (MatMulNBits / RTN, symmetric
+int4 weights, block_size=32). Build it with a weight-only precision
+(``precision="w4a32"`` or ``precision="int4"``) so the device/precision policy
+creates an RTN quant config; the registered :class:`Qwen3LMHeadOnlyQuantFinalizer`
+then pins the block size / symmetry / accuracy level.
+
+The input name ``output_hidden_states`` matches the transformer-only graph's
+``output_hidden_states`` output, so the two ONNX chain together at runtime.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+import torch
+import torch.nn as nn
+from optimum.exporters.onnx import OnnxConfig
+from optimum.utils import NormalizedConfig
+from optimum.utils.input_generators import DummyInputGenerator
+from transformers import AutoModelForCausalLM
+
+from ....config import WinMLBuildConfig
+from ....export import register_onnx_overwrite
+from ....export.config import WinMLExportConfig
+from ...winml import register_specialization
+
+
+# Distinct model_type for this variant. The underscore form is what the
+# exporter sees on ``model.config.model_type``; the hyphenated form is used for
+# the ``MODEL_CLASS_MAPPING`` / ``MODEL_BUILD_CONFIGS`` lookups (those callers
+# normalize ``_`` -> ``-``).
+LM_HEAD_ONLY_MODEL_TYPE = "qwen3_lm_head_only"
+
+
+# =============================================================================
+# Wrapper module
+# =============================================================================
+
+
+class QwenLMHeadOnlyWrapper(nn.Module):
+    """Wraps the ``Qwen3ForCausalLM`` ``lm_head`` for standalone export.
+
+    Only ``get_output_embeddings()`` (the vocab projection) is exported; the
+    embedding table and transformer stack stay out of the graph.
+    """
+
+    def __init__(self, lm_head: nn.Module, config: Any) -> None:
+        super().__init__()
+        self.lm_head = lm_head
+        # The ``lm_head`` submodule has no ``config``; carry the parent's so the
+        # exporter resolves this variant's OnnxConfig and the build pipeline can
+        # read ``model.config.model_type`` for quant-policy dispatch.
+        self.config = config
+        self.config.model_type = LM_HEAD_ONLY_MODEL_TYPE
+
+    @classmethod
+    def from_pretrained(cls, model_name_or_path: str, **kwargs: Any) -> QwenLMHeadOnlyWrapper:
+        """Load the HF model and wrap its ``lm_head`` for export."""
+        kwargs.setdefault("torch_dtype", torch.float32)
+        model = AutoModelForCausalLM.from_pretrained(model_name_or_path, **kwargs)
+        wrapper = cls(model.get_output_embeddings(), model.config)
+        wrapper.eval()
+        return wrapper
+
+    def get_export_args(self, inputs: dict[str, torch.Tensor]) -> tuple[torch.Tensor, ...]:
+        """Flatten the dummy-input dict into positional export args."""
+        return (inputs["output_hidden_states"],)
+
+    def forward(self, output_hidden_states: torch.Tensor) -> torch.Tensor:
+        """Project hidden states -> ``logits`` (FP32).
+
+        The ``lm_head`` is loaded in float32, so its output is already FP32 —
+        no explicit cast is added (keeps the graph a single projection).
+        """
+        return self.lm_head(output_hidden_states)
+
+
+# =============================================================================
+# Dummy input generator (lm_head I/O)
+# =============================================================================
+
+
+class _LMHeadHiddenStateGenerator(DummyInputGenerator):
+    """Generates ``output_hidden_states`` (FP32, ``[1, seq_len, hidden]``)."""
+
+    SUPPORTED_INPUT_NAMES = ("output_hidden_states",)
+
+    _default_seq_len: ClassVar[int] = 1
+
+    def __init__(
+        self,
+        task: str,
+        normalized_config: Any,
+        batch_size: int = 1,
+        seq_len: int | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.batch_size = batch_size
+        self.hidden_size = normalized_config.hidden_size
+        self.seq_len = seq_len or getattr(normalized_config, "seq_len", self._default_seq_len)
+
+    def generate(
+        self,
+        input_name: str,
+        framework: str = "pt",
+        int_dtype: str = "int64",
+        float_dtype: str = "fp32",
+    ) -> torch.Tensor:
+        if input_name == "output_hidden_states":
+            return torch.randn(self.batch_size, self.seq_len, self.hidden_size, dtype=torch.float32)
+        raise ValueError(f"Unknown input: {input_name}")
+
+
+# =============================================================================
+# OnnxConfig — lm_head I/O layout
+# =============================================================================
+
+
+_QWEN_LM_HEAD_NORMALIZED = NormalizedConfig.with_args(
+    hidden_size="hidden_size",
+    vocab_size="vocab_size",
+    allow_new=True,
+)
+
+
+@register_onnx_overwrite(
+    LM_HEAD_ONLY_MODEL_TYPE, "feature-extraction", library_name="transformers"
+)
+class QwenLMHeadOnlyIOConfig(OnnxConfig):
+    """LM head — ``output_hidden_states`` -> ``logits``."""
+
+    NORMALIZED_CONFIG_CLASS = _QWEN_LM_HEAD_NORMALIZED
+    DUMMY_INPUT_GENERATOR_CLASSES = (_LMHeadHiddenStateGenerator,)
+
+    @property
+    def inputs(self) -> dict[str, dict[int, str]]:
+        """ONNX input axes (hidden states)."""
+        return {"output_hidden_states": {1: "seq_len"}}
+
+    @property
+    def outputs(self) -> dict[str, dict[int, str]]:
+        """ONNX output axes (logits)."""
+        return {"logits": {1: "seq_len"}}
+
+
+# =============================================================================
+# Build config — TorchScript exporter (matches the transformer-only variant).
+# =============================================================================
+
+
+QWEN_LM_HEAD_ONLY_CONFIG = WinMLBuildConfig(
+    export=WinMLExportConfig(dynamo=False, opset_version=18),
+    # Pure graph (no post-export fusion).
+    optim=None,
+)
+
+
+# =============================================================================
+# Declarative registration (import-time)
+# =============================================================================
+
+# Wrapper-class lookup keyed by (model_type, task). Keys use the hyphenated
+# model_type form because ``_get_custom_model_class`` normalizes ``_`` -> ``-``
+# before lookup. Merged into the aggregate mapping by ``models.hf.__init__``.
+MODEL_CLASS_MAPPING: dict[tuple[str, str], type] = {
+    ("qwen3-lm-head-only", "feature-extraction"): QwenLMHeadOnlyWrapper,
+}
+
+# Inference specialization (GenericTask — the wrapper returns raw logits).
+register_specialization(
+    LM_HEAD_ONLY_MODEL_TYPE, "feature-extraction", "WinMLModelForGenericTask"
+)
+
+
+__all__ = [
+    "LM_HEAD_ONLY_MODEL_TYPE",
+    "MODEL_CLASS_MAPPING",
+    "QWEN_LM_HEAD_ONLY_CONFIG",
+    "QwenLMHeadOnlyIOConfig",
+    "QwenLMHeadOnlyWrapper",
+]

--- a/src/winml/modelkit/models/hf/qwen3/qwen_lm_head_only.py
+++ b/src/winml/modelkit/models/hf/qwen3/qwen_lm_head_only.py
@@ -39,6 +39,7 @@ from transformers import AutoModelForCausalLM
 from ....config import WinMLBuildConfig
 from ....export import register_onnx_overwrite
 from ....export.config import WinMLExportConfig
+from ....optim.config import WinMLOptimizationConfig
 from ...winml import register_specialization
 
 
@@ -89,7 +90,7 @@ class QwenLMHeadOnlyWrapper(nn.Module):
         The ``lm_head`` is loaded in float32, so its output is already FP32 —
         no explicit cast is added (keeps the graph a single projection).
         """
-        return self.lm_head(output_hidden_states)
+        return self.lm_head(output_hidden_states)  # type: ignore[no-any-return]
 
 
 # =============================================================================
@@ -97,7 +98,7 @@ class QwenLMHeadOnlyWrapper(nn.Module):
 # =============================================================================
 
 
-class _LMHeadHiddenStateGenerator(DummyInputGenerator):
+class _LMHeadHiddenStateGenerator(DummyInputGenerator):  # type: ignore[misc]  # optimum base is untyped
     """Generates ``output_hidden_states`` (FP32, ``[1, seq_len, hidden]``)."""
 
     SUPPORTED_INPUT_NAMES = ("output_hidden_states",)
@@ -114,7 +115,11 @@ class _LMHeadHiddenStateGenerator(DummyInputGenerator):
     ) -> None:
         self.batch_size = batch_size
         self.hidden_size = normalized_config.hidden_size
-        self.seq_len = seq_len or getattr(normalized_config, "seq_len", self._default_seq_len)
+        self.seq_len = (
+            int(seq_len)
+            if seq_len
+            else int(getattr(normalized_config, "seq_len", self._default_seq_len))
+        )
 
     def generate(
         self,
@@ -140,10 +145,8 @@ _QWEN_LM_HEAD_NORMALIZED = NormalizedConfig.with_args(
 )
 
 
-@register_onnx_overwrite(
-    LM_HEAD_ONLY_MODEL_TYPE, "feature-extraction", library_name="transformers"
-)
-class QwenLMHeadOnlyIOConfig(OnnxConfig):
+@register_onnx_overwrite(LM_HEAD_ONLY_MODEL_TYPE, "feature-extraction", library_name="transformers")
+class QwenLMHeadOnlyIOConfig(OnnxConfig):  # type: ignore[misc]  # optimum base is untyped
     """LM head — ``output_hidden_states`` -> ``logits``."""
 
     NORMALIZED_CONFIG_CLASS = _QWEN_LM_HEAD_NORMALIZED
@@ -168,7 +171,7 @@ class QwenLMHeadOnlyIOConfig(OnnxConfig):
 QWEN_LM_HEAD_ONLY_CONFIG = WinMLBuildConfig(
     export=WinMLExportConfig(dynamo=False, opset_version=18),
     # Pure graph (no post-export fusion).
-    optim=None,
+    optim=WinMLOptimizationConfig(),
 )
 
 
@@ -184,9 +187,7 @@ MODEL_CLASS_MAPPING: dict[tuple[str, str], type] = {
 }
 
 # Inference specialization (GenericTask — the wrapper returns raw logits).
-register_specialization(
-    LM_HEAD_ONLY_MODEL_TYPE, "feature-extraction", "WinMLModelForGenericTask"
-)
+register_specialization(LM_HEAD_ONLY_MODEL_TYPE, "feature-extraction", "WinMLModelForGenericTask")
 
 
 __all__ = [

--- a/src/winml/modelkit/quant/calibration/qwen3_lm_head_only.py
+++ b/src/winml/modelkit/quant/calibration/qwen3_lm_head_only.py
@@ -1,0 +1,91 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Weight-only int4 (RTN) quant policy for the ``qwen3_lm_head_only`` build.
+
+The LM head export (``models.hf.qwen3.qwen_lm_head_only``) emits a single
+``MatMul`` (the vocab projection). It is quantized weight-only to 4 bits with
+``MatMulNBitsQuantizer`` (RTN, symmetric int4 weights).
+
+The build pipeline's device/precision policy only sets ``mode="rtn"`` and
+``rtn_bits`` (from the precision string, e.g. ``w4a32``/``int4``); this finalizer
+is keyed on ``model_type`` and pins the remaining knobs (block size, symmetry,
+accuracy level) so they are authoritative regardless of the defaults baked into
+:class:`WinMLQuantizationConfig`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from ..config import WinMLQuantizationConfig
+
+
+logger = logging.getLogger(__name__)
+
+# Weight-only int4 RTN scheme: block_size=32, accuracy_level=4, symmetric.
+LM_HEAD_RTN_BITS = 4
+LM_HEAD_RTN_BLOCK_SIZE = 32
+LM_HEAD_RTN_ACCURACY_LEVEL = 4
+LM_HEAD_RTN_SYMMETRIC = True
+
+
+def finalize_lm_head_quant_config(
+    quant: WinMLQuantizationConfig,
+    *,
+    onnx_path: Path,
+    model_id: str | None = None,
+) -> WinMLQuantizationConfig:
+    """Pin the weight-only int4 RTN scheme for the LM head.
+
+    The precision policy must already have resolved a weight-only precision
+    (``mode="rtn"``); this hook only tightens the RTN knobs (symmetric int4
+    weights, block_size=32, accuracy_level=4).
+    """
+    # ``mode`` must be "rtn": the precision-driven flow keys the quantizer
+    # dispatch on ``config.mode``. A build whose precision resolved to "static"
+    # or "fp16" would otherwise bypass the MatMulNBits path entirely.
+    quant.mode = "rtn"
+    quant.rtn_bits = LM_HEAD_RTN_BITS
+    quant.rtn_block_size = LM_HEAD_RTN_BLOCK_SIZE
+    quant.rtn_symmetric = LM_HEAD_RTN_SYMMETRIC
+    quant.rtn_accuracy_level = LM_HEAD_RTN_ACCURACY_LEVEL
+
+    logger.info(
+        "Finalizing lm-head quant config for %s "
+        "(RTN int%d, block_size=%d, symmetric=%s, accuracy_level=%d)",
+        onnx_path.name,
+        quant.rtn_bits,
+        quant.rtn_block_size,
+        quant.rtn_symmetric,
+        quant.rtn_accuracy_level,
+    )
+    return quant
+
+
+class Qwen3LMHeadOnlyQuantFinalizer:
+    """Quant policy for the ``qwen3_lm_head_only`` model_type.
+
+    Named in :data:`~winml.modelkit.quant.calibration.registry.QUANT_FINALIZERS`
+    and resolved by :func:`~winml.modelkit.quant.get_quant_finalizer`. Adapts
+    :func:`finalize_lm_head_quant_config` to the
+    :class:`~winml.modelkit.quant.calibration.base.QuantConfigFinalizer`
+    protocol so the build pipeline applies the int4 RTN scheme (keyed on
+    ``model_type``).
+    """
+
+    def finalize(
+        self,
+        quant: WinMLQuantizationConfig,
+        *,
+        onnx_path: Path,
+        model_id: str | None = None,
+    ) -> WinMLQuantizationConfig:
+        """Populate ``quant`` with the LM-head weight-only int4 RTN scheme."""
+        return finalize_lm_head_quant_config(quant, onnx_path=onnx_path, model_id=model_id)

--- a/src/winml/modelkit/quant/calibration/registry.py
+++ b/src/winml/modelkit/quant/calibration/registry.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
 # ``config.model_type``.
 QUANT_FINALIZERS: dict[str, tuple[str, str]] = {
     "qwen3_transformer_only": (".qwen3_transformer_only", "Qwen3TransformerOnlyQuantFinalizer"),
+    "qwen3_lm_head_only": (".qwen3_lm_head_only", "Qwen3LMHeadOnlyQuantFinalizer"),
 }
 
 

--- a/tests/e2e/models/test_qwen3_embeddings_lm_head_quant.py
+++ b/tests/e2e/models/test_qwen3_embeddings_lm_head_quant.py
@@ -1,0 +1,183 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""End-to-end coverage for the standalone Qwen3 embeddings + lm_head builds.
+
+These complement ``test_qwen3_transformer_only_quant.py``: that test covers the
+transformer (w8a16 QDQ); this one covers the two remaining sub-models of the
+split Qwen3 graph:
+
+  - **embeddings** (``model_type="qwen3_embeddings_only"``) — the input
+    embedding table (``input_ids`` -> ``input_hidden_states``). Built float
+    (``precision="fp32"``); it is **not** quantized.
+  - **lm_head** (``model_type="qwen3_lm_head_only"``) — the vocab projection
+    (``output_hidden_states`` -> ``logits``). Quantized weight-only to int4 via
+    MatMulNBits/RTN (``precision="w4a32"``).
+
+Both download Qwen3-0.6B from HuggingFace and run a full CPU export, so they are
+gated behind ``slow`` + ``network`` and excluded from the default lane. All
+expectations are generated in-code (FP reference), never hardcoded.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import onnx
+import onnxruntime as ort
+import pytest
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from winml.modelkit.models.auto import WinMLAutoModel
+
+
+pytestmark = [pytest.mark.e2e, pytest.mark.slow, pytest.mark.network]
+
+MODEL_ID = "Qwen/Qwen3-0.6B"
+SEQ_LEN = 8
+
+
+def _op_counts(onnx_path: str) -> dict[str, int]:
+    graph = onnx.load(onnx_path, load_external_data=False).graph
+    counts: dict[str, int] = {}
+    for node in graph.node:
+        counts[node.op_type] = counts.get(node.op_type, 0) + 1
+    return counts
+
+
+# =============================================================================
+# Embeddings — float export, NOT quantized
+# =============================================================================
+
+
+@pytest.fixture(scope="module")
+def embeddings_model(tmp_path_factory):
+    """Export the float embeddings sub-model once on CPU (no quantization)."""
+    cache_dir = tmp_path_factory.mktemp("qwen3_embeddings")
+    return WinMLAutoModel.from_pretrained(
+        MODEL_ID,
+        task="feature-extraction",
+        model_type="qwen3_embeddings_only",
+        precision="fp32",
+        device="cpu",
+        ep="cpu",
+        no_compile=True,
+        force_rebuild=True,
+        shape_config={"seq_len": SEQ_LEN},
+        cache_dir=str(cache_dir),
+    )
+
+
+@pytest.mark.timeout(1200)
+def test_embeddings_not_quantized(embeddings_model):
+    onnx_path = str(embeddings_model.onnx_path)
+    counts = _op_counts(onnx_path)
+
+    # Embedding lookup is a Gather; it must stay float (no QDQ, no MatMulNBits).
+    assert counts.get("Gather", 0) > 0
+    assert counts.get("QuantizeLinear", 0) == 0
+    assert counts.get("DequantizeLinear", 0) == 0
+    assert counts.get("MatMulNBits", 0) == 0
+
+    # Output is named to chain into the transformer's input_hidden_states.
+    out_names = {o.name for o in onnx.load(onnx_path, load_external_data=False).graph.output}
+    assert "input_hidden_states" in out_names
+
+
+@pytest.mark.timeout(1200)
+def test_embeddings_parity_against_fp_reference(embeddings_model):
+    """The float embeddings ONNX must match HF ``embed_tokens`` exactly."""
+    onnx_path = str(embeddings_model.onnx_path)
+    session = ort.InferenceSession(onnx_path, providers=["CPUExecutionProvider"])
+
+    hf = AutoModelForCausalLM.from_pretrained(MODEL_ID, dtype=torch.float32)
+    hf.eval()
+    embed = hf.get_input_embeddings()
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+
+    # The exported embeddings bake a fixed seq_len (= SEQ_LEN), so feed exactly
+    # that many positions. Use a prompt long enough to slice to SEQ_LEN tokens.
+    text = "The capital of France is Paris and the capital of Italy is"
+    ids = tokenizer([text], return_tensors="pt").input_ids[:, :SEQ_LEN]
+    assert ids.shape[1] == SEQ_LEN, f"prompt too short: {ids.shape[1]} < {SEQ_LEN}"
+    with torch.no_grad():
+        want = embed(ids).to(torch.float32).cpu().numpy()
+
+    # The embedding Gather indexes with int64 (the exported input_ids dtype).
+    in_name = session.get_inputs()[0].name
+    got = session.run(None, {in_name: ids.to(torch.int64).cpu().numpy()})[0]
+
+    np.testing.assert_allclose(got, want, rtol=1e-3, atol=1e-3)
+
+
+# =============================================================================
+# LM head — weight-only int4 (MatMulNBits / RTN)
+# =============================================================================
+
+
+@pytest.fixture(scope="module")
+def lm_head_model(tmp_path_factory):
+    """Export + int4-RTN-quantize the lm_head sub-model once on CPU."""
+    cache_dir = tmp_path_factory.mktemp("qwen3_lm_head")
+    return WinMLAutoModel.from_pretrained(
+        MODEL_ID,
+        task="feature-extraction",
+        model_type="qwen3_lm_head_only",
+        precision="w4a32",
+        device="cpu",
+        ep="cpu",
+        no_compile=True,
+        force_rebuild=True,
+        shape_config={"seq_len": SEQ_LEN},
+        cache_dir=str(cache_dir),
+    )
+
+
+@pytest.mark.timeout(1800)
+def test_lm_head_is_int4_quantized(lm_head_model):
+    onnx_path = str(lm_head_model.onnx_path)
+    counts = _op_counts(onnx_path)
+
+    # The vocab projection is weight-only int4 -> a MatMulNBits node replaces
+    # the float MatMul.
+    assert counts.get("MatMulNBits", 0) > 0
+    assert counts.get("MatMul", 0) == 0
+
+    out_names = {o.name for o in onnx.load(onnx_path, load_external_data=False).graph.output}
+    assert "logits" in out_names
+
+
+@pytest.mark.timeout(1800)
+def test_lm_head_parity_against_fp_reference(lm_head_model):
+    """The int4 lm_head must track the FP reference's greedy token closely.
+
+    4-bit weights are lossy, so we don't require bit-exact logits — instead the
+    quantized head must pick the same argmax token as the FP head on real
+    hidden states (the metric that actually matters for generation).
+    """
+    onnx_path = str(lm_head_model.onnx_path)
+    session = ort.InferenceSession(onnx_path, providers=["CPUExecutionProvider"])
+
+    hf = AutoModelForCausalLM.from_pretrained(MODEL_ID, dtype=torch.float32)
+    hf.eval()
+    lm_head = hf.lm_head
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+
+    # The int4 lm_head bakes a fixed seq_len (= SEQ_LEN), so feed exactly that
+    # many positions. Use a prompt long enough to slice to SEQ_LEN tokens.
+    text = "The capital of France is Paris and the capital of Italy is"
+    ids = tokenizer([text], return_tensors="pt").input_ids[:, :SEQ_LEN]
+    assert ids.shape[1] == SEQ_LEN, f"prompt too short: {ids.shape[1]} < {SEQ_LEN}"
+    with torch.no_grad():
+        hidden = hf.model(input_ids=ids, use_cache=False).last_hidden_state.to(torch.float32)
+        want_logits = lm_head(hidden)
+    want_tok = int(want_logits[:, -1, :].argmax(-1))
+
+    in_name = session.get_inputs()[0].name
+    got_logits = session.run(None, {in_name: hidden.cpu().numpy().astype(np.float32)})[0]
+    got_tok = int(got_logits[0, -1].argmax())
+
+    assert got_tok == want_tok, (
+        f"int4 lm_head diverged from FP reference: fp={want_tok} quant={got_tok}"
+    )


### PR DESCRIPTION
Summary
Adds two new standalone model types to the winml-cli modelkit so the Qwen3 input-embeddings and lm_head layers can be exported as independent ONNX graphs, separately from the transformer body:

qwen3_embeddings_only — float embeddings export with no quantization.
qwen3_lm_head_only — int4 weight-only RTN quantization via MatMulNBits (block_size=32, symmetric, accuracy_level=4).
This mirrors the existing split-graph pipeline (qwen3_transformer_only) and lets the four Qwen3 sub-models (embeddings → prefill → decode → lm_head) be built and placed independently across execution providers.