### PR TITLE
ci(e2e): add MIGraphX GPU and TensorRT-RTX EP pairs on AMD agent

### DIFF
--- a/.pipelines/Modelkit E2E Test.yml
+++ b/.pipelines/Modelkit E2E Test.yml
@@ -193,10 +193,12 @@ parameters:
     type: string
     default: NPU-AMD
   - name: amdPairs
-    displayName: 'AMD: EP/device pairs (any of: vitisai_npu)'
+    displayName: 'AMD: EP/device pairs (any of: vitisai_npu, migraphx_gpu, trtrtx_gpu)'
     type: object
     default:
       - vitisai_npu
+      - migraphx_gpu
+      - trtrtx_gpu
 
 stages:
   - stage: NPU_QNN

--- a/.pipelines/templates/e2e-test-jobs.yml
+++ b/.pipelines/templates/e2e-test-jobs.yml
@@ -17,8 +17,8 @@ parameters:
   - name: agentSuffix
     type: string
   # See catalog in `eval-report-jobs.yml`. Valid names:
-  #   qnn_npu, qnn_gpu, vitisai_npu, dml_gpu,
-  #   mlas_cpu, ov_cpu, ov_gpu, ov_npu
+  #   qnn_npu, qnn_gpu, vitisai_npu, migraphx_gpu, dml_gpu,
+  #   mlas_cpu, ov_cpu, ov_gpu, ov_npu, trtrtx_gpu
   - name: pairNames
     type: object
   # Inline list of models to test. Each entry: { hf_id: <str>, task: <str> }.
@@ -178,14 +178,16 @@ jobs:
               - ${{ each pairName in parameters.pairNames }}:
                   - powershell: |
                       $catalog = @{
-                          'qnn_npu'     = @{ ep = 'qnn';      device = 'npu'; displayName = 'QNN NPU' }
-                          'qnn_gpu'     = @{ ep = 'qnn';      device = 'gpu'; displayName = 'QNN GPU' }
-                          'vitisai_npu' = @{ ep = 'vitisai';  device = 'npu'; displayName = 'VitisAI NPU' }
-                          'dml_gpu'     = @{ ep = 'dml';      device = 'gpu'; displayName = 'DML GPU' }
-                          'mlas_cpu'    = @{ ep = 'cpu';      device = 'cpu'; displayName = 'MLAS CPU' }
-                          'ov_cpu'      = @{ ep = 'openvino'; device = 'cpu'; displayName = 'OV CPU' }
-                          'ov_gpu'      = @{ ep = 'openvino'; device = 'gpu'; displayName = 'OV GPU' }
-                          'ov_npu'      = @{ ep = 'openvino'; device = 'npu'; displayName = 'OV NPU' }
+                          'qnn_npu'      = @{ ep = 'qnn';             device = 'npu'; displayName = 'QNN NPU' }
+                          'qnn_gpu'      = @{ ep = 'qnn';             device = 'gpu'; displayName = 'QNN GPU' }
+                          'vitisai_npu'  = @{ ep = 'vitisai';         device = 'npu'; displayName = 'VitisAI NPU' }
+                          'migraphx_gpu' = @{ ep = 'migraphx';        device = 'gpu'; displayName = 'MIGraphX GPU' }
+                          'dml_gpu'      = @{ ep = 'dml';             device = 'gpu'; displayName = 'DML GPU' }
+                          'mlas_cpu'     = @{ ep = 'cpu';             device = 'cpu'; displayName = 'MLAS CPU' }
+                          'ov_cpu'       = @{ ep = 'openvino';        device = 'cpu'; displayName = 'OV CPU' }
+                          'ov_gpu'       = @{ ep = 'openvino';        device = 'gpu'; displayName = 'OV GPU' }
+                          'ov_npu'       = @{ ep = 'openvino';        device = 'npu'; displayName = 'OV NPU' }
+                          'trtrtx_gpu'   = @{ ep = 'nv_tensorrt_rtx'; device = 'gpu'; displayName = 'TensorRT-RTX GPU' }
                       }
                       $name = '${{ pairName }}'
                       if (-not $catalog.ContainsKey($name)) {


### PR DESCRIPTION
Extend the E2E Test pipeline's AMD stage with two new EP/device pairs:
- migraphx_gpu -> ep=migraphx (MIGraphXExecutionProvider), device=gpu
- trtrtx_gpu   -> ep=nv_tensorrt_rtx (NvTensorRTRTXExecutionProvider), device=gpu

Add both to the e2e-test-jobs catalog and to the amdPairs default so the perf phase runs them on the NPU-AMD agent. The pytest e2e suites already parametrize these EPs and self-skip via require_ep(), so no test changes are needed.