### PR TITLE
Auto-enable op-tracing via per-model op_tracing_targets

### DIFF
--- a/scripts/e2e_eval/run_eval.py
+++ b/scripts/e2e_eval/run_eval.py
@@ -1379,6 +1379,39 @@ def _run_build_only(entries: list[ModelEntry], args: argparse.Namespace) -> None
 # ---------------------------------------------------------------------------
 
 
+def _op_tracing_target_key(ep: str | None, device: str) -> str | None:
+    """Return the ``<EP>_<device>`` key used to match ``op_tracing_targets``.
+
+    Example: ep=``qnn``, device=``npu`` -> ``QNNExecutionProvider_npu``. Returns
+    None when no EP is set (the target list only makes sense per EP/device).
+    """
+    if not ep:
+        return None
+    from winml.modelkit.utils.constants import normalize_ep_name
+
+    return f"{normalize_ep_name(ep)}_{device.lower()}"
+
+
+def _resolve_op_tracing(
+    cli_op_tracing: str | None, entry: ModelEntry, ep: str | None, device: str
+) -> str | None:
+    """Resolve the effective op-tracing level for one model run.
+
+    - ``disabled`` (explicit): never trace, even if the model opts in.
+    - ``basic``/``detail`` (explicit): use as-is.
+    - unset (None): default to ``basic`` when the model's ``op_tracing_targets``
+      includes the current ``<EP>_<device>`` target, otherwise no tracing.
+    """
+    if cli_op_tracing == "disabled":
+        return None
+    if cli_op_tracing in ("basic", "detail"):
+        return cli_op_tracing
+    key = _op_tracing_target_key(ep, device)
+    if key and key in entry.op_tracing_targets:
+        return "basic"
+    return None
+
+
 def _extract_op_trace_path(text: str) -> Path | None:
     """Parse the ``Op-trace saved to: <path>`` line from winml perf output.
 
@@ -1987,11 +2020,15 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--op-tracing",
         dest="op_tracing",
-        choices=["basic", "detail"],
+        choices=["basic", "detail", "disabled"],
         default=None,
         help=(
-            "Enable operator-level profiling in winml perf (requires onnxruntime-qnn). "
-            "The resulting op_trace.json is copied into each model's output folder."
+            "Operator-level profiling in winml perf (requires onnxruntime-qnn). "
+            "'basic'/'detail' force the tracing level; 'disabled' turns it off even "
+            "for models that opt in via 'op_tracing_targets'. When omitted, tracing "
+            "defaults to 'basic' for a model whose 'op_tracing_targets' includes the "
+            "current <EP>_<device> target (e.g. QNNExecutionProvider_npu). The "
+            "resulting op_trace.json is copied into each model's output folder."
         ),
     )
     parser.add_argument(
@@ -2353,6 +2390,7 @@ def main() -> None:
         try:
             perf_proc: dict | None = None
             accuracy_result: dict | None = None
+            op_tracing = _resolve_op_tracing(args.op_tracing, entry, args.ep, args.device)
 
             # Build phase: winml config + winml build → list of ONNX paths
             # Build is shared by perf and eval, avoiding redundant builds.
@@ -2394,7 +2432,7 @@ def main() -> None:
                     args.timeout,
                     onnx_paths,
                     ep=args.ep,
-                    op_tracing=args.op_tracing,
+                    op_tracing=op_tracing,
                     model_dir=model_dir,
                 )
             else:
@@ -2405,7 +2443,7 @@ def main() -> None:
                     args.timeout,
                     onnx_paths,
                     ep=args.ep,
-                    op_tracing=args.op_tracing,
+                    op_tracing=op_tracing,
                     model_dir=model_dir,
                 )
                 if perf_proc["exit_code"] != 0:

--- a/scripts/e2e_eval/run_eval.py
+++ b/scripts/e2e_eval/run_eval.py
@@ -57,7 +57,13 @@ from utils.accuracy import (
     format_delta,
 )
 from utils.dataset_config import get_dataset_config, register_from_registry
-from utils.registry import ModelEntry, filter_registry, load_registry, make_adhoc_entry
+from utils.registry import (
+    ModelEntry,
+    filter_registry,
+    load_registry,
+    make_adhoc_entry,
+    op_tracing_target_key,
+)
 from utils.reporter import (
     build_eval_result,
     classify_result,
@@ -1379,19 +1385,6 @@ def _run_build_only(entries: list[ModelEntry], args: argparse.Namespace) -> None
 # ---------------------------------------------------------------------------
 
 
-def _op_tracing_target_key(ep: str | None, device: str) -> str | None:
-    """Return the ``<EP>_<device>`` key used to match ``op_tracing_targets``.
-
-    Example: ep=``qnn``, device=``npu`` -> ``QNNExecutionProvider_npu``. Returns
-    None when no EP is set (the target list only makes sense per EP/device).
-    """
-    if not ep:
-        return None
-    from winml.modelkit.utils.constants import normalize_ep_name
-
-    return f"{normalize_ep_name(ep)}_{device.lower()}"
-
-
 def _resolve_op_tracing(
     cli_op_tracing: str | None, entry: ModelEntry, ep: str | None, device: str
 ) -> str | None:
@@ -1401,12 +1394,16 @@ def _resolve_op_tracing(
     - ``basic``/``detail`` (explicit): use as-is.
     - unset (None): default to ``basic`` when the model's ``op_tracing_targets``
       includes the current ``<EP>_<device>`` target, otherwise no tracing.
+
+    Auto-enable requires both a concrete ``--ep`` and ``--device`` to be set: the
+    default ``--device auto`` is not resolved here and will not match a
+    device-specific target such as ``QNNExecutionProvider_npu``.
     """
     if cli_op_tracing == "disabled":
         return None
     if cli_op_tracing in ("basic", "detail"):
         return cli_op_tracing
-    key = _op_tracing_target_key(ep, device)
+    key = op_tracing_target_key(ep, device)
     if key and key in entry.op_tracing_targets:
         return "basic"
     return None
@@ -2027,7 +2024,9 @@ def parse_args() -> argparse.Namespace:
             "'basic'/'detail' force the tracing level; 'disabled' turns it off even "
             "for models that opt in via 'op_tracing_targets'. When omitted, tracing "
             "defaults to 'basic' for a model whose 'op_tracing_targets' includes the "
-            "current <EP>_<device> target (e.g. QNNExecutionProvider_npu). The "
+            "current <EP>_<device> target (e.g. QNNExecutionProvider_npu) — this "
+            "auto-enable requires both --ep and --device to be set explicitly "
+            "(the default --device auto does not match). The "
             "resulting op_trace.json is copied into each model's output folder."
         ),
     )

--- a/scripts/e2e_eval/testsets/models_all.json
+++ b/scripts/e2e_eval/testsets/models_all.json
@@ -19,7 +19,10 @@
     "downloads": 1258716,
     "last_update_time": "2024-12-03T14:14:31+00:00",
     "optimum_supported": true,
-    "order": 5
+    "order": 5,
+    "op_tracing_targets": [
+      "QNNExecutionProvider_npu"
+    ]
   },
   {
     "hf_id": "Alexei1/imdb",
@@ -77,7 +80,10 @@
     "tags": [
       "acc"
     ],
-    "order": 8
+    "order": 8,
+    "op_tracing_targets": [
+      "QNNExecutionProvider_npu"
+    ]
   },
   {
     "hf_id": "BAAI/bge-base-en-v1.5",
@@ -91,7 +97,10 @@
     "tags": [
       "acc"
     ],
-    "order": 7
+    "order": 7,
+    "op_tracing_targets": [
+      "QNNExecutionProvider_npu"
+    ]
   },
   {
     "hf_id": "BAAI/bge-large-en-v1.5",
@@ -1685,7 +1694,10 @@
     "downloads": 629050,
     "last_update_time": "2023-11-18T20:58:42+00:00",
     "optimum_supported": true,
-    "order": 8
+    "order": 8,
+    "op_tracing_targets": [
+      "QNNExecutionProvider_npu"
+    ]
   },
   {
     "hf_id": "apple/DepthPro-hf",
@@ -1713,7 +1725,10 @@
     "tags": [
       "acc"
     ],
-    "order": 4
+    "order": 4,
+    "op_tracing_targets": [
+      "QNNExecutionProvider_npu"
+    ]
   },
   {
     "hf_id": "athrael-soju/colqwen3.5-4.5B-v3",
@@ -1870,7 +1885,10 @@
     "downloads": 2220115,
     "last_update_time": "2025-08-29T14:36:22+00:00",
     "optimum_supported": true,
-    "order": 9
+    "order": 9,
+    "op_tracing_targets": [
+      "QNNExecutionProvider_npu"
+    ]
   },
   {
     "hf_id": "cross-encoder/ms-marco-MiniLM-L4-v2",
@@ -1881,7 +1899,10 @@
     "downloads": 2220115,
     "last_update_time": "2025-08-29T14:36:22+00:00",
     "optimum_supported": true,
-    "order": 2
+    "order": 2,
+    "op_tracing_targets": [
+      "QNNExecutionProvider_npu"
+    ]
   },
   {
     "hf_id": "cross-encoder/ms-marco-MiniLM-L6-v2",
@@ -2003,7 +2024,10 @@
     "tags": [
       "acc"
     ],
-    "order": 2
+    "order": 2,
+    "op_tracing_targets": [
+      "QNNExecutionProvider_npu"
+    ]
   },
   {
     "hf_id": "deepset/roberta-large-squad2",
@@ -2028,7 +2052,10 @@
     "tags": [
       "acc"
     ],
-    "order": 9
+    "order": 9,
+    "op_tracing_targets": [
+      "QNNExecutionProvider_npu"
+    ]
   },
   {
     "hf_id": "dell-research-harvard/lt-un-data-fine-fine-es",
@@ -2292,7 +2319,10 @@
     "tags": [
       "acc"
     ],
-    "order": 12
+    "order": 12,
+    "op_tracing_targets": [
+      "QNNExecutionProvider_npu"
+    ]
   },
   {
     "hf_id": "facebook/detr-resnet-50",
@@ -2345,7 +2375,10 @@
     "tags": [
       "acc"
     ],
-    "order": 9
+    "order": 9,
+    "op_tracing_targets": [
+      "QNNExecutionProvider_npu"
+    ]
   },
   {
     "hf_id": "facebook/dinov2-base",
@@ -3783,7 +3816,10 @@
     "tags": [
       "acc"
     ],
-    "order": 11
+    "order": 11,
+    "op_tracing_targets": [
+      "QNNExecutionProvider_npu"
+    ]
   },
   {
     "hf_id": "microsoft/speecht5_tts",

--- a/scripts/e2e_eval/testsets/models_all.json
+++ b/scripts/e2e_eval/testsets/models_all.json
@@ -21,7 +21,7 @@
     "optimum_supported": true,
     "order": 5,
     "op_tracing_targets": [
-      "QNNExecutionProvider_npu"
+      "qnn_npu"
     ]
   },
   {
@@ -82,7 +82,7 @@
     ],
     "order": 8,
     "op_tracing_targets": [
-      "QNNExecutionProvider_npu"
+      "qnn_npu"
     ]
   },
   {
@@ -99,7 +99,7 @@
     ],
     "order": 7,
     "op_tracing_targets": [
-      "QNNExecutionProvider_npu"
+      "qnn_npu"
     ]
   },
   {
@@ -1696,7 +1696,7 @@
     "optimum_supported": true,
     "order": 8,
     "op_tracing_targets": [
-      "QNNExecutionProvider_npu"
+      "qnn_npu"
     ]
   },
   {
@@ -1727,7 +1727,7 @@
     ],
     "order": 4,
     "op_tracing_targets": [
-      "QNNExecutionProvider_npu"
+      "qnn_npu"
     ]
   },
   {
@@ -1887,7 +1887,7 @@
     "optimum_supported": true,
     "order": 9,
     "op_tracing_targets": [
-      "QNNExecutionProvider_npu"
+      "qnn_npu"
     ]
   },
   {
@@ -1901,7 +1901,7 @@
     "optimum_supported": true,
     "order": 2,
     "op_tracing_targets": [
-      "QNNExecutionProvider_npu"
+      "qnn_npu"
     ]
   },
   {
@@ -2026,7 +2026,7 @@
     ],
     "order": 2,
     "op_tracing_targets": [
-      "QNNExecutionProvider_npu"
+      "qnn_npu"
     ]
   },
   {
@@ -2054,7 +2054,7 @@
     ],
     "order": 9,
     "op_tracing_targets": [
-      "QNNExecutionProvider_npu"
+      "qnn_npu"
     ]
   },
   {
@@ -2321,7 +2321,7 @@
     ],
     "order": 12,
     "op_tracing_targets": [
-      "QNNExecutionProvider_npu"
+      "qnn_npu"
     ]
   },
   {
@@ -2377,7 +2377,7 @@
     ],
     "order": 9,
     "op_tracing_targets": [
-      "QNNExecutionProvider_npu"
+      "qnn_npu"
     ]
   },
   {
@@ -3818,7 +3818,7 @@
     ],
     "order": 11,
     "op_tracing_targets": [
-      "QNNExecutionProvider_npu"
+      "qnn_npu"
     ]
   },
   {

--- a/scripts/e2e_eval/utils/registry.py
+++ b/scripts/e2e_eval/utils/registry.py
@@ -29,6 +29,7 @@ class ModelEntry:
     downloads: int = 0
     last_update_time: str | None = None
     optimum_supported: bool = False
+    op_tracing_targets: list[str] = field(default_factory=list)
 
 
 _REQUIRED_FIELDS = {"hf_id", "task", "model_type", "group", "priority"}
@@ -75,6 +76,7 @@ def load_registry(path: Path) -> list[ModelEntry]:
                 downloads=item.get("downloads", 0) or 0,
                 last_update_time=item.get("last_update_time"),
                 optimum_supported=item.get("optimum_supported", False),
+                op_tracing_targets=item.get("op_tracing_targets", []) or [],
             )
         )
 

--- a/scripts/e2e_eval/utils/registry.py
+++ b/scripts/e2e_eval/utils/registry.py
@@ -36,6 +36,43 @@ _REQUIRED_FIELDS = {"hf_id", "task", "model_type", "group", "priority"}
 _VALID_PRIORITIES = {"P0", "P1", "P2", "P3"}
 
 
+def _canonical_ep_device_key(ep: str, device: str) -> str:
+    """Build the canonical ``<NormalizedEP>_<device>`` key.
+
+    The EP is normalized to its full name (``qnn`` -> ``QNNExecutionProvider``)
+    and the device is lowercased, e.g. ``QNNExecutionProvider_npu``.
+    """
+    from winml.modelkit.utils.constants import normalize_ep_name
+
+    return f"{normalize_ep_name(ep.strip())}_{device.strip().lower()}"
+
+
+def op_tracing_target_key(ep: str | None, device: str) -> str | None:
+    """Build the op-tracing target key for an EP/device pair.
+
+    Returns None when no EP is set (the target list is meaningless without an
+    explicit EP). Callers should pass a concrete device — ``auto`` is kept
+    verbatim and will not match a device-specific target such as
+    ``QNNExecutionProvider_npu``.
+    """
+    if not ep:
+        return None
+    return _canonical_ep_device_key(ep, device)
+
+
+def normalize_op_tracing_target(target: str) -> str:
+    """Normalize a raw ``op_tracing_targets`` entry to the canonical key form.
+
+    Accepts either the short EP alias (``qnn_npu``) or the full normalized name
+    (``QNNExecutionProvider_npu``); both map to ``QNNExecutionProvider_npu``.
+    Splits on the last underscore so multi-word EP aliases stay intact.
+    """
+    ep, sep, device = target.rpartition("_")
+    if not sep:
+        return target.strip().lower()
+    return _canonical_ep_device_key(ep, device)
+
+
 def load_registry(path: Path) -> list[ModelEntry]:
     """Load models.json, validate required fields, return entries."""
     with path.open(encoding="utf-8") as f:
@@ -76,7 +113,10 @@ def load_registry(path: Path) -> list[ModelEntry]:
                 downloads=item.get("downloads", 0) or 0,
                 last_update_time=item.get("last_update_time"),
                 optimum_supported=item.get("optimum_supported", False),
-                op_tracing_targets=item.get("op_tracing_targets", []) or [],
+                op_tracing_targets=[
+                    normalize_op_tracing_target(t)
+                    for t in (item.get("op_tracing_targets", []) or [])
+                ],
             )
         )
 

--- a/tests/unit/eval/test_run_eval_script.py
+++ b/tests/unit/eval/test_run_eval_script.py
@@ -98,6 +98,93 @@ class TestResolvePrecision:
         assert "vitisai" in captured.out
 
 
+class TestResolveOpTracing:
+    """Behaviour of ``_resolve_op_tracing`` and the target-key helpers."""
+
+    @staticmethod
+    def _entry(run_eval, targets):
+        return run_eval.ModelEntry(
+            hf_id="acme/model",
+            task="image-classification",
+            model_type="vit",
+            group="test",
+            priority="P0",
+            op_tracing_targets=list(targets),
+        )
+
+    def test_explicit_disabled_overrides_optin(self, run_eval):
+        # A model that opts in must still be forced off by an explicit 'disabled'.
+        entry = self._entry(run_eval, ["QNNExecutionProvider_npu"])
+        assert run_eval._resolve_op_tracing("disabled", entry, "qnn", "npu") is None
+
+    @pytest.mark.parametrize("level", ["basic", "detail"])
+    def test_explicit_level_used_as_is(self, run_eval, level):
+        # Explicit basic/detail is honoured regardless of opt-in or EP/device.
+        entry = self._entry(run_eval, [])
+        assert run_eval._resolve_op_tracing(level, entry, "qnn", "npu") == level
+        assert run_eval._resolve_op_tracing(level, entry, None, "auto") == level
+
+    def test_unset_auto_enables_on_matching_target(self, run_eval):
+        entry = self._entry(run_eval, ["QNNExecutionProvider_npu"])
+        assert run_eval._resolve_op_tracing(None, entry, "qnn", "npu") == "basic"
+
+    def test_unset_no_match_stays_off(self, run_eval):
+        entry = self._entry(run_eval, ["QNNExecutionProvider_npu"])
+        # Different device (dml/npu) and a model without targets both stay off.
+        assert run_eval._resolve_op_tracing(None, entry, "dml", "npu") is None
+        assert run_eval._resolve_op_tracing(None, self._entry(run_eval, []), "qnn", "npu") is None
+
+    def test_unset_device_auto_does_not_match(self, run_eval):
+        # 'auto' is not resolved to a concrete device here, so it never matches
+        # a device-specific target such as QNNExecutionProvider_npu.
+        entry = self._entry(run_eval, ["QNNExecutionProvider_npu"])
+        assert run_eval._resolve_op_tracing(None, entry, "qnn", "auto") is None
+
+    def test_unset_no_ep_stays_off(self, run_eval):
+        entry = self._entry(run_eval, ["QNNExecutionProvider_npu"])
+        assert run_eval._resolve_op_tracing(None, entry, None, "npu") is None
+
+
+class TestOpTracingTargetKey:
+    """The canonical key builder and the registry target normalizer."""
+
+    def test_target_key_normalizes_ep_and_device(self, run_eval):
+        assert run_eval.op_tracing_target_key("qnn", "NPU") == "QNNExecutionProvider_npu"
+        full = run_eval.op_tracing_target_key("QNNExecutionProvider", "npu")
+        assert full == "QNNExecutionProvider_npu"
+
+    def test_target_key_none_without_ep(self, run_eval):
+        assert run_eval.op_tracing_target_key(None, "npu") is None
+        assert run_eval.op_tracing_target_key("", "npu") is None
+
+    def test_normalize_target_accepts_alias_and_full_name(self, run_eval):
+        from utils.registry import normalize_op_tracing_target
+
+        assert normalize_op_tracing_target("qnn_npu") == "QNNExecutionProvider_npu"
+        assert normalize_op_tracing_target("QNNExecutionProvider_npu") == "QNNExecutionProvider_npu"
+        assert normalize_op_tracing_target("QNN_NPU") == "QNNExecutionProvider_npu"
+
+    def test_registry_normalizes_targets_on_load(self, run_eval, tmp_path):
+        registry = tmp_path / "models.json"
+        registry.write_text(
+            json.dumps(
+                [
+                    {
+                        "hf_id": "acme/model",
+                        "task": "image-classification",
+                        "model_type": "vit",
+                        "group": "test",
+                        "priority": "P0",
+                        "op_tracing_targets": ["qnn_npu"],
+                    }
+                ]
+            ),
+            encoding="utf-8",
+        )
+        entries = run_eval.load_registry(registry)
+        assert entries[0].op_tracing_targets == ["QNNExecutionProvider_npu"]
+
+
 class TestRunBuildNoQuantInjection:
     """``_run_build`` must append ``--no-quant`` to both winml config and
     winml build invocations when the EP is in ``_EPS_SKIP_WINML_QUANT``.


### PR DESCRIPTION
## Summary

Adds per-model auto-enable of op-tracing in the e2e eval runner. When `run_eval.py` runs without an explicit `--op-tracing`, a model whose registry entry opts into the current `<EP>_<device>` target now gets `basic` op-tracing automatically.

## Changes

- **`scripts/e2e_eval/utils/registry.py`** — add `op_tracing_targets: list[str]` field to `ModelEntry` and load it in `load_registry`.
- **`scripts/e2e_eval/run_eval.py`**
  - `_op_tracing_target_key(ep, device)` builds the match key, e.g. `QNNExecutionProvider_npu`.
  - `_resolve_op_tracing(cli, entry, ep, device)` resolves the effective level: `disabled` forces off (even for opted-in models); `basic`/`detail` used as-is; unset defaults to `basic` when the target key is in the model's `op_tracing_targets`, otherwise off.
  - Add `disabled` to `--op-tracing` choices with expanded help text.
  - Compute effective `op_tracing` per model in the run loop and pass it to both `run_model` call sites.
- **`scripts/e2e_eval/testsets/models_all.json`** — add `"op_tracing_targets": ["QNNExecutionProvider_npu"]` to the 10 profiled models.

## Behavior

| `--op-tracing` | Model opts in (`op_tracing_targets` matches) | Result |
| --- | --- | --- |
| omitted | yes | `basic` |
| omitted | no | off |
| `basic`/`detail` | any | as specified |
| `disabled` | any | off |