### PR TITLE
Warn users about silent dataset downloads and show live progress

### DIFF
--- a/src/winml/modelkit/_warnings.py
+++ b/src/winml/modelkit/_warnings.py
@@ -100,6 +100,16 @@ def _configure() -> None:
         "ignore", message=r".*CUDA.*", category=UserWarning, module=r"diffusers.*"
     )
 
+    # scikit-learn: HF `evaluate` metrics call `type_of_target`, which warns when
+    # the number of unique classes exceeds 50% of the samples ("could represent a
+    # regression problem"). Expected for small eval sample counts and purely
+    # cosmetic — match by message since it fires from several sklearn modules.
+    warnings.filterwarnings(
+        "ignore",
+        message=r".*number of unique classes is greater than 50% of the number of samples.*",
+        category=UserWarning,
+    )
+
     # =========================================================================
     # huggingface_hub: suppress the Windows "symlinks not supported" notice
     # =========================================================================

--- a/src/winml/modelkit/datasets/image.py
+++ b/src/winml/modelkit/datasets/image.py
@@ -74,7 +74,7 @@ class ImageDataset(BaseTaskDataset):
         # iterate the full remote stream into memory, which is worse than a
         # bulk download.
         streaming = self._config.get("streaming", False) and self._max_samples is not None
-        logger.info(f"Loading dataset: {self._dataset_name} with split: {self._data_split}")
+        logger.warning(f"Loading dataset: {self._dataset_name} with split: {self._data_split}")
         try:
             dataset = load_dataset(
                 self._dataset_name,

--- a/src/winml/modelkit/datasets/image_segmentation.py
+++ b/src/winml/modelkit/datasets/image_segmentation.py
@@ -93,7 +93,7 @@ class ImageSegmentationDataset(BaseTaskDataset):
             self._dataset_name = self.DEFAULT_DATASET
 
         # 2. Load dataset
-        logger.info(f"Loading dataset: {self._dataset_name} with split: {self._data_split}")
+        logger.warning(f"Loading dataset: {self._dataset_name} with split: {self._data_split}")
         try:
             dataset = load_dataset(self._dataset_name, split=self._data_split)
         except Exception as e:

--- a/src/winml/modelkit/datasets/text.py
+++ b/src/winml/modelkit/datasets/text.py
@@ -127,7 +127,7 @@ class TextDataset(BaseTaskDataset):
         if subset:
             load_args.append(subset)
 
-        logger.info("Loading: %s (subset=%s, split=%s)",
+        logger.warning("Loading: %s (subset=%s, split=%s)",
                     self._dataset_name, subset, self._data_split)
 
         try:

--- a/src/winml/modelkit/eval/base_evaluator.py
+++ b/src/winml/modelkit/eval/base_evaluator.py
@@ -82,7 +82,7 @@ class WinMLEvaluator:
         from datasets import Dataset, load_dataset, load_from_disk
 
         ds = self.config.dataset
-        logger.info(
+        logger.warning(
             "Loading dataset: %s (name=%s, split=%s, samples=%s)",
             ds.path,
             ds.name,

--- a/src/winml/modelkit/eval/evaluate.py
+++ b/src/winml/modelkit/eval/evaluate.py
@@ -326,7 +326,7 @@ def evaluate(config: WinMLEvaluationConfig) -> EvalResult:
 
     cls = get_evaluator_class(config)
     try:
-        console.print("[bold]Loading dataset and evaluating...[/bold]")
+        console.print("[bold]Evaluating...[/bold]")
         task_evaluator = cls(config, model)
         metrics = task_evaluator.compute()
     except DatasetValidationError as error:

--- a/src/winml/modelkit/quant/calibration/qwen3_transformer_only.py
+++ b/src/winml/modelkit/quant/calibration/qwen3_transformer_only.py
@@ -69,6 +69,9 @@ def _load_gsm8k_prompts(num_samples: int) -> list[str]:
     """GSM8K train split, shuffled seed=42 for reproducible calibration."""
     from datasets import load_dataset
 
+    logger.warning(
+        "Loading calibration dataset: %s (%s)", DEFAULT_CALIB_DATASET, DEFAULT_CALIB_DATASET_CONFIG
+    )
     ds = load_dataset(DEFAULT_CALIB_DATASET, DEFAULT_CALIB_DATASET_CONFIG)
     split = ds[DEFAULT_CALIB_SPLIT].shuffle(seed=DEFAULT_CALIB_SEED)
     return [row["question"] for row in split.select(range(num_samples))]

--- a/src/winml/modelkit/utils/console.py
+++ b/src/winml/modelkit/utils/console.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import functools
 import logging
+import time
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar
@@ -355,8 +356,11 @@ class StageLive:
         self._lines: list[RenderableType] = []
         self._live: _SafeLive | None = None
         self._status_idx: int = 0
+        self._t0: float = 0.0
+        self._done: bool = False
 
     def __enter__(self) -> StageLive:
+        self._t0 = time.monotonic()
         self._lines = [self._make_running_line()]
         self._status_idx = 0
         self._live = _SafeLive(
@@ -369,6 +373,8 @@ class StageLive:
         return self
 
     def __exit__(self, *_: object) -> None:
+        if not self._done:
+            self.set_done(time.monotonic() - self._t0)
         if self._live:
             self._live.update(self._render())
             self._live.stop()
@@ -383,13 +389,22 @@ class StageLive:
 
     # ── Status line management ────────────────────────────────────
 
-    def _make_running_line(self, detail: str = "") -> Text:
-        line = Text()
-        line.append(f"{ICON_RUNNING} ")
-        line.append(self._name.capitalize(), style="bold yellow")
-        if detail:
-            line.append(f"  {detail}", style="dim")
-        return line
+    def _make_running_line(self, detail: str = "") -> RenderableType:
+        # A self-rendering line so the elapsed counter ticks on Live's refresh
+        # thread (15fps) even while the main thread blocks in native code.
+        stage = self
+
+        class _RunningLine:
+            def __rich__(self) -> Text:
+                line = Text()
+                line.append(f"{ICON_RUNNING} ")
+                line.append(stage._name.capitalize(), style="bold yellow")
+                if detail:
+                    line.append(f"  {detail}", style="dim")
+                line.append(f"  {int(time.monotonic() - stage._t0)}s", style="dim")
+                return line
+
+        return _RunningLine()
 
     def set_status(self, detail: str) -> None:
         """Update the running status text."""
@@ -403,6 +418,7 @@ class StageLive:
         line.append(f"{self._name.capitalize():<48}", style="green")
         line.append(f"{elapsed:.1f}s", style="green")
         self._lines[self._status_idx] = line
+        self._done = True
         self._update()
 
     def set_error(self, error: str = "") -> None:
@@ -413,6 +429,7 @@ class StageLive:
         if error:
             line.append(f"  {error}", style="red")
         self._lines[self._status_idx] = line
+        self._done = True
         self._update()
 
     # ── Detail lines (indented under stage) ───────────────────────


### PR DESCRIPTION
Fix #444

### Problem
Large HuggingFace dataset downloads are triggered silently inside blocking quantize/eval stages. The UI would freeze for minutes with only a static spinner while GB of data downloaded in the background — users couldn't tell whether the tool was working or hung (#444).

### Changes

**Surface dataset loads as warnings**
Dataset-loading logs are promoted from `info` → `warning` at every `load_dataset` entry point, so users get a visible heads-up before a potentially large fetch begins:
- `datasets/image.py`, `datasets/image_segmentation.py`, `datasets/text.py`
- `eval/base_evaluator.py`
- Added an equivalent warning to the Qwen3 GSM8K calibration loader (`quant/calibration/qwen3_transformer_only.py`)

**Live elapsed-time counter during blocking stages**
`StageLive` (`utils/console.py`) now renders a self-updating elapsed-seconds counter on Rich's refresh thread (15 fps), so the timer keeps ticking even while the main thread is blocked in native code (downloads, quantization). Added `_t0`/`_done` tracking so `__exit__` finalizes timing if a stage exits without an explicit `set_done`.

**Clearer eval messaging**
Split the eval console output — `Loading dataset...` is now distinct from `Evaluating...`, so the download phase is attributable instead of hidden behind a combined "Loading dataset and evaluating..." message.

**Suppress cosmetic noise**
Filter the scikit-learn "number of unique classes is greater than 50% of the number of samples" `UserWarning` (`_warnings.py`), which fires from HF `evaluate` metrics on small eval sample counts and would otherwise clutter the newly surfaced output.

### Result
Users now see an upfront warning when a dataset is about to load and a continuously updating timer during long stages, resolving the "frozen with no feedback" experience described in #444.