### PR TITLE
Fix genai --compile fallback to use relative mirrored ONNX path

### DIFF
--- a/src/winml/modelkit/session/genai_session.py
+++ b/src/winml/modelkit/session/genai_session.py
@@ -707,6 +707,14 @@ class GenaiSession:
         compiled_dir.mkdir(exist_ok=True)
         modified_cfg = self._read_genai_config()
         any_compiled = False
+        # Original stage ONNX filenames that were replaced by a compiled
+        # EPContext artifact (``{stage_key}_ctx.onnx``) and so must NOT be
+        # mirrored into compiled_dir.  Stages that fall back to (or already are)
+        # their original ONNX are deliberately left out so that
+        # :meth:`_mirror_non_onnx_files` links them (and their weights sidecars)
+        # in — ort-genai resolves stage filenames relative to compiled_dir, so
+        # the file must physically live there.
+        compiled_stage_filenames: set[str] = set()
 
         for stage_key, onnx_filename, ep_alias, ep_opts in compilable_stages:
             src_onnx = self._bundle_dir / onnx_filename
@@ -718,15 +726,17 @@ class GenaiSession:
                 # Use just the filename — genai_config.json lives in compiled_dir,
                 # so ort-genai resolves filenames relative to compiled_dir.
                 self._patch_stage_filename(modified_cfg, stage_key, ctx_onnx.name)
+                compiled_stage_filenames.add(onnx_filename)
                 any_compiled = True
                 continue
 
             # A stage whose source ONNX is already an EPContext (pre-compiled)
-            # model needs no recompilation; point ort-genai at the original file
-            # (absolute path, since compiled stages are not mirrored into
-            # compiled_dir). A parse failure is treated as "not compiled" so a
-            # malformed source falls through to the normal compile path, which
-            # has its own error handling.
+            # model needs no recompilation; reference the original file by its
+            # bundle-relative filename and let :meth:`_mirror_non_onnx_files`
+            # link it (plus any weights sidecar) into compiled_dir.  A parse
+            # failure is treated as "not compiled" so a malformed source falls
+            # through to the normal compile path, which has its own error
+            # handling.
             already_compiled = False
             if src_onnx.exists():
                 try:
@@ -738,7 +748,7 @@ class GenaiSession:
                     "Stage %r: source is already an EPContext model; using as-is",
                     stage_key,
                 )
-                self._patch_stage_filename(modified_cfg, stage_key, str(src_onnx.resolve()))
+                self._patch_stage_filename(modified_cfg, stage_key, onnx_filename)
                 continue
 
             # Attempt compilation.
@@ -746,14 +756,18 @@ class GenaiSession:
             if success:
                 self._write_compile_marker(ctx_onnx, ep_alias, ep_opts)
                 self._patch_stage_filename(modified_cfg, stage_key, ctx_onnx.name)
+                compiled_stage_filenames.add(onnx_filename)
                 any_compiled = True
             else:
                 logger.warning(
                     "Stage %r: compilation failed; using original ONNX (JIT fallback)", stage_key
                 )
-                # Patch to the absolute source path so ort-genai can find the
-                # file when loading from compiled_dir (where it doesn't exist).
-                self._patch_stage_filename(modified_cfg, stage_key, str(src_onnx.resolve()))
+                # Fall back to the original ONNX by its bundle-relative filename.
+                # ort-genai resolves stage filenames relative to compiled_dir, so
+                # the source ONNX (+ its weights sidecar) is mirrored in by
+                # :meth:`_mirror_non_onnx_files` below; patching an absolute path
+                # would be wrongly joined onto compiled_dir into a broken path.
+                self._patch_stage_filename(modified_cfg, stage_key, onnx_filename)
 
         if not any_compiled:
             return self._bundle_dir
@@ -765,12 +779,12 @@ class GenaiSession:
         compiled_config.write_text(
             json.dumps(modified_cfg, indent=2, ensure_ascii=False), encoding="utf-8"
         )
-        # Only skip the compiled-stage ONNX files (compiled → new path, or failed
-        # → absolute path patch).  Every other ONNX file (e.g. embeddings,
-        # lm_head, or stages on non-EPContext EPs) must be symlinked into
-        # compiled_dir so ort-genai can find it by filename.
-        compiled_onnx_names = {onnx_filename for _, onnx_filename, _, _ in compilable_stages}
-        self._mirror_non_onnx_files(compiled_dir, skip_filenames=compiled_onnx_names)
+        # Skip only the stages replaced by a compiled EPContext artifact (which
+        # are referenced by their new ``{stage}_ctx.onnx`` path).  Every other
+        # ONNX file (embeddings, lm_head, stages on non-EPContext EPs, and any
+        # fallback / already-compiled stage that kept its original ONNX) must be
+        # symlinked into compiled_dir so ort-genai can find it by filename.
+        self._mirror_non_onnx_files(compiled_dir, skip_filenames=compiled_stage_filenames)
 
         logger.info("Compiled bundle prepared at %s", compiled_dir)
         return compiled_dir
@@ -840,14 +854,19 @@ class GenaiSession:
         return bool(recorded.get("provider_options") == ep_opts)
 
     @staticmethod
-    def _patch_stage_filename(cfg: dict, stage_key: str, abs_path: str) -> None:
-        """Rewrite a pipeline stage's ``filename`` to an absolute path."""
+    def _patch_stage_filename(cfg: dict, stage_key: str, filename: str) -> None:
+        """Rewrite a pipeline stage's ``filename`` to *filename*.
+
+        *filename* is normally a bundle-relative name (resolved by ort-genai
+        against the directory it loads ``genai_config.json`` from), but an
+        absolute path is also accepted.
+        """
         pipeline_list: list = cfg.get("model", {}).get("decoder", {}).get("pipeline", [])
         for stage_entry in pipeline_list:
             if isinstance(stage_entry, dict) and stage_key in stage_entry:
                 stage_cfg = stage_entry[stage_key]
                 if isinstance(stage_cfg, dict):
-                    stage_cfg["filename"] = abs_path
+                    stage_cfg["filename"] = filename
                     return
 
     def _compile_stage(

--- a/tests/unit/session/test_genai_session.py
+++ b/tests/unit/session/test_genai_session.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import json
 import os
 import sys
-from typing import TYPE_CHECKING
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -26,10 +26,6 @@ from winml.modelkit.session import (
     GenerationConfig,
     GenerationTiming,
 )
-
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 # ---------------------------------------------------------------------------
@@ -923,6 +919,90 @@ class TestPrepareCompiledBundle:
         # Only the context stage (whose .data changed) is recompiled.
         assert spy.call_count == 1
         assert spy.call_args.args[2] == "context"
+
+    def test_failed_compile_falls_back_to_relative_mirrored_onnx(
+        self, bundle_dir_with_pipeline: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A stage whose compilation fails falls back to the original ONNX by a
+        *bundle-relative* filename that is mirrored into compiled_dir.
+
+        Regression test: ort-genai resolves each pipeline stage ``filename``
+        relative to the directory it loads ``genai_config.json`` from
+        (compiled_dir). Patching an absolute path made it join compiled_dir onto
+        the absolute path (``_compiled/C:/.../ctx.onnx``), so the model could not
+        be found. The fallback must instead reference the relative filename and
+        physically place the source ONNX (and its weights sidecar) in
+        compiled_dir.
+        """
+        # Give the context stage an external-weights sidecar so we can assert it
+        # is mirrored alongside the graph (decoder graphs keep weights there).
+        (bundle_dir_with_pipeline / "ctx.onnx.data").write_bytes(b"weights")
+
+        session = GenaiSession(bundle_dir_with_pipeline, ep="qnn", compile=True)
+
+        # context fails compilation (-> fallback); iterator succeeds so a
+        # compiled_dir is produced (any_compiled is True).
+        def fake_compile(src_onnx, ctx_out, stage_key, ep_alias, ep_opts=None):
+            if stage_key == "iterator":
+                ctx_out.write_bytes(b"ep_ctx")
+                return True
+            return False
+
+        monkeypatch.setattr(session, "_compile_stage", fake_compile)
+
+        compiled_dir = bundle_dir_with_pipeline / "_compiled"
+        result = session._prepare_compiled_bundle()
+        assert result == compiled_dir
+
+        written = json.loads((compiled_dir / "genai_config.json").read_text(encoding="utf-8"))
+        pipeline = written["model"]["decoder"]["pipeline"]
+        ctx_filename = next(s["context"]["filename"] for s in pipeline if "context" in s)
+
+        # Referenced by relative filename (not an absolute path).
+        assert ctx_filename == "ctx.onnx"
+        assert not Path(ctx_filename).is_absolute()
+        # Physically present in compiled_dir so ort-genai can load it.
+        assert (compiled_dir / "ctx.onnx").exists()
+        assert (compiled_dir / "ctx.onnx.data").exists()
+
+    def test_already_compiled_stage_referenced_by_relative_mirrored_onnx(
+        self, bundle_dir_with_pipeline: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A stage whose source ONNX is already an EPContext model is referenced
+        by a *bundle-relative* filename that is mirrored into compiled_dir.
+
+        Same root cause as the compile-fallback case: an absolute path would be
+        wrongly joined onto compiled_dir by ort-genai.
+        """
+        (bundle_dir_with_pipeline / "ctx.onnx.data").write_bytes(b"weights")
+
+        session = GenaiSession(bundle_dir_with_pipeline, ep="qnn", compile=True)
+
+        # context is already an EPContext model; iterator compiles fresh so a
+        # compiled_dir is produced.
+        monkeypatch.setattr(
+            "winml.modelkit.onnx.is_compiled_onnx",
+            lambda p: Path(p).name == "ctx.onnx",
+        )
+
+        def fake_compile(src_onnx, ctx_out, stage_key, ep_alias, ep_opts=None):
+            ctx_out.write_bytes(b"ep_ctx")
+            return True
+
+        monkeypatch.setattr(session, "_compile_stage", fake_compile)
+
+        compiled_dir = bundle_dir_with_pipeline / "_compiled"
+        result = session._prepare_compiled_bundle()
+        assert result == compiled_dir
+
+        written = json.loads((compiled_dir / "genai_config.json").read_text(encoding="utf-8"))
+        pipeline = written["model"]["decoder"]["pipeline"]
+        ctx_filename = next(s["context"]["filename"] for s in pipeline if "context" in s)
+
+        assert ctx_filename == "ctx.onnx"
+        assert not Path(ctx_filename).is_absolute()
+        assert (compiled_dir / "ctx.onnx").exists()
+        assert (compiled_dir / "ctx.onnx.data").exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Running `winml perf -m <bundle> --runtime winml-genai --device npu --compile` failed to load the bundle whenever a pipeline stage's offline EPContext compilation crashed and fell back to JIT. This was hit in practice benchmarking a qwen3 export on a Snapdragon X Elite NPU: the context stage's offline compile aborted, and the fallback then produced a malformed path and errored out with "Failed to load genai bundle".

## Root cause

ort-genai resolves each pipeline stage's `filename` **relative to the directory it loads `genai_config.json` from** (the `_compiled` dir) via a naive join, and does not accept absolute Windows paths. In `_prepare_compiled_bundle`, the compile-failure fallback (and the already-precompiled-stage branch) patched the stage `filename` to an **absolute** source path *and* skipped mirroring that ONNX into the compiled dir. ort-genai then joined the compiled dir onto the absolute path, yielding a broken `_compiled\C:\...\ctx.onnx` that did not exist.

## Fix

Reference the original ONNX by its **bundle-relative** filename and let `_mirror_non_onnx_files` symlink it (plus its external-weights `.data` sidecar) into the compiled dir, exactly like the fresh-compile path already does. The mirror skip-set now contains only the stages that were actually replaced by a `{stage}_ctx.onnx` artifact, so fallback / already-compiled stages get mirrored in correctly.

## Notes for reviewers

- This only fixes the **fallback** behavior. The underlying QNN offline-compile crash (native `0xC0000005` in the EPContext compiler subprocess) is a separate pre-existing issue and is **not** addressed here; the fix ensures the JIT fallback after that crash loads correctly rather than dying on a bad path.
- Added two regression tests covering the compile-failure fallback and the already-precompiled-stage case, asserting the stage is referenced by a relative filename and that the ONNX (+ `.data` sidecar) is physically present in the compiled dir.
- Verified end-to-end on the NPU: `--compile` now completes (context stage falls back to JIT, bundle loads, benchmark runs) with the malformed-path error gone.