### PR TITLE
feat(perf): show dynamic input dims as dynamic(&lt;actual&gt;) in model info

### DIFF
--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -528,6 +528,11 @@ class PerfBenchmark:
             req_device=self.config.device,
             act_device=self._single.device,
             ep_name=self._single.ep_name,
+            actual_shapes=(
+                {name: tuple(arr.shape) for name, arr in self._inputs.items()}
+                if self._inputs
+                else None
+            ),
         )
 
         # [3] Run benchmark
@@ -1398,6 +1403,26 @@ def generate_output_path(model_id: str, *, module_class: str | None = None) -> P
 # =============================================================================
 
 
+def _format_input_shape(shape: list, actual: tuple | None) -> str:
+    """Render a declared input shape, marking dynamic dims as ``dynamic``.
+
+    A dynamic dimension (declared as ``None``) is shown as ``dynamic(<n>)``
+    where ``<n>`` is the concrete size the generated input data actually used
+    for that axis, so the real batch/sequence sizes stay visible alongside the
+    fact that the model left them free.
+    """
+    dims: list[str] = []
+    for i, dim in enumerate(shape):
+        if dim is None:
+            if actual is not None and i < len(actual):
+                dims.append(f"dynamic({actual[i]})")
+            else:
+                dims.append("dynamic")
+        else:
+            dims.append(str(dim))
+    return f"[{', '.join(dims)}]"
+
+
 def _print_model_info(
     io_config: dict,
     *,
@@ -1405,6 +1430,7 @@ def _print_model_info(
     req_device: str = "auto",
     act_device: str = "auto",
     ep_name: EPName | None = None,
+    actual_shapes: dict[str, tuple] | None = None,
 ) -> None:
     """Print model I/O metadata before the benchmark starts."""
     console = Console(stderr=True)
@@ -1427,7 +1453,8 @@ def _print_model_info(
         for i, name in enumerate(names):
             shape = shapes[i] if i < len(shapes) else []
             dtype = str(types[i]) if i < len(types) else ""
-            shape_str = f"{shape!s}"
+            actual = actual_shapes.get(name) if actual_shapes else None
+            shape_str = _format_input_shape(shape, actual)
             line = f"{name:<20s} {shape_str:<22s} {dtype}"
             console.print(f"{label if i == 0 else pad}{line}")
 

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any, Literal, cast, get_args
 import click
 import numpy as np
 from rich.console import Console
+from rich.markup import escape
 from rich.table import Table
 
 from ..utils import cli as cli_utils
@@ -1455,7 +1456,9 @@ def _print_model_info(
             dtype = str(types[i]) if i < len(types) else ""
             actual = actual_shapes.get(name) if actual_shapes else None
             shape_str = _format_input_shape(shape, actual)
-            line = f"{name:<20s} {shape_str:<22s} {dtype}"
+            # ``shape_str`` can start with a lowercase ``dynamic(...)`` which Rich
+            # would otherwise parse as a markup tag and swallow -- escape it.
+            line = f"{name:<20s} {escape(shape_str):<22s} {dtype}"
             console.print(f"{label if i == 0 else pad}{line}")
 
     out_names = io_config.get("output_names", [])

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -1468,7 +1468,8 @@ def _print_model_info(
         pad = "             "
         for i, name in enumerate(out_names):
             shape = out_shapes[i] if i < len(out_shapes) else []
-            console.print(f"{label if i == 0 else pad}{name:<20s} {shape!s}")
+            shape_str = escape(_format_input_shape(shape, None))
+            console.print(f"{label if i == 0 else pad}{name:<20s} {shape_str}")
 
     console.print()
 

--- a/tests/unit/commands/test_perf_cli.py
+++ b/tests/unit/commands/test_perf_cli.py
@@ -852,6 +852,27 @@ class TestFormatInputShape:
 
         assert _format_input_shape([None, 3], None) == "[dynamic, 3]"
 
+    def test_dynamic_shape_survives_rich_rendering(self) -> None:
+        # Regression: a lowercase ``[dynamic(...)]`` is valid Rich markup and
+        # gets swallowed unless escaped, leaving the shape column blank.
+        import contextlib
+        import io as _io
+
+        from winml.modelkit.commands.perf import _print_model_info
+
+        io_config = {
+            "input_names": ["pixel_values"],
+            "input_shapes": [[None, 3, 64, 64]],
+            "input_types": ["float32"],
+        }
+        buf = _io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            _print_model_info(
+                io_config,
+                actual_shapes={"pixel_values": (10, 3, 64, 64)},
+            )
+        assert "[dynamic(10), 3, 64, 64]" in buf.getvalue()
+
 
 class TestPerfFormatJson:
     """Test --format json produces structured JSON to stdout."""

--- a/tests/unit/commands/test_perf_cli.py
+++ b/tests/unit/commands/test_perf_cli.py
@@ -829,6 +829,30 @@ class TestEffectiveBatchSize:
 # =============================================================================
 
 
+class TestFormatInputShape:
+    """Dynamic dims render as ``dynamic(<actual>)`` with real generated sizes."""
+
+    def test_dynamic_dim_shows_actual_value(self) -> None:
+        from winml.modelkit.commands.perf import _format_input_shape
+
+        assert _format_input_shape([None, 3, 64, 64], (1, 3, 64, 64)) == "[dynamic(1), 3, 64, 64]"
+
+    def test_multiple_dynamic_dims(self) -> None:
+        from winml.modelkit.commands.perf import _format_input_shape
+
+        assert _format_input_shape([None, None], (2, 128)) == "[dynamic(2), dynamic(128)]"
+
+    def test_all_static_dims_unchanged(self) -> None:
+        from winml.modelkit.commands.perf import _format_input_shape
+
+        assert _format_input_shape([1, 3, 224, 224], (1, 3, 224, 224)) == "[1, 3, 224, 224]"
+
+    def test_dynamic_without_actual_falls_back_to_bare_dynamic(self) -> None:
+        from winml.modelkit.commands.perf import _format_input_shape
+
+        assert _format_input_shape([None, 3], None) == "[dynamic, 3]"
+
+
 class TestPerfFormatJson:
     """Test --format json produces structured JSON to stdout."""
 

--- a/tests/unit/commands/test_perf_cli.py
+++ b/tests/unit/commands/test_perf_cli.py
@@ -864,6 +864,8 @@ class TestFormatInputShape:
             "input_names": ["pixel_values"],
             "input_shapes": [[None, 3, 64, 64]],
             "input_types": ["float32"],
+            "output_names": ["logits"],
+            "output_shapes": [[None, 1000]],
         }
         buf = _io.StringIO()
         with contextlib.redirect_stderr(buf):
@@ -871,7 +873,10 @@ class TestFormatInputShape:
                 io_config,
                 actual_shapes={"pixel_values": (10, 3, 64, 64)},
             )
-        assert "[dynamic(10), 3, 64, 64]" in buf.getvalue()
+        out = buf.getvalue()
+        assert "[dynamic(10), 3, 64, 64]" in out
+        # Outputs have no generated data, so dynamic dims render bare.
+        assert "[dynamic, 1000]" in out
 
 
 class TestPerfFormatJson:


### PR DESCRIPTION
## Summary

The pre-benchmark model-info output previously printed dynamic input dimensions as `None`, which was ambiguous — it didn't convey that the axis was free, nor what size the generated benchmark data actually used.

This changes dynamic dims to render as `dynamic(<actual>)`:

**Before**
```
Inputs:      pixel_values         [None, 3, 64, 64]        float32
Outputs:     logits               [None, 1000]
```

**After**
```
Inputs:      pixel_values         [dynamic(1), 3, 64, 64]  float32
Outputs:     logits               [dynamic, 1000]
```

The value in parentheses is the concrete size the generated input tensor actually used for that axis (e.g. the resolved batch size), so both facts stay visible: the model left the axis free, and the benchmark ran it at size N.

## Changes

- Added `_format_input_shape(shape, actual)` — maps each `None` dim to `dynamic(<actual>)`, falling back to bare `dynamic` when no concrete shape is available; static dims are unchanged.
- `_print_model_info` gained an `actual_shapes` param, threaded from `self._inputs` (name → real `arr.shape`) at the call site.
- Added `TestFormatInputShape` covering single/multiple dynamic dims, all-static, and the no-actual fallback.

Close https://github.com/microsoft/winml-cli/issues/1052