### PR TITLE
feat(quant): add dynamic quantization pass

### DIFF
--- a/src/winml/modelkit/commands/quantize.py
+++ b/src/winml/modelkit/commands/quantize.py
@@ -91,6 +91,13 @@ console = Console()
     help="Use symmetric quantization",
 )
 @click.option(
+    "--reduce-range/--no-reduce-range",
+    default=False,
+    show_default=True,
+    help="Quantize weights with 7 bits to reduce int8 saturation on pre-VNNI "
+    "CPUs (dynamic quantization only; ignored by other precisions).",
+)
+@click.option(
     "--task",
     type=str,
     default=None,
@@ -116,6 +123,7 @@ def quantize(
     activation_type: str | None,
     per_channel: bool,
     symmetric: bool,
+    reduce_range: bool,
     task: str | None,
     model_id: str | None,
     verbose: int,
@@ -145,6 +153,9 @@ def quantize(
 
         # Dynamic quantization (no calibration data needed)
         winml quantize -m model.onnx --precision dynamic
+
+        # Dynamic quantization with int8 weights + reduced range (pre-VNNI CPUs)
+        winml quantize -m model.onnx --precision dynamic --weight-type int8 --reduce-range
 
         # RTN int4 followed by FP16 conversion (two-pass pipeline)
         winml quantize -m model.onnx --precision int4 --precision fp16
@@ -182,6 +193,8 @@ def quantize(
             per_channel = qc["per_channel"]
         if not cli_utils.is_cli_provided(ctx, "symmetric") and "symmetric" in qc:
             symmetric = qc["symmetric"]
+        if not cli_utils.is_cli_provided(ctx, "reduce_range") and "reduce_range" in qc:
+            reduce_range = qc["reduce_range"]
         if not cli_utils.is_cli_provided(ctx, "task") and "task" in qc:
             task = qc["task"]
         if not cli_utils.is_cli_provided(ctx, "model_id") and "model_id" in qc:
@@ -204,6 +217,7 @@ def quantize(
             activation_type=activation_type,
             per_channel=per_channel,
             symmetric=symmetric,
+            reduce_range=reduce_range,
             task=task,
             model_id=model_id,
             console=console,
@@ -249,6 +263,7 @@ def quantize(
             weight_type=cast('Literal["uint8", "int8", "uint16", "int16"]', resolved_weight),
             per_channel=per_channel,
             symmetric=symmetric,
+            reduce_range=reduce_range,
         )
         label = "Dynamic quantization"
         console.print(f"[bold blue]Weight type:[/bold blue] {resolved_weight}")
@@ -366,6 +381,7 @@ def _run_multi_precision(
     activation_type: str | None,
     per_channel: bool,
     symmetric: bool,
+    reduce_range: bool,
     task: str | None,
     model_id: str | None,
     console: Console,
@@ -407,6 +423,7 @@ def _run_multi_precision(
         activation_type=cast('Literal["uint8", "int8", "uint16", "int16"]', resolved_activation),
         per_channel=per_channel,
         symmetric=symmetric,
+        reduce_range=reduce_range,
         task=task,
         model_id=model_id,
     )

--- a/src/winml/modelkit/commands/quantize.py
+++ b/src/winml/modelkit/commands/quantize.py
@@ -46,9 +46,10 @@ console = Console()
 @cli_utils.precision_option(
     default=(),
     multiple=True,
-    help_text="Quantization precision: fp16, int4, int8, int16, or w{x}a{y} where "
+    help_text="Quantization precision: fp16, int4, int8, int16, dynamic, or w{x}a{y} where "
     "x in {4,8,16}, y in {8,16} (e.g., w8a8, w8a16). "
     "int4 uses RTN weight-only quantization; "
+    "dynamic uses dynamic quantization (no calibration data); "
     "fp16 converts all FP32 tensors to FP16 (no QDQ). "
     "Repeat to chain passes in order (e.g. -p int4 -p fp16)",
     optional_message="Overridden by explicit --weight-type/--activation-type",
@@ -125,7 +126,8 @@ def quantize(
 
     This command applies quantization to an ONNX model. The algorithm is
     auto-selected from the precision: int4 → RTN weight-only,
-    int8/int16/w8a8 → static QDQ, fp16 → FP16 conversion.
+    int8/int16/w8a8 → static QDQ, dynamic → dynamic quantization,
+    fp16 → FP16 conversion.
 
     Repeat --precision to chain passes in order:
     ``-p int4 -p fp16`` runs RTN int4 quantization then FP16 conversion.
@@ -140,6 +142,9 @@ def quantize(
 
         # RTN 4-bit weight-only quantization (no calibration data needed)
         winml quantize -m model.onnx --precision int4
+
+        # Dynamic quantization (no calibration data needed)
+        winml quantize -m model.onnx --precision dynamic
 
         # RTN int4 followed by FP16 conversion (two-pass pipeline)
         winml quantize -m model.onnx --precision int4 --precision fp16
@@ -232,6 +237,23 @@ def quantize(
         config = WinMLQuantizationConfig(mode="rtn", rtn_bits=rtn_bits)
         label = f"RTN {rtn_bits}-bit quantization"
 
+    elif precision_lower == "dynamic":
+        # Dynamic quantization: weights quantized statically, activation
+        # quantization parameters computed at runtime (no calibration data).
+        _warn_ignored_dynamic_options(ctx, console)
+        if output is None:
+            output = model.parent / f"{model.stem}_dynamic.onnx"
+        resolved_weight = weight_type or "uint8"
+        config = WinMLQuantizationConfig(
+            mode="dynamic",
+            weight_type=cast('Literal["uint8", "int8", "uint16", "int16"]', resolved_weight),
+            per_channel=per_channel,
+            symmetric=symmetric,
+        )
+        label = "Dynamic quantization"
+        console.print(f"[bold blue]Weight type:[/bold blue] {resolved_weight}")
+        console.print("[bold blue]Activations:[/bold blue] dynamic (computed at runtime)")
+
     else:
         # QDQ calibrated quantization
         resolved_weight, resolved_activation = _resolve_quant_types(
@@ -302,9 +324,33 @@ def _cli_precision_to_mode(precision: str) -> str:
     p = precision.lower()
     if p == "fp16":
         return "fp16"
+    if p == "dynamic":
+        return "dynamic"
     if is_weight_only_precision(p):
         return "rtn"
     return "static"
+
+
+def _warn_ignored_dynamic_options(ctx: click.Context, console: Console) -> None:
+    """Warn about calibration/activation options that dynamic quantization ignores.
+
+    Dynamic quantization honours ``--weight-type``, ``--per-channel`` and
+    ``--symmetric`` but derives activation quantization at runtime, so it never
+    uses calibration samples/method/task or an explicit activation type.
+    """
+    checks = [
+        ("samples", "--samples"),
+        ("method", "--method"),
+        ("activation_type", "--activation-type"),
+        ("task", "--task"),
+        ("model_id", "--model-id"),
+    ]
+    ignored = [flag for param, flag in checks if cli_utils.is_cli_provided(ctx, param)]
+    if ignored:
+        console.print(
+            f"[yellow]Warning:[/yellow] {', '.join(ignored)} ignored — "
+            "dynamic quantization does not use calibration data."
+        )
 
 
 def _run_multi_precision(

--- a/src/winml/modelkit/quant/__init__.py
+++ b/src/winml/modelkit/quant/__init__.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING, Any
 
 from .calibration import get_quant_finalizer
 from .config import QuantizeResult, WinMLQuantizationConfig
-from .passes import BaseQuantPass, FP16Pass, RTNPass, StaticPass
+from .passes import BaseQuantPass, DynamicPass, FP16Pass, RTNPass, StaticPass
 
 
 if TYPE_CHECKING:
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "BaseQuantPass",
+    "DynamicPass",
     "FP16Pass",
     "QuantizeResult",
     "Quantizer",

--- a/src/winml/modelkit/quant/config.py
+++ b/src/winml/modelkit/quant/config.py
@@ -56,7 +56,8 @@ class WinMLQuantizationConfig:
     # Quantization mode
     mode: Literal["static", "dynamic", "rtn", "fp16"] = "static"
     # "static"  — Calibrated QDQ quantization (requires calibration data)
-    # "dynamic" — Dynamic quantization (no calibration) [planned, not yet wired]
+    # "dynamic" — Dynamic quantization: weights quantized statically, activations
+    #             at runtime (no calibration data)
     # "rtn"     — Round-To-Nearest weight-only (no calibration, block-wise)
     # "fp16"    — Pure FP16 conversion only (no quantization)
 
@@ -110,6 +111,11 @@ class WinMLQuantizationConfig:
     rtn_symmetric: bool = True
     rtn_accuracy_level: int = 0
 
+    # Dynamic-specific settings (only used when mode="dynamic")
+    # Quantize weights with 7 bits instead of 8 to avoid numerical saturation
+    # of the u8*s8 accumulation on CPUs without VNNI instructions.
+    reduce_range: bool = False
+
     # FP16 conversion settings (only used when mode="fp16")
     fp16_keep_io_types: bool = True
     fp16_op_block_list: list[str] | None = None
@@ -157,6 +163,8 @@ class WinMLQuantizationConfig:
             result["rtn_block_size"] = self.rtn_block_size
             result["rtn_symmetric"] = self.rtn_symmetric
             result["rtn_accuracy_level"] = self.rtn_accuracy_level
+        if self.mode == "dynamic":
+            result["reduce_range"] = self.reduce_range
         if self.mode == "fp16":
             result["fp16_keep_io_types"] = self.fp16_keep_io_types
             result["fp16_op_block_list"] = self.fp16_op_block_list
@@ -206,6 +214,7 @@ class WinMLQuantizationConfig:
             rtn_block_size=data.get("rtn_block_size", 128),
             rtn_symmetric=data.get("rtn_symmetric", True),
             rtn_accuracy_level=data.get("rtn_accuracy_level", 0),
+            reduce_range=data.get("reduce_range", False),
             fp16_keep_io_types=data.get("fp16_keep_io_types", True),
             fp16_op_block_list=data.get("fp16_op_block_list"),
         )

--- a/src/winml/modelkit/quant/passes/__init__.py
+++ b/src/winml/modelkit/quant/passes/__init__.py
@@ -5,6 +5,7 @@
 """Quantization passes sub-package."""
 
 from .base import BaseQuantPass
+from .dynamic import DynamicPass
 from .fp16 import FP16Pass
 from .rtn import RTNPass
 from .static import StaticPass
@@ -12,6 +13,7 @@ from .static import StaticPass
 
 __all__ = [
     "BaseQuantPass",
+    "DynamicPass",
     "FP16Pass",
     "RTNPass",
     "StaticPass",

--- a/src/winml/modelkit/quant/passes/dynamic.py
+++ b/src/winml/modelkit/quant/passes/dynamic.py
@@ -32,6 +32,11 @@ logger = logging.getLogger(__name__)
 #   - DequantizeLinear: restores a statically-quantized weight/embedding back to
 #     float when it is consumed by a non-integer op (e.g. an embedding Gather
 #     feeding an Add). This is empirically confirmed on embedding models.
+# Including DequantizeLinear makes the count a heuristic: a DQL node could in
+# principle originate from something other than a quantized-weight restore, so
+# ``nodes_quantized`` may slightly over-count. That is acceptable because it is a
+# reporting metric only (not correctness-critical), analogous to — if fuzzier
+# than — the static pass's QDQ-op count.
 # QuantizeLinear is intentionally excluded: quantize_dynamic emits
 # DynamicQuantizeLinear (not QuantizeLinear) for activations and stores weights
 # as pre-quantized initializers, so a static QuantizeLinear never appears in its

--- a/src/winml/modelkit/quant/passes/dynamic.py
+++ b/src/winml/modelkit/quant/passes/dynamic.py
@@ -1,0 +1,191 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Dynamic quantization pass."""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .base import BaseQuantPass
+
+
+if TYPE_CHECKING:
+    from ..config import QuantizeResult, WinMLQuantizationConfig
+
+
+logger = logging.getLogger(__name__)
+
+
+# ONNX operator types introduced by dynamic quantization (QOperator format).
+# Counting these gives a universal, architecture-agnostic measure of how many
+# nodes were quantized — analogous to how the static pass counts QDQ ops. The
+# integer-op / DynamicQuantizeLinear markers are standard ai.onnx operators, so
+# this stays model-agnostic (no architecture-specific names).
+_DYNAMIC_QUANT_OP_TYPES: frozenset[str] = frozenset(
+    {
+        "DynamicQuantizeLinear",
+        "MatMulInteger",
+        "ConvInteger",
+        "QuantizeLinear",
+        "DequantizeLinear",
+    }
+)
+
+
+class DynamicPass(BaseQuantPass):
+    """Dynamic quantization pass.
+
+    Statically quantizes weights while activation quantization parameters are
+    computed dynamically at inference time, so **no calibration data is
+    required**. Uses ONNX Runtime's ``quantize_dynamic`` which emits QOperator
+    nodes (``DynamicQuantizeLinear`` / ``MatMulInteger`` / ``ConvInteger``).
+
+    Reads from :class:`~winml.modelkit.quant.config.WinMLQuantizationConfig`:
+
+    - ``weight_type`` — ``uint8`` → ``QUInt8``, ``int8`` → ``QInt8``. Dynamic
+      quantization only supports 8-bit weights; 16-bit values fall back to
+      ``int8`` with a warning.
+    - ``per_channel`` — per-channel weight quantization.
+    - ``reduce_range`` — quantize weights with 7 bits to avoid saturation on
+      pre-VNNI CPUs.
+    - ``weight_symmetric`` / ``symmetric`` — symmetric weight quantization
+      (activations are always dynamic/asymmetric).
+    - ``op_types_to_quantize`` — op types to quantize (``None`` = ORT default).
+    - ``nodes_to_exclude`` — node names to skip.
+
+    Example::
+
+        pass_ = DynamicPass(config)
+        result = pass_.run("model.onnx", "model_dynamic.onnx")
+    """
+
+    def __init__(self, config: WinMLQuantizationConfig) -> None:
+        super().__init__(config)
+
+    def run(
+        self,
+        model_path: Path,
+        output_path: Path,
+        *,
+        use_external_data: bool = True,
+    ) -> QuantizeResult:
+        """Apply dynamic quantization to *model_path*."""
+        from onnxruntime.quantization import QuantType, quantize_dynamic
+        from onnxruntime.quantization.quant_utils import add_pre_process_metadata
+
+        from ...onnx import (
+            capture_metadata,
+            infer_shapes,
+            load_onnx,
+            restore_metadata,
+            save_onnx,
+        )
+        from ..config import QuantizeResult
+
+        if self._config.calibration_data is not None:
+            logger.warning(
+                "calibration_data is set but this is a DynamicPass"
+                " — calibration data will be ignored."
+            )
+
+        start_time = time.perf_counter()
+        errors: list[str] = []
+        warnings: list[str] = []
+
+        # Dynamic quantization only supports 8-bit weights.
+        weight_type_map = {
+            "uint8": QuantType.QUInt8,
+            "int8": QuantType.QInt8,
+        }
+        weight_type = weight_type_map.get(self._config.weight_type)
+        if weight_type is None:
+            msg = (
+                "Dynamic quantization supports only 8-bit weights; "
+                f"weight_type={self._config.weight_type!r} is unsupported "
+                "— falling back to int8."
+            )
+            logger.warning(msg)
+            warnings.append(msg)
+            weight_type = QuantType.QInt8
+
+        weight_symmetric = (
+            self._config.weight_symmetric
+            if self._config.weight_symmetric is not None
+            else self._config.symmetric
+        )
+        extra_options = {"WeightSymmetric": weight_symmetric}
+
+        logger.info(
+            "Running dynamic quantization (weight_type=%s, per_channel=%s, reduce_range=%s)...",
+            weight_type,
+            self._config.per_channel,
+            self._config.reduce_range,
+        )
+
+        input_model = load_onnx(model_path, validate=False)
+        metadata_snapshot = capture_metadata(input_model)
+        add_pre_process_metadata(input_model)
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        abs_model_output = str(Path(output_path).resolve())
+        if output_path.exists():
+            output_path.unlink()
+        stale_sidecar = output_path.parent / f"{output_path.name}.data"
+        if stale_sidecar.exists():
+            stale_sidecar.unlink()
+
+        # ORT writes external-data sidecars relative to the cwd, so run from the
+        # output directory (mirrors StaticPass) to keep the .data file adjacent.
+        original_cwd = Path.cwd()
+        try:
+            os.chdir(output_path.parent)
+            quantize_dynamic(
+                model_input=input_model,
+                model_output=abs_model_output,
+                weight_type=weight_type,
+                per_channel=self._config.per_channel,
+                reduce_range=self._config.reduce_range,
+                op_types_to_quantize=self._config.op_types_to_quantize,
+                nodes_to_exclude=self._config.nodes_to_exclude or [],
+                use_external_data_format=use_external_data,
+                extra_options=extra_options,
+            )
+        finally:
+            os.chdir(original_cwd)
+
+        quantized_model = load_onnx(output_path, validate=False)
+
+        logger.info("Running shape inference on quantized model...")
+        quantized_model = infer_shapes(quantized_model)
+
+        if metadata_snapshot.node_count > 0:
+            logger.info("Restoring metadata from pre-quantization model...")
+            restore_metadata(quantized_model, metadata_snapshot)
+
+        nodes_quantized = sum(
+            1 for node in quantized_model.graph.node if node.op_type in _DYNAMIC_QUANT_OP_TYPES
+        )
+
+        save_onnx(quantized_model, output_path, use_external_data=use_external_data)
+
+        total_time = time.perf_counter() - start_time
+        logger.info(
+            "Dynamic quantization complete: %s -> %s (%.2fs)",
+            model_path.name,
+            output_path.name,
+            total_time,
+        )
+        return QuantizeResult(
+            success=True,
+            output_path=output_path,
+            total_time_seconds=total_time,
+            nodes_quantized=nodes_quantized,
+            errors=errors,
+            warnings=warnings,
+        )

--- a/src/winml/modelkit/quant/passes/dynamic.py
+++ b/src/winml/modelkit/quant/passes/dynamic.py
@@ -24,15 +24,23 @@ logger = logging.getLogger(__name__)
 
 # ONNX operator types introduced by dynamic quantization (QOperator format).
 # Counting these gives a universal, architecture-agnostic measure of how many
-# nodes were quantized — analogous to how the static pass counts QDQ ops. The
-# integer-op / DynamicQuantizeLinear markers are standard ai.onnx operators, so
-# this stays model-agnostic (no architecture-specific names).
+# nodes were quantized — analogous to how the static pass counts QDQ ops. These
+# are all standard ai.onnx operators, so this stays model-agnostic (no
+# architecture-specific names):
+#   - DynamicQuantizeLinear: runtime activation quantization.
+#   - MatMulInteger / ConvInteger: integer compute over quantized operands.
+#   - DequantizeLinear: restores a statically-quantized weight/embedding back to
+#     float when it is consumed by a non-integer op (e.g. an embedding Gather
+#     feeding an Add). This is empirically confirmed on embedding models.
+# QuantizeLinear is intentionally excluded: quantize_dynamic emits
+# DynamicQuantizeLinear (not QuantizeLinear) for activations and stores weights
+# as pre-quantized initializers, so a static QuantizeLinear never appears in its
+# output.
 _DYNAMIC_QUANT_OP_TYPES: frozenset[str] = frozenset(
     {
         "DynamicQuantizeLinear",
         "MatMulInteger",
         "ConvInteger",
-        "QuantizeLinear",
         "DequantizeLinear",
     }
 )

--- a/src/winml/modelkit/quant/quantizer.py
+++ b/src/winml/modelkit/quant/quantizer.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any
 
 from .config import QuantizeResult, WinMLQuantizationConfig
-from .passes import BaseQuantPass, FP16Pass, RTNPass, StaticPass
+from .passes import BaseQuantPass, DynamicPass, FP16Pass, RTNPass, StaticPass
 
 
 logger = logging.getLogger(__name__)
@@ -41,7 +41,7 @@ def expand_precision(
     ``fp16``      ``[FP16Pass(config)]``
     ``rtn``       ``[RTNPass(config)]``
     ``static``    ``[StaticPass(config)]``
-    ``dynamic``   ``[StaticPass(config)]``  (placeholder until DynamicPass is implemented)
+    ``dynamic``   ``[DynamicPass(config)]``
     ============= =======================
 
     Args:
@@ -64,7 +64,7 @@ def expand_precision(
         "fp16": FP16Pass,
         "rtn": RTNPass,
         "static": StaticPass,
-        "dynamic": StaticPass,
+        "dynamic": DynamicPass,
     }
 
     if effective_precision in _pass_types:
@@ -285,7 +285,9 @@ def quantize_onnx(
 
     - ``"fp16"`` — FP16 conversion (no quantization)
     - ``"rtn"`` — RTN weight-only quantization
-    - ``"static"`` / ``"dynamic"`` — QDQ calibrated quantization
+    - ``"static"`` — QDQ calibrated quantization (requires calibration data)
+    - ``"dynamic"`` — dynamic quantization (weights static, activations at
+      runtime; no calibration data)
 
     Args:
         model_path: Path to input ONNX model.

--- a/tests/e2e/test_quantize_e2e.py
+++ b/tests/e2e/test_quantize_e2e.py
@@ -186,6 +186,7 @@ def onnx_dinov2() -> Path:
 
 
 _QDQ_OPS = {"QuantizeLinear", "DequantizeLinear"}
+_DYNAMIC_QUANT_OPS = {"DynamicQuantizeLinear", "MatMulInteger", "ConvInteger"}
 
 
 def _dtype_of_init(model: onnx.ModelProto, name: str) -> int:
@@ -299,6 +300,46 @@ def _assert_quantized_output(
     return model
 
 
+def _assert_dynamic_quantized_output(
+    *,
+    input_onnx: Path,
+    output_onnx: Path,
+) -> onnx.ModelProto:
+    """Structural assertions for a dynamically quantized model.
+
+    Dynamic quantization emits QOperator-format ops (DynamicQuantizeLinear +
+    MatMulInteger/ConvInteger) rather than QDQ nodes, so it needs its own
+    assertions instead of ``_assert_quantized_output``.
+    """
+    model = onnx.load(str(output_onnx))
+
+    dyn_count = sum(1 for n in model.graph.node if n.op_type in _DYNAMIC_QUANT_OPS)
+    assert dyn_count >= 1, f"no dynamic-quant nodes: {[n.op_type for n in model.graph.node]}"
+    # Dynamic quantization must not emit static QDQ nodes.
+    assert not any(n.op_type in _QDQ_OPS for n in model.graph.node)
+
+    onnx.checker.check_model(model, full_check=True)
+
+    input_model = onnx.load(str(input_onnx))
+    assert [i.name for i in model.graph.input] == [i.name for i in input_model.graph.input]
+    assert [o.name for o in model.graph.output] == [o.name for o in input_model.graph.output]
+
+    # ORT-CPU runs and produces finite outputs.
+    sess = ort.InferenceSession(str(output_onnx), providers=["CPUExecutionProvider"])
+    rng = np.random.default_rng(11)
+    feed = {
+        inp.name: rng.standard_normal(
+            [d if isinstance(d, int) and d > 0 else 1 for d in inp.shape]
+        ).astype(np.float32)
+        for inp in sess.get_inputs()
+    }
+    for arr in sess.run(None, feed):
+        if np.issubdtype(arr.dtype, np.floating):
+            assert np.isfinite(arr).all()
+
+    return model
+
+
 def _invoke(runner: CliRunner, args: list[str], *, expect_success: bool = True):
     result = runner.invoke(quantize_cmd, args, obj={}, catch_exceptions=True)
     if expect_success and result.exit_code != 0:
@@ -396,10 +437,18 @@ class TestPrecision:
         assert r.exit_code == 0
         assert out.exists()
 
-
-# ===========================================================================
-# Calibration method
-# ===========================================================================
+    def test_dynamic_precision_accepted(self, runner: CliRunner, tiny_onnx: Path, tmp_path: Path):
+        """`--precision dynamic` runs dynamic quantization (no calibration data)."""
+        out = tmp_path / "a7.onnx"
+        r = _invoke(
+            runner,
+            ["-m", str(tiny_onnx), "-o", str(out), "--precision", "dynamic"],
+        )
+        assert r.exit_code == 0
+        assert out.exists()
+        model = _assert_dynamic_quantized_output(input_onnx=tiny_onnx, output_onnx=out)
+        # Weights are quantized statically -> MatMul becomes MatMulInteger.
+        assert any(n.op_type == "MatMulInteger" for n in model.graph.node)
 
 
 class TestCalibrationMethod:

--- a/tests/e2e/test_quantize_e2e.py
+++ b/tests/e2e/test_quantize_e2e.py
@@ -105,6 +105,42 @@ def tiny_onnx_external(tmp_path_factory: pytest.TempPathFactory) -> Path:
     return p
 
 
+@pytest.fixture(scope="session")
+def tiny_embed_onnx(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Embedding model where a Gather feeds a non-integer op (Add).
+
+    Dynamic quantization stores the embedding table as int8 and must insert a
+    ``DequantizeLinear`` to restore it to float before the Add — mirroring how
+    real transformer encoders (word + position embeddings) quantize. This
+    exercises the ``DequantizeLinear`` counting path that plain MatMul-only
+    models never hit.
+    """
+    d = tmp_path_factory.mktemp("tiny_embed")
+    p = d / "tiny_embed.onnx"
+    rng = np.random.default_rng(7)
+    vocab, dim, hidden = 64, 32, 16
+    input_ids = onnx.helper.make_tensor_value_info("input_ids", onnx.TensorProto.INT64, [1, 8])
+    y = onnx.helper.make_tensor_value_info("output", onnx.TensorProto.FLOAT, [1, 8, hidden])
+    emb = onnx.numpy_helper.from_array(
+        rng.standard_normal((vocab, dim), dtype=np.float32), "embedding_table"
+    )
+    pos = onnx.numpy_helper.from_array(rng.standard_normal((1, 8, dim), dtype=np.float32), "pos")
+    w = onnx.numpy_helper.from_array(rng.standard_normal((dim, hidden), dtype=np.float32), "W")
+    b = onnx.numpy_helper.from_array(rng.standard_normal((hidden,), dtype=np.float32), "B")
+    nodes = [
+        onnx.helper.make_node("Gather", ["embedding_table", "input_ids"], ["emb"]),
+        onnx.helper.make_node("Add", ["emb", "pos"], ["emb_pos"]),
+        onnx.helper.make_node("MatMul", ["emb_pos", "W"], ["mm"]),
+        onnx.helper.make_node("Add", ["mm", "B"], ["output"]),
+    ]
+    graph = onnx.helper.make_graph(nodes, "tiny_embed", [input_ids], [y], [emb, pos, w, b])
+    model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 17)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    onnx.save(model, str(p))
+    return p
+
+
 # ---------------------------------------------------------------------------
 # Real HF-exported ONNX fixtures for per-task calibration dataset coverage
 #
@@ -449,6 +485,36 @@ class TestPrecision:
         model = _assert_dynamic_quantized_output(input_onnx=tiny_onnx, output_onnx=out)
         # Weights are quantized statically -> MatMul becomes MatMulInteger.
         assert any(n.op_type == "MatMulInteger" for n in model.graph.node)
+
+    def test_dynamic_precision_embedding_emits_dequantizelinear(
+        self, runner: CliRunner, tiny_embed_onnx: Path, tmp_path: Path
+    ):
+        """Dynamic quant of an embedding feeding a non-integer op emits a
+        DequantizeLinear (counted as a quantized node) but never a static
+        QuantizeLinear."""
+        out = tmp_path / "a8.onnx"
+        r = _invoke(
+            runner,
+            ["-m", str(tiny_embed_onnx), "-o", str(out), "--precision", "dynamic"],
+        )
+        assert r.exit_code == 0
+        assert out.exists()
+
+        model = onnx.load(str(out))
+        ops = [n.op_type for n in model.graph.node]
+        # Quantized embedding restored to float before the Add.
+        assert "DequantizeLinear" in ops, ops
+        # Dynamic quantization must not emit a static QuantizeLinear.
+        assert "QuantizeLinear" not in ops, ops
+        # Still exercises the integer compute path.
+        assert "MatMulInteger" in ops, ops
+        onnx.checker.check_model(model, full_check=True)
+
+        # Runs under ORT-CPU with valid token indices (< vocab size 64).
+        sess = ort.InferenceSession(str(out), providers=["CPUExecutionProvider"])
+        feed = {"input_ids": np.array([[0, 1, 2, 3, 4, 5, 6, 7]], dtype=np.int64)}
+        outs = sess.run(None, feed)
+        assert np.isfinite(outs[0]).all()
 
 
 class TestCalibrationMethod:

--- a/tests/unit/commands/test_boolean_flag_pairs.py
+++ b/tests/unit/commands/test_boolean_flag_pairs.py
@@ -102,7 +102,17 @@ from winml.modelkit.commands.serve import serve
                 "--no-allow-unsupported-nodes",
             ],
         ),
-        (quantize, ["--per-channel", "--no-per-channel", "--symmetric", "--no-symmetric"]),
+        (
+            quantize,
+            [
+                "--per-channel",
+                "--no-per-channel",
+                "--symmetric",
+                "--no-symmetric",
+                "--reduce-range",
+                "--no-reduce-range",
+            ],
+        ),
         (serve, ["--multi", "--no-multi"]),
     ],
 )
@@ -147,6 +157,7 @@ class TestDefaultValues:
             (perf, "monitor", False),
             (quantize, "per_channel", False),
             (quantize, "symmetric", False),
+            (quantize, "reduce_range", False),
             (serve, "multi", False),
             (serve, "auto_reload", False),
             # Group C: negative-to-positive flags default True
@@ -203,6 +214,7 @@ class TestFlagValueParsing:
             (perf, "--monitor", "monitor", True),
             (quantize, "--per-channel", "per_channel", True),
             (quantize, "--symmetric", "symmetric", True),
+            (quantize, "--reduce-range", "reduce_range", True),
             (serve, "--multi", "multi", True),
             (serve, "--auto-reload", "auto_reload", True),
             # Negative form sets False
@@ -231,6 +243,7 @@ class TestFlagValueParsing:
             (perf, "--no-monitor", "monitor", False),
             (quantize, "--no-per-channel", "per_channel", False),
             (quantize, "--no-symmetric", "symmetric", False),
+            (quantize, "--no-reduce-range", "reduce_range", False),
             (serve, "--no-multi", "multi", False),
             (serve, "--no-auto-reload", "auto_reload", False),
             # Backward compat: --clean-onnx (deprecated alias for --no-hierarchy)

--- a/tests/unit/test_quant_passes.py
+++ b/tests/unit/test_quant_passes.py
@@ -547,6 +547,41 @@ class TestDynamicPassConfig:
         assert init_kwargs["weight_type"] == QuantType.QInt8
         assert any("8-bit" in w for w in result.warnings)
 
+    def test_dequantizelinear_counted_but_quantizelinear_not(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """DequantizeLinear (weight/embedding restore) is counted as a quantized
+        node; a stray static QuantizeLinear is not.
+
+        Embedding models emit DequantizeLinear when a statically-quantized
+        embedding feeds a non-integer op (e.g. Gather -> Add), so it must count
+        toward ``nodes_quantized``. QuantizeLinear never appears in
+        ``quantize_dynamic`` output and must be ignored.
+        """
+        config = WinMLQuantizationConfig(mode="dynamic")
+        model_path = tmp_path / "model.onnx"
+        model_path.write_text("x")
+
+        init_kwargs: dict = {}
+        _patch_quantize_dynamic(monkeypatch, init_kwargs)
+        fake_model = SimpleNamespace(
+            graph=SimpleNamespace(
+                node=[
+                    SimpleNamespace(op_type="DynamicQuantizeLinear"),
+                    SimpleNamespace(op_type="MatMulInteger"),
+                    SimpleNamespace(op_type="DequantizeLinear"),
+                    SimpleNamespace(op_type="QuantizeLinear"),  # must NOT count
+                    SimpleNamespace(op_type="Add"),
+                ]
+            )
+        )
+        _install_fake_onnx_for_dynamic(monkeypatch, fake_model)
+
+        result = DynamicPass(config).run(model_path, tmp_path / "out.onnx")
+        # DynamicQuantizeLinear + MatMulInteger + DequantizeLinear = 3.
+        # QuantizeLinear and Add are excluded.
+        assert result.nodes_quantized == 3
+
 
 # ---------------------------------------------------------------------------
 # WinMLQuantizationConfig — dynamic serialization

--- a/tests/unit/test_quant_passes.py
+++ b/tests/unit/test_quant_passes.py
@@ -14,7 +14,7 @@ import pytest
 
 from winml.modelkit.quant import WinMLQuantizationConfig
 from winml.modelkit.quant.config import QuantizeResult
-from winml.modelkit.quant.passes import BaseQuantPass, FP16Pass, RTNPass, StaticPass
+from winml.modelkit.quant.passes import BaseQuantPass, DynamicPass, FP16Pass, RTNPass, StaticPass
 
 
 if TYPE_CHECKING:
@@ -89,13 +89,14 @@ class TestExpandPrecision:
         assert len(passes) == 1
         assert isinstance(passes[0], StaticPass)
 
-    def test_dynamic_returns_qdq_pass(self) -> None:
+    def test_dynamic_returns_dynamic_pass(self) -> None:
         from winml.modelkit.quant.quantizer import expand_precision
 
-        config = WinMLQuantizationConfig(mode="static")
+        config = WinMLQuantizationConfig(mode="dynamic")
         passes = expand_precision("dynamic", config)
         assert len(passes) == 1
-        assert isinstance(passes[0], StaticPass)
+        assert isinstance(passes[0], DynamicPass)
+        assert passes[0].config is config
 
     def test_unknown_mode_raises(self) -> None:
         from winml.modelkit.quant.quantizer import expand_precision
@@ -411,3 +412,154 @@ class TestRTNPassConfig:
 
         RTNPass(config).run(model_path, tmp_path / "out.onnx")
         assert init_kwargs[0]["accuracy_level"] is None
+
+
+# ---------------------------------------------------------------------------
+# DynamicPass — config field wiring
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_onnx_for_dynamic(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_model: Any,
+) -> None:
+    """Install a fake ``winml.modelkit.onnx`` so DynamicPass needs no real I/O."""
+    fake_onnx_mod = ModuleType("winml.modelkit.onnx")
+    fake_onnx_mod.load_onnx = lambda *a, **k: fake_model  # type: ignore[attr-defined]
+    fake_onnx_mod.save_onnx = lambda *a, **k: None  # type: ignore[attr-defined]
+    fake_onnx_mod.capture_metadata = (  # type: ignore[attr-defined]
+        lambda m: SimpleNamespace(node_count=len(m.graph.node))
+    )
+    fake_onnx_mod.restore_metadata = lambda *a, **k: None  # type: ignore[attr-defined]
+    fake_onnx_mod.infer_shapes = lambda m: m  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "winml.modelkit.onnx", fake_onnx_mod)
+
+
+def _patch_quantize_dynamic(
+    monkeypatch: pytest.MonkeyPatch,
+    init_kwargs: dict,
+) -> None:
+    """Patch the real ``quantize_dynamic``/``add_pre_process_metadata`` with no-ops."""
+    import onnxruntime.quantization as oq
+    import onnxruntime.quantization.quant_utils as oqu
+
+    def fake_quantize_dynamic(**kwargs: Any) -> None:
+        init_kwargs.update(kwargs)
+
+    monkeypatch.setattr(oq, "quantize_dynamic", fake_quantize_dynamic)
+    monkeypatch.setattr(oqu, "add_pre_process_metadata", lambda *a, **k: None)
+
+
+class TestDynamicPassConfig:
+    def test_reads_dynamic_fields_from_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """DynamicPass should forward config fields to quantize_dynamic."""
+        from onnxruntime.quantization import QuantType
+
+        config = WinMLQuantizationConfig(
+            mode="dynamic",
+            weight_type="int8",
+            per_channel=True,
+            reduce_range=True,
+            symmetric=True,
+            op_types_to_quantize=["MatMul"],
+            nodes_to_exclude=["skip_me"],
+        )
+        model_path = tmp_path / "model.onnx"
+        model_path.write_text("x")
+        output_path = tmp_path / "out.onnx"
+
+        init_kwargs: dict = {}
+        _patch_quantize_dynamic(monkeypatch, init_kwargs)
+        fake_model = SimpleNamespace(
+            graph=SimpleNamespace(
+                node=[
+                    SimpleNamespace(op_type="MatMulInteger"),
+                    SimpleNamespace(op_type="DynamicQuantizeLinear"),
+                    SimpleNamespace(op_type="Add"),
+                ]
+            )
+        )
+        _install_fake_onnx_for_dynamic(monkeypatch, fake_model)
+
+        result = DynamicPass(config).run(model_path, output_path)
+
+        assert result.success
+        assert init_kwargs["weight_type"] == QuantType.QInt8
+        assert init_kwargs["per_channel"] is True
+        assert init_kwargs["reduce_range"] is True
+        assert init_kwargs["op_types_to_quantize"] == ["MatMul"]
+        assert init_kwargs["nodes_to_exclude"] == ["skip_me"]
+        assert init_kwargs["extra_options"]["WeightSymmetric"] is True
+        # Only the two dynamic-quant ops are counted, not the Add.
+        assert result.nodes_quantized == 2
+
+    def test_weight_symmetric_override_takes_precedence(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config = WinMLQuantizationConfig(
+            mode="dynamic",
+            symmetric=False,
+            weight_symmetric=True,
+        )
+        model_path = tmp_path / "model.onnx"
+        model_path.write_text("x")
+
+        init_kwargs: dict = {}
+        _patch_quantize_dynamic(monkeypatch, init_kwargs)
+        _install_fake_onnx_for_dynamic(monkeypatch, SimpleNamespace(graph=SimpleNamespace(node=[])))
+
+        DynamicPass(config).run(model_path, tmp_path / "out.onnx")
+        assert init_kwargs["extra_options"]["WeightSymmetric"] is True
+
+    def test_uint8_weight_maps_to_quint8(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from onnxruntime.quantization import QuantType
+
+        config = WinMLQuantizationConfig(mode="dynamic", weight_type="uint8")
+        model_path = tmp_path / "model.onnx"
+        model_path.write_text("x")
+
+        init_kwargs: dict = {}
+        _patch_quantize_dynamic(monkeypatch, init_kwargs)
+        _install_fake_onnx_for_dynamic(monkeypatch, SimpleNamespace(graph=SimpleNamespace(node=[])))
+
+        DynamicPass(config).run(model_path, tmp_path / "out.onnx")
+        assert init_kwargs["weight_type"] == QuantType.QUInt8
+
+    def test_16bit_weight_falls_back_to_int8_with_warning(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Dynamic quantization only supports 8-bit weights."""
+        from onnxruntime.quantization import QuantType
+
+        config = WinMLQuantizationConfig(mode="dynamic", weight_type="int16")
+        model_path = tmp_path / "model.onnx"
+        model_path.write_text("x")
+
+        init_kwargs: dict = {}
+        _patch_quantize_dynamic(monkeypatch, init_kwargs)
+        _install_fake_onnx_for_dynamic(monkeypatch, SimpleNamespace(graph=SimpleNamespace(node=[])))
+
+        result = DynamicPass(config).run(model_path, tmp_path / "out.onnx")
+        assert init_kwargs["weight_type"] == QuantType.QInt8
+        assert any("8-bit" in w for w in result.warnings)
+
+
+# ---------------------------------------------------------------------------
+# WinMLQuantizationConfig — dynamic serialization
+# ---------------------------------------------------------------------------
+
+
+class TestDynamicConfigSerialization:
+    def test_reduce_range_round_trips_in_dynamic_mode(self) -> None:
+        config = WinMLQuantizationConfig(mode="dynamic", reduce_range=True)
+        data = config.to_dict()
+        assert data["reduce_range"] is True
+        assert WinMLQuantizationConfig.from_dict(data).reduce_range is True
+
+    def test_reduce_range_omitted_for_non_dynamic_modes(self) -> None:
+        config = WinMLQuantizationConfig(mode="static", reduce_range=True)
+        assert "reduce_range" not in config.to_dict()


### PR DESCRIPTION
## Summary

Implements a real **dynamic quantization** pass in the `winml quantize` module. Previously `mode="dynamic"` existed in config but was a placeholder that silently routed to `StaticPass`.

Dynamic quantization quantizes **weights statically** (INT8) while **activation quantization parameters are computed at runtime** — so **no calibration data is required**. It emits QOperator-format ops (`DynamicQuantizeLinear` / `MatMulInteger` / `ConvInteger`) rather than QDQ nodes.

## Changes

- **New `DynamicPass`** (`quant/passes/dynamic.py`) wrapping ONNX Runtime's `quantize_dynamic`. Preserves model metadata, runs shape inference, and counts quantized nodes universally (no hardcoded/architecture-specific logic). Supports only 8-bit weights; 16-bit `weight_type` falls back to int8 with a warning.
- **Wired into the pass pipeline** (`quantizer.py`): `expand_precision` now maps `mode="dynamic"` → `DynamicPass` instead of `StaticPass`.
- **Config** (`config.py`): added `reduce_range` field with `to_dict`/`from_dict` round-trip (only serialized in dynamic mode).
- **CLI** (`commands/quantize.py`): new `winml quantize --precision dynamic` token. Honors `--weight-type` / `--per-channel` / `--symmetric`; warns that calibration-only options (`--samples`, `--method`, `--activation-type`, `--task`, `--model-id`) are ignored.
- **Exports** added in both `quant/__init__.py` and `quant/passes/__init__.py`.

## Behavior

| | Static | Dynamic |
|---|---|---|
| Weights | offline INT8 | offline INT8 |
| Activations | offline (needs calibration) | **runtime (no calibration)** |
| ONNX ops | QDQ | QOperator (DynamicQuantizeLinear / MatMulInteger / ConvInteger) |

Usage:
```
winml quantize -m model.onnx --precision dynamic
```

## Tests

- **Unit** (`tests/unit/test_quant_passes.py`): arg forwarding to `quantize_dynamic`, `WeightSymmetric` override, uint8/int8 mapping, 16-bit → int8 fallback warning, and `reduce_range` config serialization. Also updated the `expand_precision("dynamic")` routing test to assert `DynamicPass`.
- **E2E** (`tests/e2e/test_quantize_e2e.py`): `--precision dynamic` runs end-to-end, output contains `MatMulInteger`/`DynamicQuantizeLinear`, no QDQ nodes, passes `onnx.checker`, and runs under ORT-CPU.

Verification: unit quant passes + quantizer (31 passed), e2e `TestPrecision` (7 passed), precision + CLI-flags + integration (231 passed); `ruff check` clean.