### PR TITLE
Fix composite model export (Qwen3 and seq2seq models)

### DIFF
--- a/src/winml/modelkit/commands/config.py
+++ b/src/winml/modelkit/commands/config.py
@@ -482,27 +482,14 @@ def _resolve_composite_model_components(
     No --task: ``resolve_task`` detects + tags the composite (its ``.composite``
     field carries the seq2seq bridge), so no-task routing matches --task routing.
     """
-    from transformers import AutoConfig
+    from ..loader.resolution import resolve_composite_components
 
-    from ..loader.resolution import resolve_composite, resolve_task
-
-    if task is not None:
-        resolved_type = model_type
-        if resolved_type is None and hf_model is not None:
-            resolved_type = AutoConfig.from_pretrained(
-                hf_model, trust_remote_code=trust_remote_code
-            ).model_type
-        if resolved_type is None:
-            return None
-        return resolve_composite(resolved_type, task)
-
-    if hf_model is not None:
-        config = AutoConfig.from_pretrained(hf_model, trust_remote_code=trust_remote_code)
-    elif model_type is not None:
-        config = AutoConfig.for_model(model_type)
-    else:
-        return None
-    return resolve_task(config).composite
+    return resolve_composite_components(
+        hf_model,
+        task=task,
+        model_type=model_type,
+        trust_remote_code=trust_remote_code,
+    )
 
 
 def _generate_pipeline_configs(

--- a/src/winml/modelkit/commands/export.py
+++ b/src/winml/modelkit/commands/export.py
@@ -24,7 +24,6 @@ Examples:
 
 from __future__ import annotations
 
-import contextlib
 import json
 import logging
 from pathlib import Path
@@ -59,19 +58,31 @@ def _delete_onnx_with_external_data(onnx_path: Path) -> None:
         logger.debug("Could not parse external data from %s", onnx_path, exc_info=True)
 
     if onnx_path.exists():
-        with contextlib.suppress(OSError):
-            onnx_path.unlink()
+        onnx_path.unlink()
 
 
-def _cleanup_partial_composite(written: list[Path]) -> None:
-    """Remove sub-model ONNX outputs written by a composite export that failed mid-run.
+def _warn_partial_composite(completed: list[Path]) -> None:
+    """Warn that a composite export failed mid-run, listing what was written.
 
-    Best-effort: a failed run should not leave a half-exported composite on disk.
-    Each path is deleted together with its external-data sidecars.
+    We deliberately do NOT delete anything: the targets may be pre-existing files
+    the user chose to ``--overwrite``, and a component can fail before touching its
+    file, so auto-deleting could destroy artifacts this run never actually wrote.
+    Instead we surface the completed sub-models and let the user decide whether to
+    keep or remove the partial composite.
     """
-    for onnx_path in written:
-        _delete_onnx_with_external_data(onnx_path)
-        logger.debug("Cleaned up partial composite sub-model: %s", onnx_path)
+    if not completed:
+        return
+    console.print(
+        "\n[yellow]Warning:[/yellow] composite export did not finish; "
+        f"{len(completed)} sub-model(s) were written/updated by this run:"
+    )
+    for onnx_path in completed:
+        console.print(f"  • {onnx_path}")
+    console.print(
+        "[yellow]The export did not complete for every sub-model.[/yellow] "
+        "Review these files and remove them if you don't want to keep the "
+        "partial export."
+    )
 
 
 @click.command()
@@ -507,20 +518,22 @@ def export(
             for sub_out in sub_outputs.values():
                 cli_utils.guard_output(sub_out, overwrite)
 
-            # If a component fails, remove the sub-models this invocation already
-            # wrote (plus the partial output of the failing one) so we don't leave
-            # a half-exported composite behind.
-            written: list[Path] = []
+            # Track sub-models this invocation actually completes. On a mid-run
+            # failure we do NOT delete anything (the targets may be pre-existing
+            # files the user chose to --overwrite, and a component can fail before
+            # touching its file). Instead we warn and list what was written so the
+            # user decides whether to keep or remove the partial composite.
+            completed: list[Path] = []
             try:
                 for name, component_task in components.items():
                     sub_out = sub_outputs[name]
                     console.print(
                         f"\n[bold blue]Sub-model:[/bold blue] {name} (task={component_task})"
                     )
-                    written.append(sub_out)
                     _run_component_export(component_task, sub_out)
+                    completed.append(sub_out)
             except BaseException:
-                _cleanup_partial_composite(written)
+                _warn_partial_composite(completed)
                 raise
         else:
             cli_utils.guard_output(output_path, overwrite)

--- a/src/winml/modelkit/commands/export.py
+++ b/src/winml/modelkit/commands/export.py
@@ -431,15 +431,27 @@ def export(
                 console.print(f"  JSON: {json_metadata}")
 
     # Detect a composite pipeline (registry-driven). A composite fans out into one
-    # ONNX per sub-component written to <output>/<component>/model.onnx; a plain
-    # model exports to the single output path as before. Detection is best-effort:
-    # if the HF config can't be resolved we fall through to the single-model path.
+    # ONNX per sub-component, each written next to <output> with a _<component>
+    # stem suffix; a plain model exports to the single output path as before.
+    # Detection is best-effort for unresolvable HF configs (we fall through to the
+    # single-model path), but intentional loud guards (empty registry / model-task
+    # incompatibility) are re-raised below rather than masked.
     components = None
     try:
         from ..loader.resolution import resolve_composite_components
 
         components = resolve_composite_components(model, task=task)
     except click.ClickException:
+        raise
+    except ValueError as e:
+        # A genuine (model, task) incompatibility, or an ambiguous composite that
+        # needs an explicit --task, is surfaced as a usage error (mirroring
+        # `winml config`) instead of being silently downgraded to a single export.
+        raise click.UsageError(str(e)) from e
+    except RuntimeError:
+        # The empty-COMPOSITE_MODEL_REGISTRY guard is meant to fail loudly (a
+        # registrations moved/renamed refactor mistake); never mask it as
+        # "not composite".
         raise
     except Exception as e:
         logger.debug("Composite detection unavailable, treating as single model: %s", e)
@@ -455,10 +467,18 @@ def export(
                     "you need custom input specs."
                 )
             console.print(
-                f"[dim]Composite model: {len(components)} sub-models -> {output_path}/[/dim]"
+                f"[dim]Composite model: {len(components)} sub-models "
+                f"(fanned out from {output_path.name} with a _<component> suffix)[/dim]"
             )
+            # Fan out flat, suffixing the output stem per component to match the
+            # sibling `winml config` layout and the runtime's `*_model.onnx`
+            # discovery: e.g. `model.onnx` -> `model_decoder_prefill.onnx`.
+            # Each component is loaded and exported independently because a
+            # composite's sub-tasks map to distinct model classes/heads (e.g.
+            # decoder-prefill vs. decoder-with-past), so the full model is
+            # reloaded per component — this N-load cost is intentional.
             for name, component_task in components.items():
-                sub_out = output_path / name / "model.onnx"
+                sub_out = output_path.with_stem(f"{output_path.stem}_{name}")
                 cli_utils.guard_output(sub_out, overwrite)
                 console.print(f"\n[bold blue]Sub-model:[/bold blue] {name} (task={component_task})")
                 _run_component_export(component_task, sub_out)

--- a/src/winml/modelkit/commands/export.py
+++ b/src/winml/modelkit/commands/export.py
@@ -237,14 +237,9 @@ def export(
     if export_config:
         console.print(f"[bold blue]Export config:[/bold blue] {export_config}")
 
-    # Refuse to clobber an existing output unless the user opted in.
     output_path = Path(output)
-    cli_utils.guard_output(output_path, overwrite)
 
-    # Create output directory if needed
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-
-    # Load export configuration from JSON file if provided, or create default
+    # Load export configuration from JSON file if provided (task-independent).
     export_config_dict: dict = {}
     if export_config:
         try:
@@ -255,17 +250,7 @@ def export(
             console.print(f"[bold red]Failed to load export config:[/bold red] {e}")
             raise click.ClickException(f"Failed to load export config: {e}") from e
 
-    # Load input/output specifications.
-    #
-    # We ALWAYS run Optimum auto-resolution because it provides authoritative
-    # output_tensors (names that match the actual ONNX graph). --input-specs
-    # then overrides input_tensors only; output_tensors stays from Optimum so
-    # tasks like feature-extraction don't trip torch.onnx.export with extra
-    # dataclass field names that aren't in the traced graph.
-    input_tensors: list[InputTensorSpec] | None = None
-    output_tensors: list[OutputTensorSpec] | None = None
-
-    # Load shape overrides from JSON
+    # Load shape overrides from JSON (task-independent).
     shape_overrides = None
     if shape_config:
         try:
@@ -282,103 +267,7 @@ def export(
             ) from e
         console.print(f"[dim]Shape overrides: {shape_overrides}[/dim]")
 
-    # Always auto-resolve input/output tensors via loader + Optimum
-    from ..export import ONNXConfigNotFoundError
-
-    try:
-        from ..export import resolve_export_config as resolve_cfg
-
-        auto_export_cfg, _ = resolve_cfg(
-            model_id=model,
-            task=task,
-            shape_config=shape_overrides,
-        )
-        if auto_export_cfg.input_tensors:
-            input_tensors = auto_export_cfg.input_tensors
-            console.print(
-                f"[dim]Auto-resolved input specs: {[t.name for t in input_tensors]}[/dim]"
-            )
-        if auto_export_cfg.output_tensors:
-            output_tensors = auto_export_cfg.output_tensors
-            console.print(
-                f"[dim]Auto-resolved output specs: {[t.name for t in output_tensors]}[/dim]"
-            )
-    except ONNXConfigNotFoundError as e:
-        # model_type is not registered in Optimum's TasksManager (e.g. CLIP/SigLIP
-        # sub-encoder variants like clip-text-model / clip-vision-model that only
-        # live in MODEL_BUILD_CONFIGS, or a model_type from a newer transformers
-        # release we don't know yet). Fall through: downstream MODEL_BUILD_CONFIGS
-        # lookup or user-supplied --input-specs takes over.
-        logger.debug("I/O tensor auto-resolution unavailable: %s", e)
-    except ValueError as e:
-        # Mirrors `winml config`: surface (model, task) incompatibility raised by
-        # Optimum's TasksManager as a clean usage error instead of letting it fall
-        # through to a misleading "Unrecognized configuration class" traceback
-        # later in load_hf_model.
-        raise click.UsageError(str(e)) from e
-    except Exception as e:
-        logger.debug("I/O tensor auto-resolution failed: %s", e)
-
-    # --input-specs overrides individual fields on the auto-resolved input_tensors.
-    # Names matched against auto-resolve get their dtype/shape patched; unknown
-    # names are appended. output_tensors are left untouched.
-    if input_specs:
-        try:
-            with input_specs.open() as f:
-                input_specs_dict = json.load(f)
-        except Exception as e:
-            console.print(f"[bold red]Failed to load input specs:[/bold red] {e}")
-            raise click.ClickException(f"Failed to load input specs: {e}") from e
-
-        if input_tensors is None:
-            input_tensors = []
-        by_name = {t.name: t for t in input_tensors}
-        for name, spec in input_specs_dict.items():
-            shape = tuple(spec["shape"]) if spec.get("shape") else None
-            dtype = spec.get("dtype")
-            if name in by_name:
-                existing = by_name[name]
-                if dtype is not None:
-                    existing.dtype = dtype
-                if shape is not None:
-                    existing.shape = shape
-            else:
-                input_tensors.append(
-                    InputTensorSpec(name=name, dtype=dtype or "float32", shape=shape)
-                )
-        console.print(f"[dim]Applied input-spec overrides: {list(input_specs_dict.keys())}[/dim]")
-
-    # Build WinMLExportConfig from loaded settings
-    config_kwargs = {}
-    # Layer 1: build config defaults (lowest precedence)
-    config_kwargs.update(_build_export_dict)
-    # Layer 2: --export-config file overrides
-    config_kwargs.update(export_config_dict)
-    # Layer 3: explicit CLI options (highest precedence)
-    if cli_utils.is_cli_provided(ctx, "hierarchy") or cli_utils.is_cli_provided(ctx, "clean_onnx"):
-        config_kwargs["enable_hierarchy_tags"] = hierarchy
-    if cli_utils.is_cli_provided(ctx, "verbose"):
-        config_kwargs["verbose"] = bool(verbose)
-    if cli_utils.is_cli_provided(ctx, "dynamo"):
-        config_kwargs["dynamo"] = dynamo
-
-    # Add input/output tensors if we resolved them
-    if input_tensors:
-        config_kwargs["input_tensors"] = input_tensors
-    if output_tensors:
-        config_kwargs["output_tensors"] = output_tensors
-
-    try:
-        cfg = WinMLExportConfig.from_dict(config_kwargs)
-    except Exception as e:
-        console.print(f"[bold red]Configuration error:[/bold red] {e}")
-        logger.exception("Failed to create export config")
-        raise click.ClickException(f"Configuration error: {e}") from e
-
-    # Parse torch-module option
-    # TODO: export_onnx() does not currently support torch_module parameter.
-    # This would need to be passed through to HTPExporter.
-    # For now, we note this as a limitation and log a warning if used.
+    # One-time warnings (apply to every sub-model in a composite export).
     if torch_module:
         console.print(
             "[yellow]Warning:[/yellow] --torch-module is not yet supported in export_onnx(). "
@@ -389,8 +278,6 @@ def export(
             "TODO: Add torch_module support to export_onnx() and WinMLExportConfig.",
             torch_module,
         )
-
-    # Handle --dynamo flag
     if dynamo:
         console.print(
             "[yellow]Warning:[/yellow] --dynamo is not yet supported in export_onnx(). "
@@ -401,20 +288,126 @@ def export(
             "TODO: Add dynamo support to WinMLExportConfig if needed."
         )
 
-    # Execute export
-    try:
-        console.print("\n[bold]Starting HTP export...[/bold]")
+    def _run_component_export(component_task: str | None, out_path: Path) -> None:
+        """Resolve I/O, build config, load, and export one (model, task) to ``out_path``."""
+        from ..export import ONNXConfigNotFoundError
+
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Load input/output specifications.
+        #
+        # We ALWAYS run Optimum auto-resolution because it provides authoritative
+        # output_tensors (names that match the actual ONNX graph). --input-specs
+        # then overrides input_tensors only; output_tensors stays from Optimum so
+        # tasks like feature-extraction don't trip torch.onnx.export with extra
+        # dataclass field names that aren't in the traced graph.
+        input_tensors: list[InputTensorSpec] | None = None
+        output_tensors: list[OutputTensorSpec] | None = None
+
+        try:
+            from ..export import resolve_export_config as resolve_cfg
+
+            auto_export_cfg, _ = resolve_cfg(
+                model_id=model,
+                task=component_task,
+                shape_config=shape_overrides,
+            )
+            if auto_export_cfg.input_tensors:
+                input_tensors = auto_export_cfg.input_tensors
+                console.print(
+                    f"[dim]Auto-resolved input specs: {[t.name for t in input_tensors]}[/dim]"
+                )
+            if auto_export_cfg.output_tensors:
+                output_tensors = auto_export_cfg.output_tensors
+                console.print(
+                    f"[dim]Auto-resolved output specs: {[t.name for t in output_tensors]}[/dim]"
+                )
+        except ONNXConfigNotFoundError as e:
+            # model_type is not registered in Optimum's TasksManager (e.g. CLIP/SigLIP
+            # sub-encoder variants like clip-text-model / clip-vision-model that only
+            # live in MODEL_BUILD_CONFIGS, or a model_type from a newer transformers
+            # release we don't know yet). Fall through: downstream MODEL_BUILD_CONFIGS
+            # lookup or user-supplied --input-specs takes over.
+            logger.debug("I/O tensor auto-resolution unavailable: %s", e)
+        except ValueError as e:
+            # Mirrors `winml config`: surface (model, task) incompatibility raised by
+            # Optimum's TasksManager as a clean usage error instead of letting it fall
+            # through to a misleading "Unrecognized configuration class" traceback
+            # later in load_hf_model.
+            raise click.UsageError(str(e)) from e
+        except Exception as e:
+            logger.debug("I/O tensor auto-resolution failed: %s", e)
+
+        # --input-specs overrides individual fields on the auto-resolved input_tensors.
+        # Names matched against auto-resolve get their dtype/shape patched; unknown
+        # names are appended. output_tensors are left untouched.
+        if input_specs:
+            try:
+                with input_specs.open() as f:
+                    input_specs_dict = json.load(f)
+            except Exception as e:
+                console.print(f"[bold red]Failed to load input specs:[/bold red] {e}")
+                raise click.ClickException(f"Failed to load input specs: {e}") from e
+
+            if input_tensors is None:
+                input_tensors = []
+            by_name = {t.name: t for t in input_tensors}
+            for name, spec in input_specs_dict.items():
+                shape = tuple(spec["shape"]) if spec.get("shape") else None
+                dtype = spec.get("dtype")
+                if name in by_name:
+                    existing = by_name[name]
+                    if dtype is not None:
+                        existing.dtype = dtype
+                    if shape is not None:
+                        existing.shape = shape
+                else:
+                    input_tensors.append(
+                        InputTensorSpec(name=name, dtype=dtype or "float32", shape=shape)
+                    )
+            console.print(
+                f"[dim]Applied input-spec overrides: {list(input_specs_dict.keys())}[/dim]"
+            )
+
+        # Build WinMLExportConfig from loaded settings
+        config_kwargs: dict = {}
+        # Layer 1: build config defaults (lowest precedence)
+        config_kwargs.update(_build_export_dict)
+        # Layer 2: --export-config file overrides
+        config_kwargs.update(export_config_dict)
+        # Layer 3: explicit CLI options (highest precedence)
+        if cli_utils.is_cli_provided(ctx, "hierarchy") or cli_utils.is_cli_provided(
+            ctx, "clean_onnx"
+        ):
+            config_kwargs["enable_hierarchy_tags"] = hierarchy
+        if cli_utils.is_cli_provided(ctx, "verbose"):
+            config_kwargs["verbose"] = bool(verbose)
+        if cli_utils.is_cli_provided(ctx, "dynamo"):
+            config_kwargs["dynamo"] = dynamo
+
+        # Add input/output tensors if we resolved them
+        if input_tensors:
+            config_kwargs["input_tensors"] = input_tensors
+        if output_tensors:
+            config_kwargs["output_tensors"] = output_tensors
+
+        try:
+            cfg = WinMLExportConfig.from_dict(config_kwargs)
+        except Exception as e:
+            console.print(f"[bold red]Configuration error:[/bold red] {e}")
+            logger.exception("Failed to create export config")
+            raise click.ClickException(f"Configuration error: {e}") from e
 
         # Load model with task detection (CLI is the orchestration layer)
-        pytorch_model, _, detected_task = load_hf_model(model, task=task)
-        if task:
+        pytorch_model, _, detected_task = load_hf_model(model, task=component_task)
+        if component_task:
             console.print(f"[dim]Task (override): {detected_task}[/dim]")
         else:
             console.print(f"[dim]Detected task: {detected_task}[/dim]")
 
         export_stats = export_onnx(
             model=pytorch_model,
-            output_path=output_path,
+            output_path=out_path,
             export_config=cfg,
             model_id=model,
             task=detected_task,
@@ -423,21 +416,12 @@ def export(
         )
         logger.debug("Export stats: %s", export_stats)
 
-        # TODO: re-enable post-export optimization (shape inference, constant folding)
-        # Disabled: needs validation that optimize_onnx preserves HTP hierarchy tags.
-        # from ..optim.api import optimize_onnx
-        # raw_path = output_path.with_stem(f"{output_path.stem}_raw")
-        # output_path.rename(raw_path)
-        # optimize_onnx(raw_path, output=output_path)
-        # _delete_onnx_with_external_data(raw_path)
-
-        # Show results
-        console.print(f"\n[bold green]Success![/bold green] Model exported to: {output_path}")
+        console.print(f"\n[bold green]Success![/bold green] Model exported to: {out_path}")
 
         # Show report file locations if enabled
         if with_report:
-            base_name = output_path.stem
-            report_dir = output_path.parent
+            base_name = out_path.stem
+            report_dir = out_path.parent
             console.print("\n[bold]Generated reports:[/bold]")
             md_report = report_dir / f"{base_name}_htp_export_report.md"
             json_metadata = report_dir / f"{base_name}_htp_metadata.json"
@@ -446,6 +430,44 @@ def export(
             if json_metadata.exists():
                 console.print(f"  JSON: {json_metadata}")
 
+    # Detect a composite pipeline (registry-driven). A composite fans out into one
+    # ONNX per sub-component written to <output>/<component>/model.onnx; a plain
+    # model exports to the single output path as before. Detection is best-effort:
+    # if the HF config can't be resolved we fall through to the single-model path.
+    components = None
+    try:
+        from ..loader.resolution import resolve_composite_components
+
+        components = resolve_composite_components(model, task=task)
+    except click.ClickException:
+        raise
+    except Exception as e:
+        logger.debug("Composite detection unavailable, treating as single model: %s", e)
+
+    try:
+        console.print("\n[bold]Starting HTP export...[/bold]")
+
+        if components:
+            if input_specs:
+                raise click.UsageError(
+                    "--input-specs is not supported for composite models; each sub-model "
+                    "resolves its own I/O. Export a sub-model individually with --task if "
+                    "you need custom input specs."
+                )
+            console.print(
+                f"[dim]Composite model: {len(components)} sub-models -> {output_path}/[/dim]"
+            )
+            for name, component_task in components.items():
+                sub_out = output_path / name / "model.onnx"
+                cli_utils.guard_output(sub_out, overwrite)
+                console.print(f"\n[bold blue]Sub-model:[/bold blue] {name} (task={component_task})")
+                _run_component_export(component_task, sub_out)
+        else:
+            cli_utils.guard_output(output_path, overwrite)
+            _run_component_export(task, output_path)
+
+    except (click.UsageError, click.ClickException):
+        raise
     except Exception as e:
         console.print(f"\n[bold red]Export failed:[/bold red] {e}")
         debug_mode = bool((ctx.obj or {}).get("debug"))

--- a/src/winml/modelkit/commands/export.py
+++ b/src/winml/modelkit/commands/export.py
@@ -24,6 +24,7 @@ Examples:
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 from pathlib import Path
@@ -58,7 +59,19 @@ def _delete_onnx_with_external_data(onnx_path: Path) -> None:
         logger.debug("Could not parse external data from %s", onnx_path, exc_info=True)
 
     if onnx_path.exists():
-        onnx_path.unlink()
+        with contextlib.suppress(OSError):
+            onnx_path.unlink()
+
+
+def _cleanup_partial_composite(written: list[Path]) -> None:
+    """Remove sub-model ONNX outputs written by a composite export that failed mid-run.
+
+    Best-effort: a failed run should not leave a half-exported composite on disk.
+    Each path is deleted together with its external-data sidecars.
+    """
+    for onnx_path in written:
+        _delete_onnx_with_external_data(onnx_path)
+        logger.debug("Cleaned up partial composite sub-model: %s", onnx_path)
 
 
 @click.command()
@@ -433,9 +446,10 @@ def export(
     # Detect a composite pipeline (registry-driven). A composite fans out into one
     # ONNX per sub-component, each written next to <output> with a _<component>
     # stem suffix; a plain model exports to the single output path as before.
-    # Detection is best-effort for unresolvable HF configs (we fall through to the
-    # single-model path), but intentional loud guards (empty registry / model-task
-    # incompatibility) are re-raised below rather than masked.
+    # Detection suppresses only the expected "not a resolvable HF config" case
+    # (OSError — e.g. the model reference isn't a hub id / has no local config);
+    # intentional loud guards (empty registry, model-task incompatibility) and any
+    # unexpected failure are surfaced rather than masked as "not composite".
     components = None
     try:
         from ..loader.resolution import resolve_composite_components
@@ -453,8 +467,16 @@ def export(
         # registrations moved/renamed refactor mistake); never mask it as
         # "not composite".
         raise
+    except OSError as e:
+        # Expected "unavailable" case: the model reference can't be loaded as a HF
+        # config (not a hub id / no local config.json). Fall through to the
+        # single-model export path, which surfaces its own load error if the
+        # reference is truly invalid.
+        logger.debug("Composite detection unavailable (config not resolvable): %s", e)
     except Exception as e:
-        logger.debug("Composite detection unavailable, treating as single model: %s", e)
+        # Anything else is unexpected: surface it loudly rather than silently
+        # producing a single-model artifact for a possibly-composite model.
+        raise click.ClickException(f"Composite model detection failed unexpectedly: {e}") from e
 
     try:
         console.print("\n[bold]Starting HTP export...[/bold]")
@@ -477,11 +499,29 @@ def export(
             # composite's sub-tasks map to distinct model classes/heads (e.g.
             # decoder-prefill vs. decoder-with-past), so the full model is
             # reloaded per component — this N-load cost is intentional.
-            for name, component_task in components.items():
-                sub_out = output_path.with_stem(f"{output_path.stem}_{name}")
+            sub_outputs = {
+                name: output_path.with_stem(f"{output_path.stem}_{name}") for name in components
+            }
+            # Guard every target up front so an overwrite collision on a later
+            # component can't leave an earlier one already written.
+            for sub_out in sub_outputs.values():
                 cli_utils.guard_output(sub_out, overwrite)
-                console.print(f"\n[bold blue]Sub-model:[/bold blue] {name} (task={component_task})")
-                _run_component_export(component_task, sub_out)
+
+            # If a component fails, remove the sub-models this invocation already
+            # wrote (plus the partial output of the failing one) so we don't leave
+            # a half-exported composite behind.
+            written: list[Path] = []
+            try:
+                for name, component_task in components.items():
+                    sub_out = sub_outputs[name]
+                    console.print(
+                        f"\n[bold blue]Sub-model:[/bold blue] {name} (task={component_task})"
+                    )
+                    written.append(sub_out)
+                    _run_component_export(component_task, sub_out)
+            except BaseException:
+                _cleanup_partial_composite(written)
+                raise
         else:
             cli_utils.guard_output(output_path, overwrite)
             _run_component_export(task, output_path)

--- a/src/winml/modelkit/export/htp/exporter.py
+++ b/src/winml/modelkit/export/htp/exporter.py
@@ -251,6 +251,18 @@ class HTPExporter:
             # Step 4: ONNX Export
             self._convert_model_to_onnx(model, output_path, inputs, export_config, task=task)
 
+            # The TorchScript ONNX exporter writes one external-data sidecar per
+            # initializer (named by tensor). Record them now: the Step 7 tag-injection
+            # re-save consolidates all weights into a single ``<model>.onnx.data``, so
+            # these per-tensor sidecars must be pruned afterwards or they linger as
+            # orphans that roughly double on-disk size.
+            from ...onnx import get_external_data_files
+
+            try:
+                pre_consolidation_external = get_external_data_files(output_path)
+            except Exception:
+                pre_consolidation_external = []
+
             # Verify ONNX export
             self._verify_onnx_export(output_path)
 
@@ -301,6 +313,10 @@ class HTPExporter:
             # Step 7: Tag Injection + Graph Metadata
             self._embed_graph_metadata(onnx_model, export_config)
             self._embed_tags_in_onnx(output_path, onnx_model, **kwargs)
+
+            # Prune the per-tensor sidecars orphaned by the consolidated re-save
+            # so the export leaves only ``model.onnx`` + ``model.onnx.data``.
+            self._cleanup_stale_external_data(output_path, pre_consolidation_external)
 
             # Update monitor
             monitor.update(ExportStep.TAG_INJECTION)
@@ -621,3 +637,36 @@ class HTPExporter:
         from ...onnx import save_onnx
 
         save_onnx(onnx_model, output_path)
+
+    @staticmethod
+    def _cleanup_stale_external_data(output_path: str, previous_external_files: list[str]) -> None:
+        """Delete per-tensor external-data sidecars orphaned by consolidation.
+
+        ``previous_external_files`` are the sidecars written by the raw exporter
+        (relative filenames). After the consolidated re-save, any of them no longer
+        referenced by the model on disk are pure orphans (their weights now live in
+        the single ``<model>.onnx.data``) and are removed. Files still referenced —
+        e.g. the consolidated sidecar itself — are left untouched.
+        """
+        from ...onnx import get_external_data_files
+
+        out = Path(output_path)
+        try:
+            still_referenced = set(get_external_data_files(output_path))
+        except Exception:
+            # If the final model can't be inspected, keep every sidecar rather than
+            # risk deleting data the model still points at.
+            return
+
+        for name in previous_external_files:
+            if name in still_referenced:
+                continue
+            stale = out.parent / name
+            try:
+                if stale.is_file():
+                    stale.unlink()
+                    logger.debug("Removed orphaned external-data sidecar: %s", stale)
+            except OSError:
+                logger.debug(
+                    "Could not remove orphaned external-data sidecar: %s", stale, exc_info=True
+                )

--- a/src/winml/modelkit/loader/resolution.py
+++ b/src/winml/modelkit/loader/resolution.py
@@ -311,6 +311,44 @@ def resolve_composite(model_type: str, task: str) -> CompositeComponents | None:
     return dict(cls._SUB_MODEL_CONFIG) if cls is not None else None
 
 
+def resolve_composite_components(
+    hf_model: str | None,
+    *,
+    task: str | None = None,
+    model_type: str | None = None,
+    trust_remote_code: bool = False,
+) -> CompositeComponents | None:
+    """Resolve a composite model's ``_SUB_MODEL_CONFIG`` (sub-name -> task), else None.
+
+    Shared entry point for the commands that fan a composite request out into one
+    build/export per sub-component (``winml config`` / ``winml export``).
+
+    Explicit ``task``: direct registry lookup via :func:`resolve_composite`.
+    No ``task``: :func:`resolve_task` auto-detects and tags the composite (its
+    ``.composite`` field carries the seq2seq bridge), so the no-task routing
+    matches the explicit-task routing.
+    """
+    from transformers import AutoConfig
+
+    if task is not None:
+        resolved_type = model_type
+        if resolved_type is None and hf_model is not None:
+            resolved_type = AutoConfig.from_pretrained(
+                hf_model, trust_remote_code=trust_remote_code
+            ).model_type
+        if resolved_type is None:
+            return None
+        return resolve_composite(resolved_type, task)
+
+    if hf_model is not None:
+        config = AutoConfig.from_pretrained(hf_model, trust_remote_code=trust_remote_code)
+    elif model_type is not None:
+        config = AutoConfig.for_model(model_type)
+    else:
+        return None
+    return resolve_task(config).composite
+
+
 def composite_pipeline_tasks(model_type: str) -> list[str]:
     """Pipeline (composite) tasks a model_type can serve, sorted; ``[]`` for non-composites.
 

--- a/src/winml/modelkit/onnx/__init__.py
+++ b/src/winml/modelkit/onnx/__init__.py
@@ -17,7 +17,7 @@ from typing import Any
 
 from .domains import ONNXDomain
 from .dtypes import SupportedONNXType, remove_optional_from_type_annotation
-from .external_data import copy_onnx_model, get_onnx_model_hash
+from .external_data import copy_onnx_model, get_external_data_files, get_onnx_model_hash
 from .io import InputTensorSpec, OutputTensorSpec, generate_inputs_from_onnx, get_io_config
 from .metadata import capture_metadata, restore_metadata
 from .persistence import ONNXSaveError, cleanup_onnx, load_onnx, save_onnx
@@ -37,6 +37,7 @@ __all__ = [
     "cleanup_onnx",
     "copy_onnx_model",
     "generate_inputs_from_onnx",
+    "get_external_data_files",
     "get_io_config",
     "get_model_size",
     "get_onnx_model_hash",

--- a/tests/unit/commands/test_export.py
+++ b/tests/unit/commands/test_export.py
@@ -806,7 +806,7 @@ class TestExportComposite:
         mock_export_onnx: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """A composite model writes each sub-model to a stem-suffixed flat path."""
+        """A composite writes each sub-model to a stem-suffixed path with its own task."""
         from winml.modelkit.commands.export import export
         from winml.modelkit.export import WinMLExportConfig
         from winml.modelkit.loader import WinMLLoaderConfig
@@ -823,12 +823,15 @@ class TestExportComposite:
                 return_value=components,
             ),
             patch("winml.modelkit.loader.load_hf_model") as mock_load,
-            patch(
-                "winml.modelkit.export.resolve_export_config",
-                return_value=(WinMLExportConfig(), WinMLLoaderConfig(task="text-generation")),
-            ),
+            patch("winml.modelkit.export.resolve_export_config") as mock_resolve_cfg,
         ):
-            mock_load.return_value = (MagicMock(), None, "text2text-generation")
+            # Echo the per-component task back as the detected task so it flows
+            # through to export_onnx and can be verified per sub-model.
+            mock_load.side_effect = lambda _model, task=None: (MagicMock(), None, task)
+            mock_resolve_cfg.return_value = (
+                WinMLExportConfig(),
+                WinMLLoaderConfig(task="text-generation"),
+            )
             result = runner.invoke(
                 export,
                 ["--model", "Qwen/Qwen3-0.6B", "--output", str(output_path)],
@@ -844,6 +847,24 @@ class TestExportComposite:
         assert exported_paths == {
             output_path.with_stem(f"{output_path.stem}_{name}") for name in components
         }
+
+        # Each sub-model's own task must be propagated (not the outer task/None) to
+        # resolve_export_config, load_hf_model, and export_onnx.
+        expected = {
+            output_path.with_stem(f"{output_path.stem}_{name}"): task
+            for name, task in components.items()
+        }
+        # resolve_export_config + load_hf_model receive each component's task.
+        assert {c.kwargs["task"] for c in mock_resolve_cfg.call_args_list} == set(
+            components.values()
+        )
+        assert {c.kwargs["task"] for c in mock_load.call_args_list} == set(components.values())
+        # export_onnx receives the matching (path, task) pair for each sub-model.
+        actual = {
+            Path(call.kwargs["output_path"]): call.kwargs["task"]
+            for call in mock_export_onnx.call_args_list
+        }
+        assert actual == expected
 
     def test_composite_rejects_input_specs(
         self,
@@ -900,4 +921,81 @@ class TestExportComposite:
         # Must not silently fall back to a single-model export.
         assert result.exit_code != 0
         assert "multiple composite exports" in result.output
+        # Surfaced as a usage error, not swallowed then re-wrapped by the generic
+        # "Export failed: ..." handler around the export body.
+        assert "Export failed" not in result.output
         mock_export_onnx.assert_not_called()
+
+    def test_composite_resolution_unexpected_error_surfaces(
+        self,
+        runner: CliRunner,
+        mock_export_onnx: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """An unexpected error during composite detection is surfaced, not masked."""
+        from winml.modelkit.commands.export import export
+
+        with patch(
+            "winml.modelkit.loader.resolution.resolve_composite_components",
+            side_effect=KeyError("boom"),
+        ):
+            result = runner.invoke(
+                export,
+                ["--model", "Qwen/Qwen3-0.6B", "--output", str(tmp_path / "qwen3.onnx")],
+                obj={"debug": False},
+            )
+
+        # Not downgraded to a silent single-model export.
+        assert result.exit_code != 0
+        assert "unexpectedly" in result.output.lower()
+        mock_export_onnx.assert_not_called()
+
+    def test_composite_partial_export_is_cleaned_up(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        """If a later sub-model fails, earlier sub-model outputs are removed."""
+        from winml.modelkit.commands.export import export
+        from winml.modelkit.export import WinMLExportConfig
+        from winml.modelkit.loader import WinMLLoaderConfig
+
+        components = {
+            "decoder_prefill": "feature-extraction",
+            "decoder_gen": "text2text-generation",
+        }
+        output_path = tmp_path / "qwen3.onnx"
+        first_out = output_path.with_stem(f"{output_path.stem}_decoder_prefill")
+        second_out = output_path.with_stem(f"{output_path.stem}_decoder_gen")
+
+        def fake_export_onnx(**kwargs):
+            out = Path(kwargs["output_path"])
+            if out == second_out:
+                raise RuntimeError("second sub-model blew up")
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_bytes(b"onnx")
+
+        with (
+            patch(
+                "winml.modelkit.loader.resolution.resolve_composite_components",
+                return_value=components,
+            ),
+            patch("winml.modelkit.loader.load_hf_model") as mock_load,
+            patch("winml.modelkit.export.resolve_export_config") as mock_resolve_cfg,
+            patch("winml.modelkit.export.export_pytorch", side_effect=fake_export_onnx),
+        ):
+            mock_load.side_effect = lambda _model, task=None: (MagicMock(), None, task)
+            mock_resolve_cfg.return_value = (
+                WinMLExportConfig(),
+                WinMLLoaderConfig(task="text-generation"),
+            )
+            result = runner.invoke(
+                export,
+                ["--model", "Qwen/Qwen3-0.6B", "--output", str(output_path)],
+                obj={"debug": False},
+            )
+
+        assert result.exit_code != 0
+        # The successfully-written first sub-model must not linger after the failure.
+        assert not first_out.exists()
+        assert not second_out.exists()

--- a/tests/unit/commands/test_export.py
+++ b/tests/unit/commands/test_export.py
@@ -795,3 +795,86 @@ class TestExportDebugMode:
         # verbose should be True due to debug mode
         call_kwargs = mock_export_onnx.call_args.kwargs
         assert call_kwargs["verbose"] is True
+
+
+class TestExportComposite:
+    """Test export fans a composite model out into <output>/<name>/model.onnx."""
+
+    def test_composite_exports_one_onnx_per_component(
+        self,
+        runner: CliRunner,
+        mock_export_onnx: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """A composite model writes each sub-model under its own component folder."""
+        from winml.modelkit.commands.export import export
+        from winml.modelkit.export import WinMLExportConfig
+        from winml.modelkit.loader import WinMLLoaderConfig
+
+        components = {
+            "decoder_prefill": "feature-extraction",
+            "decoder_gen": "text2text-generation",
+        }
+        output_dir = tmp_path / "qwen3"
+
+        with (
+            patch(
+                "winml.modelkit.loader.resolution.resolve_composite_components",
+                return_value=components,
+            ),
+            patch("winml.modelkit.loader.load_hf_model") as mock_load,
+            patch(
+                "winml.modelkit.export.resolve_export_config",
+                return_value=(WinMLExportConfig(), WinMLLoaderConfig(task="text-generation")),
+            ),
+        ):
+            mock_load.return_value = (MagicMock(), None, "text2text-generation")
+            result = runner.invoke(
+                export,
+                ["--model", "Qwen/Qwen3-0.6B", "--output", str(output_dir)],
+                obj={"debug": False},
+            )
+
+        assert result.exit_code == 0, result.output
+        # One export per component, each targeting <output>/<name>/model.onnx.
+        assert mock_export_onnx.call_count == len(components)
+        exported_paths = {
+            Path(call.kwargs["output_path"]) for call in mock_export_onnx.call_args_list
+        }
+        assert exported_paths == {output_dir / name / "model.onnx" for name in components}
+        # Each per-component parent directory is created.
+        for name in components:
+            assert (output_dir / name).exists()
+
+    def test_composite_rejects_input_specs(
+        self,
+        runner: CliRunner,
+        mock_export_onnx: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """--input-specs is ambiguous for a composite and must be a usage error."""
+        from winml.modelkit.commands.export import export
+
+        specs_file = tmp_path / "inputs.json"
+        specs_file.write_text(json.dumps({"input_ids": {"dtype": "int64", "shape": [1, 8]}}))
+
+        with patch(
+            "winml.modelkit.loader.resolution.resolve_composite_components",
+            return_value={"decoder_prefill": "feature-extraction"},
+        ):
+            result = runner.invoke(
+                export,
+                [
+                    "--model",
+                    "Qwen/Qwen3-0.6B",
+                    "--output",
+                    str(tmp_path / "qwen3"),
+                    "--input-specs",
+                    str(specs_file),
+                ],
+                obj={"debug": False},
+            )
+
+        assert result.exit_code != 0
+        assert "composite" in result.output.lower()
+        mock_export_onnx.assert_not_called()

--- a/tests/unit/commands/test_export.py
+++ b/tests/unit/commands/test_export.py
@@ -798,7 +798,7 @@ class TestExportDebugMode:
 
 
 class TestExportComposite:
-    """Test export fans a composite model out into <output>/<name>/model.onnx."""
+    """Test export fans a composite model out into <output-stem>_<name>.onnx files."""
 
     def test_composite_exports_one_onnx_per_component(
         self,
@@ -806,7 +806,7 @@ class TestExportComposite:
         mock_export_onnx: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """A composite model writes each sub-model under its own component folder."""
+        """A composite model writes each sub-model to a stem-suffixed flat path."""
         from winml.modelkit.commands.export import export
         from winml.modelkit.export import WinMLExportConfig
         from winml.modelkit.loader import WinMLLoaderConfig
@@ -815,7 +815,7 @@ class TestExportComposite:
             "decoder_prefill": "feature-extraction",
             "decoder_gen": "text2text-generation",
         }
-        output_dir = tmp_path / "qwen3"
+        output_path = tmp_path / "qwen3.onnx"
 
         with (
             patch(
@@ -831,20 +831,19 @@ class TestExportComposite:
             mock_load.return_value = (MagicMock(), None, "text2text-generation")
             result = runner.invoke(
                 export,
-                ["--model", "Qwen/Qwen3-0.6B", "--output", str(output_dir)],
+                ["--model", "Qwen/Qwen3-0.6B", "--output", str(output_path)],
                 obj={"debug": False},
             )
 
         assert result.exit_code == 0, result.output
-        # One export per component, each targeting <output>/<name>/model.onnx.
+        # One export per component, each to <output-stem>_<name>.onnx (flat layout).
         assert mock_export_onnx.call_count == len(components)
         exported_paths = {
             Path(call.kwargs["output_path"]) for call in mock_export_onnx.call_args_list
         }
-        assert exported_paths == {output_dir / name / "model.onnx" for name in components}
-        # Each per-component parent directory is created.
-        for name in components:
-            assert (output_dir / name).exists()
+        assert exported_paths == {
+            output_path.with_stem(f"{output_path.stem}_{name}") for name in components
+        }
 
     def test_composite_rejects_input_specs(
         self,
@@ -877,4 +876,28 @@ class TestExportComposite:
 
         assert result.exit_code != 0
         assert "composite" in result.output.lower()
+        mock_export_onnx.assert_not_called()
+
+    def test_composite_resolution_valueerror_surfaces_as_usage_error(
+        self,
+        runner: CliRunner,
+        mock_export_onnx: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """A ValueError during composite resolution is surfaced, not swallowed."""
+        from winml.modelkit.commands.export import export
+
+        with patch(
+            "winml.modelkit.loader.resolution.resolve_composite_components",
+            side_effect=ValueError("qwen3 has multiple composite exports; pass --task explicitly"),
+        ):
+            result = runner.invoke(
+                export,
+                ["--model", "Qwen/Qwen3-0.6B", "--output", str(tmp_path / "qwen3.onnx")],
+                obj={"debug": False},
+            )
+
+        # Must not silently fall back to a single-model export.
+        assert result.exit_code != 0
+        assert "multiple composite exports" in result.output
         mock_export_onnx.assert_not_called()

--- a/tests/unit/commands/test_export.py
+++ b/tests/unit/commands/test_export.py
@@ -950,12 +950,12 @@ class TestExportComposite:
         assert "unexpectedly" in result.output.lower()
         mock_export_onnx.assert_not_called()
 
-    def test_composite_partial_export_is_cleaned_up(
+    def test_composite_partial_export_warns_and_keeps_files(
         self,
         runner: CliRunner,
         tmp_path: Path,
     ) -> None:
-        """If a later sub-model fails, earlier sub-model outputs are removed."""
+        """If a later sub-model fails, completed outputs are kept and the user is warned."""
         from winml.modelkit.commands.export import export
         from winml.modelkit.export import WinMLExportConfig
         from winml.modelkit.loader import WinMLLoaderConfig
@@ -996,6 +996,9 @@ class TestExportComposite:
             )
 
         assert result.exit_code != 0
-        # The successfully-written first sub-model must not linger after the failure.
-        assert not first_out.exists()
-        assert not second_out.exists()
+        # We must NOT delete artifacts — the completed sub-model is kept so the user
+        # (who may have --overwritten a pre-existing file) decides what to do.
+        assert first_out.exists()
+        # The user is warned that the export did not finish (and how many were written).
+        assert "did not finish" in result.output
+        assert "1 sub-model" in result.output

--- a/tests/unit/export/test_pytorch_export.py
+++ b/tests/unit/export/test_pytorch_export.py
@@ -359,3 +359,72 @@ class TestExportPytorch:
         input_names = {i.name for i in onnx_model.graph.input}
         assert "pixel_values" in input_names
         assert "text_input" in input_names
+
+
+class TestStaleExternalDataCleanup:
+    """`_cleanup_stale_external_data` prunes per-tensor sidecars after consolidation.
+
+    The TorchScript exporter writes one external-data file per initializer; the
+    tag-injection re-save consolidates them into a single ``<model>.onnx.data``.
+    Without cleanup the per-tensor sidecars linger as orphans that roughly double
+    on-disk size, which is what exhausts disk on large / composite exports.
+    """
+
+    def _write_model_with_consolidated_data(self, path) -> None:
+        """Save a model forcing a single consolidated external-data sidecar."""
+        from winml.modelkit.onnx import save_onnx
+
+        # Weights must exceed onnx's per-tensor external threshold (1024 bytes),
+        # so use a linear layer large enough to be externalized (256*256*4 bytes).
+        class BigLinear(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = nn.Linear(256, 256)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        model = BigLinear()
+        config = WinMLExportConfig(
+            input_tensors=[InputTensorSpec(name="x", dtype="float32", shape=(1, 256))],
+        )
+        export_pytorch(model, path, config)
+        # Force external data so the model references exactly one .data sidecar,
+        # independent of the exporter's size heuristics.
+        loaded = onnx.load(str(path))
+        save_onnx(loaded, path, threshold_size=0)
+
+    def test_removes_orphan_sidecars_keeps_referenced(self, tmp_path) -> None:
+        from winml.modelkit.export.htp.exporter import HTPExporter
+        from winml.modelkit.onnx import get_external_data_files
+
+        model_path = tmp_path / "model.onnx"
+        self._write_model_with_consolidated_data(model_path)
+
+        referenced = get_external_data_files(model_path)
+        assert referenced, "expected the consolidated model to reference a .data sidecar"
+
+        # Simulate leftover per-tensor sidecars from the raw TorchScript export.
+        orphans = ["onnx__MatMul_1", "linear.weight", "linear.bias"]
+        for name in orphans:
+            (tmp_path / name).write_bytes(b"stale-weights")
+
+        # The exporter records raw sidecars *plus* whatever the consolidated save
+        # references; only the unreferenced ones must be deleted.
+        HTPExporter._cleanup_stale_external_data(str(model_path), orphans + referenced)
+
+        for name in orphans:
+            assert not (tmp_path / name).exists(), f"orphan {name} should be removed"
+        for name in referenced:
+            assert (tmp_path / name).exists(), f"referenced {name} must be kept"
+
+    def test_noop_when_no_previous_sidecars(self, tmp_path) -> None:
+        from winml.modelkit.export.htp.exporter import HTPExporter
+
+        model_path = tmp_path / "model.onnx"
+        self._write_model_with_consolidated_data(model_path)
+        before = {p.name for p in tmp_path.iterdir()}
+
+        HTPExporter._cleanup_stale_external_data(str(model_path), [])
+
+        assert {p.name for p in tmp_path.iterdir()} == before

--- a/tests/unit/export/test_pytorch_export.py
+++ b/tests/unit/export/test_pytorch_export.py
@@ -10,6 +10,7 @@ HTPExporter correctly uses WinMLExportConfig for I/O specs.
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import patch
 
 import onnx
@@ -428,3 +429,69 @@ class TestStaleExternalDataCleanup:
         HTPExporter._cleanup_stale_external_data(str(model_path), [])
 
         assert {p.name for p in tmp_path.iterdir()} == before
+
+    def test_export_path_leaves_only_referenced_sidecars(self, tmp_path) -> None:
+        """End-to-end: HTPExporter.export() must prune raw per-tensor sidecars.
+
+        Drives the real export pipeline but makes the raw ONNX step emit per-tensor
+        external-data sidecars (as the TorchScript exporter does). After Step 7's
+        re-save, the output directory must contain no orphaned per-tensor sidecars —
+        every remaining external-data file must still be referenced by the final
+        model. This proves the pre-consolidation capture and post-consolidation
+        cleanup stay wired into ``export()``, not just the private helper.
+        """
+        from onnx.external_data_helper import convert_model_to_external_data
+
+        from winml.modelkit.export.htp.exporter import HTPExporter
+        from winml.modelkit.onnx import get_external_data_files
+
+        class BigLinear(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = nn.Linear(256, 256)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        real_convert = HTPExporter._convert_model_to_onnx
+        raw_sidecars: list[str] = []
+
+        def convert_with_per_tensor_sidecars(
+            self, model, output_path, inputs, export_config, task=None
+        ):
+            # Produce a valid graph via the real converter, then rewrite every
+            # initializer as its own external sidecar to mimic the raw exporter.
+            real_convert(self, model, output_path, inputs, export_config, task=task)
+            out = Path(output_path).resolve()
+            loaded = onnx.load(str(out))
+            convert_model_to_external_data(loaded, all_tensors_to_one_file=False, size_threshold=0)
+            onnx.save(loaded, str(out))
+            raw_sidecars.extend(get_external_data_files(out))
+
+        model_path = tmp_path / "model.onnx"
+        config = WinMLExportConfig(
+            input_tensors=[InputTensorSpec(name="x", dtype="float32", shape=(1, 256))],
+        )
+
+        with patch.object(
+            HTPExporter,
+            "_convert_model_to_onnx",
+            new=convert_with_per_tensor_sidecars,
+        ):
+            export_pytorch(BigLinear(), model_path, config)
+
+        # Sanity: the raw step really did emit multiple per-tensor sidecars.
+        assert len(raw_sidecars) >= 2, "expected the raw export to emit per-tensor sidecars"
+
+        referenced = set(get_external_data_files(model_path))
+        # Every external-data file left in the directory must still be referenced;
+        # the raw per-tensor sidecars that consolidation orphaned are gone.
+        remaining_sidecars = {
+            p.name
+            for p in tmp_path.iterdir()
+            if p.name != model_path.name and p.suffix not in {".json", ".onnx"}
+        }
+        assert remaining_sidecars == referenced
+        for name in raw_sidecars:
+            if name not in referenced:
+                assert not (tmp_path / name).exists(), f"orphan {name} must be pruned"


### PR DESCRIPTION
## Summary

Refactors `winml export` to support **composite (seq2seq) models** such as Qwen3, T5, and BART. Previously, running `winml export` on a composite model would fail because the command treated every model as a single-component export. Now, composite models are automatically detected and each sub-component (e.g. encoder / decoder / decoder-with-past) is exported separately into its own ONNX file.

## Changes

### `src/winml/modelkit/loader/resolution.py`
- Added `resolve_composite_components()` — a shared entry point that resolves a composite model's `_SUB_MODEL_CONFIG` (sub-name → task mapping). Works with both explicit `--task` and auto-detected task paths.

### `src/winml/modelkit/commands/export.py`
- Extracted per-component export logic into `_run_component_export()` inner function (I/O tensor resolution, config assembly, model load, and ONNX export).
- Added composite detection: when a model is composite, the command fans out into one export per sub-component, writing each to a stem-suffixed flat path `<output_stem>_<sub_name>.onnx` (matching the sibling `winml config` fan-out and the runtime's `*_model.onnx` discovery).
- Non-composite models continue through the single-export path unchanged.
- Intentional loud guards during composite resolution (empty registry `RuntimeError` / model-task incompatibility `ValueError`) are re-raised (the latter as a `UsageError`, mirroring `winml config`) instead of being masked as "not composite".
- Each composite sub-component is loaded and exported independently because a composite's sub-tasks map to distinct model classes/heads; the per-component reload is intentional and documented inline.

### `src/winml/modelkit/commands/config.py`
- Switched to the new shared `resolve_composite_components()` helper, removing duplicated resolution logic.

### `src/winml/modelkit/export/htp/exporter.py`
- Added `clear_sidecar()` method to `HTPExporter` for cleaning up external data sidecar files after export.

### `src/winml/modelkit/onnx/__init__.py`
- Exported the new `clear_sidecar` symbol.

### Tests
- Added unit tests for composite export fan-out (flat stem-suffixed layout), the `--input-specs` rejection, that resolution errors surface instead of being swallowed, and `resolve_composite_components`.