### PR TITLE
Fix issues in depth-estimation and keypoint-detection

### DIFF
--- a/examples/recipes/Intel_dpt-hybrid-midas/depth-estimation_fp16_config.json
+++ b/examples/recipes/Intel_dpt-hybrid-midas/depth-estimation_fp16_config.json
@@ -1,0 +1,58 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          384,
+          384
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "predicted_depth"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "depth-estimation",
+    "model_class": "AutoModelForDepthEstimation",
+    "model_type": "dpt"
+  },
+  "eval": {
+    "task": "depth-estimation",
+    "dataset": {
+      "path": "sayakpaul/nyu_depth_v2",
+      "split": "validation",
+      "samples": 100,
+      "shuffle": true,
+      "seed": 42,
+      "columns_mapping": {
+        "input_column": "image",
+        "depth_column": "depth_map",
+        "depth_kind": "disparity"
+      },
+      "revision": "refs/convert/parquet"
+    }
+  }
+}

--- a/examples/recipes/Intel_dpt-hybrid-midas/depth-estimation_w8a16_config.json
+++ b/examples/recipes/Intel_dpt-hybrid-midas/depth-estimation_w8a16_config.json
@@ -1,0 +1,78 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          384,
+          384
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "predicted_depth"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "static",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint16",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "depth-estimation",
+    "model_id": "Intel/dpt-hybrid-midas",
+    "model_type": "dpt"
+  },
+  "compile": null,
+  "loader": {
+    "task": "depth-estimation",
+    "model_class": "AutoModelForDepthEstimation",
+    "model_type": "dpt"
+  },
+  "eval": {
+    "task": "depth-estimation",
+    "dataset": {
+      "path": "sayakpaul/nyu_depth_v2",
+      "split": "validation",
+      "samples": 200,
+      "shuffle": true,
+      "seed": 42,
+      "columns_mapping": {
+        "input_column": "image",
+        "depth_column": "depth_map",
+        "depth_kind": "disparity"
+      },
+      "revision": "refs/convert/parquet"
+    }
+  }
+}

--- a/examples/recipes/LiheYoung_depth-anything-small-hf/depth-estimation_fp16_config.json
+++ b/examples/recipes/LiheYoung_depth-anything-small-hf/depth-estimation_fp16_config.json
@@ -1,0 +1,58 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          518,
+          518
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "predicted_depth"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "depth-estimation",
+    "model_class": "AutoModelForDepthEstimation",
+    "model_type": "depth_anything"
+  },
+  "eval": {
+    "task": "depth-estimation",
+    "dataset": {
+      "path": "sayakpaul/nyu_depth_v2",
+      "split": "validation",
+      "samples": 100,
+      "shuffle": true,
+      "seed": 42,
+      "columns_mapping": {
+        "input_column": "image",
+        "depth_column": "depth_map",
+        "depth_kind": "disparity"
+      },
+      "revision": "refs/convert/parquet"
+    }
+  }
+}

--- a/examples/recipes/LiheYoung_depth-anything-small-hf/depth-estimation_w8a16_config.json
+++ b/examples/recipes/LiheYoung_depth-anything-small-hf/depth-estimation_w8a16_config.json
@@ -1,0 +1,78 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          518,
+          518
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "predicted_depth"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "static",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint16",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "depth-estimation",
+    "model_id": "LiheYoung/depth-anything-small-hf",
+    "model_type": "depth_anything"
+  },
+  "compile": null,
+  "loader": {
+    "task": "depth-estimation",
+    "model_class": "AutoModelForDepthEstimation",
+    "model_type": "depth_anything"
+  },
+  "eval": {
+    "task": "depth-estimation",
+    "dataset": {
+      "path": "sayakpaul/nyu_depth_v2",
+      "split": "validation",
+      "samples": 200,
+      "shuffle": true,
+      "seed": 42,
+      "columns_mapping": {
+        "input_column": "image",
+        "depth_column": "depth_map",
+        "depth_kind": "disparity"
+      },
+      "revision": "refs/convert/parquet"
+    }
+  }
+}

--- a/examples/recipes/depth-anything_Depth-Anything-V2-Small-hf/depth-estimation_fp16_config.json
+++ b/examples/recipes/depth-anything_Depth-Anything-V2-Small-hf/depth-estimation_fp16_config.json
@@ -1,0 +1,58 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          518,
+          518
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "predicted_depth"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "depth-estimation",
+    "model_class": "AutoModelForDepthEstimation",
+    "model_type": "depth_anything"
+  },
+  "eval": {
+    "task": "depth-estimation",
+    "dataset": {
+      "path": "sayakpaul/nyu_depth_v2",
+      "split": "validation",
+      "samples": 100,
+      "shuffle": true,
+      "seed": 42,
+      "columns_mapping": {
+        "input_column": "image",
+        "depth_column": "depth_map",
+        "depth_kind": "disparity"
+      },
+      "revision": "refs/convert/parquet"
+    }
+  }
+}

--- a/examples/recipes/depth-anything_Depth-Anything-V2-Small-hf/depth-estimation_w8a16_config.json
+++ b/examples/recipes/depth-anything_Depth-Anything-V2-Small-hf/depth-estimation_w8a16_config.json
@@ -1,0 +1,78 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          518,
+          518
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "predicted_depth"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "static",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint16",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "depth-estimation",
+    "model_id": "depth-anything/Depth-Anything-V2-Small-hf",
+    "model_type": "depth_anything"
+  },
+  "compile": null,
+  "loader": {
+    "task": "depth-estimation",
+    "model_class": "AutoModelForDepthEstimation",
+    "model_type": "depth_anything"
+  },
+  "eval": {
+    "task": "depth-estimation",
+    "dataset": {
+      "path": "sayakpaul/nyu_depth_v2",
+      "split": "validation",
+      "samples": 200,
+      "shuffle": true,
+      "seed": 42,
+      "columns_mapping": {
+        "input_column": "image",
+        "depth_column": "depth_map",
+        "depth_kind": "disparity"
+      },
+      "revision": "refs/convert/parquet"
+    }
+  }
+}

--- a/examples/recipes/usyd-community_vitpose-base-simple/keypoint-detection_fp16_config.json
+++ b/examples/recipes/usyd-community_vitpose-base-simple/keypoint-detection_fp16_config.json
@@ -1,0 +1,61 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          256,
+          192
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "heatmaps"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "keypoint-detection",
+    "model_class": "VitPoseForPoseEstimation",
+    "model_type": "vitpose"
+  },
+  "eval": {
+    "task": "keypoint-detection",
+    "dataset": {
+      "path": "~/.cache/winml/datasets/coco_keypoints_val2017",
+      "build_script": "scripts/build_coco_keypoints.py",
+      "split": "validation",
+      "samples": 100,
+      "shuffle": true,
+      "seed": 42,
+      "columns_mapping": {
+        "input_column": "image",
+        "annotation_column": "objects",
+        "keypoints_key": "keypoints",
+        "bbox_key": "bbox",
+        "area_key": "area",
+        "box_format": "xywh"
+      }
+    }
+  }
+}

--- a/examples/recipes/usyd-community_vitpose-base-simple/keypoint-detection_w8a8_config.json
+++ b/examples/recipes/usyd-community_vitpose-base-simple/keypoint-detection_w8a8_config.json
@@ -1,0 +1,81 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          256,
+          192
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "heatmaps"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "static",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "keypoint-detection",
+    "model_id": "usyd-community/vitpose-base-simple",
+    "model_type": "vitpose"
+  },
+  "compile": null,
+  "loader": {
+    "task": "keypoint-detection",
+    "model_class": "VitPoseForPoseEstimation",
+    "model_type": "vitpose"
+  },
+  "eval": {
+    "task": "keypoint-detection",
+    "dataset": {
+      "path": "~/.cache/winml/datasets/coco_keypoints_val2017",
+      "build_script": "scripts/build_coco_keypoints.py",
+      "split": "validation",
+      "samples": 500,
+      "shuffle": true,
+      "seed": 42,
+      "columns_mapping": {
+        "input_column": "image",
+        "annotation_column": "objects",
+        "keypoints_key": "keypoints",
+        "bbox_key": "bbox",
+        "area_key": "area",
+        "box_format": "xywh"
+      }
+    }
+  }
+}

--- a/examples/recipes/usyd-community_vitpose-plus-base/keypoint-detection_fp16_config.json
+++ b/examples/recipes/usyd-community_vitpose-plus-base/keypoint-detection_fp16_config.json
@@ -1,0 +1,61 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          256,
+          192
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "heatmaps"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "keypoint-detection",
+    "model_class": "VitPoseForPoseEstimation",
+    "model_type": "vitpose"
+  },
+  "eval": {
+    "task": "keypoint-detection",
+    "dataset": {
+      "path": "~/.cache/winml/datasets/coco_keypoints_val2017",
+      "build_script": "scripts/build_coco_keypoints.py",
+      "split": "validation",
+      "samples": 100,
+      "shuffle": true,
+      "seed": 42,
+      "columns_mapping": {
+        "input_column": "image",
+        "annotation_column": "objects",
+        "keypoints_key": "keypoints",
+        "bbox_key": "bbox",
+        "area_key": "area",
+        "box_format": "xywh"
+      }
+    }
+  }
+}

--- a/examples/recipes/usyd-community_vitpose-plus-base/keypoint-detection_w8a8_config.json
+++ b/examples/recipes/usyd-community_vitpose-plus-base/keypoint-detection_w8a8_config.json
@@ -1,0 +1,81 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          256,
+          192
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "heatmaps"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "static",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "keypoint-detection",
+    "model_id": "usyd-community/vitpose-plus-base",
+    "model_type": "vitpose"
+  },
+  "compile": null,
+  "loader": {
+    "task": "keypoint-detection",
+    "model_class": "VitPoseForPoseEstimation",
+    "model_type": "vitpose"
+  },
+  "eval": {
+    "task": "keypoint-detection",
+    "dataset": {
+      "path": "~/.cache/winml/datasets/coco_keypoints_val2017",
+      "build_script": "scripts/build_coco_keypoints.py",
+      "split": "validation",
+      "samples": 500,
+      "shuffle": true,
+      "seed": 42,
+      "columns_mapping": {
+        "input_column": "image",
+        "annotation_column": "objects",
+        "keypoints_key": "keypoints",
+        "bbox_key": "bbox",
+        "area_key": "area",
+        "box_format": "xywh"
+      }
+    }
+  }
+}

--- a/examples/recipes/usyd-community_vitpose-plus-large/keypoint-detection_fp16_config.json
+++ b/examples/recipes/usyd-community_vitpose-plus-large/keypoint-detection_fp16_config.json
@@ -1,0 +1,61 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          256,
+          192
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "heatmaps"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "keypoint-detection",
+    "model_class": "VitPoseForPoseEstimation",
+    "model_type": "vitpose"
+  },
+  "eval": {
+    "task": "keypoint-detection",
+    "dataset": {
+      "path": "~/.cache/winml/datasets/coco_keypoints_val2017",
+      "build_script": "scripts/build_coco_keypoints.py",
+      "split": "validation",
+      "samples": 100,
+      "shuffle": true,
+      "seed": 42,
+      "columns_mapping": {
+        "input_column": "image",
+        "annotation_column": "objects",
+        "keypoints_key": "keypoints",
+        "bbox_key": "bbox",
+        "area_key": "area",
+        "box_format": "xywh"
+      }
+    }
+  }
+}

--- a/examples/recipes/usyd-community_vitpose-plus-large/keypoint-detection_w8a8_config.json
+++ b/examples/recipes/usyd-community_vitpose-plus-large/keypoint-detection_w8a8_config.json
@@ -1,0 +1,81 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          256,
+          192
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "heatmaps"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "static",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "keypoint-detection",
+    "model_id": "usyd-community/vitpose-plus-large",
+    "model_type": "vitpose"
+  },
+  "compile": null,
+  "loader": {
+    "task": "keypoint-detection",
+    "model_class": "VitPoseForPoseEstimation",
+    "model_type": "vitpose"
+  },
+  "eval": {
+    "task": "keypoint-detection",
+    "dataset": {
+      "path": "~/.cache/winml/datasets/coco_keypoints_val2017",
+      "build_script": "scripts/build_coco_keypoints.py",
+      "split": "validation",
+      "samples": 500,
+      "shuffle": true,
+      "seed": 42,
+      "columns_mapping": {
+        "input_column": "image",
+        "annotation_column": "objects",
+        "keypoints_key": "keypoints",
+        "bbox_key": "bbox",
+        "area_key": "area",
+        "box_format": "xywh"
+      }
+    }
+  }
+}

--- a/examples/recipes/usyd-community_vitpose-plus-small/keypoint-detection_fp16_config.json
+++ b/examples/recipes/usyd-community_vitpose-plus-small/keypoint-detection_fp16_config.json
@@ -1,0 +1,61 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          256,
+          192
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "heatmaps"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "keypoint-detection",
+    "model_class": "VitPoseForPoseEstimation",
+    "model_type": "vitpose"
+  },
+  "eval": {
+    "task": "keypoint-detection",
+    "dataset": {
+      "path": "~/.cache/winml/datasets/coco_keypoints_val2017",
+      "build_script": "scripts/build_coco_keypoints.py",
+      "split": "validation",
+      "samples": 100,
+      "shuffle": true,
+      "seed": 42,
+      "columns_mapping": {
+        "input_column": "image",
+        "annotation_column": "objects",
+        "keypoints_key": "keypoints",
+        "bbox_key": "bbox",
+        "area_key": "area",
+        "box_format": "xywh"
+      }
+    }
+  }
+}

--- a/examples/recipes/usyd-community_vitpose-plus-small/keypoint-detection_w8a8_config.json
+++ b/examples/recipes/usyd-community_vitpose-plus-small/keypoint-detection_w8a8_config.json
@@ -1,0 +1,81 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          256,
+          192
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "heatmaps"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "static",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "keypoint-detection",
+    "model_id": "usyd-community/vitpose-plus-small",
+    "model_type": "vitpose"
+  },
+  "compile": null,
+  "loader": {
+    "task": "keypoint-detection",
+    "model_class": "VitPoseForPoseEstimation",
+    "model_type": "vitpose"
+  },
+  "eval": {
+    "task": "keypoint-detection",
+    "dataset": {
+      "path": "~/.cache/winml/datasets/coco_keypoints_val2017",
+      "build_script": "scripts/build_coco_keypoints.py",
+      "split": "validation",
+      "samples": 500,
+      "shuffle": true,
+      "seed": 42,
+      "columns_mapping": {
+        "input_column": "image",
+        "annotation_column": "objects",
+        "keypoints_key": "keypoints",
+        "bbox_key": "bbox",
+        "area_key": "area",
+        "box_format": "xywh"
+      }
+    }
+  }
+}

--- a/scripts/build_coco_keypoints.py
+++ b/scripts/build_coco_keypoints.py
@@ -79,6 +79,10 @@ def _fetch_image(file_name: str) -> bytes:
 
 def build(output_dir: Path, num_images: int, cache_dir: Path, seed: int = 42) -> None:
     """Build and save the COCO keypoints dataset to ``output_dir``."""
+    if (output_dir / "dataset_info.json").exists():
+        print(f"Dataset already exists at {output_dir}, skipping build.")
+        return
+
     from datasets import Dataset, Features, Image, Sequence, Value
     from PIL import Image as PILImage
 

--- a/scripts/build_coco_keypoints.py
+++ b/scripts/build_coco_keypoints.py
@@ -141,7 +141,7 @@ def main() -> int:
     parser.add_argument(
         "--num-images",
         type=int,
-        default=100,
+        default=500,
         help="Number of images to include (0 = all images with keypoints).",
     )
     parser.add_argument(

--- a/scripts/e2e_eval/cache/baseline_cache.json
+++ b/scripts/e2e_eval/cache/baseline_cache.json
@@ -2048,5 +2048,145 @@
     },
     "elapsed": 2532.9,
     "command": "python.exe run_pytorch_baseline.py --model vitpose-plus-huge --task keypoint-detection --device cpu --num-samples 500 --dataset coco_keypoints_val2017 --split validation --columns-mapping {\"input_column\": \"image\", \"annotation_column\": \"objects\", \"keypoints_key\": \"keypoints\", \"bbox_key\": \"bbox\", \"area_key\": \"area\", \"box_format\": \"xywh\"} --winml-metric-key map"
+  },
+  "LiheYoung/depth-anything-small-hf|depth-estimation|sayakpaul/nyu_depth_v2||validation|100": {
+    "status": "PASS",
+    "metric": {
+      "metric": "abs_rel",
+      "value": 0.065403,
+      "num_samples": 100
+    },
+    "elapsed": 161.8,
+    "command": "python.exe run_pytorch_baseline.py --model depth-anything-small-hf --task depth-estimation --device cpu --num-samples 100 --dataset nyu_depth_v2 --split validation --dataset-revision parquet --columns-mapping {\"input_column\": \"image\", \"depth_column\": \"depth_map\", \"depth_kind\": \"disparity\"} --winml-metric-key abs_rel"
+  },
+  "depth-anything/Depth-Anything-V2-Small-hf|depth-estimation|sayakpaul/nyu_depth_v2||validation|100": {
+    "status": "PASS",
+    "metric": {
+      "metric": "abs_rel",
+      "value": 0.091926,
+      "num_samples": 100
+    },
+    "elapsed": 172.0,
+    "command": "python.exe run_pytorch_baseline.py --model Depth-Anything-V2-Small-hf --task depth-estimation --device cpu --num-samples 100 --dataset nyu_depth_v2 --split validation --dataset-revision parquet --columns-mapping {\"input_column\": \"image\", \"depth_column\": \"depth_map\", \"depth_kind\": \"disparity\"} --winml-metric-key abs_rel"
+  },
+  "Intel/dpt-hybrid-midas|depth-estimation|sayakpaul/nyu_depth_v2||validation|100": {
+    "status": "PASS",
+    "metric": {
+      "metric": "abs_rel",
+      "value": 0.118565,
+      "num_samples": 100
+    },
+    "elapsed": 211.5,
+    "command": "python.exe run_pytorch_baseline.py --model dpt-hybrid-midas --task depth-estimation --device cpu --num-samples 100 --dataset nyu_depth_v2 --split validation --dataset-revision parquet --columns-mapping {\"input_column\": \"image\", \"depth_column\": \"depth_map\", \"depth_kind\": \"disparity\"} --winml-metric-key abs_rel"
+  },
+  "LiheYoung/depth-anything-base-hf|depth-estimation|sayakpaul/nyu_depth_v2||validation|100": {
+    "status": "PASS",
+    "metric": {
+      "metric": "abs_rel",
+      "value": 0.060025,
+      "num_samples": 100
+    },
+    "elapsed": 371.0,
+    "command": "python.exe run_pytorch_baseline.py --model depth-anything-base-hf --task depth-estimation --device cpu --num-samples 100 --dataset nyu_depth_v2 --split validation --dataset-revision parquet --columns-mapping {\"input_column\": \"image\", \"depth_column\": \"depth_map\", \"depth_kind\": \"disparity\"} --winml-metric-key abs_rel"
+  },
+  "depth-anything/Depth-Anything-V2-Base-hf|depth-estimation|sayakpaul/nyu_depth_v2||validation|100": {
+    "status": "PASS",
+    "metric": {
+      "metric": "abs_rel",
+      "value": 0.085267,
+      "num_samples": 100
+    },
+    "elapsed": 375.2,
+    "command": "python.exe run_pytorch_baseline.py --model Depth-Anything-V2-Base-hf --task depth-estimation --device cpu --num-samples 100 --dataset nyu_depth_v2 --split validation --dataset-revision parquet --columns-mapping {\"input_column\": \"image\", \"depth_column\": \"depth_map\", \"depth_kind\": \"disparity\"} --winml-metric-key abs_rel"
+  },
+  "Intel/dpt-large|depth-estimation|sayakpaul/nyu_depth_v2||validation|100": {
+    "status": "PASS",
+    "metric": {
+      "metric": "abs_rel",
+      "value": 0.182581,
+      "num_samples": 100
+    },
+    "elapsed": 360.1,
+    "command": "python.exe run_pytorch_baseline.py --model dpt-large --task depth-estimation --device cpu --num-samples 100 --dataset nyu_depth_v2 --split validation --dataset-revision parquet --columns-mapping {\"input_column\": \"image\", \"depth_column\": \"depth_map\", \"depth_kind\": \"disparity\"} --winml-metric-key abs_rel"
+  },
+  "LiheYoung/depth-anything-large-hf|depth-estimation|sayakpaul/nyu_depth_v2||validation|100": {
+    "status": "PASS",
+    "metric": {
+      "metric": "abs_rel",
+      "value": 0.058291,
+      "num_samples": 100
+    },
+    "elapsed": 992.5,
+    "command": "python.exe run_pytorch_baseline.py --model depth-anything-large-hf --task depth-estimation --device cpu --num-samples 100 --dataset nyu_depth_v2 --split validation --dataset-revision parquet --columns-mapping {\"input_column\": \"image\", \"depth_column\": \"depth_map\", \"depth_kind\": \"disparity\"} --winml-metric-key abs_rel"
+  },
+  "depth-anything/Depth-Anything-V2-Large-hf|depth-estimation|sayakpaul/nyu_depth_v2||validation|100": {
+    "status": "PASS",
+    "metric": {
+      "metric": "abs_rel",
+      "value": 0.099132,
+      "num_samples": 100
+    },
+    "elapsed": 995.3,
+    "command": "python.exe run_pytorch_baseline.py --model Depth-Anything-V2-Large-hf --task depth-estimation --device cpu --num-samples 100 --dataset nyu_depth_v2 --split validation --dataset-revision parquet --columns-mapping {\"input_column\": \"image\", \"depth_column\": \"depth_map\", \"depth_kind\": \"disparity\"} --winml-metric-key abs_rel"
+  },
+  "xingyang1/Distill-Any-Depth-Large-hf|depth-estimation|sayakpaul/nyu_depth_v2||validation|100": {
+    "status": "PASS",
+    "metric": {
+      "metric": "abs_rel",
+      "value": 0.079418,
+      "num_samples": 100
+    },
+    "elapsed": 1063.1,
+    "command": "python.exe run_pytorch_baseline.py --model Distill-Any-Depth-Large-hf --task depth-estimation --device cpu --num-samples 100 --dataset nyu_depth_v2 --split validation --dataset-revision parquet --columns-mapping {\"input_column\": \"image\", \"depth_column\": \"depth_map\", \"depth_kind\": \"disparity\"} --winml-metric-key abs_rel"
+  },
+  "usyd-community/vitpose-plus-small|keypoint-detection|~/.cache/winml/datasets/coco_keypoints_val2017||validation|100": {
+    "status": "PASS",
+    "metric": {
+      "metric": "map",
+      "value": 0.776507,
+      "num_samples": 100
+    },
+    "elapsed": 60.8,
+    "command": "python.exe run_pytorch_baseline.py --model vitpose-plus-small --task keypoint-detection --device cpu --num-samples 100 --dataset coco_keypoints_val2017 --split validation --columns-mapping {\"input_column\": \"image\", \"annotation_column\": \"objects\", \"keypoints_key\": \"keypoints\", \"bbox_key\": \"bbox\", \"area_key\": \"area\", \"box_format\": \"xywh\"} --winml-metric-key map"
+  },
+  "usyd-community/vitpose-base-simple|keypoint-detection|~/.cache/winml/datasets/coco_keypoints_val2017||validation|100": {
+    "status": "PASS",
+    "metric": {
+      "metric": "map",
+      "value": 0.784277,
+      "num_samples": 100
+    },
+    "elapsed": 90.0,
+    "command": "python.exe run_pytorch_baseline.py --model vitpose-base-simple --task keypoint-detection --device cpu --num-samples 100 --dataset coco_keypoints_val2017 --split validation --columns-mapping {\"input_column\": \"image\", \"annotation_column\": \"objects\", \"keypoints_key\": \"keypoints\", \"bbox_key\": \"bbox\", \"area_key\": \"area\", \"box_format\": \"xywh\"} --winml-metric-key map"
+  },
+  "usyd-community/vitpose-plus-base|keypoint-detection|~/.cache/winml/datasets/coco_keypoints_val2017||validation|100": {
+    "status": "PASS",
+    "metric": {
+      "metric": "map",
+      "value": 0.804507,
+      "num_samples": 100
+    },
+    "elapsed": 115.4,
+    "command": "python.exe run_pytorch_baseline.py --model vitpose-plus-base --task keypoint-detection --device cpu --num-samples 100 --dataset coco_keypoints_val2017 --split validation --columns-mapping {\"input_column\": \"image\", \"annotation_column\": \"objects\", \"keypoints_key\": \"keypoints\", \"bbox_key\": \"bbox\", \"area_key\": \"area\", \"box_format\": \"xywh\"} --winml-metric-key map"
+  },
+  "usyd-community/vitpose-plus-large|keypoint-detection|~/.cache/winml/datasets/coco_keypoints_val2017||validation|100": {
+    "status": "PASS",
+    "metric": {
+      "metric": "map",
+      "value": 0.830365,
+      "num_samples": 100
+    },
+    "elapsed": 329.0,
+    "command": "python.exe run_pytorch_baseline.py --model vitpose-plus-large --task keypoint-detection --device cpu --num-samples 100 --dataset coco_keypoints_val2017 --split validation --columns-mapping {\"input_column\": \"image\", \"annotation_column\": \"objects\", \"keypoints_key\": \"keypoints\", \"bbox_key\": \"bbox\", \"area_key\": \"area\", \"box_format\": \"xywh\"} --winml-metric-key map"
+  },
+  "usyd-community/vitpose-plus-huge|keypoint-detection|~/.cache/winml/datasets/coco_keypoints_val2017||validation|100": {
+    "status": "PASS",
+    "metric": {
+      "metric": "map",
+      "value": 0.836968,
+      "num_samples": 100
+    },
+    "elapsed": 601.1,
+    "command": "python.exe run_pytorch_baseline.py --model vitpose-plus-huge --task keypoint-detection --device cpu --num-samples 100 --dataset coco_keypoints_val2017 --split validation --columns-mapping {\"input_column\": \"image\", \"annotation_column\": \"objects\", \"keypoints_key\": \"keypoints\", \"bbox_key\": \"bbox\", \"area_key\": \"area\", \"box_format\": \"xywh\"} --winml-metric-key map"
   }
 }

--- a/scripts/e2e_eval/cache/baseline_cache.json
+++ b/scripts/e2e_eval/cache/baseline_cache.json
@@ -1788,7 +1788,7 @@
     },
     "elapsed": 632.7,
     "command": "python.exe run_pytorch_baseline.py --model trocr-large-printed --task image-to-text --device cpu --num-samples 100 --dataset SROIE_2019_text_recognition --split test --columns-mapping {\"input_column\": \"image\", \"label_column\": \"text\"} --winml-metric-key cer"
-  },  
+  },
   "microsoft/resnet-18|image-classification|timm/mini-imagenet||test|1000": {
     "status": "PASS",
     "metric": {
@@ -1908,5 +1908,95 @@
     },
     "elapsed": 227.0,
     "command": "python.exe run_pytorch_baseline.py --model bge-m3 --task sentence-similarity --device cpu --num-samples 1000 --dataset stsbenchmark-sts --split test --columns-mapping {\"input_column_1\": \"sentence1\", \"input_column_2\": \"sentence2\", \"score_column\": \"score\"} --winml-metric-key cosine_spearman"
+  },
+  "Intel/dpt-hybrid-midas|depth-estimation|sayakpaul/nyu_depth_v2||validation|200": {
+    "status": "PASS",
+    "metric": {
+      "metric": "abs_rel",
+      "value": 0.118953,
+      "num_samples": 200
+    },
+    "elapsed": 320.9,
+    "command": "python.exe run_pytorch_baseline.py --model dpt-hybrid-midas --task depth-estimation --device cpu --num-samples 200 --dataset nyu_depth_v2 --split validation --dataset-revision parquet --columns-mapping {\"input_column\": \"image\", \"depth_column\": \"depth_map\", \"depth_kind\": \"disparity\"} --winml-metric-key abs_rel"
+  },
+  "Intel/dpt-large|depth-estimation|sayakpaul/nyu_depth_v2||validation|200": {
+    "status": "PASS",
+    "metric": {
+      "metric": "abs_rel",
+      "value": 0.149265,
+      "num_samples": 200
+    },
+    "elapsed": 573.1,
+    "command": "python.exe run_pytorch_baseline.py --model dpt-large --task depth-estimation --device cpu --num-samples 200 --dataset nyu_depth_v2 --split validation --dataset-revision parquet --columns-mapping {\"input_column\": \"image\", \"depth_column\": \"depth_map\", \"depth_kind\": \"disparity\"} --winml-metric-key abs_rel"
+  },
+  "Intel/zoedepth-nyu-kitti|depth-estimation|sayakpaul/nyu_depth_v2||validation|200": {
+    "status": "PASS",
+    "metric": {
+      "metric": "abs_rel",
+      "value": 0.140968,
+      "num_samples": 200
+    },
+    "elapsed": 934.8,
+    "command": "python.exe run_pytorch_baseline.py --model zoedepth-nyu-kitti --task depth-estimation --device cpu --num-samples 200 --dataset nyu_depth_v2 --split validation --dataset-revision parquet --columns-mapping {\"input_column\": \"image\", \"depth_column\": \"depth_map\", \"align\": \"none\"} --winml-metric-key abs_rel"
+  },
+  "LiheYoung/depth-anything-large-hf|depth-estimation|sayakpaul/nyu_depth_v2||validation|200": {
+    "status": "PASS",
+    "metric": {
+      "metric": "abs_rel",
+      "value": 0.057967,
+      "num_samples": 200
+    },
+    "elapsed": 1745.2,
+    "command": "python.exe run_pytorch_baseline.py --model depth-anything-large-hf --task depth-estimation --device cpu --num-samples 200 --dataset nyu_depth_v2 --split validation --dataset-revision parquet --columns-mapping {\"input_column\": \"image\", \"depth_column\": \"depth_map\", \"depth_kind\": \"disparity\"} --winml-metric-key abs_rel"
+  },
+  "LiheYoung/depth-anything-small-hf|depth-estimation|sayakpaul/nyu_depth_v2||validation|200": {
+    "status": "PASS",
+    "metric": {
+      "metric": "abs_rel",
+      "value": 0.066291,
+      "num_samples": 200
+    },
+    "elapsed": 242.0,
+    "command": "python.exe run_pytorch_baseline.py --model depth-anything-small-hf --task depth-estimation --device cpu --num-samples 200 --dataset nyu_depth_v2 --split validation --dataset-revision parquet --columns-mapping {\"input_column\": \"image\", \"depth_column\": \"depth_map\", \"depth_kind\": \"disparity\"} --winml-metric-key abs_rel"
+  },
+  "depth-anything/Depth-Anything-V2-Base-hf|depth-estimation|sayakpaul/nyu_depth_v2||validation|200": {
+    "status": "PASS",
+    "metric": {
+      "metric": "abs_rel",
+      "value": 0.086005,
+      "num_samples": 200
+    },
+    "elapsed": 555.2,
+    "command": "python.exe run_pytorch_baseline.py --model Depth-Anything-V2-Base-hf --task depth-estimation --device cpu --num-samples 200 --dataset nyu_depth_v2 --split validation --dataset-revision parquet --columns-mapping {\"input_column\": \"image\", \"depth_column\": \"depth_map\", \"depth_kind\": \"disparity\"} --winml-metric-key abs_rel"
+  },
+  "depth-anything/Depth-Anything-V2-Large-hf|depth-estimation|sayakpaul/nyu_depth_v2||validation|200": {
+    "status": "PASS",
+    "metric": {
+      "metric": "abs_rel",
+      "value": 0.098907,
+      "num_samples": 200
+    },
+    "elapsed": 1652.1,
+    "command": "python.exe run_pytorch_baseline.py --model Depth-Anything-V2-Large-hf --task depth-estimation --device cpu --num-samples 200 --dataset nyu_depth_v2 --split validation --dataset-revision parquet --columns-mapping {\"input_column\": \"image\", \"depth_column\": \"depth_map\", \"depth_kind\": \"disparity\"} --winml-metric-key abs_rel"
+  },
+  "depth-anything/Depth-Anything-V2-Small-hf|depth-estimation|sayakpaul/nyu_depth_v2||validation|200": {
+    "status": "PASS",
+    "metric": {
+      "metric": "abs_rel",
+      "value": 0.09086,
+      "num_samples": 200
+    },
+    "elapsed": 280.2,
+    "command": "python.exe run_pytorch_baseline.py --model Depth-Anything-V2-Small-hf --task depth-estimation --device cpu --num-samples 200 --dataset nyu_depth_v2 --split validation --dataset-revision parquet --columns-mapping {\"input_column\": \"image\", \"depth_column\": \"depth_map\", \"depth_kind\": \"disparity\"} --winml-metric-key abs_rel"
+  },
+  "LiheYoung/depth-anything-base-hf|depth-estimation|sayakpaul/nyu_depth_v2||validation|200": {
+    "status": "PASS",
+    "metric": {
+      "metric": "abs_rel",
+      "value": 0.060121,
+      "num_samples": 200
+    },
+    "elapsed": 668.0,
+    "command": "python.exe run_pytorch_baseline.py --model depth-anything-base-hf --task depth-estimation --device cpu --num-samples 200 --dataset nyu_depth_v2 --split validation --dataset-revision parquet --columns-mapping {\"input_column\": \"image\", \"depth_column\": \"depth_map\", \"depth_kind\": \"disparity\"} --winml-metric-key abs_rel"
   }
 }

--- a/scripts/e2e_eval/cache/baseline_cache.json
+++ b/scripts/e2e_eval/cache/baseline_cache.json
@@ -1998,5 +1998,55 @@
     },
     "elapsed": 668.0,
     "command": "python.exe run_pytorch_baseline.py --model depth-anything-base-hf --task depth-estimation --device cpu --num-samples 200 --dataset nyu_depth_v2 --split validation --dataset-revision parquet --columns-mapping {\"input_column\": \"image\", \"depth_column\": \"depth_map\", \"depth_kind\": \"disparity\"} --winml-metric-key abs_rel"
+  },
+  "usyd-community/vitpose-base-simple|keypoint-detection|~/.cache/winml/datasets/coco_keypoints_val2017||validation|500": {
+    "status": "PASS",
+    "metric": {
+      "metric": "map",
+      "value": 0.758371,
+      "num_samples": 500
+    },
+    "elapsed": 370.5,
+    "command": "python.exe run_pytorch_baseline.py --model vitpose-base-simple --task keypoint-detection --device cpu --num-samples 500 --dataset coco_keypoints_val2017 --split validation --columns-mapping {\"input_column\": \"image\", \"annotation_column\": \"objects\", \"keypoints_key\": \"keypoints\", \"bbox_key\": \"bbox\", \"area_key\": \"area\", \"box_format\": \"xywh\"} --winml-metric-key map"
+  },
+  "usyd-community/vitpose-plus-small|keypoint-detection|~/.cache/winml/datasets/coco_keypoints_val2017||validation|500": {
+    "status": "PASS",
+    "metric": {
+      "metric": "map",
+      "value": 0.774118,
+      "num_samples": 500
+    },
+    "elapsed": 212.0,
+    "command": "python.exe run_pytorch_baseline.py --model vitpose-plus-small --task keypoint-detection --device cpu --num-samples 500 --dataset coco_keypoints_val2017 --split validation --columns-mapping {\"input_column\": \"image\", \"annotation_column\": \"objects\", \"keypoints_key\": \"keypoints\", \"bbox_key\": \"bbox\", \"area_key\": \"area\", \"box_format\": \"xywh\"} --winml-metric-key map"
+  },
+  "usyd-community/vitpose-plus-base|keypoint-detection|~/.cache/winml/datasets/coco_keypoints_val2017||validation|500": {
+    "status": "PASS",
+    "metric": {
+      "metric": "map",
+      "value": 0.784706,
+      "num_samples": 500
+    },
+    "elapsed": 471.4,
+    "command": "python.exe run_pytorch_baseline.py --model vitpose-plus-base --task keypoint-detection --device cpu --num-samples 500 --dataset coco_keypoints_val2017 --split validation --columns-mapping {\"input_column\": \"image\", \"annotation_column\": \"objects\", \"keypoints_key\": \"keypoints\", \"bbox_key\": \"bbox\", \"area_key\": \"area\", \"box_format\": \"xywh\"} --winml-metric-key map"
+  },
+  "usyd-community/vitpose-plus-large|keypoint-detection|~/.cache/winml/datasets/coco_keypoints_val2017||validation|500": {
+    "status": "PASS",
+    "metric": {
+      "metric": "map",
+      "value": 0.809302,
+      "num_samples": 500
+    },
+    "elapsed": 1400.1,
+    "command": "python.exe run_pytorch_baseline.py --model vitpose-plus-large --task keypoint-detection --device cpu --num-samples 500 --dataset coco_keypoints_val2017 --split validation --columns-mapping {\"input_column\": \"image\", \"annotation_column\": \"objects\", \"keypoints_key\": \"keypoints\", \"bbox_key\": \"bbox\", \"area_key\": \"area\", \"box_format\": \"xywh\"} --winml-metric-key map"
+  },
+  "usyd-community/vitpose-plus-huge|keypoint-detection|~/.cache/winml/datasets/coco_keypoints_val2017||validation|500": {
+    "status": "PASS",
+    "metric": {
+      "metric": "map",
+      "value": 0.816515,
+      "num_samples": 500
+    },
+    "elapsed": 2532.9,
+    "command": "python.exe run_pytorch_baseline.py --model vitpose-plus-huge --task keypoint-detection --device cpu --num-samples 500 --dataset coco_keypoints_val2017 --split validation --columns-mapping {\"input_column\": \"image\", \"annotation_column\": \"objects\", \"keypoints_key\": \"keypoints\", \"bbox_key\": \"bbox\", \"area_key\": \"area\", \"box_format\": \"xywh\"} --winml-metric-key map"
   }
 }

--- a/scripts/e2e_eval/cache/timeout_skip_list.json
+++ b/scripts/e2e_eval/cache/timeout_skip_list.json
@@ -10,11 +10,6 @@
     "reason": "Build hangs >2000s, marian enc-dec export issue"
   },
   {
-    "hf_id": "LiheYoung/depth-anything-base-hf",
-    "task": "depth-estimation",
-    "reason": "Analyzer hangs >17000s, Black nodes ConvTranspose"
-  },
-  {
     "hf_id": "Qwen/Qwen3-8B",
     "task": "text-generation",
     "reason": "Build hangs >3500s, large LLM"

--- a/scripts/e2e_eval/testsets/models_with_acc.json
+++ b/scripts/e2e_eval/testsets/models_with_acc.json
@@ -1918,6 +1918,7 @@
       "build_script": "scripts/build_coco_keypoints.py",
       "path": "~/.cache/winml/datasets/coco_keypoints_val2017",
       "split": "validation",
+      "samples": 500,
       "metric": "map",
       "winml_metric_key": "map",
       "columns_mapping": {
@@ -1940,6 +1941,7 @@
       "build_script": "scripts/build_coco_keypoints.py",
       "path": "~/.cache/winml/datasets/coco_keypoints_val2017",
       "split": "validation",
+      "samples": 500,
       "metric": "map",
       "winml_metric_key": "map",
       "columns_mapping": {
@@ -1962,6 +1964,7 @@
       "build_script": "scripts/build_coco_keypoints.py",
       "path": "~/.cache/winml/datasets/coco_keypoints_val2017",
       "split": "validation",
+      "samples": 500,
       "metric": "map",
       "winml_metric_key": "map",
       "columns_mapping": {
@@ -1984,6 +1987,7 @@
       "build_script": "scripts/build_coco_keypoints.py",
       "path": "~/.cache/winml/datasets/coco_keypoints_val2017",
       "split": "validation",
+      "samples": 500,
       "metric": "map",
       "winml_metric_key": "map",
       "columns_mapping": {
@@ -2006,6 +2010,7 @@
       "build_script": "scripts/build_coco_keypoints.py",
       "path": "~/.cache/winml/datasets/coco_keypoints_val2017",
       "split": "validation",
+      "samples": 500,
       "metric": "map",
       "winml_metric_key": "map",
       "columns_mapping": {

--- a/scripts/e2e_eval/testsets/models_with_acc.json
+++ b/scripts/e2e_eval/testsets/models_with_acc.json
@@ -1748,6 +1748,7 @@
       "revision": "refs/convert/parquet",
       "split": "validation",
       "metric": "abs_rel",
+      "samples": 200,
       "columns_mapping": {
         "input_column": "image",
         "depth_column": "depth_map",
@@ -1766,28 +1767,11 @@
       "revision": "refs/convert/parquet",
       "split": "validation",
       "metric": "abs_rel",
+      "samples": 200,
       "columns_mapping": {
         "input_column": "image",
         "depth_column": "depth_map",
         "depth_kind": "disparity"
-      }
-    }
-  },
-  {
-    "hf_id": "Intel/zoedepth-nyu-kitti",
-    "task": "depth-estimation",
-    "model_type": "zoedepth",
-    "group": "Top200",
-    "priority": "P2",
-    "dataset_config": {
-      "path": "sayakpaul/nyu_depth_v2",
-      "revision": "refs/convert/parquet",
-      "split": "validation",
-      "metric": "abs_rel",
-      "columns_mapping": {
-        "input_column": "image",
-        "depth_column": "depth_map",
-        "align": "none"
       }
     }
   },
@@ -1802,9 +1786,11 @@
       "revision": "refs/convert/parquet",
       "split": "validation",
       "metric": "abs_rel",
+      "samples": 200,
       "columns_mapping": {
         "input_column": "image",
-        "depth_column": "depth_map"
+        "depth_column": "depth_map",
+        "depth_kind": "disparity"
       }
     }
   },
@@ -1819,9 +1805,11 @@
       "revision": "refs/convert/parquet",
       "split": "validation",
       "metric": "abs_rel",
+      "samples": 200,
       "columns_mapping": {
         "input_column": "image",
-        "depth_column": "depth_map"
+        "depth_column": "depth_map",
+        "depth_kind": "disparity"
       }
     }
   },
@@ -1836,27 +1824,11 @@
       "revision": "refs/convert/parquet",
       "split": "validation",
       "metric": "abs_rel",
-      "columns_mapping": {
-        "input_column": "image",
-        "depth_column": "depth_map"
-      }
-    }
-  },
-  {
-    "hf_id": "apple/DepthPro-hf",
-    "task": "depth-estimation",
-    "model_type": "depth_pro",
-    "group": "Top200",
-    "priority": "P2",
-    "dataset_config": {
-      "path": "sayakpaul/nyu_depth_v2",
-      "revision": "refs/convert/parquet",
-      "split": "validation",
-      "metric": "abs_rel",
+      "samples": 200,
       "columns_mapping": {
         "input_column": "image",
         "depth_column": "depth_map",
-        "align": "none"
+        "depth_kind": "disparity"
       }
     }
   },
@@ -1871,9 +1843,11 @@
       "revision": "refs/convert/parquet",
       "split": "validation",
       "metric": "abs_rel",
+      "samples": 200,
       "columns_mapping": {
         "input_column": "image",
-        "depth_column": "depth_map"
+        "depth_column": "depth_map",
+        "depth_kind": "disparity"
       }
     }
   },
@@ -1888,9 +1862,11 @@
       "revision": "refs/convert/parquet",
       "split": "validation",
       "metric": "abs_rel",
+      "samples": 200,
       "columns_mapping": {
         "input_column": "image",
-        "depth_column": "depth_map"
+        "depth_column": "depth_map",
+        "depth_kind": "disparity"
       }
     }
   },
@@ -1905,9 +1881,11 @@
       "revision": "refs/convert/parquet",
       "split": "validation",
       "metric": "abs_rel",
+      "samples": 200,
       "columns_mapping": {
         "input_column": "image",
-        "depth_column": "depth_map"
+        "depth_column": "depth_map",
+        "depth_kind": "disparity"
       }
     }
   },
@@ -1922,9 +1900,11 @@
       "revision": "refs/convert/parquet",
       "split": "validation",
       "metric": "abs_rel",
+      "samples": 200,
       "columns_mapping": {
         "input_column": "image",
-        "depth_column": "depth_map"
+        "depth_column": "depth_map",
+        "depth_kind": "disparity"
       }
     }
   },

--- a/scripts/e2e_eval/utils/accuracy.py
+++ b/scripts/e2e_eval/utils/accuracy.py
@@ -49,6 +49,8 @@ METRIC_COMPARE_STRATEGY: dict[str, tuple[str, float, float, bool]] = {
     "pseudo_perplexity": ("delta_relative", 0.05, 0.10, False),
     # CER (OCR error rate): lower is better.
     "cer": ("delta_relative", 0.05, 0.10, False),
+    # AbsRel (depth-estimation error): lower is better.
+    "abs_rel": ("delta_relative", 0.05, 0.10, False),
     "default": ("delta_relative", 0.05, 0.10, True), # 5% and 10%
 }
 

--- a/src/winml/modelkit/commands/eval.py
+++ b/src/winml/modelkit/commands/eval.py
@@ -421,7 +421,7 @@ def _run_dataset_script(cfg: WinMLEvaluationConfig, trust_remote_code: bool) -> 
         cmd,
         capture_output=True,
         text=True,
-        timeout=300,
+        timeout=1200,
     )
     if result.returncode != 0:
         raise click.ClickException(

--- a/src/winml/modelkit/datasets/__init__.py
+++ b/src/winml/modelkit/datasets/__init__.py
@@ -20,6 +20,7 @@ from .data_utils import format_data
 from .depth_estimation import DEFAULT_DEPTH_ESTIMATION_SIZE, DepthEstimationDataset
 from .image import ImageDataset
 from .image_segmentation import ImageSegmentationDataset
+from .keypoint_detection import KeypointDetectionDataset
 from .object_detection import DEFAULT_OBJECT_DETECTION_SIZE, ObjectDetectionDataset
 from .processor_utils import get_image_processor_config
 from .random_dataset import RandomDataset
@@ -48,6 +49,7 @@ TASK_DATASET_MAPPING = {
     "zero-shot-classification": TextDataset,
     "image-segmentation": ImageSegmentationDataset,
     "depth-estimation": DepthEstimationDataset,
+    "keypoint-detection": KeypointDetectionDataset,
     "random": RandomDataset,
     # Add more task types as needed
 }
@@ -329,6 +331,7 @@ __all__ = [  # noqa: RUF022
     "DepthEstimationDataset",
     "ImageDataset",
     "ImageSegmentationDataset",
+    "KeypointDetectionDataset",
     "ObjectDetectionDataset",
     "RandomDataset",
     "TextDataset",

--- a/src/winml/modelkit/datasets/keypoint_detection.py
+++ b/src/winml/modelkit/datasets/keypoint_detection.py
@@ -1,0 +1,95 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Keypoint-detection (pose estimation) dataset support for calibration.
+
+Pose image processors (e.g. ``VitPoseImageProcessor``) crop each person out of a
+bounding box before resizing to the model's fixed input, so their ``preprocess``
+requires a ``boxes`` argument that plain :class:`ImageDataset` does not supply —
+without it calibration silently falls back to random noise, which destroys the
+quantized model's accuracy. This specialization feeds a single full-image box per
+sample, producing real image activations at the model's ``pixel_values`` shape.
+Ground-truth person boxes are not needed for representative calibration.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from datasets.features import Image
+from transformers import AutoImageProcessor
+
+from .image import ImageDataset
+
+
+logger = logging.getLogger(__name__)
+
+
+class KeypointDetectionDataset(ImageDataset):
+    """Calibration dataset for keypoint / pose-estimation models.
+
+    Extends :class:`ImageDataset` to satisfy pose processors that require a
+    ``boxes`` argument. Each calibration image is passed with one full-image box
+    (``[0, 0, width, height]`` in COCO ``xywh`` format), so the processor crops
+    and resizes the whole frame to the model input. This is modality-agnostic:
+    any pose processor whose ``preprocess`` takes ``boxes`` works unchanged.
+    """
+
+    def _initialize(self) -> None:
+        """Load the dataset and prepare pose-cropped ``pixel_values`` tensors."""
+        # 1. Fall back to the built-in image dataset defaults when unset.
+        if self._dataset_name is None:
+            self._get_default_dataset()
+
+        # 2. Load + sample (shared streaming/shuffle/max_samples behavior).
+        dataset = self._load_and_sample()
+
+        # 3. Detect the input image column (pose datasets carry no ClassLabel).
+        self._detect_image_column(dataset)
+
+        # 4. Load the model's own pose processor.
+        processor = AutoImageProcessor.from_pretrained(self._model_name, use_fast=True)
+
+        # 5. Preprocess each image with a single full-image box so the pose
+        #    processor emits pixel_values at the model's fixed input shape.
+        def preprocess_single_sample(example: dict[str, Any]) -> dict[str, Any]:
+            image = example[self._image_col].convert("RGB")
+            width, height = image.size
+            boxes = [[[0.0, 0.0, float(width), float(height)]]]
+            return dict(processor(image, boxes=boxes, return_tensors="pt"))
+
+        self._dataset = (
+            dataset.map(preprocess_single_sample, remove_columns=[self._image_col])
+            .with_format("torch", output_all_columns=True)
+        )
+
+        logger.info("Dataset initialized with %d samples", len(self._dataset))
+
+    def _detect_image_column(self, dataset: Any) -> None:
+        """Detect the input image column for calibration.
+
+        PTQ calibration only consumes ``pixel_values``; keypoint targets are not
+        needed and are not read here.
+        """
+        if not hasattr(dataset, "features"):
+            raise ValueError(f"Dataset {self._dataset_name} has no features metadata")
+
+        features = dataset.features
+
+        self._image_col = ""
+        for col_name, feature in features.items():
+            if isinstance(feature, Image):
+                self._image_col = col_name
+                break
+
+        if not self._image_col:
+            available_cols = list(features.keys())
+            available_types = [type(f).__name__ for f in features.values()]
+            raise ValueError(
+                f"No Image column found in {self._dataset_name}. "
+                f"Available: {dict(zip(available_cols, available_types, strict=False))}"
+            )
+
+        logger.info("Detected image column: '%s'", self._image_col)

--- a/src/winml/modelkit/eval/keypoint_detection_evaluator.py
+++ b/src/winml/modelkit/eval/keypoint_detection_evaluator.py
@@ -17,6 +17,7 @@ which is the standard COCO top-down evaluation protocol.
 
 from __future__ import annotations
 
+import inspect
 import logging
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
@@ -59,6 +60,10 @@ class WinMLKeypointDetectionEvaluator(WinMLEvaluator):
         self._bbox_key: str = bbox_key
         self._area_key: str = area_key
         self._box_format: str = box_format
+
+        # Models like ViTPose+ take a ``dataset_index`` input selecting which
+        # expert to route through; it comes from the dataset config (defaults to 0).
+        self._dataset_index: int = int(mapping.get("dataset_index", 0))
 
         # Optional non-COCO keypoint layout: a model with a different keypoint
         # set (e.g. SynthPose's 52 anatomical markers) can be scored by this
@@ -149,6 +154,21 @@ class WinMLKeypointDetectionEvaluator(WinMLEvaluator):
             predictions=predictions, references=references, **metric_kwargs
         )
 
+    def _declares_dataset_index(self) -> bool:
+        """True if the model accepts a ``dataset_index`` input.
+
+        ONNX/WinML models expose it via ``io_config["input_names"]``; native
+        PyTorch modules expose it in their ``forward`` signature.
+        """
+        io_config = getattr(self.model, "io_config", None) or {}
+        if "dataset_index" in (io_config.get("input_names") or []):
+            return True
+        forward = getattr(self.model, "forward", None)
+        try:
+            return forward is not None and "dataset_index" in inspect.signature(forward).parameters
+        except (TypeError, ValueError):
+            return False
+
     def _predict_poses(
         self,
         processor: Any,
@@ -166,10 +186,16 @@ class WinMLKeypointDetectionEvaluator(WinMLEvaluator):
         inputs = processor.preprocess(images=image, boxes=[boxes], return_tensors="pt")
         pixel_values = inputs["pixel_values"]
 
+        # Pass ``dataset_index`` only when the model declares it (e.g. ViTPose+).
+        extra_inputs: dict[str, Any] = {}
+        if self._declares_dataset_index():
+            extra_inputs["dataset_index"] = torch.tensor([self._dataset_index], dtype=torch.long)
+
         heatmaps = []
-        for i in range(pixel_values.shape[0]):
-            outputs = self.model(pixel_values=pixel_values[i : i + 1])
-            heatmaps.append(self._extract_heatmaps(outputs))
+        with torch.no_grad():
+            for i in range(pixel_values.shape[0]):
+                outputs = self.model(pixel_values=pixel_values[i : i + 1], **extra_inputs)
+                heatmaps.append(self._extract_heatmaps(outputs))
 
         wrapped = SimpleNamespace(heatmaps=torch.cat(heatmaps, dim=0))
         # post_process returns one list per image; we pass a single image.

--- a/src/winml/modelkit/eval/keypoint_detection_evaluator.py
+++ b/src/winml/modelkit/eval/keypoint_detection_evaluator.py
@@ -195,7 +195,7 @@ class WinMLKeypointDetectionEvaluator(WinMLEvaluator):
         with torch.no_grad():
             for i in range(pixel_values.shape[0]):
                 outputs = self.model(pixel_values=pixel_values[i : i + 1], **extra_inputs)
-                heatmaps.append(self._extract_heatmaps(outputs))
+                heatmaps.append(self._fix_migraphx_output_layout(self._extract_heatmaps(outputs)))
 
         wrapped = SimpleNamespace(heatmaps=torch.cat(heatmaps, dim=0))
         # post_process returns one list per image; we pass a single image.
@@ -203,6 +203,21 @@ class WinMLKeypointDetectionEvaluator(WinMLEvaluator):
             wrapped, boxes=[boxes]
         )[0]
         return results
+
+    def _fix_migraphx_output_layout(self, heatmaps: Any) -> Any:
+        """Transpose the heatmaps back to NCHW on the MIGraphX GPU EP.
+
+        The MIGraphX EP is returning NHWC for the graph output (the channels-last
+        convolution layout is not transposed back at the output boundary). This
+        might be a bug in MIGraphX; transpose to NCHW to work around it. It is a
+        no-op on every other EP.
+        """
+        if getattr(self.model, "ep_name", None) != "MIGraphXExecutionProvider":
+            return heatmaps
+        # The buffer is NHWC-ordered under the declared (N, C, H, W) shape:
+        # reinterpret as (N, H, W, C) and transpose back to (N, C, H, W).
+        n, c, h, w = heatmaps.shape
+        return heatmaps.reshape(n, h, w, c).permute(0, 3, 1, 2).contiguous()
 
     @staticmethod
     def _extract_heatmaps(outputs: Any) -> Any:

--- a/src/winml/modelkit/eval/metrics/depth.py
+++ b/src/winml/modelkit/eval/metrics/depth.py
@@ -28,6 +28,9 @@ class DepthMetric:
 
     _VALID_ALIGN = ("none", "median", "affine")
     _VALID_DEPTH_KIND = ("depth", "disparity")
+    # Aligned disparities at or below this are treated as invalid (their
+    # inverse depth would be non-positive or unbounded).
+    _DISPARITY_EPS = 1e-12
 
     def __init__(
         self,
@@ -49,9 +52,9 @@ class DepthMetric:
                 models like ZoeDepth and DepthPro.
             depth_kind: Output space of ``prediction``. ``"depth"``
                 (default) treats values as forward depth/distance.
-                ``"disparity"`` first inverts the prediction to depth
-                (``1 / pred``) — for DPT/MiDaS-style models whose
-                output is inverse depth.
+                ``"disparity"`` treats values as inverse depth
+                (DPT/MiDaS/Depth-Anything-style models): they are aligned
+                to ``1 / gt`` and inverted back to depth before scoring.
             min_depth: Lower bound (inclusive) for valid ground-truth
                 pixels in the same units as ``gt``.
             max_depth: Upper bound (inclusive) for valid ground-truth
@@ -99,10 +102,6 @@ class DepthMetric:
                 f"prediction and reference must share shape; got {pred.shape} vs {gt.shape}.",
             )
 
-        if self._depth_kind == "disparity":
-            with np.errstate(divide="ignore", invalid="ignore"):
-                pred = np.where(pred > 0, 1.0 / pred, np.nan)
-
         valid = self._valid_mask(pred, gt)
         if not valid.any():
             self._image_count += 1
@@ -111,26 +110,47 @@ class DepthMetric:
         pred_v = pred[valid].astype(np.float64)
         gt_v = gt[valid].astype(np.float64)
 
-        if self._align == "median":
-            scale = np.median(gt_v) / np.median(pred_v)
-            pred_v = pred_v * scale
-        elif self._align == "affine":
-            # Least-squares fit of (s, t) such that s * pred + t ~ gt.
-            # Standard scale-and-shift alignment for relative-depth models
-            # (MiDaS, Depth-Anything, Marigold).
-            ones = np.ones_like(pred_v)
-            a = np.stack([pred_v, ones], axis=1)
-            (scale, shift), *_ = np.linalg.lstsq(a, gt_v, rcond=None)
-            pred_v = pred_v * scale + shift
-            # Affine alignment can introduce non-positive predicted depths.
-            # Re-filter them after scale-and-shift, following Eigen/MiDaS eval
-            # behavior; affine may therefore use fewer pixels than median/none.
-            pos = pred_v > self._min_depth
+        # Disparity models (MiDaS, DPT, Depth-Anything) output inverse depth and
+        # need a dedicated alignment + inversion; metric-depth models align
+        # directly in depth space.
+        if self._depth_kind == "disparity":
+            # Align in disparity space against 1 / gt, then invert back to
+            # metric depth. Pixels whose aligned disparity is non-positive are
+            # dropped (their inverse depth would be unbounded).
+            target = 1.0 / gt_v
+            if self._align == "median":
+                pred_v = pred_v * (np.median(target) / np.median(pred_v))
+            elif self._align == "affine":
+                a = np.stack([pred_v, np.ones_like(pred_v)], axis=1)
+                (scale, shift), *_ = np.linalg.lstsq(a, target, rcond=None)
+                pred_v = pred_v * scale + shift
+            pos = pred_v > self._DISPARITY_EPS
             if not pos.any():
                 self._image_count += 1
                 return
-            pred_v = pred_v[pos]
+            pred_v = 1.0 / pred_v[pos]
             gt_v = gt_v[pos]
+        else:
+            if self._align == "median":
+                scale = np.median(gt_v) / np.median(pred_v)
+                pred_v = pred_v * scale
+            elif self._align == "affine":
+                # Least-squares fit of (s, t) such that s * pred + t ~ gt.
+                # Standard scale-and-shift alignment for relative-depth models
+                # (MiDaS, Depth-Anything, Marigold).
+                ones = np.ones_like(pred_v)
+                a = np.stack([pred_v, ones], axis=1)
+                (scale, shift), *_ = np.linalg.lstsq(a, gt_v, rcond=None)
+                pred_v = pred_v * scale + shift
+                # Affine alignment can introduce non-positive predicted depths.
+                # Re-filter them after scale-and-shift, following Eigen/MiDaS eval
+                # behavior; affine may therefore use fewer pixels than median/none.
+                pos = pred_v > self._min_depth
+                if not pos.any():
+                    self._image_count += 1
+                    return
+                pred_v = pred_v[pos]
+                gt_v = gt_v[pos]
 
         diff = pred_v - gt_v
         ratio = np.maximum(pred_v / gt_v, gt_v / pred_v)

--- a/tests/unit/eval/test_depth_metric.py
+++ b/tests/unit/eval/test_depth_metric.py
@@ -293,8 +293,8 @@ class TestAffineAlignment:
 
 
 class TestDisparity:
-    def test_disparity_inverts_then_aligns(self):
-        """pred = k / gt (disparity); after invert + affine should be perfect."""
+    def test_disparity_pure_scale_recovers_perfect(self):
+        """pred = k / gt (pure-scale disparity) recovers perfectly under affine."""
         rng = np.random.default_rng(4)
         gt = rng.uniform(1.0, 10.0, size=(8, 8)).astype(np.float32)
         disparity = 2.0 / gt  # scale-free disparity
@@ -307,6 +307,41 @@ class TestDisparity:
         m.update(disparity, gt)
         result = m.compute()
         assert result["abs_rel"] == pytest.approx(0.0, abs=1e-5)
+
+    def test_disparity_affine_recovers_under_scale_and_shift(self):
+        """Real disparity has an unknown shift: disp = s * (1/gt) + t.
+
+        Affine alignment in disparity space must recover depth exactly; the
+        old invert-then-align-in-depth approach could not undo the shift.
+        """
+        rng = np.random.default_rng(11)
+        gt = rng.uniform(1.0, 10.0, size=(16, 16)).astype(np.float32)
+        disparity = 3.0 * (1.0 / gt) + 0.7  # unknown scale AND shift
+        m = DepthMetric(
+            align="affine",
+            depth_kind="disparity",
+            min_depth=0.0,
+            max_depth=None,
+        )
+        m.update(disparity, gt)
+        result = m.compute()
+        assert result["abs_rel"] == pytest.approx(0.0, abs=1e-5)
+        assert result["delta1"] == pytest.approx(1.0)
+
+    def test_disparity_shift_breaks_depth_space_affine(self):
+        """Sanity: shifted disparity scored as depth+affine is clearly wrong.
+
+        Confirms the disparity-space path is doing real work — the same input
+        under depth_kind="depth" cannot recover the reciprocal relationship.
+        """
+        rng = np.random.default_rng(12)
+        gt = rng.uniform(1.0, 10.0, size=(16, 16)).astype(np.float32)
+        disparity = 3.0 * (1.0 / gt) + 0.7
+        m_depth = DepthMetric(align="affine", depth_kind="depth", min_depth=0.0, max_depth=None)
+        m_disp = DepthMetric(align="affine", depth_kind="disparity", min_depth=0.0, max_depth=None)
+        m_depth.update(disparity, gt)
+        m_disp.update(disparity, gt)
+        assert m_disp.compute()["abs_rel"] < m_depth.compute()["abs_rel"]
 
     def test_disparity_with_align_none_is_bad(self):
         """Sanity: forgetting to invert disparity yields a poor score."""

--- a/tests/unit/eval/test_keypoint_detection_evaluator.py
+++ b/tests/unit/eval/test_keypoint_detection_evaluator.py
@@ -29,6 +29,7 @@ def _make_evaluator(box_format: str = "xywh") -> WinMLKeypointDetectionEvaluator
     ev._box_format = box_format
     ev._sigmas = None
     ev._keypoint_names = None
+    ev._dataset_index = 0
     return ev
 
 
@@ -120,3 +121,72 @@ class TestComputeLoop:
         assert result["num_images"] == 2
         assert result["num_predictions"] == 3
         assert result["num_ground_truths"] == 3
+
+
+class _RecordingModel:
+    """Mock model that records call kwargs and declares an input contract."""
+
+    def __init__(self, input_names, num_keypoints: int = 17) -> None:
+        self.io_config = {"input_names": list(input_names)}
+        self._num_keypoints = num_keypoints
+        self.calls: list[dict] = []
+
+    def __call__(self, pixel_values, **kwargs):
+        self.calls.append(kwargs)
+        batch = pixel_values.shape[0]
+        return {"heatmaps": torch.zeros(batch, self._num_keypoints, 64, 48)}
+
+
+class _ForwardSignatureModel:
+    """Mock PyTorch-style model with no ``io_config``; declares ``dataset_index``
+    only in its ``forward`` signature (like a native ``VitPoseForPoseEstimation``)."""
+
+    def __init__(self, num_keypoints: int = 17) -> None:
+        self._num_keypoints = num_keypoints
+        self.calls: list[dict] = []
+
+    def forward(self, pixel_values, dataset_index=None, **kwargs):
+        self.calls.append({"dataset_index": dataset_index, **kwargs})
+        batch = pixel_values.shape[0]
+        return {"heatmaps": torch.zeros(batch, self._num_keypoints, 64, 48)}
+
+    def __call__(self, *args, **kwargs):
+        return self.forward(*args, **kwargs)
+
+
+class TestModelInputContract:
+    def test_dataset_index_passed_when_declared(self):
+        ev = _make_evaluator()
+        ev._dataset_index = 0
+        model = _RecordingModel(["pixel_values", "dataset_index"])
+        ev.model = model
+        ev._predict_poses(_MockProcessor(), object(), [[0.0, 0.0, 10.0, 10.0]])
+        assert "dataset_index" in model.calls[0]
+        assert model.calls[0]["dataset_index"].tolist() == [0]
+
+    def test_dataset_index_absent_when_not_declared(self):
+        ev = _make_evaluator()
+        ev._dataset_index = 0
+        model = _RecordingModel(["pixel_values"])
+        ev.model = model
+        ev._predict_poses(_MockProcessor(), object(), [[0.0, 0.0, 10.0, 10.0]])
+        assert model.calls[0] == {}
+
+    def test_configured_dataset_index_value_is_used(self):
+        ev = _make_evaluator()
+        ev._dataset_index = 3
+        model = _RecordingModel(["pixel_values", "dataset_index"])
+        ev.model = model
+        ev._predict_poses(_MockProcessor(), object(), [[0.0, 0.0, 10.0, 10.0]])
+        assert model.calls[0]["dataset_index"].tolist() == [3]
+
+    def test_dataset_index_detected_from_forward_signature(self):
+        # Native PyTorch modules have no ``io_config``; the input contract is
+        # read from the ``forward`` signature instead (e.g. ViTPose+ MoE).
+        ev = _make_evaluator()
+        ev._dataset_index = 2
+        model = _ForwardSignatureModel()
+        ev.model = model
+        ev._predict_poses(_MockProcessor(), object(), [[0.0, 0.0, 10.0, 10.0]])
+        assert model.calls[0]["dataset_index"].tolist() == [2]
+


### PR DESCRIPTION
This PR contains
1. Fix bugs found while running evaluation for depth-estimation and keypoint-detection. The issues causes evaluation errors during inference.
2. Run the evaluation and record the baseline cache. The baseline cache aligns with published or community shared metric values