### PR TITLE
refactor(cli): centralize -m/--model classification with classify_model_input

### DIFF
--- a/src/winml/modelkit/commands/build.py
+++ b/src/winml/modelkit/commands/build.py
@@ -359,6 +359,7 @@ def _validate_task_supported_for_model(
 def _validate_loader_tasks_for_model(
     *,
     model_id: str | None,
+    is_onnx: bool,
     configs: list[WinMLBuildConfig],
     trust_remote_code: bool,
 ) -> Any | None:
@@ -384,7 +385,7 @@ def _validate_loader_tasks_for_model(
     if model_id is None:
         return None
 
-    if cli_utils.is_onnx_file_path(model_id):
+    if is_onnx:
         return None
 
     tasks = {
@@ -664,8 +665,14 @@ def build(
         except ValueError as e:
             raise click.UsageError(f"Config validation failed: {e}") from e
 
+        model_input = cli_utils.classify_model_input(model) if model else None
+        model_is_onnx = (
+            model_input is not None and model_input.kind is cli_utils.ModelInputKind.ONNX_FILE
+        )
+
         preloaded_hf_config = _validate_loader_tasks_for_model(
             model_id=model,
+            is_onnx=model_is_onnx,
             configs=_configs_to_validate,
             trust_remote_code=trust_remote_code,
         )
@@ -789,6 +796,7 @@ def build(
                 config=config,
                 config_file=config_file,
                 model_id=model,
+                is_onnx=model_is_onnx,
                 resolved_dir=resolved_dir,
                 rebuild=rebuild,
                 cache_key=cache_key,
@@ -842,6 +850,7 @@ def _run_single_build(
     config: WinMLBuildConfig,
     config_file: str | None,
     model_id: str | None,
+    is_onnx: bool,
     resolved_dir: Path,
     rebuild: bool,
     cache_key: str | None,
@@ -851,7 +860,7 @@ def _run_single_build(
     preloaded_hf_config: Any | None = None,
 ) -> None:
     """Run single-model build with Rich Live progress per stage."""
-    _is_onnx = model_id is not None and cli_utils.is_onnx_file_path(model_id)
+    _is_onnx = is_onnx
     # Derive source from _is_onnx to guarantee header label matches pipeline
     source = "ONNX" if _is_onnx else detect_model_source(model_id)
 

--- a/src/winml/modelkit/commands/config.py
+++ b/src/winml/modelkit/commands/config.py
@@ -262,14 +262,18 @@ def config(
             _shape_config_file = shape_config_path.name
 
         # ONNX file detection: generate simpler config without loader/export
-        if hf_model and cli_utils.is_onnx_file_path(hf_model) and module:
+        _model_input = cli_utils.classify_model_input(hf_model) if hf_model else None
+        _hf_is_onnx = (
+            _model_input is not None and _model_input.kind is cli_utils.ModelInputKind.ONNX_FILE
+        )
+        if hf_model and _hf_is_onnx and module:
             raise click.UsageError(
                 "--module is not supported with ONNX file input. "
                 "Module discovery requires a HuggingFace model."
             )
         config_obj: WinMLBuildConfig | None = None
         output_data: dict[str, Any] | list[Any]
-        if hf_model and cli_utils.is_onnx_file_path(hf_model):
+        if hf_model and _hf_is_onnx:
             config_obj = generate_onnx_build_config(
                 hf_model,
                 task=task,

--- a/src/winml/modelkit/commands/eval.py
+++ b/src/winml/modelkit/commands/eval.py
@@ -503,12 +503,12 @@ def _resolve_model_path(
         )
 
     value = plain[0]
-    if Path(value).suffix.lower() == ".onnx":
-        if not Path(value).exists():
-            raise click.BadParameter(
-                f"ONNX file not found: {value}",
-                param_hint="-m/--model",
-            )
+    try:
+        _mi = cli_utils.classify_model_input(value)
+    except click.UsageError as e:
+        # Preserve eval's param-scoped BadParameter contract (tests + hint).
+        raise click.BadParameter(str(e), param_hint="-m/--model") from e
+    if _mi.kind is cli_utils.ModelInputKind.ONNX_FILE:
         if model_id is None:
             raise click.UsageError(
                 "When using an ONNX file, --model-id is required "

--- a/src/winml/modelkit/commands/export.py
+++ b/src/winml/modelkit/commands/export.py
@@ -190,6 +190,21 @@ def export(
         # Custom ONNX export configuration
         winml export -m bert-base-uncased -o bert.onnx --export-config config.json
     """
+    # Classify the -m value once (existence-first). Export only works with
+    # HuggingFace model IDs — reject ONNX files and folders early.
+    if model:
+        model_input = cli_utils.classify_model_input(model)
+        if model_input.kind is cli_utils.ModelInputKind.ONNX_FILE:
+            raise click.UsageError(
+                "export requires a HuggingFace model ID, not an ONNX file. "
+                "Use 'winml inspect -m model.onnx' to inspect an existing ONNX model."
+            )
+        if model_input.kind is cli_utils.ModelInputKind.FOLDER:
+            raise click.UsageError(
+                "export requires a HuggingFace model ID, not a directory. "
+                "Provide a HuggingFace model ID (e.g., prajjwal1/bert-tiny)."
+            )
+
     # Merge top-level -v/-q with subcommand-level flags so either position works.
     verbose, quiet = cli_utils.resolve_verbosity(ctx, verbose, quiet)
 

--- a/src/winml/modelkit/commands/inspect.py
+++ b/src/winml/modelkit/commands/inspect.py
@@ -37,11 +37,6 @@ logger = logging.getLogger(__name__)
 console = Console()
 _stderr_console = Console(stderr=True, highlight=False)
 
-# File extensions that unambiguously indicate a local file path.
-# HF model IDs routinely contain dots in version numbers (Phi-3.5, Qwen2.5, …)
-# so matching on any suffix would cause false-positives; restrict to known extensions.
-_LOCAL_FILE_EXTS = frozenset({".onnx", ".pt", ".pth", ".safetensors", ".bin"})
-
 
 def _validate_task(ctx: click.Context, param: click.Parameter, value: str | None) -> str | None:
     """Click-time validation for --task against the hand-coded KNOWN_TASKS set.
@@ -59,24 +54,6 @@ def _validate_task(ctx: click.Context, param: click.Parameter, value: str | None
     raise click.UsageError(
         f"Invalid task '{value}'. Valid: {examples}, ... ({len(KNOWN_TASKS)} total). "
         f"See 'winml inspect --list-tasks' for the full list."
-    )
-
-
-def _looks_like_local_path(model_id: str) -> bool:
-    """Return True when model_id is explicitly a local path.
-
-    Conservative heuristic — only returns True for unambiguous local indicators:
-    path separators, absolute paths, dot/tilde prefixes, or known model file extensions.
-    """
-    from pathlib import Path
-
-    _p = Path(model_id).expanduser()
-    return (
-        _p.exists()
-        or _p.is_absolute()
-        or "\\" in model_id
-        or model_id.startswith(("./", "../", "~/"))
-        or _p.suffix.lower() in _LOCAL_FILE_EXTS
     )
 
 
@@ -176,20 +153,19 @@ def inspect(
             "Use --list-tasks to see available tasks."
         )
 
-    # Classify the input before hitting HF Hub: local paths must exist.
-    # _looks_like_local_path uses a conservative allowlist to avoid misclassifying
-    # HF IDs with version dots (Phi-3.5, Qwen2.5, …) as local paths.
-    if model and _looks_like_local_path(model):
-        from pathlib import Path
-
-        _p = Path(model).expanduser()
-        if _p.suffix == ".onnx" and _p.is_file():
+    # Classify the -m value once (existence-first). Rejects a missing path or
+    # invalid id up front, and keeps dotted HF IDs (Phi-3.5, Qwen2.5, …) on the
+    # Hub path instead of misclassifying them as local files.
+    if model:
+        try:
+            model_input = cli_utils.classify_model_input(model)
+        except click.UsageError as e:
+            raise click.ClickException(str(e)) from e
+        if model_input.kind is cli_utils.ModelInputKind.ONNX_FILE:
             raise click.ClickException(
                 "ONNX file inspection is not yet supported. "
                 "Use 'winml config -m model.onnx' for ONNX build config."
             )
-        if not _p.exists():
-            raise click.ClickException(f"Local path '{model}' does not exist.")
 
     # Merge top-level -v/-q with subcommand-level flags so either position
     # works, once and up front. The banner decision below needs the merged

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -1833,6 +1833,12 @@ def perf(
         _run_genai_runtime(ctx, console=console, json_mode=json_mode)
         return
 
+    # Classify the -m value once (existence-first) so module mode and the
+    # single-model path share one source of truth. Raises cleanly on a missing
+    # .onnx or an invalid id instead of a confusing downstream config error.
+    model_input = cli_utils.classify_model_input(hf_model)
+    is_onnx = model_input.kind is cli_utils.ModelInputKind.ONNX_FILE
+
     # =========================================================================
     # MODULE MODE: per-module build + benchmark
     # =========================================================================
@@ -1842,7 +1848,7 @@ def perf(
         # not carry. Without this guard, the user sees a misleading
         # "not a valid JSON file" error from AutoConfig.from_pretrained
         # trying to load the .onnx as an HF config dir (issue #553).
-        if Path(hf_model).suffix.lower() == ".onnx":
+        if is_onnx:
             raise click.UsageError(
                 f"--module is not supported for ONNX files. "
                 f"Submodule benchmarking requires a HuggingFace model ID "
@@ -1938,14 +1944,9 @@ def perf(
 
     try:
         model_path = Path(hf_model)
-        is_onnx = model_path.suffix.lower() == ".onnx"
 
         if is_onnx:
-            # Validate file existence up front; otherwise WinMLAutoModel would
-            # fall through to HF loading and surface a confusing
-            # "not a valid JSON file" error from AutoConfig.
-            if not model_path.exists():
-                raise FileNotFoundError(f"ONNX file not found: {model_path}")
+            # Existence already validated by classify_model_input above.
             if shape_config:
                 console.print(
                     "[yellow]Warning:[/yellow] --shape-config is ignored for "

--- a/src/winml/modelkit/utils/cli.py
+++ b/src/winml/modelkit/utils/cli.py
@@ -8,6 +8,9 @@ from __future__ import annotations
 
 import json
 import os
+import re
+from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, TypeAlias, TypeVar
 
@@ -1036,6 +1039,118 @@ def is_onnx_file_path(model_input: str) -> bool:
     """
     path = Path(model_input)
     return path.suffix == ".onnx" and path.exists()
+
+
+# ---------------------------------------------------------------------------
+# ``-m/--model`` input classification
+# ---------------------------------------------------------------------------
+
+# Local model-file extensions used only to give a "path does not exist" error
+# (instead of "not a valid HF id") when a path-shaped, non-existent value is
+# passed.  ``.onnx`` is handled separately so it gets its own message.
+_LOCAL_MODEL_FILE_EXTS = frozenset({".onnx", ".pt", ".pth", ".safetensors", ".bin", ".gguf"})
+
+# HuggingFace repo id: an optional ``org/`` prefix plus a repo name, each
+# segment built from ``[A-Za-z0-9]`` plus ``._-`` (must start alphanumeric).
+_HF_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*(/[A-Za-z0-9][A-Za-z0-9._-]*)?$")
+
+
+class ModelInputKind(Enum):
+    """What a ``-m/--model`` value resolves to.
+
+    - ``HF_ID``: not present on disk; a HuggingFace hub reference (``org/name``).
+    - ``ONNX_FILE``: an existing local ``.onnx`` file.
+    - ``FOLDER``: an existing local directory. The ``is_*``/``folder_has_onnx``
+      flags on :class:`ModelInput` describe what the folder contains so each
+      command can apply its own policy (build-family treats it as a transformers
+      source; run/serve load the ONNX the engine discovers inside it).
+    """
+
+    HF_ID = "hf_id"
+    ONNX_FILE = "onnx_file"
+    FOLDER = "folder"
+
+
+@dataclass(frozen=True)
+class ModelInput:
+    """Classification result for a ``-m/--model`` value.
+
+    The folder flags are only meaningful when ``kind is FOLDER`` (all ``False``
+    otherwise). ``is_winml_cli_folder`` implies ``folder_has_onnx``.
+    """
+
+    kind: ModelInputKind
+    raw: str
+    is_hf_folder: bool = False
+    folder_has_onnx: bool = False
+    is_winml_cli_folder: bool = False
+
+
+def _looks_like_path(raw: str) -> bool:
+    """Return True when *raw* is clearly a filesystem path (not an HF id).
+
+    Used only for a non-existent value to choose between a "path does not
+    exist" error and a "not a valid HF id" error. HF ids carry at most one
+    ``/`` and none of these path indicators.
+    """
+    if "\\" in raw:
+        return True
+    if raw.startswith(("./", "../", "~/", ".\\", "..\\", "~\\")):
+        return True
+    p = Path(raw)
+    if p.is_absolute():
+        return True
+    # Windows drive-letter prefix, e.g. ``C:models``.
+    if len(raw) >= 2 and raw[1] == ":":
+        return True
+    if raw.count("/") > 1:
+        return True
+    return p.suffix.lower() in _LOCAL_MODEL_FILE_EXTS
+
+
+def classify_model_input(raw: str) -> ModelInput:
+    """Classify a ``-m/--model`` value into a :class:`ModelInput`.
+
+    Existence-first: a value present on disk is a local file or directory; a
+    value absent from disk is a HuggingFace hub id (or an error). The engine
+    remains responsible for locating the actual ``*.onnx`` inside a folder.
+
+    Raises:
+        click.UsageError: for a non-existent ``.onnx`` path, a non-existent
+            path-shaped value, a syntactically invalid HF id, or an existing
+            non-``.onnx`` file.
+    """
+    path = Path(raw)
+
+    if not path.exists():
+        if path.suffix.lower() == ".onnx":
+            raise click.UsageError(f"ONNX file not found: {raw}")
+        if _looks_like_path(raw):
+            raise click.UsageError(f"Model path does not exist: {raw}")
+        if _HF_ID_RE.match(raw):
+            return ModelInput(kind=ModelInputKind.HF_ID, raw=raw)
+        raise click.UsageError(
+            f"'{raw}' is not a valid HuggingFace model id, an existing .onnx "
+            "file, or an existing directory."
+        )
+
+    if path.is_file():
+        if path.suffix.lower() == ".onnx":
+            return ModelInput(kind=ModelInputKind.ONNX_FILE, raw=raw)
+        raise click.UsageError(
+            f"Unsupported model file: {raw} (expected a .onnx file or a directory)."
+        )
+
+    # Existing directory: report what it contains; callers apply policy.
+    folder_has_onnx = any(path.glob("*.onnx"))
+    is_winml_cli_folder = folder_has_onnx and any(path.glob("*build_manifest.json"))
+    return ModelInput(
+        kind=ModelInputKind.FOLDER,
+        raw=raw,
+        is_hf_folder=(path / "config.json").is_file(),
+        folder_has_onnx=folder_has_onnx,
+        is_winml_cli_folder=is_winml_cli_folder,
+    )
 
 
 def is_cli_provided(ctx: click.Context, param_name: str) -> bool:

--- a/src/winml/modelkit/utils/cli.py
+++ b/src/winml/modelkit/utils/cli.py
@@ -1031,16 +1031,6 @@ def load_build_config(config_path: Path) -> tuple[WinMLBuildConfig, dict]:
     return WinMLBuildConfig.from_dict(data), data
 
 
-def is_onnx_file_path(model_input: str) -> bool:
-    """Check if input is a path to an existing ``.onnx`` file.
-
-    Shared helper for CLI commands that accept either a HuggingFace model ID
-    or a local ``.onnx`` file path for the ``-m/--model`` option.
-    """
-    path = Path(model_input)
-    return path.suffix == ".onnx" and path.exists()
-
-
 # ---------------------------------------------------------------------------
 # ``-m/--model`` input classification
 # ---------------------------------------------------------------------------

--- a/tests/unit/commands/test_build.py
+++ b/tests/unit/commands/test_build.py
@@ -1374,14 +1374,14 @@ class TestBuildOnnxAutoDetect:
         call_kwargs = mock_build_api.call_args.kwargs
         assert call_kwargs["model_id"] == "microsoft/resnet-50"
 
-    def test_build_onnx_suffix_but_not_exists_uses_hf(
+    def test_build_onnx_suffix_but_not_exists_raises(
         self,
         runner: CliRunner,
         sample_config_file: Path,
         mock_build_api: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """An .onnx path that doesn't exist falls through to HF path."""
+        """A non-existent .onnx path raises cleanly instead of HF fallthrough (#553)."""
         from winml.modelkit.commands.build import build
 
         output_dir = tmp_path / "out"
@@ -1390,12 +1390,11 @@ class TestBuildOnnxAutoDetect:
             ["-c", str(sample_config_file), "-m", "nonexistent.onnx", "-o", str(output_dir)],
             obj={"debug": False},
         )
-        # is_onnx_file_path checks suffix AND exists(); nonexistent.onnx
-        # falls through to HF path since the file doesn't exist on disk
-        assert result.exit_code == 0, f"Build failed: {result.output}"
-        assert mock_build_api.called
-        call_kwargs = mock_build_api.call_args.kwargs
-        assert call_kwargs["model_id"] == "nonexistent.onnx"
+        # classify_model_input rejects a missing .onnx path up front rather than
+        # handing it to the HF loader (which would give a confusing config error).
+        assert result.exit_code != 0
+        assert "ONNX file not found" in result.output
+        assert not mock_build_api.called
 
 
 # =============================================================================

--- a/tests/unit/commands/test_config_cli.py
+++ b/tests/unit/commands/test_config_cli.py
@@ -330,7 +330,7 @@ class TestConfigOnnxOverrides:
         """--no-quant should set quant=None even for ONNX configs."""
         from winml.modelkit.commands.config import config
 
-        # Create a fake .onnx file so is_onnx_file_path returns True
+        # Create a fake .onnx file so it classifies as an ONNX_FILE input
         onnx_file = tmp_path / "model.onnx"
         onnx_file.write_bytes(b"fake")
 

--- a/tests/unit/commands/test_inspect_cli.py
+++ b/tests/unit/commands/test_inspect_cli.py
@@ -312,7 +312,7 @@ class TestInspectErrors:
         missing = str(tmp_path / "missing.onnx")
         result = runner.invoke(inspect, ["-m", missing], obj={})
         assert result.exit_code != 0
-        assert "does not exist" in result.output
+        assert "ONNX file not found" in result.output
         assert "Network error" not in result.output
 
     def test_missing_local_relative_path_shows_path_error(self, runner: CliRunner) -> None:
@@ -321,7 +321,7 @@ class TestInspectErrors:
 
         result = runner.invoke(inspect, ["-m", "./does-not-exist.onnx"], obj={})
         assert result.exit_code != 0
-        assert "does not exist" in result.output
+        assert "ONNX file not found" in result.output
         assert "Network error" not in result.output
 
     def test_bogus_hf_id_shows_model_not_found(self, runner: CliRunner) -> None:

--- a/tests/unit/config/test_build.py
+++ b/tests/unit/config/test_build.py
@@ -2340,41 +2340,22 @@ class TestConfigOnnxAutoDetect:
         assert output_data["compile"] is not None
         assert output_data["compile"]["execution_provider"] == "qnn"
 
-    def test_config_onnx_suffix_not_exists_uses_hf(
+    def test_config_onnx_suffix_not_exists_raises(
         self,
         tmp_path,
-        mock_hf_config: MagicMock,
-        mock_model_class: MagicMock,
-        mock_loader_config: WinMLLoaderConfig,
-        mock_export_config: WinMLExportConfig,
     ) -> None:
-        """An .onnx path that doesn't exist falls through to HF config generation."""
+        """A missing .onnx path raises instead of silently falling through to HF (#553)."""
         output_file = tmp_path / "result.json"
 
-        with (
-            patch(
-                "winml.modelkit.config.build.resolve_loader_config",
-                return_value=(mock_loader_config, mock_hf_config, mock_model_class, MagicMock()),
-            ),
-            patch(
-                "winml.modelkit.config.build._resolve_export_config_from_specs",
-                return_value=mock_export_config,
-            ),
-            patch("winml.modelkit.models.hf.MODEL_BUILD_CONFIGS", {}),
-            # config now inspects the HF config to route seq2seq composites (#850);
-            # stub that load (bert -> no composite) so the placeholder -m isn't fetched.
-            patch("transformers.AutoConfig.from_pretrained", return_value=BertConfig()),
-        ):
-            runner = CliRunner()
-            result = runner.invoke(
-                config_command,
-                ["-m", "nonexistent.onnx", "-o", str(output_file)],
-            )
+        runner = CliRunner()
+        result = runner.invoke(
+            config_command,
+            ["-m", "nonexistent.onnx", "-o", str(output_file)],
+        )
 
-        assert result.exit_code == 0, f"CLI failed: {result.output}"
-        output_data = json.loads(output_file.read_text())
-        # Should be HF config (export present)
-        assert output_data["export"] is not None
+        assert result.exit_code != 0
+        assert "ONNX file not found" in result.output
+        assert not output_file.exists()
 
 
 # =============================================================================

--- a/tests/unit/config/test_build_onnx.py
+++ b/tests/unit/config/test_build_onnx.py
@@ -19,7 +19,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
-from transformers import BertConfig
 
 # Import models package to trigger ONNX config registration with TasksManager
 import winml.modelkit.models  # noqa: F401
@@ -142,41 +141,22 @@ class TestConfigOnnxAutoDetect:
         assert output_data["compile"] is not None
         assert output_data["compile"]["execution_provider"] == "qnn"
 
-    def test_config_onnx_suffix_not_exists_uses_hf(
+    def test_config_onnx_suffix_not_exists_raises(
         self,
         tmp_path,
-        mock_hf_config: MagicMock,
-        mock_model_class: MagicMock,
-        mock_loader_config: WinMLLoaderConfig,
-        mock_export_config: WinMLExportConfig,
     ) -> None:
-        """An .onnx path that doesn't exist falls through to HF config generation."""
+        """A missing .onnx path raises instead of silently falling through to HF (#553)."""
         output_file = tmp_path / "result.json"
 
-        with (
-            patch(
-                "winml.modelkit.config.build.resolve_loader_config",
-                return_value=(mock_loader_config, mock_hf_config, mock_model_class, MagicMock()),
-            ),
-            patch(
-                "winml.modelkit.config.build._resolve_export_config_from_specs",
-                return_value=mock_export_config,
-            ),
-            patch("winml.modelkit.models.hf.MODEL_BUILD_CONFIGS", {}),
-            # config now inspects the HF config to route seq2seq composites (#850);
-            # stub that load (bert -> no composite) so the placeholder -m isn't fetched.
-            patch("transformers.AutoConfig.from_pretrained", return_value=BertConfig()),
-        ):
-            runner = CliRunner()
-            result = runner.invoke(
-                config_command,
-                ["-m", "nonexistent.onnx", "-o", str(output_file)],
-            )
+        runner = CliRunner()
+        result = runner.invoke(
+            config_command,
+            ["-m", "nonexistent.onnx", "-o", str(output_file)],
+        )
 
-        assert result.exit_code == 0, f"CLI failed: {result.output}"
-        output_data = json.loads(output_file.read_text())
-        # Should be HF config (export present)
-        assert output_data["export"] is not None
+        assert result.exit_code != 0
+        assert "ONNX file not found" in result.output
+        assert not output_file.exists()
 
 
 # =============================================================================

--- a/tests/unit/utils/test_cli.py
+++ b/tests/unit/utils/test_cli.py
@@ -14,8 +14,10 @@ import pytest
 from click.testing import CliRunner
 
 from winml.modelkit.utils.cli import (
+    ModelInputKind,
     analyze_option,
     build_pipeline_extra_kwargs,
+    classify_model_input,
     guard_output,
     ignored_build_flags_warning,
     max_optim_iterations_option,
@@ -362,6 +364,123 @@ class TestIgnoredBuildFlagsWarning:
         msg = ignored_build_flags_warning(skip_build_onnx=True, max_optim_iterations=0)
         assert msg is not None
         assert "--max-optim-iterations" in msg
+
+
+class TestClassifyModelInput:
+    """Tests for classify_model_input() and ModelInput."""
+
+    # --- not present on disk ------------------------------------------------
+
+    def test_hf_id_bare_name(self) -> None:
+        result = classify_model_input("bert-base-uncased")
+        assert result.kind is ModelInputKind.HF_ID
+        assert result.raw == "bert-base-uncased"
+        assert not result.is_hf_folder
+        assert not result.folder_has_onnx
+        assert not result.is_winml_cli_folder
+
+    def test_hf_id_org_name(self) -> None:
+        result = classify_model_input("microsoft/resnet-50")
+        assert result.kind is ModelInputKind.HF_ID
+
+    def test_hf_id_with_dots_in_name(self) -> None:
+        """Version dots (e.g. Qwen2.5) are valid HF id characters."""
+        result = classify_model_input("Qwen/Qwen2.5-0.5B")
+        assert result.kind is ModelInputKind.HF_ID
+
+    def test_missing_onnx_file_raises(self) -> None:
+        """A non-existent .onnx path is an error, not an HF id (#553)."""
+        with pytest.raises(click.UsageError, match="ONNX file not found"):
+            classify_model_input("does_not_exist.onnx")
+
+    def test_missing_path_shaped_value_raises(self) -> None:
+        with pytest.raises(click.UsageError, match="path does not exist"):
+            classify_model_input("./nope/model_dir")
+
+    def test_missing_nested_path_raises(self) -> None:
+        """More than one slash marks a path, not an org/name HF id."""
+        with pytest.raises(click.UsageError, match="path does not exist"):
+            classify_model_input("a/b/c")
+
+    def test_invalid_hf_id_raises(self) -> None:
+        with pytest.raises(click.UsageError, match="not a valid HuggingFace"):
+            classify_model_input("has spaces")
+
+    # --- existing file ------------------------------------------------------
+
+    def test_existing_onnx_file(self, tmp_path: Path) -> None:
+        onnx = tmp_path / "model.onnx"
+        onnx.write_bytes(b"\x00")
+        result = classify_model_input(str(onnx))
+        assert result.kind is ModelInputKind.ONNX_FILE
+        assert result.raw == str(onnx)
+
+    def test_existing_non_onnx_file_raises(self, tmp_path: Path) -> None:
+        other = tmp_path / "weights.safetensors"
+        other.write_bytes(b"\x00")
+        with pytest.raises(click.UsageError, match="Unsupported model file"):
+            classify_model_input(str(other))
+
+    # --- existing directory -------------------------------------------------
+
+    def test_hf_source_folder(self, tmp_path: Path) -> None:
+        """config.json but no onnx -> HF source folder."""
+        (tmp_path / "config.json").write_text("{}")
+        result = classify_model_input(str(tmp_path))
+        assert result.kind is ModelInputKind.FOLDER
+        assert result.is_hf_folder
+        assert not result.folder_has_onnx
+        assert not result.is_winml_cli_folder
+
+    def test_loose_onnx_folder(self, tmp_path: Path) -> None:
+        """onnx but no manifest -> loadable dir, not a winml build output."""
+        (tmp_path / "model.onnx").write_bytes(b"\x00")
+        result = classify_model_input(str(tmp_path))
+        assert result.kind is ModelInputKind.FOLDER
+        assert result.folder_has_onnx
+        assert not result.is_winml_cli_folder
+        assert not result.is_hf_folder
+
+    def test_winml_build_folder(self, tmp_path: Path) -> None:
+        """onnx + build_manifest.json -> winml cli build output."""
+        (tmp_path / "model.onnx").write_bytes(b"\x00")
+        (tmp_path / "build_manifest.json").write_text("{}")
+        result = classify_model_input(str(tmp_path))
+        assert result.kind is ModelInputKind.FOLDER
+        assert result.folder_has_onnx
+        assert result.is_winml_cli_folder
+
+    def test_winml_build_folder_cache_prefixed(self, tmp_path: Path) -> None:
+        """Cache-key-prefixed artifact names are recognized too."""
+        (tmp_path / "abc123_model.onnx").write_bytes(b"\x00")
+        (tmp_path / "abc123_build_manifest.json").write_text("{}")
+        result = classify_model_input(str(tmp_path))
+        assert result.folder_has_onnx
+        assert result.is_winml_cli_folder
+
+    def test_manifest_without_onnx_is_not_winml_folder(self, tmp_path: Path) -> None:
+        """A manifest with no onnx (partial build) is not a winml build dir."""
+        (tmp_path / "build_manifest.json").write_text("{}")
+        result = classify_model_input(str(tmp_path))
+        assert not result.folder_has_onnx
+        assert not result.is_winml_cli_folder
+
+    def test_winml_folder_can_also_be_hf_folder(self, tmp_path: Path) -> None:
+        """Build dirs often carry a copied config.json; flags are independent."""
+        (tmp_path / "model.onnx").write_bytes(b"\x00")
+        (tmp_path / "build_manifest.json").write_text("{}")
+        (tmp_path / "config.json").write_text("{}")
+        result = classify_model_input(str(tmp_path))
+        assert result.is_winml_cli_folder
+        assert result.is_hf_folder
+
+    def test_existing_dir_wins_over_hf_id_shape(self, tmp_path: Path) -> None:
+        """An on-disk directory is classified as FOLDER even if its name
+        would parse as an HF id."""
+        d = tmp_path / "org"
+        d.mkdir()
+        result = classify_model_input(str(d))
+        assert result.kind is ModelInputKind.FOLDER
 
 
 class TestOverwriteOption:


### PR DESCRIPTION
Close https://github.com/microsoft/winml-cli/issues/959

## Summary

Introduces a centralized `classify_model_input()` in `utils/cli.py` and adopts it across the CLI commands so all commands share one existence-first classification of the `-m/--model` input (ONNX file vs HuggingFace id vs folder), replacing per-command ad-hoc discriminators.

## Classifier

`classify_model_input(raw) -> ModelInput` with `ModelInputKind` = `HF_ID | ONNX_FILE | FOLDER`:
- **Not on local disk:** `.onnx` suffix → raises "ONNX file not found" (#553 guard); path-shaped → raises "path does not exist"; valid HF-id format → `HF_ID`; else → raises "not a valid HuggingFace id".
- **Exists + file:** `.onnx` → `ONNX_FILE`; else → raises "Unsupported model file".
- **Exists + dir:** `FOLDER` with flags `is_hf_folder` (`config.json` present), `folder_has_onnx` (`*.onnx`), `is_winml_cli_folder` (`folder_has_onnx` and `*build_manifest.json`).

## Wiring

Adopted in `build.py`, `config.py`, `perf.py`, `eval.py`, `inspect.py` — each classifies once and threads the result down. eval converts the classifier's `UsageError`→`BadParameter` and inspect converts it→`ClickException` to preserve each command's existing error contract.

## Behavior change

A missing `.onnx` path now raises a clean error everywhere instead of silently falling through to HuggingFace loading. Three tests that encoded the old fallthrough were updated to the unified messages.

## Notes

Library dispatchers (`inference/engine.py`, `models/auto.py`) and `perf.py._load_model` are intentionally left unwired — they must not raise click exceptions (layering).

Pushing to let CI run the full suite with timeouts, since the local combined run appeared to hang.