### PR TITLE
feat(genai): honor --ep/--device as an EP override for GenaiSession (#1025)

### DIFF
--- a/src/winml/modelkit/commands/_perf_genai.py
+++ b/src/winml/modelkit/commands/_perf_genai.py
@@ -41,7 +41,7 @@ from ..session import (
     GenaiSessionError,
     GenerationConfig,
 )
-from ..utils.constants import EPNameOrAlias
+from ..utils.constants import EP_NAME_TO_ALIAS, EPNameOrAlias
 
 
 if TYPE_CHECKING:
@@ -60,30 +60,43 @@ RUNTIME_TYPE = "winml-genai"
 # ``GenaiPerfConfig.prompt`` field default (a test asserts the two stay in sync).
 _DEFAULT_PROMPT = "Explain the theory of relativity in simple terms."
 
-# --device -> GenaiSession EP override.  The default ("auto") resolves to
-# ``None`` = *respect the bundle config*: genai bundles route each stage via its
-# own session_options in genai_config.json (e.g. ctx/iter on the NPU/QNN,
-# embeddings/lm_head on CPU), and ``None`` honors that per-stage routing while
-# still registering the WinML EPs those stages need.  A concrete device forces
-# the whole decoder pipeline onto one EP override: "cpu" strips the hardware
-# providers (CPU fallback, no WinML EP registration), "qnn"/"dml" route every
-# stage to that accelerator.  An unknown device also falls back to ``None``.
-_DEVICE_TO_GENAI_EP: dict[str, EPNameOrAlias | None] = {
-    "cpu": "cpu",
-    "npu": "qnn",
-    "gpu": "dml",
-    "auto": None,
-}
+# Sentinel ``--device`` value meaning "respect the bundle's genai_config.json
+# routing" (no EP override).  It is the winml-genai default: a genai bundle is
+# mixed by design (e.g. ctx/iter on the NPU, embeddings/lm_head on CPU) and its
+# config already encodes that per-stage routing, so the common case leaves it
+# untouched.  A concrete ``--device`` (or ``--ep``) is an explicit override that
+# forces the *whole* decoder pipeline onto one EP.
+GENAI_CONFIG_DEVICE = "config"
 
 
-def device_to_genai_ep(device: str) -> EPNameOrAlias | None:
-    """Map a ``--device`` value to a :class:`GenaiSession` EP override.
+def resolve_genai_ep(device: str) -> EPNameOrAlias | None:
+    """Resolve a ``--device`` value to a :class:`GenaiSession` EP override.
 
-    Returns ``None`` for ``auto`` (and any unrecognized device), meaning the
-    bundle's ``genai_config.json`` routing is respected; otherwise a concrete
-    EP short name that forces the whole decoder pipeline onto that provider.
+    ``config`` -> ``None`` (respect ``genai_config.json`` as-is).  Any concrete
+    device (``auto``/``npu``/``gpu``/``cpu``) goes through the same
+    :func:`resolve_device` / :func:`resolve_eps` path the WinML ONNX runtime
+    uses, so it forces the whole pipeline onto the *best EP actually available
+    for that device on this machine* (e.g. an NPU that is VitisAI/OpenVINO
+    rather than QNN) instead of a static short-name guess.  Returns the EP's
+    canonical short alias, or ``None`` when the device resolves to no EP.
+
+    Raises:
+        ValueError: propagated from :func:`resolve_device` when the requested
+            device has no compatible EP available -- fail fast, like the ONNX
+            path, rather than silently falling back to CPU.
     """
-    return _DEVICE_TO_GENAI_EP.get(device.lower())
+    if device == GENAI_CONFIG_DEVICE:
+        return None
+
+    # Function-local import mirrors the ONNX path (perf.py) and avoids a
+    # module-level cycle: ``sysinfo`` pulls in heavier device-probing deps.
+    from ..sysinfo import resolve_device, resolve_eps
+
+    resolved_device, _ = resolve_device(device=device, ep=None)
+    eps = resolve_eps(resolved_device)
+    if not eps:
+        return None
+    return EP_NAME_TO_ALIAS[eps[0]]
 
 
 def genai_output_path(bundle_dir: str | Path) -> Path:

--- a/src/winml/modelkit/commands/_perf_genai.py
+++ b/src/winml/modelkit/commands/_perf_genai.py
@@ -328,6 +328,8 @@ class GenaiPerfBenchmark:
         if device and device not in ("config", "auto"):
             return device
         canonical = normalize_ep_name(ep)
+        if canonical is None:
+            return None
         devices = EP_SUPPORTED_DEVICES.get(canonical)
         return devices[0] if devices else None
 

--- a/src/winml/modelkit/commands/_perf_genai.py
+++ b/src/winml/modelkit/commands/_perf_genai.py
@@ -41,6 +41,7 @@ from ..session import (
     GenaiSessionError,
     GenerationConfig,
 )
+from ..utils.constants import EPNameOrAlias
 
 
 if TYPE_CHECKING:
@@ -59,24 +60,30 @@ RUNTIME_TYPE = "winml-genai"
 # ``GenaiPerfConfig.prompt`` field default (a test asserts the two stay in sync).
 _DEFAULT_PROMPT = "Explain the theory of relativity in simple terms."
 
-# --device -> GenaiSession EP short name.  The default ("auto") resolves to
-# "mixed": genai bundles route each stage via its own session_options in
-# genai_config.json (e.g. ctx/iter on the NPU/QNN, embeddings/lm_head on CPU).
-# "mixed" registers the WinML EPs those stages need while honoring that
-# per-stage routing, so it is the correct default for real decoder bundles.
-# "cpu" skips WinML EP registration (CPU-only bundles); "qnn"/"dml" register
-# the WinML EPs like "mixed" but name the intended accelerator explicitly.
-_DEVICE_TO_GENAI_EP: dict[str, str] = {
+# --device -> GenaiSession EP override.  The default ("auto") resolves to
+# ``None`` = *respect the bundle config*: genai bundles route each stage via its
+# own session_options in genai_config.json (e.g. ctx/iter on the NPU/QNN,
+# embeddings/lm_head on CPU), and ``None`` honors that per-stage routing while
+# still registering the WinML EPs those stages need.  A concrete device forces
+# the whole decoder pipeline onto one EP override: "cpu" strips the hardware
+# providers (CPU fallback, no WinML EP registration), "qnn"/"dml" route every
+# stage to that accelerator.  An unknown device also falls back to ``None``.
+_DEVICE_TO_GENAI_EP: dict[str, EPNameOrAlias | None] = {
     "cpu": "cpu",
     "npu": "qnn",
     "gpu": "dml",
-    "auto": "mixed",
+    "auto": None,
 }
 
 
-def device_to_genai_ep(device: str) -> str:
-    """Map a ``--device`` value to a :class:`GenaiSession` EP short name."""
-    return _DEVICE_TO_GENAI_EP.get(device.lower(), "mixed")
+def device_to_genai_ep(device: str) -> EPNameOrAlias | None:
+    """Map a ``--device`` value to a :class:`GenaiSession` EP override.
+
+    Returns ``None`` for ``auto`` (and any unrecognized device), meaning the
+    bundle's ``genai_config.json`` routing is respected; otherwise a concrete
+    EP short name that forces the whole decoder pipeline onto that provider.
+    """
+    return _DEVICE_TO_GENAI_EP.get(device.lower())
 
 
 def genai_output_path(bundle_dir: str | Path) -> Path:
@@ -125,7 +132,7 @@ class GenaiPerfConfig:
     """Resolved request for a genai generation benchmark."""
 
     bundle_dir: Path
-    ep: str = "mixed"
+    ep: EPNameOrAlias | None = None
     device: str = "auto"
     prompt: str = _DEFAULT_PROMPT
     max_new_tokens: int = 128
@@ -195,7 +202,7 @@ class GenaiBenchmarkResult:
             "benchmark_info": {
                 "runtime": RUNTIME_TYPE,
                 "bundle_dir": str(self.config.bundle_dir),
-                "ep": self.config.ep,
+                "ep": self.config.ep or "config",
                 "device": self.config.device,
                 "compile": self.config.compile,
                 "compile_timeout": self.config.compile_timeout,
@@ -391,7 +398,8 @@ def display_genai_report(result: GenaiBenchmarkResult, console: Console) -> None
     cfg = result.config
     console.print()
     console.print(f"[dim]Runtime:[/dim]   {RUNTIME_TYPE}")
-    device_str = cfg.device if cfg.device == cfg.ep else f"{cfg.device} ({cfg.ep})"
+    ep_label = cfg.ep or "config"
+    device_str = cfg.device if cfg.device == ep_label else f"{cfg.device} ({ep_label})"
     console.print(f"[dim]Device:[/dim]    {device_str}")
     console.print(f"[dim]Bundle:[/dim]    {cfg.bundle_dir}")
     console.print(

--- a/src/winml/modelkit/commands/_perf_genai.py
+++ b/src/winml/modelkit/commands/_perf_genai.py
@@ -41,7 +41,12 @@ from ..session import (
     GenaiSessionError,
     GenerationConfig,
 )
-from ..utils.constants import EP_NAME_TO_ALIAS, EPNameOrAlias
+from ..utils.constants import (
+    EP_NAME_TO_ALIAS,
+    EP_SUPPORTED_DEVICES,
+    EPNameOrAlias,
+    normalize_ep_name,
+)
 
 
 if TYPE_CHECKING:
@@ -182,6 +187,12 @@ class GenaiBenchmarkResult:
     generated_tokens: int = 0
     context_length: int | None = None
 
+    # EP that actually took effect (from GenaiSession.effective_ep): the override
+    # alias when it applied, or None to mean "config" (no override, or an
+    # override that matched no stage).  Reported instead of the *requested* ep so
+    # the report never claims an EP that never applied.
+    effective_ep: str | None = None
+
     # Time to first token (prefill + first decode), milliseconds
     ttft_mean_ms: float = 0.0
     ttft_min_ms: float = 0.0
@@ -216,7 +227,7 @@ class GenaiBenchmarkResult:
             "benchmark_info": {
                 "runtime": RUNTIME_TYPE,
                 "bundle_dir": str(self.config.bundle_dir),
-                "ep": self.config.ep or "config",
+                "ep": self.effective_ep or "config",
                 "device": self.config.device,
                 "compile": self.config.compile,
                 "compile_timeout": self.config.compile_timeout,
@@ -295,10 +306,30 @@ class GenaiPerfBenchmark:
         return GenaiSession(
             self._config.bundle_dir,
             self._config.ep,
+            device=self._session_device(),
             context_length=self._config.context_length,
             compile=self._config.compile,
             compile_timeout=self._config.compile_timeout,
         )
+
+    def _session_device(self) -> str | None:
+        """Concrete device (npu/gpu/cpu) the forced EP should target, or None.
+
+        Only meaningful when an EP override is active: it lets the session
+        synthesize ``device_type`` for device-parameterized EPs (OpenVINO /
+        VitisAI) when a re-routed stage has no reusable options.  A concrete
+        ``--device`` is used verbatim; the sentinels ``config``/``auto`` (e.g.
+        ``--ep`` given alone) fall back to the EP's primary supported device.
+        """
+        ep = self._config.ep
+        if ep is None:
+            return None
+        device = (self._config.device or "").lower()
+        if device and device not in ("config", "auto"):
+            return device
+        canonical = normalize_ep_name(ep)
+        devices = EP_SUPPORTED_DEVICES.get(canonical)
+        return devices[0] if devices else None
 
     def _prompt_text(self, session: GenaiSession) -> str:
         """Return the prompt to benchmark, chat-templated when enabled.
@@ -397,6 +428,7 @@ class GenaiPerfBenchmark:
 
         return GenaiBenchmarkResult(
             config=self._config,
+            effective_ep=getattr(self._session, "effective_ep", None),
             prompt_tokens=len(self._prompt_token_ids),
             generated_tokens=timed[0].n_tokens if timed else 0,
             context_length=self._session.context_length if self._session else None,
@@ -432,7 +464,7 @@ def display_genai_report(result: GenaiBenchmarkResult, console: Console) -> None
     cfg = result.config
     console.print()
     console.print(f"[dim]Runtime:[/dim]   {RUNTIME_TYPE}")
-    ep_label = cfg.ep or "config"
+    ep_label = result.effective_ep or "config"
     device_str = cfg.device if cfg.device == ep_label else f"{cfg.device} ({ep_label})"
     console.print(f"[dim]Device:[/dim]    {device_str}")
     console.print(f"[dim]Bundle:[/dim]    {cfg.bundle_dir}")

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -1499,10 +1499,11 @@ def _run_simple_loop(
 
 # perf() param names for WinML-only options that a prebuilt genai bundle
 # ignores. Mapped to the user-facing flag for the warning message.
+# NB: ``--ep`` is intentionally absent — it is honored for winml-genai as an EP
+# override (explicit --ep > concrete --device > respect config).
 _GENAI_IGNORED_FLAGS: dict[str, str] = {
     "task": "--task",
     "precision": "--precision",
-    "ep": "--ep",
     "ep_options": "--ep-options",
     "shape_config_path": "--shape-config",
     "quant": "--quant/--no-quantize",
@@ -1576,9 +1577,16 @@ def _run_genai_runtime(ctx: click.Context, *, console: Console, json_mode: bool)
     output = p.get("output") or genai_output_path(bundle_dir)
     cli_utils.guard_output(output, p["overwrite"])
 
+    # EP override precedence: an explicit ``--ep`` wins over the ``--device``
+    # mapping, which in turn wins over the default (``None`` = respect the
+    # bundle's genai_config.json routing).  GenaiSession validates the value.
+    ep: EPNameOrAlias | None = (
+        p["ep"] if cli_utils.is_cli_provided(ctx, "ep") else device_to_genai_ep(device)
+    )
+
     config = GenaiPerfConfig(
         bundle_dir=bundle_dir,
-        ep=device_to_genai_ep(device),
+        ep=ep,
         device=device,
         prompt=p["prompt"],
         max_new_tokens=p["max_new_tokens"],

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -1543,8 +1543,8 @@ def _run_genai_runtime(ctx: click.Context, *, console: Console, json_mode: bool)
     """
     from ._perf_genai import (
         GenaiPerfConfig,
-        device_to_genai_ep,
         genai_output_path,
+        resolve_genai_ep,
         run_genai_perf,
     )
 
@@ -1573,15 +1573,18 @@ def _run_genai_runtime(ctx: click.Context, *, console: Console, json_mode: bool)
     iterations = p["iterations"] if cli_utils.is_cli_provided(ctx, "iterations") else 10
     warmup = p["warmup"] if cli_utils.is_cli_provided(ctx, "warmup") else 2
 
-    device = p["device"].lower()
+    # genai defaults to "config" (respect the bundle's own per-stage routing).
+    # The shared --device default is "auto" (the ONNX default), so an omitted
+    # flag is treated as "config"; an explicit --device is a deliberate override.
+    device = p["device"].lower() if cli_utils.is_cli_provided(ctx, "device") else "config"
     output = p.get("output") or genai_output_path(bundle_dir)
     cli_utils.guard_output(output, p["overwrite"])
 
     # EP override precedence: an explicit ``--ep`` wins over the ``--device``
-    # mapping, which in turn wins over the default (``None`` = respect the
+    # resolution, which in turn wins over the default ("config" = respect the
     # bundle's genai_config.json routing).  GenaiSession validates the value.
     ep: EPNameOrAlias | None = (
-        p["ep"] if cli_utils.is_cli_provided(ctx, "ep") else device_to_genai_ep(device)
+        p["ep"] if cli_utils.is_cli_provided(ctx, "ep") else resolve_genai_ep(device)
     )
 
     config = GenaiPerfConfig(
@@ -1661,7 +1664,13 @@ def _run_genai_runtime(ctx: click.Context, *, console: Console, json_mode: bool)
     show_default=True,
     help="Number of warmup iterations (excluded from statistics; must be >= 0)",
 )
-@cli_utils.device_option(required=False, default="auto", include_auto=True)
+@cli_utils.device_option(
+    required=False,
+    default="auto",
+    include_auto=True,
+    include_config=True,
+    optional_message="'config' (winml-genai only) respects the bundle's genai_config.json routing.",
+)
 @cli_utils.precision_option()
 @cli_utils.ep_option(
     required=False,
@@ -1850,6 +1859,16 @@ def perf(
     if runtime == "winml-genai":
         _run_genai_runtime(ctx, console=console, json_mode=json_mode)
         return
+
+    # ``--device config`` is a winml-genai-only sentinel (respect the bundle's
+    # genai_config.json routing).  It is meaningless for the single-shot WinML
+    # path, so reject it explicitly rather than letting resolve_device raise a
+    # generic "unknown device" error.
+    if device.lower() == "config":
+        raise click.UsageError(
+            "--device config is only valid with --runtime winml-genai "
+            "(it means 'respect the bundle's genai_config.json routing')."
+        )
 
     # Classify the -m value once (existence-first) so module mode and the
     # single-model path share one source of truth. Raises cleanly on a missing

--- a/src/winml/modelkit/session/genai_session.py
+++ b/src/winml/modelkit/session/genai_session.py
@@ -45,6 +45,7 @@ Dependencies::
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
 import shutil
@@ -53,11 +54,14 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from ..utils.constants import EP_NAME_TO_ALIAS, EP_NAMES, normalize_ep_name
 from .ep_registry import WinMLEPRegistry
 
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
+
+    from ..utils.constants import EPAlias, EPName, EPNameOrAlias
 
 
 logger = logging.getLogger(__name__)
@@ -250,12 +254,25 @@ class GenaiSession:
     Args:
         bundle_dir: Path to the genai bundle directory.  Must contain
             ``genai_config.json`` and the ONNX files it references.
-        ep: Execution provider short name (e.g. ``"cpu"``, ``"qnn"``, ``"dml"``,
-            ``"mixed"``), recorded for reporting.  Whether WinML EPs are
-            registered and whether stages are pre-compiled is decided from the
-            bundle's ``genai_config.json`` (per-stage ``session_options``), not
-            from this argument.  Overriding the config via ``ep``/``device`` is
-            tracked in #1025.
+        ep: Execution-provider **override** (short alias such as ``"cpu"``,
+            ``"qnn"``, ``"dml"``, or a full ``*ExecutionProvider`` name).  The
+            precedence is **explicit arg > bundle config**:
+
+            * ``None`` (default) — *respect the bundle config*.  EP registration
+              and pre-compilation are decided from ``genai_config.json`` (per-stage
+              ``session_options.provider_options``), exactly as the bundle
+              author intended.
+            * a concrete EP — *force the whole decoder pipeline onto that EP*,
+              rewriting every stage's ``provider_options``.  ``"cpu"`` strips the
+              hardware providers (falling back to CPU, no WinML EP registration or
+              compilation); a hardware EP routes every stage to it (registering the
+              WinML EPs it needs, and pre-compiling when ``compile=True``).
+
+            The override is generic — it is validated against and rewritten from
+            the shared EP union, with no hardcoded EP short-name → behavior map.
+            Forcing a hardware EP onto stages the bundle did not build for it
+            (e.g. ``embeddings``/``lm_head``) may fall back to JIT/CPU inside
+            onnxruntime-genai; the always-safe override direction is ``"cpu"``.
         context_length: Override for the static KV cache length.  When
             ``None`` (default), read from ``genai_config.json``.
             Must match the ``--max-cache-len`` used during the winml-cli build.
@@ -263,13 +280,18 @@ class GenaiSession:
         compile: Pre-compile EPContext-capable pipeline stages (e.g. QNN) to
             EPContext ONNX on first run (inside ``bundle_dir/_compiled/``).
             Subsequent calls reuse the cached EPContext files, eliminating
-            per-run JIT overhead.  Only stages that ``genai_config.json`` routes
-            to an EPContext-capable EP and that can be compiled without hanging
-            are attempted; stages that fail compilation fall back to the
-            original ONNX.  A CPU-only bundle is a no-op.
+            per-run JIT overhead.  Only stages that the *effective* config (after
+            any ``ep`` override) routes to an EPContext-capable EP and that can be
+            compiled without hanging are attempted; stages that fail compilation
+            fall back to the original ONNX.  A CPU-only (or CPU-forced) bundle is
+            a no-op.
         compile_timeout: Maximum seconds to wait for each stage to compile
             before killing the subprocess and falling back to the original
             ONNX.  Defaults to 300 seconds (5 minutes).
+
+    Raises:
+        ValueError: *ep* is not ``None`` and does not resolve to a known
+            execution provider.
     """
 
     # Sub-directory within the bundle that holds pre-compiled EPContext ONNX files.
@@ -283,7 +305,7 @@ class GenaiSession:
     def __init__(
         self,
         bundle_dir: str | Path,
-        ep: str = "cpu",
+        ep: EPNameOrAlias | None = None,
         *,
         context_length: int | None = None,
         verbose: bool = False,
@@ -291,7 +313,10 @@ class GenaiSession:
         compile_timeout: int = 300,
     ) -> None:
         self._bundle_dir = Path(bundle_dir)
-        self._ep = ep.lower()
+        # None => respect the bundle config; otherwise an EP override.  Validated
+        # and normalized to a canonical EPName so the rewrite/registration logic
+        # stays generic (no hardcoded EP short-name behavior).
+        self._ep_override: EPName | None = self._resolve_ep_override(ep)
         self._context_length_override = context_length
         self._verbose = verbose
         self._compile = compile
@@ -313,7 +338,35 @@ class GenaiSession:
                 "Ensure the bundle was created with a winml-cli export command."
             )
 
-        logger.info("GenaiSession initialized: bundle=%s ep=%s", self._bundle_dir, self._ep)
+        logger.info(
+            "GenaiSession initialized: bundle=%s ep=%s",
+            self._bundle_dir,
+            self._ep_override or "config",
+        )
+
+    @staticmethod
+    def _resolve_ep_override(ep: EPNameOrAlias | None) -> EPName | None:
+        """Validate and normalize the ``ep`` override to a canonical EPName.
+
+        Returns ``None`` when *ep* is ``None`` (respect the bundle config).
+        Otherwise the value is normalized via the shared EP union; an
+        unrecognized provider is rejected so an override can never silently
+        become a no-op.
+
+        Raises:
+            ValueError: *ep* does not resolve to a known execution provider.
+        """
+        if ep is None:
+            return None
+        normalized = normalize_ep_name(ep)
+        if normalized not in EP_NAMES:
+            valid = ", ".join(sorted(EP_NAME_TO_ALIAS.values()))
+            raise ValueError(
+                f"Unknown execution provider {ep!r} for GenaiSession ep override. "
+                f"Pass one of: {valid} (or a full *ExecutionProvider name), or None "
+                "to respect the bundle's genai_config.json."
+            )
+        return normalized
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -336,27 +389,34 @@ class GenaiSession:
 
         cfg = self._read_genai_config()
 
-        # Register WinML EPs only when the bundle routes at least one stage to a
-        # hardware EP.  This decision comes from genai_config.json, not the
-        # ``ep`` argument (see #1025 for the planned override path).
-        if self._bundle_uses_hardware_ep(cfg):
+        # Apply the ``ep`` override (if any) to obtain the *effective* config that
+        # actually drives routing.  Precedence is explicit arg > bundle config:
+        # when no override is set this is the bundle config verbatim.
+        effective_cfg, overridden = self._apply_ep_override(cfg)
+
+        # Register WinML EPs only when the *effective* config routes at least one
+        # stage to a hardware EP.  Reading it from the post-override config means
+        # a "force cpu" override skips registration and a "force <hw ep>" override
+        # triggers it — all without a hardcoded EP short-name → behavior map.
+        if self._bundle_uses_hardware_ep(effective_cfg):
             self._register_eps()
 
         if self._verbose:
             og.set_log_options(enabled=True, model_input_values=True, model_output_shapes=True)
 
-        # Pre-compile EPContext-capable stages when requested.  The bundle config
-        # decides which stages are compilable; a bundle with none is a no-op.
+        # Materialize the directory og.Model loads from.  A derived ``_compiled/``
+        # bundle is written when the override rewrote the config and/or stages
+        # were pre-compiled; otherwise the original bundle dir is used as-is.
         load_dir = self._bundle_dir
-        if self._compile:
-            load_dir = self._prepare_compiled_bundle()
+        if self._compile or overridden:
+            load_dir = self._prepare_compiled_bundle(effective_cfg, overridden=overridden)
 
         try:
             config = og.Config(str(load_dir))
-            # EP routing is driven entirely by genai_config.json (per-stage
-            # session_options).  Do NOT call clear_providers/append_provider —
-            # those only touch the top-level provider and cannot override
-            # per-stage session_options already embedded in the pipeline config.
+            # Per-stage EP routing lives in the (possibly overridden) genai_config
+            # that og.Config loads from ``load_dir``.  Do NOT call
+            # clear_providers/append_provider — those only touch the top-level
+            # provider and cannot override per-stage session_options.
             self._model = og.Model(config)
             self._tokenizer = og.Tokenizer(self._model)
         except Exception as exc:
@@ -367,7 +427,7 @@ class GenaiSession:
         self._context_length = self._context_length_override or self._read_context_length()
         logger.info(
             "GenaiSession loaded: ep=%s context_length=%d",
-            self._ep,
+            self._ep_override or "config",
             self._context_length,
         )
 
@@ -615,9 +675,16 @@ class GenaiSession:
         return self._bundle_dir
 
     @property
-    def ep(self) -> str:
-        """Execution provider short name (as passed to ``__init__``)."""
-        return self._ep
+    def ep(self) -> EPAlias | None:
+        """The execution-provider override alias, or ``None`` when respecting config.
+
+        ``None`` means EP routing follows the bundle's ``genai_config.json``.  A
+        non-``None`` value is the canonical short alias of the forced provider
+        (e.g. ``"cpu"``, ``"qnn"``, ``"dml"``).
+        """
+        if self._ep_override is None:
+            return None
+        return EP_NAME_TO_ALIAS[self._ep_override]
 
     @property
     def context_length(self) -> int | None:
@@ -656,56 +723,172 @@ class GenaiSession:
         )
         return og.Generator(self._model, params)
 
-    def _prepare_compiled_bundle(self) -> Path:
-        """Create (or reuse) a *compiled* bundle directory.
+    # ------------------------------------------------------------------
+    # EP override (explicit arg > bundle config)
+    # ------------------------------------------------------------------
 
-        Reads ``genai_config.json`` and finds pipeline stages whose execution
-        provider supports EPContext pre-compilation (resolved generically via
+    def _apply_ep_override(self, cfg: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+        """Return ``(effective_cfg, changed)`` after applying the ``ep`` override.
+
+        When no override is set (:attr:`_ep_override` is ``None``) the bundle
+        config is returned verbatim (``changed=False``) so config-driven bundles
+        behave exactly as before.
+
+        Otherwise every stage in ``model.decoder.pipeline`` has its
+        ``session_options.provider_options`` rewritten so the *whole* decoder
+        pipeline is forced onto the override EP:
+
+        * **CPU** — strip hardware ``provider_options`` (set to ``[]``) so
+          onnxruntime-genai falls back to the CPU provider.  Stages that were
+          already CPU are left untouched.
+        * **hardware EP** — route every stage to that EP as
+          ``[{alias: opts}]``.  A stage's existing options are carried over only
+          when it already targeted the *same* provider (so re-selecting the
+          bundle's own EP is a no-op); otherwise empty options are written and
+          the registered EP supplies its defaults.
+
+        The rewrite is generic: EPs are compared/aliased through the shared EP
+        union, and the only literal provider name is the universal ``"cpu"``.
+
+        Returns:
+            The effective config (a deep copy when modified) and whether it
+            differs from *cfg*.
+        """
+        if self._ep_override is None:
+            return cfg, False
+
+        effective = copy.deepcopy(cfg)
+        pipeline = effective.get("model", {}).get("decoder", {}).get("pipeline", [])
+        if isinstance(pipeline, list):
+            for stage_entry in pipeline:
+                if not isinstance(stage_entry, dict):
+                    continue
+                for stage_cfg in stage_entry.values():
+                    if isinstance(stage_cfg, dict):
+                        self._override_stage_provider(stage_cfg)
+
+        return effective, effective != cfg
+
+    def _override_stage_provider(self, stage_cfg: dict[str, Any]) -> None:
+        """Rewrite one pipeline stage's ``provider_options`` for the override EP.
+
+        Mutates *stage_cfg* in place.  Assumes :attr:`_ep_override` is set.
+        """
+        if self._ep_override == "CPUExecutionProvider":
+            # Force CPU: drop any hardware provider_options so og falls back to
+            # CPU.  Only touch stages that actually carry a hardware provider so
+            # an already-CPU stage stays byte-for-byte identical.
+            so = stage_cfg.get("session_options")
+            if isinstance(so, dict):
+                po = so.get("provider_options")
+                if isinstance(po, list) and self._provider_list_has_hardware_ep(po):
+                    so["provider_options"] = []
+            return
+
+        # Force a hardware EP: route the stage to it, carrying over the stage's
+        # own options only when it already targeted the same provider.
+        alias = EP_NAME_TO_ALIAS[self._ep_override]
+        so = stage_cfg.get("session_options")
+        if not isinstance(so, dict):
+            so = {}
+            stage_cfg["session_options"] = so
+        opts = self._existing_opts_for_ep(so.get("provider_options"), self._ep_override)
+        so["provider_options"] = [{alias: opts}]
+
+    @staticmethod
+    def _provider_list_has_hardware_ep(provider_options: list) -> bool:
+        """True if *provider_options* names any non-CPU execution provider."""
+        for entry in provider_options:
+            if isinstance(entry, dict) and any(str(name).lower() != "cpu" for name in entry):
+                return True
+        return False
+
+    @staticmethod
+    def _existing_opts_for_ep(provider_options: Any, target: EPName) -> dict:
+        """Return the stage's existing options iff it already targets *target*.
+
+        Lets "force the bundle's own EP" preserve the finely-tuned options the
+        bundle shipped (e.g. QNN ``backend_path``/``soc_model``); a different
+        provider starts from empty options.
+        """
+        if isinstance(provider_options, list):
+            for entry in provider_options:
+                if not isinstance(entry, dict):
+                    continue
+                for name, opts in entry.items():
+                    if normalize_ep_name(str(name)) == target and isinstance(opts, dict):
+                        return dict(opts)
+        return {}
+
+    def _prepare_compiled_bundle(
+        self, effective_cfg: dict[str, Any] | None = None, *, overridden: bool = False
+    ) -> Path:
+        """Create (or reuse) a derived bundle directory og.Model can load from.
+
+        Starts from *effective_cfg* (the post-override config; when ``None`` the
+        on-disk ``genai_config.json`` is read, preserving the pre-override
+        behavior) and finds pipeline stages whose execution provider supports
+        EPContext pre-compilation (resolved generically via
         :meth:`WinMLCompileConfig.for_provider` — QNN, OpenVINO, VitisAI, …),
         then tries to compile their ONNX to EPContext format through the shared
         compiler.  Stages on EPs that do not emit EPContext (CPU, DML, …) are
         left untouched and load via JIT.
 
-        The compiled bundle is stored under ``bundle_dir/_compiled/``.  A cached
+        The derived bundle is stored under ``bundle_dir/_compiled/``.  A cached
         EPContext file is reused only when it is newer than the source graph and
         its external-weights sidecar *and* was built with the same provider
         options (see :meth:`_epcontext_is_fresh`); otherwise it is recompiled.
 
+        Args:
+            effective_cfg: The config to compile/load from (post ``ep`` override).
+                ``None`` reads the bundle's on-disk config unchanged.
+            overridden: Whether *effective_cfg* differs from the on-disk config.
+                When ``True`` a derived directory is always written (even if no
+                stage was compiled) so the rewritten routing reaches og.Model.
+
         Returns:
-            Path to the compiled bundle directory (may equal ``bundle_dir``
-            if no compilable stages were found, or if all compilations failed).
+            Path to the derived bundle directory (equals ``bundle_dir`` when the
+            config was not overridden and no stage needed compiling).
         """
         from ..onnx import is_compiled_onnx
 
         compiled_dir = self._bundle_dir / self._COMPILED_SUBDIR
-        cfg = self._read_genai_config()
+        cfg = effective_cfg if effective_cfg is not None else self._read_genai_config()
 
         # Collect pipeline stages whose EP supports EPContext pre-compilation.
         # genai_config pipeline entries: [{"context": {...}}, {"iterator": {...}}, ...]
         # provider_options format: [{"<ep_alias>": {...}}]
+        # Only scan when compilation was requested; an override-only pass writes
+        # the rewritten config without compiling anything.
         pipeline_list: list = cfg.get("model", {}).get("decoder", {}).get("pipeline", [])
         # [(stage_key, onnx_filename, ep_alias, ep_opts), ...]
         compilable_stages: list[tuple[str, str, str, dict]] = []
-        for stage_entry in pipeline_list:
-            if not isinstance(stage_entry, dict):
-                continue
-            for stage_key, stage_cfg in stage_entry.items():
-                if not isinstance(stage_cfg, dict):
+        if self._compile:
+            for stage_entry in pipeline_list:
+                if not isinstance(stage_entry, dict):
                     continue
-                so = stage_cfg.get("session_options", {})
-                ep_alias, ep_opts = self._resolve_stage_ep(so.get("provider_options", []))
-                if ep_alias is not None:
-                    onnx_filename = stage_cfg.get("filename", f"{stage_key}.onnx")
-                    compilable_stages.append((stage_key, onnx_filename, ep_alias, ep_opts))
+                for stage_key, stage_cfg in stage_entry.items():
+                    if not isinstance(stage_cfg, dict):
+                        continue
+                    so = stage_cfg.get("session_options", {})
+                    ep_alias, ep_opts = self._resolve_stage_ep(so.get("provider_options", []))
+                    if ep_alias is not None:
+                        onnx_filename = stage_cfg.get("filename", f"{stage_key}.onnx")
+                        compilable_stages.append((stage_key, onnx_filename, ep_alias, ep_opts))
 
         if not compilable_stages:
-            logger.info(
-                "No EPContext-capable stages found in genai_config.json; skipping pre-compilation"
-            )
-            return self._bundle_dir
+            if self._compile:
+                logger.info(
+                    "No EPContext-capable stages found in the effective genai_config; "
+                    "skipping pre-compilation"
+                )
+            # Nothing to compile.  Still write a derived bundle when the ``ep``
+            # override rewrote routing, so the change reaches og.Model.
+            if not overridden:
+                return self._bundle_dir
 
         compiled_dir.mkdir(exist_ok=True)
-        modified_cfg = self._read_genai_config()
+        modified_cfg = copy.deepcopy(cfg)
         any_compiled = False
 
         for stage_key, onnx_filename, ep_alias, ep_opts in compilable_stages:
@@ -755,7 +938,9 @@ class GenaiSession:
                 # file when loading from compiled_dir (where it doesn't exist).
                 self._patch_stage_filename(modified_cfg, stage_key, str(src_onnx.resolve()))
 
-        if not any_compiled:
+        # A derived bundle is only needed when routing changed: either a stage
+        # was (re)compiled or the ``ep`` override rewrote the config.
+        if not any_compiled and not overridden:
             return self._bundle_dir
 
         # Write the modified genai_config into the compiled sub-directory.

--- a/src/winml/modelkit/session/genai_session.py
+++ b/src/winml/modelkit/session/genai_session.py
@@ -834,10 +834,13 @@ class GenaiSession:
         compiler.  Stages on EPs that do not emit EPContext (CPU, DML, …) are
         left untouched and load via JIT.
 
-        The derived bundle is stored under ``bundle_dir/_compiled/``.  A cached
-        EPContext file is reused only when it is newer than the source graph and
-        its external-weights sidecar *and* was built with the same provider
-        options (see :meth:`_epcontext_is_fresh`); otherwise it is recompiled.
+        The derived bundle is stored under ``bundle_dir/_compiled/``.  Each
+        compiled artifact is named ``{stage}_{ep}_ctx.onnx`` so stages compiled
+        for different execution providers never collide.  A cached EPContext
+        file is reused only when it is newer than the source graph and its
+        external-weights sidecar *and* was built with the same execution
+        provider and provider options (see :meth:`_epcontext_is_fresh`);
+        otherwise it is recompiled.
 
         Args:
             effective_cfg: The config to compile/load from (post ``ep`` override).
@@ -893,10 +896,13 @@ class GenaiSession:
 
         for stage_key, onnx_filename, ep_alias, ep_opts in compilable_stages:
             src_onnx = self._bundle_dir / onnx_filename
-            ctx_onnx = compiled_dir / f"{stage_key}_ctx.onnx"
+            # The EP is part of the cache key: an ``ep`` override can route the
+            # same stage onto different EPContext providers across runs, so each
+            # EP gets its own artifact and EP-A's binary is never reused for EP-B.
+            ctx_onnx = compiled_dir / f"{stage_key}_{ep_alias}_ctx.onnx"
 
             # Skip recompilation only when the cache is genuinely up-to-date.
-            if self._epcontext_is_fresh(src_onnx, ctx_onnx, ep_opts):
+            if self._epcontext_is_fresh(src_onnx, ctx_onnx, ep_alias, ep_opts):
                 logger.info("Stage %r: reusing cached EPContext %s", stage_key, ctx_onnx.name)
                 # Use just the filename — genai_config.json lives in compiled_dir,
                 # so ort-genai resolves filenames relative to compiled_dir.
@@ -994,7 +1000,9 @@ class GenaiSession:
         )
 
     @classmethod
-    def _epcontext_is_fresh(cls, src_onnx: Path, ctx_onnx: Path, ep_opts: dict) -> bool:
+    def _epcontext_is_fresh(
+        cls, src_onnx: Path, ctx_onnx: Path, ep_alias: str, ep_opts: dict
+    ) -> bool:
         """Return ``True`` when a cached EPContext file may be reused as-is.
 
         The cache is stale (forcing a recompile) when any of these hold:
@@ -1004,6 +1012,9 @@ class GenaiSession:
         * the source external-weights ``.data`` sidecar is newer (decoder graphs
           often keep all weights there, so the ``.onnx`` mtime alone is not a
           sufficient cache key);
+        * the execution provider recorded at compile time differs from
+          *ep_alias* (a stage forced onto a different EPContext provider must not
+          reuse a binary built for another one, even if their options match);
         * the provider options recorded at compile time differ from *ep_opts*
           (so changing a knob like ``soc_model`` re-compiles even when the
           ``.onnx`` mtime is unchanged).
@@ -1022,7 +1033,7 @@ class GenaiSession:
             recorded = json.loads(marker.read_text(encoding="utf-8"))
         except (OSError, ValueError):
             return False
-        return bool(recorded.get("provider_options") == ep_opts)
+        return bool(recorded.get("ep") == ep_alias and recorded.get("provider_options") == ep_opts)
 
     @staticmethod
     def _patch_stage_filename(cfg: dict, stage_key: str, abs_path: str) -> None:

--- a/src/winml/modelkit/session/genai_session.py
+++ b/src/winml/modelkit/session/genai_session.py
@@ -54,7 +54,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
-from ..utils.constants import EP_NAME_TO_ALIAS, EP_NAMES, normalize_ep_name
+from ..utils.constants import (
+    EP_NAME_TO_ALIAS,
+    EP_NAMES,
+    EP_SUPPORTED_DEVICES,
+    normalize_ep_name,
+)
 from .ep_registry import WinMLEPRegistry
 
 
@@ -65,6 +70,14 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+# EPs whose hardware target is selected by a ``device_type`` provider option
+# (rather than a backend path/library).  When forcing one of these onto a stage
+# the bundle defines no options for, synthesize ``device_type`` from the
+# requested device.  Kept as full EP names so comparisons stay canonical.
+_DEVICE_TYPE_EPS: frozenset[str] = frozenset(
+    {"OpenVINOExecutionProvider", "VitisAIExecutionProvider"}
+)
 
 
 # ---------------------------------------------------------------------------
@@ -264,17 +277,28 @@ class GenaiSession:
               and pre-compilation are decided from ``genai_config.json`` (per-stage
               ``session_options.provider_options``), exactly as the bundle
               author intended.
-            * a concrete EP — *force the whole decoder pipeline onto that EP*,
-              rewriting every stage's ``provider_options``.  ``"cpu"`` strips the
-              hardware providers (falling back to CPU, no WinML EP registration or
-              compilation); a hardware EP routes every stage to it (registering the
-              WinML EPs it needs, and pre-compiling when ``compile=True``).
+            * a concrete EP — *override the pipeline's execution provider*.
+              ``"cpu"`` strips the hardware providers from every stage (CPU
+              fallback, no WinML EP registration or compilation).  A hardware EP
+              re-routes **only the stages that already run on a hardware EP**,
+              leaving stages the bundle deliberately keeps on CPU (e.g.
+              ``embeddings``/``lm_head``) untouched — forcing a large
+              CPU-intended graph onto an accelerator is rarely wanted and can
+              trigger very slow on-the-fly compilation.  A re-routed stage reuses
+              the bundle's own options for the target EP when available (e.g. QNN
+              ``backend_path``/``soc_model``, borrowed from any stage), otherwise
+              synthesizes ``device_type`` from *device* for device-parameterized
+              EPs (OpenVINO/VitisAI).
 
-            The override is generic — it is validated against and rewritten from
-            the shared EP union, with no hardcoded EP short-name → behavior map.
-            Forcing a hardware EP onto stages the bundle did not build for it
-            (e.g. ``embeddings``/``lm_head``) may fall back to JIT/CPU inside
-            onnxruntime-genai; the always-safe override direction is ``"cpu"``.
+            The override is generic — validated against and rewritten from the
+            shared EP union, with no hardcoded EP short-name → behavior map.  If
+            the override matches no stage (flat/empty pipeline, or an all-CPU
+            bundle) the run follows the bundle config and :attr:`effective_ep`
+            reports ``None`` (the always-safe override direction is ``"cpu"``).
+        device: Concrete target device (``"npu"``/``"gpu"``/``"cpu"``) the forced
+            *ep* should run on.  Used only to synthesize ``device_type`` for
+            device-parameterized EPs (OpenVINO/VitisAI) when a re-routed stage
+            has no reusable options; ignored when respecting the bundle config.
         context_length: Override for the static KV cache length.  When
             ``None`` (default), read from ``genai_config.json``.
             Must match the ``--max-cache-len`` used during the winml-cli build.
@@ -309,6 +333,7 @@ class GenaiSession:
         bundle_dir: str | Path,
         ep: EPNameOrAlias | None = None,
         *,
+        device: str | None = None,
         context_length: int | None = None,
         verbose: bool = False,
         compile: bool = False,
@@ -319,6 +344,15 @@ class GenaiSession:
         # and normalized to a canonical EPName so the rewrite/registration logic
         # stays generic (no hardcoded EP short-name behavior).
         self._ep_override: EPName | None = self._resolve_ep_override(ep)
+        # Concrete target device (npu/gpu/cpu) for the forced EP, or None.  Only
+        # used to synthesize device-parameterized provider options (OpenVINO /
+        # VitisAI ``device_type``) when re-routing a stage that has no reusable
+        # options for the target EP; QNN reuses the bundle's own ``backend_path``.
+        self._device: str | None = device.lower() if device else None
+        # Set at load(): did the override actually take effect (rewrite/strip at
+        # least one stage)?  Drives :attr:`effective_ep` so the report never
+        # claims an EP that never applied (flat/empty pipeline, all-CPU bundle).
+        self._override_effective: bool = False
         self._context_length_override = context_length
         self._verbose = verbose
         self._compile = compile
@@ -395,6 +429,19 @@ class GenaiSession:
         # actually drives routing.  Precedence is explicit arg > bundle config:
         # when no override is set this is the bundle config verbatim.
         effective_cfg, overridden = self._apply_ep_override(cfg)
+
+        # Record whether the override actually applied so :attr:`effective_ep`
+        # (and the perf report) never claim an EP that matched no stage.  Warn
+        # when a requested override is a no-op so ``--ep qnn`` on a flat/all-CPU
+        # bundle is visibly reported as "config" rather than silently ignored.
+        self._override_effective = self._override_took_effect(effective_cfg)
+        if self._ep_override is not None and not self._override_effective:
+            logger.warning(
+                "EP override %r was requested but did not take effect (flat/empty "
+                "pipeline, or every stage runs on CPU); the run follows the "
+                "bundle's genai_config.json instead.",
+                EP_NAME_TO_ALIAS[self._ep_override],
+            )
 
         # Register WinML EPs only when the *effective* config routes at least one
         # stage to a hardware EP.  Reading it from the post-override config means
@@ -710,6 +757,19 @@ class GenaiSession:
         return EP_NAME_TO_ALIAS[self._ep_override]
 
     @property
+    def effective_ep(self) -> EPAlias | None:
+        """The EP alias that actually took effect, or ``None`` to mean "config".
+
+        Differs from :attr:`ep` (the *requested* override) when the override was
+        a no-op: ``None`` when there was no override, **or** when the requested EP
+        matched no pipeline stage (flat/empty pipeline, or an all-CPU bundle) so
+        the run follows the bundle config.  Valid only after :meth:`load`.
+        """
+        if self._ep_override is None or not self._override_effective:
+            return None
+        return EP_NAME_TO_ALIAS[self._ep_override]
+
+    @property
     def context_length(self) -> int | None:
         """Static KV cache length, populated after :meth:`load`."""
         return self._context_length
@@ -764,18 +824,19 @@ class GenaiSession:
         config is returned verbatim (``changed=False``) so config-driven bundles
         behave exactly as before.
 
-        Otherwise every stage in ``model.decoder.pipeline`` has its
-        ``session_options.provider_options`` rewritten so the *whole* decoder
-        pipeline is forced onto the override EP:
+        Otherwise the stages in ``model.decoder.pipeline`` are rewritten:
 
         * **CPU** — strip hardware ``provider_options`` (set to ``[]``) so
           onnxruntime-genai falls back to the CPU provider.  Stages that were
           already CPU are left untouched.
-        * **hardware EP** — route every stage to that EP as
-          ``[{alias: opts}]``.  A stage's existing options are carried over only
-          when it already targeted the *same* provider (so re-selecting the
-          bundle's own EP is a no-op); otherwise empty options are written and
-          the registered EP supplies its defaults.
+        * **hardware EP** — re-route only the stages that *already run on a
+          hardware EP* to that EP as ``[{alias: opts}]``, leaving CPU-intended
+          stages (``embeddings``/``lm_head``) untouched.  A re-routed stage's
+          options are, in priority order: its own options when it already
+          targeted the *same* provider; else options borrowed from any pipeline
+          stage that targets the provider (e.g. QNN ``backend_path``); else a
+          ``device_type`` synthesized from *device* for device-parameterized EPs
+          (OpenVINO/VitisAI), else empty.
 
         The rewrite is generic: EPs are compared/aliased through the shared EP
         union, and the only literal provider name is the universal ``"cpu"``.
@@ -790,19 +851,26 @@ class GenaiSession:
         effective = copy.deepcopy(cfg)
         pipeline = effective.get("model", {}).get("decoder", {}).get("pipeline", [])
         if isinstance(pipeline, list):
+            # Pre-scan for options the bundle already defines for the target EP,
+            # so re-routing another hardware stage onto it can reuse the bundle's
+            # own machine-correct options (e.g. QNN backend_path/soc_model)
+            # instead of guessing them.
+            borrow_opts = self._pipeline_opts_for_ep(pipeline, self._ep_override)
             for stage_entry in pipeline:
                 if not isinstance(stage_entry, dict):
                     continue
                 for stage_cfg in stage_entry.values():
                     if isinstance(stage_cfg, dict):
-                        self._override_stage_provider(stage_cfg)
+                        self._override_stage_provider(stage_cfg, borrow_opts)
 
         return effective, effective != cfg
 
-    def _override_stage_provider(self, stage_cfg: dict[str, Any]) -> None:
+    def _override_stage_provider(self, stage_cfg: dict[str, Any], borrow_opts: dict) -> None:
         """Rewrite one pipeline stage's ``provider_options`` for the override EP.
 
         Mutates *stage_cfg* in place.  Assumes :attr:`_ep_override` is set.
+        *borrow_opts* are options harvested from another pipeline stage that
+        already targets the override EP (empty when none exist).
         """
         ep = self._ep_override
         if ep is None:
@@ -819,15 +887,86 @@ class GenaiSession:
                     so["provider_options"] = []
             return
 
-        # Force a hardware EP: route the stage to it, carrying over the stage's
-        # own options only when it already targeted the same provider.
-        alias = EP_NAME_TO_ALIAS[ep]
+        # Force a hardware EP: only re-route stages the bundle already runs on a
+        # hardware EP.  Stages it deliberately keeps on CPU (empty/missing
+        # provider_options — typically embeddings/lm_head) are left untouched;
+        # forcing a large CPU-intended graph onto an accelerator is rarely wanted
+        # and can trigger very slow on-the-fly compilation.
         so = stage_cfg.get("session_options")
+        current_po = so.get("provider_options") if isinstance(so, dict) else None
+        if not (isinstance(current_po, list) and self._provider_list_has_hardware_ep(current_po)):
+            return
+
+        alias = EP_NAME_TO_ALIAS[ep]
+        if self._stage_targets_ep(current_po, ep):
+            # Re-selecting the stage's own EP: preserve its shipped options
+            # verbatim (even when empty) — this is a byte-for-byte no-op.
+            opts = self._existing_opts_for_ep(current_po, ep)
+        elif borrow_opts:
+            opts = dict(borrow_opts)
+        else:
+            opts = self._default_opts_for_device(ep)
         if not isinstance(so, dict):
             so = {}
             stage_cfg["session_options"] = so
-        opts = self._existing_opts_for_ep(so.get("provider_options"), ep)
         so["provider_options"] = [{alias: opts}]
+
+    def _default_opts_for_device(self, ep: EPName) -> dict[str, Any]:
+        """Synthesize provider options for *ep* when the bundle defines none.
+
+        Device-parameterized EPs (OpenVINO/VitisAI) need a ``device_type`` to
+        target hardware; it is derived from the session's *device* (falling back
+        to the EP's primary supported device).  QNN needs a ``backend_path`` that
+        this code must not hardcode, so it warns and returns empty options; other
+        EPs (e.g. DML) take no options.
+        """
+        if ep in _DEVICE_TYPE_EPS:
+            device = self._device or EP_SUPPORTED_DEVICES[ep][0]
+            return {"device_type": device.upper()}
+        if ep == "QNNExecutionProvider":
+            logger.warning(
+                "Forcing %s onto a stage the bundle did not route to it, and no "
+                "reusable QNN options were found in the pipeline; writing empty "
+                "QNN options. QNN will fall back to its default backend and may "
+                "not target the intended device. Point --ep/--device at a bundle "
+                "whose config already defines QNN, or rebuild it for this EP.",
+                EP_NAME_TO_ALIAS[ep],
+            )
+        return {}
+
+    @staticmethod
+    def _stage_targets_ep(provider_options: Any, target: EPName) -> bool:
+        """True if *provider_options* already names *target* (any options)."""
+        if isinstance(provider_options, list):
+            for entry in provider_options:
+                if isinstance(entry, dict):
+                    for name in entry:
+                        if normalize_ep_name(cast("EPNameOrAlias", str(name))) == target:
+                            return True
+        return False
+
+    @classmethod
+    def _pipeline_opts_for_ep(cls, pipeline: list, target: EPName) -> dict:
+        """Return the first non-empty options any pipeline stage defines for *target*.
+
+        Lets forcing a hardware EP onto a stage reuse the bundle's own
+        machine-correct options for that EP (e.g. QNN ``backend_path``/
+        ``soc_model``) rather than guessing them.  Empty (``{}``) stage options
+        are skipped since borrowing them adds nothing.
+        """
+        for stage_entry in pipeline:
+            if not isinstance(stage_entry, dict):
+                continue
+            for stage_cfg in stage_entry.values():
+                if not isinstance(stage_cfg, dict):
+                    continue
+                so = stage_cfg.get("session_options")
+                if not isinstance(so, dict):
+                    continue
+                opts = cls._existing_opts_for_ep(so.get("provider_options"), target)
+                if opts:
+                    return opts
+        return {}
 
     @staticmethod
     def _provider_list_has_hardware_ep(provider_options: list) -> bool:
@@ -1294,6 +1433,44 @@ class GenaiSession:
                 if ep is not None:
                     return ep
         return None
+
+    def _override_took_effect(self, effective_cfg: dict[str, Any]) -> bool:
+        """Whether the ``ep`` override actually applied to *effective_cfg*.
+
+        Drives :attr:`effective_ep`: ``False`` means the override matched no
+        stage (flat/empty pipeline, or an all-CPU bundle) so the report should
+        say "config" rather than claim an EP that never applied.
+
+        * no override → ``False`` (there is nothing to claim).
+        * force CPU → ``True`` iff no hardware EP remains (so ``--ep cpu`` on a
+          bundle whose hardware lives outside the pipeline honestly reports
+          "config").
+        * force a hardware EP → ``True`` iff a stage routes to it.
+        """
+        ep = self._ep_override
+        if ep is None:
+            return False
+        if ep == "CPUExecutionProvider":
+            return self._bundle_uses_hardware_ep(effective_cfg) is None
+        return self._config_routes_to_ep(effective_cfg, ep)
+
+    @classmethod
+    def _config_routes_to_ep(cls, cfg: dict[str, Any], target: EPName) -> bool:
+        """True if any decoder-pipeline stage's provider_options names *target*."""
+        pipeline = cfg.get("model", {}).get("decoder", {}).get("pipeline", [])
+        if not isinstance(pipeline, list):
+            return False
+        for stage_entry in pipeline:
+            if not isinstance(stage_entry, dict):
+                continue
+            for stage_cfg in stage_entry.values():
+                if not isinstance(stage_cfg, dict):
+                    continue
+                so = stage_cfg.get("session_options")
+                po = so.get("provider_options") if isinstance(so, dict) else None
+                if cls._stage_targets_ep(po, target):
+                    return True
+        return False
 
     def _read_context_length(self) -> int:
         """Read ``model.context_length`` from ``genai_config.json``."""

--- a/src/winml/modelkit/utils/cli.py
+++ b/src/winml/modelkit/utils/cli.py
@@ -472,6 +472,7 @@ def device_option(
     default: str | None = "NPU",
     include_auto: bool = False,
     include_all: bool = False,
+    include_config: bool = False,
 ) -> Callable[[F], F]:
     """Add --device option to a Click command.
 
@@ -485,12 +486,16 @@ def device_option(
             (default: False).
         include_all: Whether to include "all" as a valid choice
             (default: False).
+        include_config: Whether to include "config" as a valid choice
+            (default: False). Used by ``perf`` for the winml-genai sentinel
+            meaning "respect the bundle's genai_config.json routing".
 
     Returns:
         Decorator function
     """
     device_choices = [device.lower() for device in SUPPORTED_DEVICES]
     choices = ["auto", *device_choices] if include_auto else device_choices
+    choices = ["config", *choices] if include_config else choices
     choices = ["all", *choices] if include_all else choices
     help_text = f"Target device type ({', '.join(choices)})"
     if optional_message:

--- a/tests/e2e/test_perf_e2e.py
+++ b/tests/e2e/test_perf_e2e.py
@@ -29,7 +29,9 @@ Running these tests:
 
 from __future__ import annotations
 
+import importlib.util
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -737,3 +739,185 @@ class TestPerfModule:
         # The real ResNetStage class should appear in the available list.
         assert "ResNetStage" in result.output
         assert not output_file.exists(), "Output file should not be written on failure"
+
+
+# ===========================================================================
+# GenAI runtime (winml-genai): --device / --ep override
+# ===========================================================================
+
+
+def _genai_perf_args(
+    *,
+    bundle_dir: Path,
+    output_file: Path,
+    device: str | None = None,
+    ep: str | None = None,
+) -> list[str]:
+    """Build argv for a fast winml-genai perf run against a tiny bundle.
+
+    Kept deliberately small (2 iterations, 1 warmup, 4 new tokens) so the
+    generation loop stays quick while still producing real timing samples.
+    """
+    args: list[str] = [
+        "-m",
+        str(bundle_dir),
+        "--runtime",
+        "winml-genai",
+        "--iterations",
+        "2",
+        "--warmup",
+        "1",
+        "--max-new-tokens",
+        "4",
+        "-o",
+        str(output_file),
+    ]
+    if device is not None:
+        args += ["--device", device]
+    if ep is not None:
+        args += ["--ep", ep]
+    return args
+
+
+class TestPerfGenaiContract:
+    """Contract for the winml-genai ``config`` sentinel — no bundle required.
+
+    These lock the CLI surface that ``config`` is a winml-genai-only
+    ``--device`` value: it is advertised in ``--help`` and rejected with a
+    helpful message on the single-shot ONNX path. They run on any host under
+    ``-m e2e`` (no genai stack, model download, or accelerator needed).
+    """
+
+    def test_help_lists_config_device(self):
+        """``perf --help`` advertises ``config`` as a --device choice."""
+        result = CliRunner().invoke(perf, ["--help"], obj={}, catch_exceptions=False)
+        assert result.exit_code == 0
+        assert "[config|auto|cpu|gpu|npu]" in result.output
+        assert "winml-genai only" in result.output
+
+    def test_onnx_rejects_device_config(self, tmp_path: Path, onnx_model_path: Path):
+        """``--device config`` is rejected on the ONNX runtime (genai-only sentinel)."""
+        output_file = tmp_path / "perf_reject.json"
+
+        result = CliRunner().invoke(
+            perf,
+            _build_perf_args(
+                model_arg=str(onnx_model_path), output_file=output_file, device="config"
+            ),
+            obj={},
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 2, f"expected UsageError exit 2, got {result.exit_code}"
+        assert "--device config is only valid with --runtime winml-genai" in result.output
+        assert not output_file.exists(), "no report should be written on rejection"
+
+
+@pytest.mark.slow
+@pytest.mark.network
+@pytest.mark.timeout(1800)
+class TestPerfGenai:
+    """Benchmark a real onnxruntime-genai bundle across --device / --ep overrides.
+
+    A tiny Qwen3-0.6B int4 CPU bundle is built once per class via the
+    onnxruntime-genai model builder (slow + network), then the perf CLI runs
+    for each device/ep resolution. Skipped unless ``onnxruntime_genai`` /
+    ``torch`` / ``transformers`` are importable and the build succeeds.
+
+    Only ``config`` / CPU routing is asserted: the builder emits a *flat*
+    bundle (single ``model.onnx``, no ``decoder.pipeline``), so a hardware-EP
+    override would be a silent no-op there. The pipeline-rewrite override is
+    covered by the GenaiSession unit tests.
+    """
+
+    @pytest.fixture(scope="class")
+    def genai_bundle(self, tmp_path_factory: pytest.TempPathFactory) -> Path:
+        """Build a tiny Qwen3-0.6B int4 CPU genai bundle once for the class."""
+        for mod in ("onnxruntime_genai", "torch", "transformers"):
+            if importlib.util.find_spec(mod) is None:
+                pytest.skip(f"{mod} not installed; genai perf e2e needs the full LLM stack")
+
+        out = tmp_path_factory.mktemp("genai_bundle") / "qwen3_0_6b_int4_cpu"
+        cache = tmp_path_factory.mktemp("genai_hf_cache")
+        cmd = [
+            sys.executable,
+            "-m",
+            "onnxruntime_genai.models.builder",
+            "-m",
+            "Qwen/Qwen3-0.6B",
+            "-o",
+            str(out),
+            "-p",
+            "int4",
+            "-e",
+            "cpu",
+            "-c",
+            str(cache),
+            "--extra_options",
+            "hf_token=false",
+        ]
+        try:
+            proc = subprocess.run(  # noqa: S603 -- trusted args (sys.executable + constants)
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=1500,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            pytest.skip("onnxruntime-genai model build timed out")
+
+        if proc.returncode != 0 or not (out / "genai_config.json").exists():
+            pytest.skip(
+                "onnxruntime-genai model build failed (network / auth / unsupported):\n"
+                f"stdout:\n{proc.stdout[-2000:]}\nstderr:\n{proc.stderr[-2000:]}"
+            )
+        return out
+
+    def _run(
+        self,
+        bundle: Path,
+        output_file: Path,
+        *,
+        device: str | None = None,
+        ep: str | None = None,
+    ) -> dict:
+        """Invoke perf on the bundle and return the parsed JSON report."""
+        result = CliRunner().invoke(
+            perf,
+            _genai_perf_args(bundle_dir=bundle, output_file=output_file, device=device, ep=ep),
+            obj={},
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, (
+            f"genai perf failed (exit {result.exit_code}):\n{result.output}"
+        )
+        assert output_file.exists(), f"report not written: {output_file}"
+        data = json.loads(output_file.read_text())
+        assert data["benchmark_info"]["runtime"] == "winml-genai"
+        assert data["benchmark_info"]["generated_tokens"] > 0
+        return data
+
+    def test_default_respects_config(self, tmp_path: Path, genai_bundle: Path):
+        """Omitting --device respects the bundle config (device == ep == config)."""
+        data = self._run(genai_bundle, tmp_path / "genai_default.json")
+        assert data["benchmark_info"]["device"] == "config"
+        assert data["benchmark_info"]["ep"] == "config"
+
+    def test_device_config_respects_config(self, tmp_path: Path, genai_bundle: Path):
+        """--device config is the explicit form of the default (no override)."""
+        data = self._run(genai_bundle, tmp_path / "genai_device_config.json", device="config")
+        assert data["benchmark_info"]["device"] == "config"
+        assert data["benchmark_info"]["ep"] == "config"
+
+    def test_ep_cpu_overrides_ep_only(self, tmp_path: Path, genai_bundle: Path):
+        """--ep cpu forces the EP but leaves device at the config default."""
+        data = self._run(genai_bundle, tmp_path / "genai_ep_cpu.json", ep="cpu")
+        assert data["benchmark_info"]["device"] == "config"
+        assert data["benchmark_info"]["ep"] == "cpu"
+
+    def test_device_cpu_overrides_device_and_ep(self, tmp_path: Path, genai_bundle: Path):
+        """--device cpu forces both the device and the resolved EP to cpu."""
+        data = self._run(genai_bundle, tmp_path / "genai_device_cpu.json", device="cpu")
+        assert data["benchmark_info"]["device"] == "cpu"
+        assert data["benchmark_info"]["ep"] == "cpu"

--- a/tests/e2e/test_perf_e2e.py
+++ b/tests/e2e/test_perf_e2e.py
@@ -865,9 +865,11 @@ class TestPerfGenai:
                 check=False,
             )
         except subprocess.TimeoutExpired:
-            pytest.skip("onnxruntime-genai model build timed out")
+            proc = None
 
-        if proc.returncode != 0 or not (out / "genai_config.json").exists():
+        if proc is None:
+            pytest.skip("onnxruntime-genai model build timed out")
+        elif proc.returncode != 0 or not (out / "genai_config.json").exists():
             pytest.skip(
                 "onnxruntime-genai model build failed (network / auth / unsupported):\n"
                 f"stdout:\n{proc.stdout[-2000:]}\nstderr:\n{proc.stderr[-2000:]}"

--- a/tests/e2e/test_perf_e2e.py
+++ b/tests/e2e/test_perf_e2e.py
@@ -824,10 +824,12 @@ class TestPerfGenai:
     for each device/ep resolution. Skipped unless ``onnxruntime_genai`` /
     ``torch`` / ``transformers`` are importable and the build succeeds.
 
-    Only ``config`` / CPU routing is asserted: the builder emits a *flat*
-    bundle (single ``model.onnx``, no ``decoder.pipeline``), so a hardware-EP
-    override would be a silent no-op there. The pipeline-rewrite override is
-    covered by the GenaiSession unit tests.
+    Both ``config`` / CPU routing and the honest-reporting path are asserted:
+    the builder emits a *flat* bundle (single ``model.onnx``, no
+    ``decoder.pipeline``), so a hardware-EP override matches no stage and is
+    reported as ``config`` rather than the requested EP (and still runs on CPU).
+    The pipeline-rewrite override (skip-CPU, device-aware options) is covered by
+    the GenaiSession unit tests.
     """
 
     @pytest.fixture(scope="class")
@@ -923,3 +925,16 @@ class TestPerfGenai:
         data = self._run(genai_bundle, tmp_path / "genai_device_cpu.json", device="cpu")
         assert data["benchmark_info"]["device"] == "cpu"
         assert data["benchmark_info"]["ep"] == "cpu"
+
+    def test_ep_qnn_on_flat_bundle_reports_config(self, tmp_path: Path, genai_bundle: Path):
+        """A hardware-EP override matching no stage is reported as config.
+
+        The flat CPU bundle has no ``decoder.pipeline`` for ``--ep qnn`` to
+        rewrite, so the override takes no effect: nothing routes to QNN (so QNN
+        never has to register — this runs on CPU-only CI), and the report says
+        ``ep: config`` instead of falsely claiming ``qnn`` (comment #3).  The
+        *requested* device is still echoed back.
+        """
+        data = self._run(genai_bundle, tmp_path / "genai_ep_qnn_flat.json", ep="qnn")
+        assert data["benchmark_info"]["ep"] == "config"
+        assert data["benchmark_info"]["device"] == "config"

--- a/tests/unit/commands/test_perf_genai.py
+++ b/tests/unit/commands/test_perf_genai.py
@@ -76,6 +76,7 @@ class _FakeSession:
         prompt_ids: list[int] | None = None,
         context_length: int = 256,
         chat_template: bool = True,
+        effective_ep: str | None = None,
     ) -> None:
         self._timings = list(timings)
         self._i = 0
@@ -84,6 +85,10 @@ class _FakeSession:
         self._chat_template = chat_template
         self.encoded_text: str | None = None
         self.template_applied = False
+        # Mirrors GenaiSession.effective_ep: the EP that actually took effect (or
+        # None to mean "config").  Reported by the benchmark instead of the
+        # requested ep so a no-op override is not falsely claimed.
+        self.effective_ep = effective_ep
 
     def encode(self, text: str) -> list[int]:
         self.encoded_text = text
@@ -342,7 +347,9 @@ class TestResultToDict:
             compile=True,
             compile_timeout=120,
         )
-        session = _FakeSession([_timing(0.4, 0.6, [0.4, 0.4, 0.4])], prompt_ids=[1, 2, 3])
+        session = _FakeSession(
+            [_timing(0.4, 0.6, [0.4, 0.4, 0.4])], prompt_ids=[1, 2, 3], effective_ep="qnn"
+        )
         bench = GenaiPerfBenchmark(cfg, session=session)
         return bench.run()
 
@@ -393,6 +400,59 @@ class TestResultToDict:
         info = GenaiPerfBenchmark(cfg, session=session).run().to_dict()["benchmark_info"]
         assert info["ep"] == "config"
         assert info["device"] == "auto"
+
+    def test_to_dict_reports_effective_ep_over_requested_ep(self) -> None:
+        # A hardware override that took no effect (session.effective_ep is None,
+        # e.g. flat/all-CPU bundle) is reported as "config", never the requested
+        # ep — so the JSON never claims an EP that never applied.
+        cfg = GenaiPerfConfig(
+            bundle_dir=Path("bundle"), ep="qnn", device="npu", iterations=1, warmup=0
+        )
+        session = _FakeSession([_timing(0.4, 0.6, [0.4, 0.4])], effective_ep=None)
+        info = GenaiPerfBenchmark(cfg, session=session).run().to_dict()["benchmark_info"]
+        assert info["ep"] == "config"
+        assert info["device"] == "npu"
+
+
+# ---------------------------------------------------------------------------
+# _session_device (concrete device for a forced EP)
+# ---------------------------------------------------------------------------
+
+
+class TestSessionDevice:
+    """``_session_device`` resolves the device a forced EP should target."""
+
+    @staticmethod
+    def _bench(ep: str | None, device: str) -> GenaiPerfBenchmark:
+        cfg = GenaiPerfConfig(bundle_dir=Path("bundle"), ep=ep, device=device)
+        return GenaiPerfBenchmark(cfg, session=_FakeSession([]))
+
+    def test_none_without_override(self) -> None:
+        assert self._bench(None, "config")._session_device() is None
+
+    def test_concrete_device_used_verbatim(self) -> None:
+        assert self._bench("openvino", "npu")._session_device() == "npu"
+
+    def test_config_sentinel_falls_back_to_ep_primary_device(self) -> None:
+        # --ep given alone (device defaults to "config"): use the EP's primary
+        # supported device so device-parameterized EPs still get a device_type.
+        assert self._bench("openvino", "config")._session_device() == "npu"
+
+    def test_auto_falls_back_to_ep_primary_device(self) -> None:
+        assert self._bench("qnn", "auto")._session_device() == "npu"
+
+    def test_build_session_forwards_device(self, monkeypatch) -> None:
+        captured: dict = {}
+
+        def fake_ctor(bundle_dir, ep, *, device=None, **_kwargs):
+            captured["ep"] = ep
+            captured["device"] = device
+            return _FakeSession([])
+
+        monkeypatch.setattr(perf_genai, "GenaiSession", fake_ctor)
+        cfg = GenaiPerfConfig(bundle_dir=Path("bundle"), ep="openvino", device="npu")
+        GenaiPerfBenchmark(cfg)._build_session()
+        assert captured == {"ep": "openvino", "device": "npu"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/commands/test_perf_genai.py
+++ b/tests/unit/commands/test_perf_genai.py
@@ -25,9 +25,9 @@ from winml.modelkit.commands._perf_genai import (
     GenaiBenchmarkResult,
     GenaiPerfBenchmark,
     GenaiPerfConfig,
-    device_to_genai_ep,
     display_genai_report,
     genai_output_path,
+    resolve_genai_ep,
     run_genai_perf,
     write_genai_report,
 )
@@ -112,26 +112,80 @@ def _make_bundle(tmp_path: Path, name: str = "bundle") -> Path:
 
 
 # ---------------------------------------------------------------------------
-# device_to_genai_ep
+# resolve_genai_ep
 # ---------------------------------------------------------------------------
 
 
-class TestDeviceToGenaiEp:
+class TestResolveGenaiEp:
+    """``resolve_genai_ep`` reuses the shared resolve_device/resolve_eps path.
+
+    ``resolve_genai_ep`` imports them from ``..sysinfo`` at call time, so the
+    tests patch ``winml.modelkit.sysinfo`` and assert the *device -> best
+    available EP alias* mapping without probing real hardware.
+    """
+
+    def test_config_short_circuits_without_resolving(self, monkeypatch) -> None:
+        # "config" means "respect the bundle": no device resolution happens.
+        import winml.modelkit.sysinfo as sysinfo
+
+        def _must_not_run(*_args: object, **_kwargs: object) -> object:
+            raise AssertionError("resolve_device must not be called for 'config'")
+
+        monkeypatch.setattr(sysinfo, "resolve_device", _must_not_run)
+        monkeypatch.setattr(sysinfo, "resolve_eps", _must_not_run)
+        assert resolve_genai_ep("config") is None
+
     @pytest.mark.parametrize(
-        ("device", "expected"),
+        ("device", "resolved_device", "eps", "expected"),
         [
-            ("cpu", "cpu"),
-            ("npu", "qnn"),
-            ("gpu", "dml"),
-            # "auto" (and any unrecognized device) resolves to None = respect
-            # the bundle's genai_config.json routing rather than forcing an EP.
-            ("auto", None),
-            ("NPU", "qnn"),
-            ("unknown-device", None),
+            # auto picks the highest-priority available device + its best EP.
+            ("auto", "npu", ["QNNExecutionProvider"], "qnn"),
+            # npu that is QNN vs VitisAI/OpenVINO -- whatever ORT advertises,
+            # not a static "npu -> qnn" guess.
+            ("npu", "npu", ["QNNExecutionProvider", "OpenVINOExecutionProvider"], "qnn"),
+            ("npu", "npu", ["VitisAIExecutionProvider"], "vitisai"),
+            ("gpu", "gpu", ["DmlExecutionProvider"], "dml"),
+            # cpu matches ONNX: OpenVINO-on-CPU when available, else plain CPU.
+            ("cpu", "cpu", ["OpenVINOExecutionProvider", "CPUExecutionProvider"], "openvino"),
+            ("cpu", "cpu", ["CPUExecutionProvider"], "cpu"),
         ],
     )
-    def test_mapping(self, device: str, expected: str | None) -> None:
-        assert device_to_genai_ep(device) == expected
+    def test_resolves_best_available_ep_alias(
+        self,
+        monkeypatch,
+        device: str,
+        resolved_device: str,
+        eps: list[str],
+        expected: str,
+    ) -> None:
+        import winml.modelkit.sysinfo as sysinfo
+
+        monkeypatch.setattr(
+            sysinfo, "resolve_device", lambda **_kwargs: (resolved_device, [resolved_device])
+        )
+        monkeypatch.setattr(sysinfo, "resolve_eps", lambda _device: list(eps))
+        assert resolve_genai_ep(device) == expected
+
+    def test_no_available_ep_returns_none(self, monkeypatch) -> None:
+        # A device that resolves to an empty EP list falls back to None
+        # (respect config) rather than raising.
+        import winml.modelkit.sysinfo as sysinfo
+
+        monkeypatch.setattr(sysinfo, "resolve_device", lambda **_kwargs: ("npu", ["npu"]))
+        monkeypatch.setattr(sysinfo, "resolve_eps", lambda _device: [])
+        assert resolve_genai_ep("npu") is None
+
+    def test_unavailable_device_propagates_valueerror(self, monkeypatch) -> None:
+        # resolve_device raises for an unavailable device; genai fails fast
+        # (matches the ONNX path) instead of silently respecting config.
+        import winml.modelkit.sysinfo as sysinfo
+
+        def _raise(**_kwargs: object) -> object:
+            raise ValueError("Device 'npu' requested but no compatible EP is available.")
+
+        monkeypatch.setattr(sysinfo, "resolve_device", _raise)
+        with pytest.raises(ValueError, match="no compatible EP"):
+            resolve_genai_ep("npu")
 
 
 # ---------------------------------------------------------------------------
@@ -467,8 +521,14 @@ class TestCliDispatch:
         return captured
 
     def test_dispatches_and_maps_device_to_ep(
-        self, runner: CliRunner, tmp_path: Path, capture_run: dict
+        self, runner: CliRunner, tmp_path: Path, capture_run: dict, monkeypatch
     ) -> None:
+        # A concrete --device resolves to the best available EP for that device
+        # via the shared resolve_device/resolve_eps path (here: npu -> qnn).
+        import winml.modelkit.sysinfo as sysinfo
+
+        monkeypatch.setattr(sysinfo, "resolve_device", lambda **_k: ("npu", ["npu"]))
+        monkeypatch.setattr(sysinfo, "resolve_eps", lambda _d: ["QNNExecutionProvider"])
         bundle = _make_bundle(tmp_path)
         result = runner.invoke(
             perf, ["-m", str(bundle), "--runtime", "winml-genai", "--device", "npu"]
@@ -478,6 +538,24 @@ class TestCliDispatch:
         assert cfg.ep == "qnn"
         assert cfg.device == "npu"
         assert cfg.bundle_dir == bundle
+
+    def test_device_auto_resolves_best_ep(
+        self, runner: CliRunner, tmp_path: Path, capture_run: dict, monkeypatch
+    ) -> None:
+        # Explicit --device auto matches the ONNX path: pick the best device +
+        # its best available EP and force the whole pipeline onto it.
+        import winml.modelkit.sysinfo as sysinfo
+
+        monkeypatch.setattr(sysinfo, "resolve_device", lambda **_k: ("gpu", ["gpu"]))
+        monkeypatch.setattr(sysinfo, "resolve_eps", lambda _d: ["DmlExecutionProvider"])
+        bundle = _make_bundle(tmp_path)
+        result = runner.invoke(
+            perf, ["-m", str(bundle), "--runtime", "winml-genai", "--device", "auto"]
+        )
+        assert result.exit_code == 0, result.output
+        cfg = capture_run["config"]
+        assert cfg.ep == "dml"
+        assert cfg.device == "auto"
 
     def test_explicit_ep_overrides_device(
         self, runner: CliRunner, tmp_path: Path, capture_run: dict
@@ -497,14 +575,47 @@ class TestCliDispatch:
     def test_explicit_ep_without_device(
         self, runner: CliRunner, tmp_path: Path, capture_run: dict
     ) -> None:
-        # --ep alone forces that EP even though --device stays at its "auto"
-        # default (which on its own would mean "respect config").
+        # --ep alone forces that EP even though --device is omitted (its
+        # effective default for genai is "config" = respect the bundle).
         bundle = _make_bundle(tmp_path)
         result = runner.invoke(perf, ["-m", str(bundle), "--runtime", "winml-genai", "--ep", "dml"])
         assert result.exit_code == 0, result.output
         cfg = capture_run["config"]
         assert cfg.ep == "dml"
-        assert cfg.device == "auto"
+        assert cfg.device == "config"
+
+    def test_default_device_is_config(
+        self, runner: CliRunner, tmp_path: Path, capture_run: dict
+    ) -> None:
+        # Omitting --device is genai's "respect the bundle" default: no EP
+        # override, device recorded as "config".
+        bundle = _make_bundle(tmp_path)
+        result = runner.invoke(perf, ["-m", str(bundle), "--runtime", "winml-genai"])
+        assert result.exit_code == 0, result.output
+        cfg = capture_run["config"]
+        assert cfg.device == "config"
+        assert cfg.ep is None
+
+    def test_explicit_device_config_respects_bundle(
+        self, runner: CliRunner, tmp_path: Path, capture_run: dict
+    ) -> None:
+        # Passing --device config explicitly is the same as omitting it: no EP
+        # override (and it must not trigger device resolution).
+        bundle = _make_bundle(tmp_path)
+        result = runner.invoke(
+            perf, ["-m", str(bundle), "--runtime", "winml-genai", "--device", "config"]
+        )
+        assert result.exit_code == 0, result.output
+        cfg = capture_run["config"]
+        assert cfg.device == "config"
+        assert cfg.ep is None
+
+    def test_onnx_runtime_rejects_device_config(self, runner: CliRunner, tmp_path: Path) -> None:
+        # "config" is a winml-genai-only sentinel; the default (winml) runtime
+        # rejects it with a clear message rather than a generic device error.
+        result = runner.invoke(perf, ["-m", str(tmp_path / "model.onnx"), "--device", "config"])
+        assert result.exit_code != 0
+        assert "winml-genai" in result.output
 
     def test_ep_flag_not_warned_as_ignored(
         self, runner: CliRunner, tmp_path: Path, capture_run: dict
@@ -524,10 +635,10 @@ class TestCliDispatch:
         cfg = capture_run["config"]
         assert cfg.iterations == 10
         assert cfg.warmup == 2
-        # Default device ("auto") resolves to None: no EP override, so the
-        # bundle's own per-stage routing in genai_config.json is respected
-        # (ctx/iter on QNN, embeddings/lm_head on CPU).
-        assert cfg.device == "auto"
+        # Omitting --device means "config": no EP override, so the bundle's own
+        # per-stage routing in genai_config.json is respected (ctx/iter on QNN,
+        # embeddings/lm_head on CPU).
+        assert cfg.device == "config"
         assert cfg.ep is None
 
     def test_explicit_iterations_honored(

--- a/tests/unit/commands/test_perf_genai.py
+++ b/tests/unit/commands/test_perf_genai.py
@@ -121,12 +121,14 @@ class TestDeviceToGenaiEp:
             ("cpu", "cpu"),
             ("npu", "qnn"),
             ("gpu", "dml"),
-            ("auto", "mixed"),
+            # "auto" (and any unrecognized device) resolves to None = respect
+            # the bundle's genai_config.json routing rather than forcing an EP.
+            ("auto", None),
             ("NPU", "qnn"),
-            ("unknown-device", "mixed"),
+            ("unknown-device", None),
         ],
     )
-    def test_mapping(self, device: str, expected: str) -> None:
+    def test_mapping(self, device: str, expected: str | None) -> None:
         assert device_to_genai_ep(device) == expected
 
 
@@ -302,6 +304,17 @@ class TestResultToDict:
         # Round-trips without error.
         json.dumps(self._result().to_dict())
 
+    def test_to_dict_ep_none_reports_config(self) -> None:
+        # ep=None (respect the bundle config) is reported as the label "config"
+        # so the JSON never carries a null EP.
+        cfg = GenaiPerfConfig(
+            bundle_dir=Path("bundle"), ep=None, device="auto", iterations=1, warmup=0
+        )
+        session = _FakeSession([_timing(0.4, 0.6, [0.4, 0.4])])
+        info = GenaiPerfBenchmark(cfg, session=session).run().to_dict()["benchmark_info"]
+        assert info["ep"] == "config"
+        assert info["device"] == "auto"
+
 
 # ---------------------------------------------------------------------------
 # Reporting helpers
@@ -331,6 +344,15 @@ class TestReporting:
 
     def test_display_genai_report_does_not_crash(self) -> None:
         display_genai_report(self._result(), Console())
+
+    def test_display_genai_report_ep_none_does_not_crash(self) -> None:
+        # ep=None renders as "<device> (config)" without error.
+        cfg = GenaiPerfConfig(
+            bundle_dir=Path("bundle"), ep=None, device="auto", iterations=1, warmup=0
+        )
+        session = _FakeSession([_timing(0.4, 0.6, [0.4, 0.4, 0.4])])
+        result = GenaiPerfBenchmark(cfg, session=session).run()
+        display_genai_report(result, Console())
 
     def test_genai_output_path_uses_bundle_name(self) -> None:
         path = genai_output_path(Path("/some/dir/my-bundle"))
@@ -432,6 +454,43 @@ class TestCliDispatch:
         assert cfg.device == "npu"
         assert cfg.bundle_dir == bundle
 
+    def test_explicit_ep_overrides_device(
+        self, runner: CliRunner, tmp_path: Path, capture_run: dict
+    ) -> None:
+        # Explicit --ep wins over the --device mapping (precedence:
+        # --ep > concrete --device > respect config).
+        bundle = _make_bundle(tmp_path)
+        result = runner.invoke(
+            perf,
+            ["-m", str(bundle), "--runtime", "winml-genai", "--device", "npu", "--ep", "cpu"],
+        )
+        assert result.exit_code == 0, result.output
+        cfg = capture_run["config"]
+        assert cfg.ep == "cpu"
+        assert cfg.device == "npu"
+
+    def test_explicit_ep_without_device(
+        self, runner: CliRunner, tmp_path: Path, capture_run: dict
+    ) -> None:
+        # --ep alone forces that EP even though --device stays at its "auto"
+        # default (which on its own would mean "respect config").
+        bundle = _make_bundle(tmp_path)
+        result = runner.invoke(perf, ["-m", str(bundle), "--runtime", "winml-genai", "--ep", "dml"])
+        assert result.exit_code == 0, result.output
+        cfg = capture_run["config"]
+        assert cfg.ep == "dml"
+        assert cfg.device == "auto"
+
+    def test_ep_flag_not_warned_as_ignored(
+        self, runner: CliRunner, tmp_path: Path, capture_run: dict
+    ) -> None:
+        # --ep is honored for winml-genai, so it must not appear in the
+        # "options are ignored" warning.
+        bundle = _make_bundle(tmp_path)
+        result = runner.invoke(perf, ["-m", str(bundle), "--runtime", "winml-genai", "--ep", "qnn"])
+        assert result.exit_code == 0, result.output
+        assert "--ep" not in result.output
+
     def test_genai_iteration_defaults(
         self, runner: CliRunner, tmp_path: Path, capture_run: dict
     ) -> None:
@@ -440,11 +499,11 @@ class TestCliDispatch:
         cfg = capture_run["config"]
         assert cfg.iterations == 10
         assert cfg.warmup == 2
-        # Default device ("auto") must resolve to mixed execution so the
-        # bundle's per-stage EP routing (ctx/iter on QNN, embeddings/lm_head
-        # on CPU) is honored.
+        # Default device ("auto") resolves to None: no EP override, so the
+        # bundle's own per-stage routing in genai_config.json is respected
+        # (ctx/iter on QNN, embeddings/lm_head on CPU).
         assert cfg.device == "auto"
-        assert cfg.ep == "mixed"
+        assert cfg.ep is None
 
     def test_explicit_iterations_honored(
         self, runner: CliRunner, tmp_path: Path, capture_run: dict

--- a/tests/unit/session/test_genai_session.py
+++ b/tests/unit/session/test_genai_session.py
@@ -91,6 +91,39 @@ def bundle_dir_with_pipeline(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
+def bundle_dir_cpu_pipeline(tmp_path: Path) -> Path:
+    """CPU-only bundle WITH pipeline stages (no hardware provider_options).
+
+    Used to verify that forcing a hardware EP override rewrites the whole
+    pipeline and flips the registration/compile gates on, even though the
+    bundle itself never asked for a hardware EP.
+    """
+    cfg = {
+        "model": {
+            "type": "decoder-pipeline",
+            "context_length": 256,
+            "decoder": {
+                "pipeline": [
+                    {"embeddings": {"filename": "embeddings.onnx"}},
+                    {
+                        "context": {
+                            "filename": "ctx.onnx",
+                            "session_options": {"provider_options": []},
+                        }
+                    },
+                ]
+            },
+        },
+        "search": {"max_length": 256},
+    }
+    (tmp_path / "genai_config.json").write_text(json.dumps(cfg), encoding="utf-8")
+    (tmp_path / "ctx.onnx").write_bytes(b"fake")
+    (tmp_path / "embeddings.onnx").write_bytes(b"fake")
+    (tmp_path / "tokenizer.json").write_text("{}", encoding="utf-8")
+    return tmp_path
+
+
+@pytest.fixture
 def mock_og() -> MagicMock:
     """Return a fully mocked onnxruntime_genai module."""
     og = MagicMock(name="onnxruntime_genai")
@@ -146,9 +179,10 @@ class TestGenaiSessionInit:
         with pytest.raises(FileNotFoundError, match="winml-cli export"):
             GenaiSession(tmp_path)
 
-    def test_default_ep_is_cpu(self, bundle_dir: Path) -> None:
+    def test_default_ep_is_none_respects_config(self, bundle_dir: Path) -> None:
+        # No ep override -> respect the bundle's genai_config.json routing.
         session = GenaiSession(bundle_dir)
-        assert session.ep == "cpu"
+        assert session.ep is None
 
     def test_not_loaded_after_init(self, bundle_dir: Path) -> None:
         session = GenaiSession(bundle_dir)
@@ -160,9 +194,25 @@ class TestGenaiSessionInit:
         assert session.bundle_dir == bundle_dir
 
     def test_supported_eps(self, bundle_dir: Path) -> None:
-        for ep in ("cpu", "mixed", "qnn", "dml"):
+        # A concrete override is normalized to its canonical short alias,
+        # whether passed as an alias or a full *ExecutionProvider name.
+        for ep, expected in (
+            ("cpu", "cpu"),
+            ("qnn", "qnn"),
+            ("dml", "dml"),
+            ("openvino", "openvino"),
+            ("QNNExecutionProvider", "qnn"),
+            ("DmlExecutionProvider", "dml"),
+        ):
             session = GenaiSession(bundle_dir, ep=ep)
-            assert session.ep == ep
+            assert session.ep == expected
+
+    def test_invalid_ep_raises_value_error(self, bundle_dir: Path) -> None:
+        # The retired "mixed"/"auto" sentinels (and any unknown provider) are
+        # rejected rather than silently becoming a no-op override.
+        for bad in ("mixed", "auto", "not-an-ep"):
+            with pytest.raises(ValueError, match="Unknown execution provider"):
+                GenaiSession(bundle_dir, ep=bad)
 
     def test_compile_timeout_default(self, bundle_dir: Path) -> None:
         session = GenaiSession(bundle_dir)
@@ -281,17 +331,49 @@ class TestEPRegistration:
             patch("winml.modelkit.session.genai_session.WinMLEPRegistry") as mock_reg_cls,
         ):
             mock_reg_cls.get_instance.return_value = mock_registry
-            # ep defaults to "cpu"; registration is driven by the bundle config,
-            # which routes the ctx/iter stages to QNN.
+            # ep defaults to None (respect config); registration is driven by
+            # the bundle config, which routes the ctx/iter stages to QNN.
             session = GenaiSession(bundle_dir_with_pipeline)
             session.load()
         mock_registry.register_execution_providers.assert_called_once_with(ort_genai=True)
 
-    def test_registration_follows_config_not_ep_arg(
-        self, bundle_dir: Path, mock_og: MagicMock
+    def test_force_hardware_ep_on_cpu_bundle_registers(
+        self, bundle_dir_cpu_pipeline: Path, mock_og: MagicMock
     ) -> None:
-        # A CPU-only bundle must NOT register even when ep="qnn" is requested;
-        # EP routing is read from genai_config.json (override tracked in #1025).
+        # Overriding a CPU-only *pipeline* bundle to a hardware EP rewrites every
+        # stage, so the effective config now routes to hardware -> WinML EPs are
+        # registered even though the bundle itself never asked for them.
+        mock_registry = MagicMock()
+        mock_registry.winml_available = True
+        mock_registry.register_execution_providers.return_value = {
+            "onnxruntime_genai": ["QNNExecutionProvider"]
+        }
+        with (
+            _patch_og(mock_og),
+            patch("winml.modelkit.session.genai_session.WinMLEPRegistry") as mock_reg_cls,
+        ):
+            mock_reg_cls.get_instance.return_value = mock_registry
+            session = GenaiSession(bundle_dir_cpu_pipeline, ep="qnn")
+            session.load()
+        mock_registry.register_execution_providers.assert_called_once_with(ort_genai=True)
+
+    def test_force_cpu_on_hardware_bundle_skips_registration(
+        self, bundle_dir_with_pipeline: Path, mock_og: MagicMock
+    ) -> None:
+        # Overriding a hardware bundle to CPU strips every stage's hardware
+        # provider_options, so the effective config is CPU-only -> no WinML EP
+        # registration.
+        with (
+            _patch_og(mock_og),
+            patch("winml.modelkit.session.genai_session.WinMLEPRegistry") as mock_reg_cls,
+        ):
+            session = GenaiSession(bundle_dir_with_pipeline, ep="cpu")
+            session.load()
+        mock_reg_cls.assert_not_called()
+
+    def test_force_ep_on_empty_pipeline_is_noop(self, bundle_dir: Path, mock_og: MagicMock) -> None:
+        # A bundle with no pipeline stages has nothing to route: forcing "qnn"
+        # cannot invent hardware stages, so registration stays off.
         with (
             _patch_og(mock_og),
             patch("winml.modelkit.session.genai_session.WinMLEPRegistry") as mock_reg_cls,
@@ -307,6 +389,32 @@ class TestEPRegistration:
             session.load()
         mock_og.Config.return_value.clear_providers.assert_not_called()
         mock_og.Config.return_value.append_provider.assert_not_called()
+
+    def test_override_loads_model_from_derived_bundle(
+        self, bundle_dir_with_pipeline: Path, mock_og: MagicMock
+    ) -> None:
+        # A concrete override rewrites the config, so og.Model must load from the
+        # derived _compiled/ directory (not the original bundle) to pick it up.
+        with _patch_og(mock_og):
+            session = GenaiSession(bundle_dir_with_pipeline, ep="cpu")
+            session.load()
+        compiled_dir = bundle_dir_with_pipeline / "_compiled"
+        mock_og.Config.assert_called_once_with(str(compiled_dir))
+        written = json.loads((compiled_dir / "genai_config.json").read_text(encoding="utf-8"))
+        assert GenaiSession._bundle_uses_hardware_ep(written) is False
+
+    def test_no_override_loads_model_from_original_bundle(
+        self, bundle_dir_with_pipeline: Path, mock_og: MagicMock
+    ) -> None:
+        # ep=None + compile=False: no derived bundle, load straight from source.
+        with (
+            _patch_og(mock_og),
+            patch("winml.modelkit.session.genai_session.WinMLEPRegistry"),
+        ):
+            session = GenaiSession(bundle_dir_with_pipeline)
+            session.load()
+        mock_og.Config.assert_called_once_with(str(bundle_dir_with_pipeline))
+        assert not (bundle_dir_with_pipeline / "_compiled").exists()
 
 
 # ---------------------------------------------------------------------------
@@ -362,6 +470,103 @@ class TestBundleUsesHardwareEp:
     def test_provider_options_not_a_list_returns_false(self) -> None:
         cfg = self._pipeline({"context": {"session_options": {"provider_options": {}}}})
         assert GenaiSession._bundle_uses_hardware_ep(cfg) is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: _apply_ep_override (explicit arg > bundle config)
+# ---------------------------------------------------------------------------
+
+
+class TestEPOverride:
+    """The ``ep`` override rewrites the whole pipeline generically."""
+
+    @staticmethod
+    def _pipeline_cfg(*stages: dict) -> dict:
+        return {"model": {"context_length": 256, "decoder": {"pipeline": list(stages)}}}
+
+    def test_none_override_returns_config_verbatim(self, bundle_dir: Path) -> None:
+        # ep=None must not copy or touch the config (config-driven bundles
+        # behave exactly as before).
+        session = GenaiSession(bundle_dir)
+        cfg = self._pipeline_cfg(
+            {"context": {"session_options": {"provider_options": [{"qnn": {}}]}}}
+        )
+        effective, changed = session._apply_ep_override(cfg)
+        assert changed is False
+        assert effective is cfg
+
+    def test_force_cpu_strips_hardware_provider_options(self, bundle_dir: Path) -> None:
+        session = GenaiSession(bundle_dir, ep="cpu")
+        cfg = self._pipeline_cfg(
+            {"context": {"session_options": {"provider_options": [{"qnn": {}}]}}},
+            {"iterator": {"session_options": {"provider_options": [{"dml": {}}]}}},
+        )
+        effective, changed = session._apply_ep_override(cfg)
+        assert changed is True
+        stages = effective["model"]["decoder"]["pipeline"]
+        assert stages[0]["context"]["session_options"]["provider_options"] == []
+        assert stages[1]["iterator"]["session_options"]["provider_options"] == []
+        assert GenaiSession._bundle_uses_hardware_ep(effective) is False
+
+    def test_force_cpu_leaves_cpu_stage_untouched(self, bundle_dir: Path) -> None:
+        # A stage with no session_options is already CPU; forcing CPU is a no-op.
+        session = GenaiSession(bundle_dir, ep="cpu")
+        cfg = self._pipeline_cfg({"embeddings": {"filename": "embeddings.onnx"}})
+        effective, changed = session._apply_ep_override(cfg)
+        assert changed is False
+        assert "session_options" not in effective["model"]["decoder"]["pipeline"][0]["embeddings"]
+
+    def test_force_hardware_ep_routes_all_stages(self, bundle_dir: Path) -> None:
+        session = GenaiSession(bundle_dir, ep="qnn")
+        cfg = self._pipeline_cfg(
+            {"embeddings": {"filename": "embeddings.onnx"}},
+            {"context": {"session_options": {"provider_options": []}}},
+        )
+        effective, changed = session._apply_ep_override(cfg)
+        assert changed is True
+        stages = effective["model"]["decoder"]["pipeline"]
+        assert stages[0]["embeddings"]["session_options"]["provider_options"] == [{"qnn": {}}]
+        assert stages[1]["context"]["session_options"]["provider_options"] == [{"qnn": {}}]
+        assert GenaiSession._bundle_uses_hardware_ep(effective) is True
+
+    def test_force_same_ep_preserves_existing_options(self, bundle_dir: Path) -> None:
+        # Re-selecting the bundle's own EP keeps its finely-tuned options.
+        session = GenaiSession(bundle_dir, ep="qnn")
+        opts = {"backend_path": "QnnHtp.dll", "soc_model": "60"}
+        cfg = self._pipeline_cfg(
+            {"context": {"session_options": {"provider_options": [{"qnn": dict(opts)}]}}}
+        )
+        effective, _ = session._apply_ep_override(cfg)
+        stage = effective["model"]["decoder"]["pipeline"][0]["context"]
+        assert stage["session_options"]["provider_options"] == [{"qnn": opts}]
+
+    def test_force_different_hardware_ep_drops_foreign_options(self, bundle_dir: Path) -> None:
+        # Switching QNN -> DML must not carry QNN's backend_path across.
+        session = GenaiSession(bundle_dir, ep="dml")
+        cfg = self._pipeline_cfg(
+            {"context": {"session_options": {"provider_options": [{"qnn": {"backend_path": "x"}}]}}}
+        )
+        effective, changed = session._apply_ep_override(cfg)
+        assert changed is True
+        stage = effective["model"]["decoder"]["pipeline"][0]["context"]
+        assert stage["session_options"]["provider_options"] == [{"dml": {}}]
+
+    def test_full_name_override_uses_canonical_alias(self, bundle_dir: Path) -> None:
+        # A full *ExecutionProvider name overrides identically to its alias.
+        session = GenaiSession(bundle_dir, ep="OpenVINOExecutionProvider")
+        cfg = self._pipeline_cfg({"context": {"session_options": {"provider_options": []}}})
+        effective, _ = session._apply_ep_override(cfg)
+        stage = effective["model"]["decoder"]["pipeline"][0]["context"]
+        assert stage["session_options"]["provider_options"] == [{"openvino": {}}]
+
+    def test_override_does_not_mutate_input_config(self, bundle_dir: Path) -> None:
+        session = GenaiSession(bundle_dir, ep="cpu")
+        cfg = self._pipeline_cfg(
+            {"context": {"session_options": {"provider_options": [{"qnn": {"backend_path": "x"}}]}}}
+        )
+        original = json.loads(json.dumps(cfg))
+        session._apply_ep_override(cfg)
+        assert cfg == original
 
 
 # ---------------------------------------------------------------------------
@@ -859,6 +1064,29 @@ class TestPrepareCompiledBundle:
         assert "model" in written
         # A cache marker is written next to each compiled stage.
         assert (compiled_dir / "context_ctx.onnx.meta.json").exists()
+
+    def test_override_only_writes_derived_bundle_without_compile(
+        self, bundle_dir_with_pipeline: Path
+    ) -> None:
+        """An override with compile=False still writes a derived _compiled/ bundle.
+
+        The rewritten routing must reach og.Model even when nothing is compiled,
+        and the non-compiled ONNX files must be mirrored so they resolve.
+        """
+        session = GenaiSession(bundle_dir_with_pipeline, ep="cpu")
+        cfg = session._read_genai_config()
+        effective, overridden = session._apply_ep_override(cfg)
+        assert overridden is True
+
+        compiled_dir = bundle_dir_with_pipeline / "_compiled"
+        result = session._prepare_compiled_bundle(effective, overridden=True)
+
+        assert result == compiled_dir
+        written = json.loads((compiled_dir / "genai_config.json").read_text(encoding="utf-8"))
+        assert GenaiSession._bundle_uses_hardware_ep(written) is False
+        # ONNX files are mirrored (not compiled) so og.Model finds them by name.
+        assert (compiled_dir / "ctx.onnx").exists()
+        assert (compiled_dir / "iter.onnx").exists()
 
     @staticmethod
     def _prime_cache(bundle_dir: Path, marker_opts: dict) -> Path:

--- a/tests/unit/session/test_genai_session.py
+++ b/tests/unit/session/test_genai_session.py
@@ -11,6 +11,7 @@ real model files or GPU/NPU hardware is required.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import sys
 from pathlib import Path
@@ -90,9 +91,9 @@ def bundle_dir_with_pipeline(tmp_path: Path) -> Path:
 def bundle_dir_cpu_pipeline(tmp_path: Path) -> Path:
     """CPU-only bundle WITH pipeline stages (no hardware provider_options).
 
-    Used to verify that forcing a hardware EP override rewrites the whole
-    pipeline and flips the registration/compile gates on, even though the
-    bundle itself never asked for a hardware EP.
+    Used to verify that forcing a hardware EP override is a no-op on an all-CPU
+    bundle: skip-CPU leaves every stage untouched, so the registration/compile
+    gates stay off and the run honestly reports "config".
     """
     cfg = {
         "model": {
@@ -105,6 +106,39 @@ def bundle_dir_cpu_pipeline(tmp_path: Path) -> Path:
                         "context": {
                             "filename": "ctx.onnx",
                             "session_options": {"provider_options": []},
+                        }
+                    },
+                ]
+            },
+        },
+        "search": {"max_length": 256},
+    }
+    (tmp_path / "genai_config.json").write_text(json.dumps(cfg), encoding="utf-8")
+    (tmp_path / "ctx.onnx").write_bytes(b"fake")
+    (tmp_path / "embeddings.onnx").write_bytes(b"fake")
+    (tmp_path / "tokenizer.json").write_text("{}", encoding="utf-8")
+    return tmp_path
+
+
+@pytest.fixture
+def bundle_dir_dml_pipeline(tmp_path: Path) -> Path:
+    """Bundle whose context stage runs on a hardware EP (DML), with a CPU
+    embeddings stage.
+
+    Used to verify that forcing a *different* hardware EP re-routes the existing
+    hardware stage (flipping registration on) while leaving the CPU stage alone.
+    """
+    cfg = {
+        "model": {
+            "type": "decoder-pipeline",
+            "context_length": 256,
+            "decoder": {
+                "pipeline": [
+                    {"embeddings": {"filename": "embeddings.onnx"}},
+                    {
+                        "context": {
+                            "filename": "ctx.onnx",
+                            "session_options": {"provider_options": [{"dml": {}}]},
                         }
                     },
                 ]
@@ -337,12 +371,32 @@ class TestEPRegistration:
             session.load()
         mock_registry.register_execution_providers.assert_called_once_with(ort_genai=True)
 
-    def test_force_hardware_ep_on_cpu_bundle_registers(
-        self, bundle_dir_cpu_pipeline: Path, mock_og: MagicMock
+    def test_force_hardware_ep_on_cpu_bundle_skips_registration(
+        self,
+        bundle_dir_cpu_pipeline: Path,
+        mock_og: MagicMock,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
-        # Overriding a CPU-only *pipeline* bundle to a hardware EP rewrites every
-        # stage, so the effective config now routes to hardware -> WinML EPs are
-        # registered even though the bundle itself never asked for them.
+        # Forcing a hardware EP on an all-CPU pipeline is a no-op: skip-CPU leaves
+        # every stage untouched, so the effective config stays CPU-only, no WinML
+        # EPs are registered, and the override is reported as ineffective.
+        with (
+            _patch_og(mock_og),
+            patch("winml.modelkit.session.genai_session.WinMLEPRegistry") as mock_reg_cls,
+            caplog.at_level(logging.WARNING),
+        ):
+            session = GenaiSession(bundle_dir_cpu_pipeline, ep="qnn")
+            session.load()
+        mock_reg_cls.assert_not_called()
+        assert session.effective_ep is None
+        assert "did not take effect" in caplog.text
+
+    def test_force_hardware_ep_reroutes_hardware_stage_registers(
+        self, bundle_dir_dml_pipeline: Path, mock_og: MagicMock
+    ) -> None:
+        # Forcing QNN onto a bundle whose context stage runs on DML re-routes that
+        # hardware stage to QNN (the CPU embeddings stage is left alone), so the
+        # effective config now needs WinML EP registration.
         mock_registry = MagicMock()
         mock_registry.winml_available = True
         mock_registry.register_execution_providers.return_value = {
@@ -353,9 +407,10 @@ class TestEPRegistration:
             patch("winml.modelkit.session.genai_session.WinMLEPRegistry") as mock_reg_cls,
         ):
             mock_reg_cls.get_instance.return_value = mock_registry
-            session = GenaiSession(bundle_dir_cpu_pipeline, ep="qnn")
+            session = GenaiSession(bundle_dir_dml_pipeline, ep="qnn")
             session.load()
         mock_registry.register_execution_providers.assert_called_once_with(ort_genai=True)
+        assert session.effective_ep == "qnn"
 
     def test_force_cpu_on_hardware_bundle_skips_registration(
         self, bundle_dir_with_pipeline: Path, mock_og: MagicMock
@@ -498,7 +553,7 @@ class TestBundleUsesHardwareEp:
 
 
 class TestEPOverride:
-    """The ``ep`` override rewrites the whole pipeline generically."""
+    """The ``ep`` override re-routes hardware stages generically."""
 
     @staticmethod
     def _pipeline_cfg(*stages: dict) -> dict:
@@ -536,18 +591,89 @@ class TestEPOverride:
         assert changed is False
         assert "session_options" not in effective["model"]["decoder"]["pipeline"][0]["embeddings"]
 
-    def test_force_hardware_ep_routes_all_stages(self, bundle_dir: Path) -> None:
+    def test_force_hardware_reroutes_only_hardware_stages(self, bundle_dir: Path) -> None:
+        # Forcing a hardware EP re-routes stages already on a hardware EP but
+        # leaves CPU-intended stages (empty/missing provider_options, e.g.
+        # embeddings/lm_head) untouched, so a large CPU graph is never forced
+        # onto an accelerator (which can trigger a very slow on-the-fly compile).
         session = GenaiSession(bundle_dir, ep="qnn")
         cfg = self._pipeline_cfg(
             {"embeddings": {"filename": "embeddings.onnx"}},
-            {"context": {"session_options": {"provider_options": []}}},
+            {"lm_head": {"session_options": {"provider_options": []}}},
+            {"context": {"session_options": {"provider_options": [{"dml": {}}]}}},
         )
         effective, changed = session._apply_ep_override(cfg)
         assert changed is True
         stages = effective["model"]["decoder"]["pipeline"]
-        assert stages[0]["embeddings"]["session_options"]["provider_options"] == [{"qnn": {}}]
-        assert stages[1]["context"]["session_options"]["provider_options"] == [{"qnn": {}}]
+        # CPU-intended stages are left exactly as-is.
+        assert "session_options" not in stages[0]["embeddings"]
+        assert stages[1]["lm_head"]["session_options"]["provider_options"] == []
+        # Only the hardware stage is re-routed to the forced EP.
+        assert stages[2]["context"]["session_options"]["provider_options"] == [{"qnn": {}}]
         assert GenaiSession._bundle_uses_hardware_ep(effective) == "qnn"
+
+    def test_reroute_borrows_options_from_another_stage(self, bundle_dir: Path) -> None:
+        # Forcing QNN onto a DML stage reuses QNN options the bundle already
+        # defines elsewhere (backend_path/soc_model) rather than guessing them.
+        session = GenaiSession(bundle_dir, ep="qnn")
+        qnn_opts = {"backend_path": "QnnHtp.dll", "soc_model": "60"}
+        cfg = self._pipeline_cfg(
+            {"context": {"session_options": {"provider_options": [{"qnn": dict(qnn_opts)}]}}},
+            {"iterator": {"session_options": {"provider_options": [{"dml": {}}]}}},
+        )
+        effective, _ = session._apply_ep_override(cfg)
+        stages = effective["model"]["decoder"]["pipeline"]
+        assert stages[0]["context"]["session_options"]["provider_options"] == [{"qnn": qnn_opts}]
+        assert stages[1]["iterator"]["session_options"]["provider_options"] == [{"qnn": qnn_opts}]
+
+    def test_reroute_synthesizes_device_type_for_openvino(self, bundle_dir: Path) -> None:
+        # OpenVINO selects hardware via device_type; forcing it derives that from
+        # the requested --device when the stage has no reusable options.
+        session = GenaiSession(bundle_dir, ep="openvino", device="npu")
+        cfg = self._pipeline_cfg(
+            {"context": {"session_options": {"provider_options": [{"dml": {}}]}}}
+        )
+        effective, _ = session._apply_ep_override(cfg)
+        stage = effective["model"]["decoder"]["pipeline"][0]["context"]
+        assert stage["session_options"]["provider_options"] == [
+            {"openvino": {"device_type": "NPU"}}
+        ]
+
+    def test_reroute_openvino_defaults_device_type_without_device(self, bundle_dir: Path) -> None:
+        # No --device: fall back to the EP's primary supported device (npu).
+        session = GenaiSession(bundle_dir, ep="openvino")
+        cfg = self._pipeline_cfg(
+            {"context": {"session_options": {"provider_options": [{"dml": {}}]}}}
+        )
+        effective, _ = session._apply_ep_override(cfg)
+        stage = effective["model"]["decoder"]["pipeline"][0]["context"]
+        assert stage["session_options"]["provider_options"] == [
+            {"openvino": {"device_type": "NPU"}}
+        ]
+
+    def test_reroute_synthesizes_device_type_for_vitisai(self, bundle_dir: Path) -> None:
+        session = GenaiSession(bundle_dir, ep="vitisai", device="npu")
+        cfg = self._pipeline_cfg(
+            {"context": {"session_options": {"provider_options": [{"dml": {}}]}}}
+        )
+        effective, _ = session._apply_ep_override(cfg)
+        stage = effective["model"]["decoder"]["pipeline"][0]["context"]
+        assert stage["session_options"]["provider_options"] == [{"vitisai": {"device_type": "NPU"}}]
+
+    def test_reroute_qnn_without_reusable_options_warns_and_empties(
+        self, bundle_dir: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # Forcing QNN onto a stage with no borrowable QNN options must NOT
+        # hardcode a backend_path: it warns and writes empty options.
+        session = GenaiSession(bundle_dir, ep="qnn")
+        cfg = self._pipeline_cfg(
+            {"context": {"session_options": {"provider_options": [{"dml": {}}]}}}
+        )
+        with caplog.at_level(logging.WARNING):
+            effective, _ = session._apply_ep_override(cfg)
+        stage = effective["model"]["decoder"]["pipeline"][0]["context"]
+        assert stage["session_options"]["provider_options"] == [{"qnn": {}}]
+        assert "empty QNN options" in caplog.text
 
     def test_force_same_ep_preserves_existing_options(self, bundle_dir: Path) -> None:
         # Re-selecting the bundle's own EP keeps its finely-tuned options.
@@ -572,12 +698,17 @@ class TestEPOverride:
         assert stage["session_options"]["provider_options"] == [{"dml": {}}]
 
     def test_full_name_override_uses_canonical_alias(self, bundle_dir: Path) -> None:
-        # A full *ExecutionProvider name overrides identically to its alias.
-        session = GenaiSession(bundle_dir, ep="OpenVINOExecutionProvider")
-        cfg = self._pipeline_cfg({"context": {"session_options": {"provider_options": []}}})
+        # A full *ExecutionProvider name overrides identically to its alias: the
+        # re-routed stage is keyed by the canonical short alias ("openvino").
+        session = GenaiSession(bundle_dir, ep="OpenVINOExecutionProvider", device="gpu")
+        cfg = self._pipeline_cfg(
+            {"context": {"session_options": {"provider_options": [{"dml": {}}]}}}
+        )
         effective, _ = session._apply_ep_override(cfg)
         stage = effective["model"]["decoder"]["pipeline"][0]["context"]
-        assert stage["session_options"]["provider_options"] == [{"openvino": {}}]
+        assert stage["session_options"]["provider_options"] == [
+            {"openvino": {"device_type": "GPU"}}
+        ]
 
     def test_override_does_not_mutate_input_config(self, bundle_dir: Path) -> None:
         session = GenaiSession(bundle_dir, ep="cpu")
@@ -587,6 +718,81 @@ class TestEPOverride:
         original = json.loads(json.dumps(cfg))
         session._apply_ep_override(cfg)
         assert cfg == original
+
+    def test_device_param_stored_lowercased(self, bundle_dir: Path) -> None:
+        assert GenaiSession(bundle_dir, ep="openvino", device="NPU")._device == "npu"
+        assert GenaiSession(bundle_dir, ep="openvino")._device is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: effective_ep (honest reporting when an override is a no-op)
+# ---------------------------------------------------------------------------
+
+
+class TestEffectiveEp:
+    """``effective_ep`` reports the EP that actually applied, else "config"."""
+
+    @staticmethod
+    def _pipeline_cfg(*stages: dict) -> dict:
+        return {"model": {"context_length": 256, "decoder": {"pipeline": list(stages)}}}
+
+    def test_no_override_is_not_effective(self, bundle_dir: Path) -> None:
+        session = GenaiSession(bundle_dir)
+        assert session._override_took_effect(self._pipeline_cfg()) is False
+        assert session.effective_ep is None
+
+    def test_hardware_override_effective_when_a_stage_routes_to_it(self, bundle_dir: Path) -> None:
+        session = GenaiSession(bundle_dir, ep="qnn")
+        cfg = self._pipeline_cfg(
+            {"context": {"session_options": {"provider_options": [{"qnn": {}}]}}}
+        )
+        effective, _ = session._apply_ep_override(cfg)
+        assert session._override_took_effect(effective) is True
+
+    def test_hardware_override_not_effective_on_empty_pipeline(self, bundle_dir: Path) -> None:
+        # Flat/empty pipeline: nothing routes to qnn, so the override is a no-op.
+        session = GenaiSession(bundle_dir, ep="qnn")
+        effective, _ = session._apply_ep_override(self._pipeline_cfg())
+        assert session._override_took_effect(effective) is False
+
+    def test_hardware_override_not_effective_on_all_cpu_bundle(self, bundle_dir: Path) -> None:
+        # Every stage is CPU-intended, so skip-CPU leaves nothing on qnn.
+        session = GenaiSession(bundle_dir, ep="qnn")
+        cfg = self._pipeline_cfg(
+            {"embeddings": {"filename": "e.onnx"}},
+            {"context": {"session_options": {"provider_options": []}}},
+        )
+        effective, _ = session._apply_ep_override(cfg)
+        assert session._override_took_effect(effective) is False
+
+    def test_cpu_override_effective_when_hardware_removed(self, bundle_dir: Path) -> None:
+        session = GenaiSession(bundle_dir, ep="cpu")
+        cfg = self._pipeline_cfg(
+            {"context": {"session_options": {"provider_options": [{"qnn": {}}]}}}
+        )
+        effective, _ = session._apply_ep_override(cfg)
+        assert session._override_took_effect(effective) is True
+
+    def test_cpu_override_not_effective_when_hardware_outside_pipeline(
+        self, bundle_dir: Path
+    ) -> None:
+        # Hardware on a flat decoder the pipeline walk cannot strip: cpu did not
+        # actually take effect, so report "config" rather than falsely "cpu".
+        session = GenaiSession(bundle_dir, ep="cpu")
+        cfg = {
+            "model": {
+                "context_length": 256,
+                "decoder": {"session_options": {"provider_options": [{"qnn": {}}]}},
+            }
+        }
+        effective, _ = session._apply_ep_override(cfg)
+        assert session._override_took_effect(effective) is False
+
+    def test_effective_ep_property_reflects_effectiveness(self, bundle_dir: Path) -> None:
+        session = GenaiSession(bundle_dir, ep="qnn")
+        assert session.effective_ep is None  # not yet applied (pre-load default)
+        session._override_effective = True
+        assert session.effective_ep == "qnn"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/session/test_genai_session.py
+++ b/tests/unit/session/test_genai_session.py
@@ -1063,7 +1063,7 @@ class TestPrepareCompiledBundle:
         written = json.loads(config_out.read_text(encoding="utf-8"))
         assert "model" in written
         # A cache marker is written next to each compiled stage.
-        assert (compiled_dir / "context_ctx.onnx.meta.json").exists()
+        assert (compiled_dir / "context_qnn_ctx.onnx.meta.json").exists()
 
     def test_override_only_writes_derived_bundle_without_compile(
         self, bundle_dir_with_pipeline: Path
@@ -1094,7 +1094,7 @@ class TestPrepareCompiledBundle:
         compiled_dir = bundle_dir / "_compiled"
         compiled_dir.mkdir()
         for stage, src_name in (("context", "ctx.onnx"), ("iterator", "iter.onnx")):
-            ctx = compiled_dir / f"{stage}_ctx.onnx"
+            ctx = compiled_dir / f"{stage}_qnn_ctx.onnx"
             ctx.write_bytes(b"ep_ctx")
             GenaiSession._write_compile_marker(ctx, "qnn", marker_opts)
             src_mtime = (bundle_dir / src_name).stat().st_mtime
@@ -1138,7 +1138,7 @@ class TestPrepareCompiledBundle:
         compiled_dir = self._prime_cache(bundle_dir_with_pipeline, {"backend_path": "QnnHtp.dll"})
 
         # ctx.onnx.data is newer than the compiled context stage -> stale.
-        ctx_stage = compiled_dir / "context_ctx.onnx"
+        ctx_stage = compiled_dir / "context_qnn_ctx.onnx"
         data_sidecar = bundle_dir_with_pipeline / "ctx.onnx.data"
         data_sidecar.write_bytes(b"weights")
         ctx_mtime = ctx_stage.stat().st_mtime
@@ -1151,6 +1151,68 @@ class TestPrepareCompiledBundle:
         # Only the context stage (whose .data changed) is recompiled.
         assert spy.call_count == 1
         assert spy.call_args.args[2] == "context"
+
+    def test_compiled_artifact_path_is_keyed_by_ep(
+        self, bundle_dir_with_pipeline: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Different EPContext-capable EPs compile to distinct cache artifacts.
+
+        Regression: the derived-bundle cache key must encode the execution
+        provider.  Forcing a bundle onto EP-A and later onto EP-B (both leaving
+        empty provider options, as happens when a non-native EP is forced) must
+        not let EP-A's compiled binary be reused for EP-B, which would load a
+        graph built for the wrong accelerator.
+        """
+
+        def _context_ctx_path_for(ep: str) -> Path:
+            session = GenaiSession(bundle_dir_with_pipeline, ep=ep, compile=True)
+            effective, overridden = session._apply_ep_override(session._read_genai_config())
+            captured: list[Path] = []
+
+            def _fake_compile(src, ctx, stage_key, ep_alias, ep_opts):
+                captured.append(ctx)
+                return True
+
+            monkeypatch.setattr(session, "_compile_stage", _fake_compile)
+            session._prepare_compiled_bundle(effective, overridden=overridden)
+            return next(p for p in captured if p.name.startswith("context"))
+
+        ov_ctx = _context_ctx_path_for("openvino")
+        vitis_ctx = _context_ctx_path_for("vitisai")
+
+        assert ov_ctx.name == "context_openvino_ctx.onnx"
+        assert vitis_ctx.name == "context_vitisai_ctx.onnx"
+        assert ov_ctx != vitis_ctx
+
+    def test_different_ep_does_not_reuse_cached_epcontext(
+        self, bundle_dir_with_pipeline: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A fresh cache built for one EP is not reused when a different EP is forced.
+
+        Regression companion to :meth:`test_compiled_artifact_path_is_keyed_by_ep`:
+        prime a genuinely-fresh OpenVINO cache (matching mtimes + marker with
+        empty options), then force VitisAI with identically-empty options and
+        assert both stages are recompiled rather than served from the OpenVINO
+        artifacts.
+        """
+        compiled_dir = bundle_dir_with_pipeline / "_compiled"
+        compiled_dir.mkdir()
+        for stage, src_name in (("context", "ctx.onnx"), ("iterator", "iter.onnx")):
+            ov_ctx = compiled_dir / f"{stage}_openvino_ctx.onnx"
+            ov_ctx.write_bytes(b"ep_ctx")
+            GenaiSession._write_compile_marker(ov_ctx, "openvino", {})
+            src_mtime = (bundle_dir_with_pipeline / src_name).stat().st_mtime
+            os.utime(ov_ctx, (src_mtime + 100, src_mtime + 100))
+
+        session = GenaiSession(bundle_dir_with_pipeline, ep="vitisai", compile=True)
+        effective, overridden = session._apply_ep_override(session._read_genai_config())
+        spy = MagicMock(return_value=True)
+        monkeypatch.setattr(session, "_compile_stage", spy)
+        session._prepare_compiled_bundle(effective, overridden=overridden)
+
+        # Both stages recompiled for VitisAI; the OpenVINO cache is untouched.
+        assert spy.call_count == 2
+        assert (compiled_dir / "context_openvino_ctx.onnx").exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #1025.

Previously `GenaiSession`'s `ep` argument (and `winml perf --runtime winml-genai`'s `--ep`/`--device`) was **informational only**: EP registration and pre-compilation were decided purely from the bundle's `genai_config.json` per-stage `session_options`. This PR adds an explicit override path so callers can force EP routing that differs from the bundle config, with precedence **explicit arg > bundle config**.

## What changed

### `GenaiSession`
- **`ep` default is now `None`** (was `"cpu"`), and the `"mixed"` sentinel is retired.
  - `ep=None` — **respect the bundle config** unchanged (registration + compile derive from `genai_config.json` exactly as before).
  - `ep=<concrete EP>` — **force the whole decoder pipeline onto that EP** by rewriting every stage's `provider_options`:
    - `cpu` strips hardware providers (CPU fallback; no WinML EP registration/compile).
    - a hardware EP routes every stage to it (registers the WinML EPs it needs; pre-compiles when `compile=True`). A stage's existing options are carried over only when it already targeted the same canonical EP.
- Registration and compile gates now derive from the **effective (post-override) config** via the existing generic `_bundle_uses_hardware_ep` — no hardcoded EP short-name → behavior map.
- Because `og.Config.clear_providers/append_provider` can only touch the top-level provider (not per-stage `session_options`), an override loads `og.Model` from a derived `_compiled/` bundle. `_prepare_compiled_bundle` now writes that derived bundle for override-only passes too (not just compilation).
- Invalid `ep` values raise `ValueError` (validated against the shared EP union), so an override can never silently become a no-op.

### `perf --runtime winml-genai`
- Precedence: **explicit `--ep` > concrete `--device` > respect config**. Removed `ep` from `_GENAI_IGNORED_FLAGS` (it is now honored).
- `device_to_genai_ep` returns `EPNameOrAlias | None` — `auto` (and any unrecognized device) maps to `None` (respect config), replacing the old `auto → "mixed"`.
- Reporting (`benchmark_info.ep` / device line) shows the resolved override alias, or `"config"` when respecting the bundle.

## Design notes / compatibility
- The rewrite and validation are **generic** — EPs are compared/aliased through the shared EP union (`normalize_ep_name` / `EP_NAME_TO_ALIAS` / `EP_NAMES`); the only literal provider name is the universal `cpu` fallback.
- The always-safe override direction is `cpu`. Forcing a hardware EP onto stages the bundle did not build for it (e.g. `embeddings`/`lm_head`) may fall back to JIT/CPU inside onnxruntime-genai, which is documented in the `ep` docstring.