### PR TITLE
feat: Add dynamic axes export support

### DIFF
--- a/docs/commands/export.md
+++ b/docs/commands/export.md
@@ -28,6 +28,7 @@ $ winml export [options]
 | `--task` | `-t` | string | `None` | Override auto-detected Hugging Face task (e.g., `image-feature-extraction`). |
 | `--export-config` | | path | `None` | JSON file with ONNX export parameters such as `opset_version` and `do_constant_folding`. |
 | `--shape-config` | | path | `None` | JSON object mapping symbolic dimension names to concrete sizes (e.g., `{"sequence_length": 2048}`). Ignored when `--input-specs` is provided. |
+| `--dynamic-axes` | | path | `None` | JSON object mapping tensor names to dynamic axis names for ONNX export (e.g., `{"input_ids": {"0": "batch", "1": "sequence"}}`). |
 | `--trust-remote-code/--no-trust-remote-code` | | flag | `false` | Allow executing custom code from model repositories during export. Use only with trusted sources. |
 | `--allow-unsupported-nodes/--no-allow-unsupported-nodes` | | flag | `false` | Allow unsupported nodes to remain in the exported graph instead of failing export. |
 | `--help` | `-h` | flag | | Show this message and exit. |
@@ -79,6 +80,19 @@ winml export -m bert-base-uncased -o bert.onnx --input-specs inputs.json
 ```
 
 ```bash
+# Export with dynamic batch and sequence dimensions
+winml export -m bert-base-uncased -o bert.onnx --dynamic-axes dynamic_axes.json
+# dynamic_axes.json:
+# {"input_ids": {"0": "batch", "1": "sequence"}, "attention_mask": {"0": "batch", "1": "sequence"}}
+```
+
+`--input-specs` also accepts symbolic dimension names in `shape`; symbolic
+entries are used as dynamic ONNX axis names while size `1` is used for the
+dummy input tensor. For example, `{"input_ids": {"dtype": "int64", "shape":
+["batch", "sequence"]}}` exports `input_ids` with dynamic `batch` and
+`sequence` dimensions.
+
+```bash
 # Produce clean ONNX without hierarchy metadata (for third-party optimizers)
 winml export -m microsoft/resnet-50 -o resnet50_clean.onnx --no-hierarchy
 ```
@@ -97,6 +111,9 @@ winml export -m microsoft/resnet-50 -o resnet50_clean.onnx --no-hierarchy
 - **`--shape-config` is silently ignored when `--input-specs` is set.**
   `--input-specs` takes full priority; remove it if you only want to override
   individual dimensions.
+- **Dynamic dimensions can reduce QNN optimization coverage.** Static batch and
+  static shapes remain the default because some QNN fusions require them. Use
+  `--dynamic-axes` only when downstream runtime scenarios need variable sizes.
 - **`--dynamo` and `--torch-module` are experimental.** Both flags emit a
   warning and have no effect in the current release. Do not rely on them in
   automated pipelines yet.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -50,7 +50,7 @@ stages based on the target device and precision.
 | `batch_size` | `int` | `1` | Static batch size. Use 1 for QNN compatibility. |
 | `input_tensors` | `list[InputTensorSpec] \| null` | `null` | Input tensor specifications. Auto-inferred if omitted. |
 | `output_tensors` | `list[OutputTensorSpec] \| null` | `null` | Output tensor specifications. |
-| `dynamic_axes` | `dict \| null` | `null` | Dynamic axes mapping. ⚠️ Breaks MatMulAddFusion on QNN. |
+| `dynamic_axes` | `dict \| null` | `null` | Dynamic axes mapping. Static shapes remain the QNN-safe default; dynamic batch may reduce fusion coverage. |
 | `export_params` | `bool` | `true` | Include model parameters in ONNX. |
 | `do_constant_folding` | `bool` | `true` | Fold constants during export. |
 | `verbose` | `bool` | `false` | Verbose export logging. |
@@ -65,7 +65,7 @@ stages based on the target device and precision.
 |-------|------|-------------|
 | `name` | `str \| null` | Tensor name (e.g., `pixel_values`). |
 | `dtype` | `str \| null` | Data type (e.g., `float32`, `int64`). |
-| `shape` | `list[int] \| null` | Tensor shape (e.g., `[1, 3, 224, 224]`). |
+| `shape` | `list[int \| str] \| null` | Tensor shape (e.g., `[1, 3, 224, 224]`). String entries declare symbolic dynamic axes and use size `1` for dummy inputs. |
 | `value_range` | `[float, float] \| null` | Min/max for dummy tensor generation. |
 
 ---

--- a/src/winml/modelkit/commands/export.py
+++ b/src/winml/modelkit/commands/export.py
@@ -85,6 +85,23 @@ def _warn_partial_composite(completed: list[Path]) -> None:
     )
 
 
+def _load_json_object(path: Path, option_name: str) -> dict:
+    """Load a JSON object from a CLI option path."""
+    try:
+        with path.open() as f:
+            data = json.load(f)
+    except json.JSONDecodeError as e:
+        raise click.ClickException(f"Invalid JSON in {option_name}: {path}: {e}") from e
+    except Exception as e:
+        raise click.ClickException(f"Failed to load {option_name}: {e}") from e
+
+    if not isinstance(data, dict):
+        raise click.ClickException(
+            f"{option_name} must contain a JSON object, got {type(data).__name__}"
+        )
+    return data
+
+
 @click.command()
 @cli_utils.model_option(
     required=True,
@@ -151,6 +168,15 @@ def _warn_partial_composite(completed: list[Path]) -> None:
     default=None,
     help='JSON with shape overrides (e.g., {"sequence_length": 2048, "height": 640}).',
 )
+@click.option(
+    "--dynamic-axes",
+    type=click.Path(exists=True, path_type=Path),
+    default=None,
+    help=(
+        "JSON dynamic axes mapping for ONNX export "
+        '(e.g., {"input_ids": {"0": "batch", "1": "sequence"}}).'
+    ),
+)
 @cli_utils.build_config_option()
 @cli_utils.verbosity_options()
 @cli_utils.no_color_option()
@@ -171,6 +197,7 @@ def export(
     input_specs: Path | None,
     export_config: Path | None,
     shape_config: Path | None,
+    dynamic_axes: Path | None,
     config_file: Path | None,
 ) -> None:
     r"""Export HuggingFace model to ONNX format with HTP.
@@ -213,6 +240,9 @@ def export(
 
         # Custom ONNX export configuration
         winml export -m bert-base-uncased -o bert.onnx --export-config config.json
+
+        # Dynamic dimensions from a dedicated JSON file
+        winml export -m bert-base-uncased -o bert.onnx --dynamic-axes dynamic_axes.json
     """
     # Classify the -m value once (existence-first). Export only works with
     # HuggingFace model IDs — reject ONNX files and folders early.
@@ -275,6 +305,8 @@ def export(
         console.print(f"[bold blue]Input specs:[/bold blue] {input_specs}")
     if export_config:
         console.print(f"[bold blue]Export config:[/bold blue] {export_config}")
+    if dynamic_axes:
+        console.print(f"[bold blue]Dynamic axes:[/bold blue] {dynamic_axes}")
 
     output_path = Path(output)
 
@@ -282,8 +314,7 @@ def export(
     export_config_dict: dict = {}
     if export_config:
         try:
-            with export_config.open() as f:
-                export_config_dict = json.load(f)
+            export_config_dict = _load_json_object(export_config, "--export-config")
             console.print(f"[dim]Loaded export config: {list(export_config_dict.keys())}[/dim]")
         except Exception as e:
             console.print(f"[bold red]Failed to load export config:[/bold red] {e}")
@@ -292,19 +323,13 @@ def export(
     # Load shape overrides from JSON (task-independent).
     shape_overrides = None
     if shape_config:
-        try:
-            with shape_config.open() as f:
-                shape_overrides = json.load(f)
-            if not isinstance(shape_overrides, dict):
-                raise click.ClickException(
-                    f"--shape-config must contain a JSON object, "
-                    f"got {type(shape_overrides).__name__}"
-                )
-        except json.JSONDecodeError as e:
-            raise click.ClickException(
-                f"Invalid JSON in --shape-config: {shape_config}: {e}"
-            ) from e
+        shape_overrides = _load_json_object(shape_config, "--shape-config")
         console.print(f"[dim]Shape overrides: {shape_overrides}[/dim]")
+
+    dynamic_axes_dict = None
+    if dynamic_axes:
+        dynamic_axes_dict = _load_json_object(dynamic_axes, "--dynamic-axes")
+        console.print(f"[dim]Dynamic axes: {dynamic_axes_dict}[/dim]")
 
     # One-time warnings (apply to every sub-model in a composite export).
     if torch_module:
@@ -423,6 +448,8 @@ def export(
             config_kwargs["verbose"] = bool(verbose)
         if cli_utils.is_cli_provided(ctx, "dynamo"):
             config_kwargs["dynamo"] = dynamo
+        if dynamic_axes_dict is not None:
+            config_kwargs["dynamic_axes"] = dynamic_axes_dict
 
         # Add input/output tensors if we resolved them
         if input_tensors:

--- a/src/winml/modelkit/commands/export.py
+++ b/src/winml/modelkit/commands/export.py
@@ -313,12 +313,8 @@ def export(
     # Load export configuration from JSON file if provided (task-independent).
     export_config_dict: dict = {}
     if export_config:
-        try:
-            export_config_dict = _load_json_object(export_config, "--export-config")
-            console.print(f"[dim]Loaded export config: {list(export_config_dict.keys())}[/dim]")
-        except Exception as e:
-            console.print(f"[bold red]Failed to load export config:[/bold red] {e}")
-            raise click.ClickException(f"Failed to load export config: {e}") from e
+        export_config_dict = _load_json_object(export_config, "--export-config")
+        console.print(f"[dim]Loaded export config: {list(export_config_dict.keys())}[/dim]")
 
     # Load shape overrides from JSON (task-independent).
     shape_overrides = None

--- a/src/winml/modelkit/config/build.py
+++ b/src/winml/modelkit/config/build.py
@@ -756,9 +756,7 @@ def generate_hf_build_config(
 
         # Extract input shapes and dtypes from export_config -- NO HARDCODED VALUES
         input_tensors = [t for t in (export_config.input_tensors or []) if t.shape is not None]
-        input_shapes = [
-            _concrete_input_shape(t.shape) for t in input_tensors if t.shape is not None
-        ]
+        input_shapes = [t._concrete_shape() for t in input_tensors]
         input_dtypes = [t.dtype for t in input_tensors]
         if not input_shapes:
             raise ValueError(
@@ -1258,11 +1256,6 @@ def _find_submodules_by_class(
         )
 
     return results
-
-
-def _concrete_input_shape(shape: tuple[int | str, ...]) -> tuple[int, ...]:
-    """Return a torch-compatible shape, replacing symbolic dimensions with 1."""
-    return tuple(1 if isinstance(dim, str) else dim for dim in shape)
 
 
 def _build_dummy_inputs(

--- a/src/winml/modelkit/config/build.py
+++ b/src/winml/modelkit/config/build.py
@@ -756,7 +756,9 @@ def generate_hf_build_config(
 
         # Extract input shapes and dtypes from export_config -- NO HARDCODED VALUES
         input_tensors = [t for t in (export_config.input_tensors or []) if t.shape is not None]
-        input_shapes = [t.shape for t in input_tensors if t.shape is not None]
+        input_shapes = [
+            _concrete_input_shape(t.shape) for t in input_tensors if t.shape is not None
+        ]
         input_dtypes = [t.dtype for t in input_tensors]
         if not input_shapes:
             raise ValueError(
@@ -1256,6 +1258,11 @@ def _find_submodules_by_class(
         )
 
     return results
+
+
+def _concrete_input_shape(shape: tuple[int | str, ...]) -> tuple[int, ...]:
+    """Return a torch-compatible shape, replacing symbolic dimensions with 1."""
+    return tuple(1 if isinstance(dim, str) else dim for dim in shape)
 
 
 def _build_dummy_inputs(

--- a/src/winml/modelkit/config/build.py
+++ b/src/winml/modelkit/config/build.py
@@ -756,7 +756,7 @@ def generate_hf_build_config(
 
         # Extract input shapes and dtypes from export_config -- NO HARDCODED VALUES
         input_tensors = [t for t in (export_config.input_tensors or []) if t.shape is not None]
-        input_shapes = [t._concrete_shape() for t in input_tensors]
+        input_shapes = [t.concrete_shape() for t in input_tensors]
         input_dtypes = [t.dtype for t in input_tensors]
         if not input_shapes:
             raise ValueError(

--- a/src/winml/modelkit/export/config.py
+++ b/src/winml/modelkit/export/config.py
@@ -28,6 +28,96 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+DynamicAxes = dict[str, dict[int, str]]
+
+
+def _normalize_dynamic_axes(dynamic_axes: Any) -> DynamicAxes | None:
+    """Validate and normalize a torch.onnx.export dynamic_axes mapping."""
+    if dynamic_axes is None:
+        return None
+    if not isinstance(dynamic_axes, dict):
+        raise TypeError(
+            f"dynamic_axes must be a JSON object, got {type(dynamic_axes).__name__}"
+        )
+
+    normalized: DynamicAxes = {}
+    for tensor_name, axes in dynamic_axes.items():
+        if not isinstance(tensor_name, str) or not tensor_name:
+            raise ValueError("dynamic_axes tensor names must be non-empty strings")
+        if not isinstance(axes, dict):
+            raise TypeError(
+                f"dynamic_axes['{tensor_name}'] must be an object mapping axis to name"
+            )
+
+        normalized_axes: dict[int, str] = {}
+        for axis, dim_name in axes.items():
+            try:
+                axis_index = int(axis)
+            except (TypeError, ValueError) as e:
+                raise ValueError(
+                    f"dynamic_axes['{tensor_name}'] axis {axis!r} must be an integer"
+                ) from e
+            if axis_index < 0:
+                raise ValueError(
+                    f"dynamic_axes['{tensor_name}'] axis {axis_index} must be non-negative"
+                )
+            if not isinstance(dim_name, str) or not dim_name:
+                raise ValueError(
+                    f"dynamic_axes['{tensor_name}'][{axis_index}] must be a non-empty string"
+                )
+            normalized_axes[axis_index] = dim_name
+
+        normalized[tensor_name] = normalized_axes
+
+    return normalized
+
+
+def _dynamic_axes_from_input_tensors(
+    input_tensors: list[InputTensorSpec] | None,
+) -> DynamicAxes | None:
+    """Infer dynamic axes from symbolic string dimensions in input tensor specs."""
+    if not input_tensors:
+        return None
+
+    dynamic_axes: DynamicAxes = {}
+    for spec in input_tensors:
+        if not spec.name or not spec.shape:
+            continue
+        axes = {
+            axis: dim_name
+            for axis, dim_name in enumerate(spec.shape)
+            if isinstance(dim_name, str)
+        }
+        if axes:
+            dynamic_axes[spec.name] = axes
+
+    return dynamic_axes or None
+
+
+def _merge_dynamic_axes(
+    explicit: DynamicAxes | None,
+    inferred: DynamicAxes | None,
+) -> DynamicAxes | None:
+    """Merge explicit dynamic axes with axes inferred from symbolic input shapes."""
+    if not explicit:
+        return inferred
+    if not inferred:
+        return explicit
+
+    merged: DynamicAxes = {name: dict(axes) for name, axes in explicit.items()}
+    for tensor_name, axes in inferred.items():
+        merged_axes = merged.setdefault(tensor_name, {})
+        for axis, dim_name in axes.items():
+            existing = merged_axes.get(axis)
+            if existing is not None and existing != dim_name:
+                raise ValueError(
+                    f"Conflicting dynamic axis for '{tensor_name}' axis {axis}: "
+                    f"{existing!r} vs {dim_name!r}"
+                )
+            merged_axes[axis] = dim_name
+
+    return merged
+
 
 @dataclass
 class WinMLExportConfig:
@@ -80,7 +170,7 @@ class WinMLExportConfig:
     output_tensors: list[OutputTensorSpec] | None = None
 
     # Dynamic axes for ONNX export (optional)
-    dynamic_axes: dict[str, dict[int, str]] | None = None
+    dynamic_axes: DynamicAxes | None = None
 
     # Export behavior
     export_params: bool = True
@@ -129,10 +219,20 @@ class WinMLExportConfig:
         if self.opset_version < 11:
             logger.warning("opset_version %s is very old, consider using 17+", self.opset_version)
 
+        self.dynamic_axes = _merge_dynamic_axes(
+            _normalize_dynamic_axes(self.dynamic_axes),
+            _dynamic_axes_from_input_tensors(self.input_tensors),
+        )
+
         # Validate input tensor shapes match batch_size if specified
         if self.input_tensors:
             for spec in self.input_tensors:
-                if spec.shape and len(spec.shape) > 0 and spec.shape[0] != self.batch_size:
+                if (
+                    spec.shape
+                    and len(spec.shape) > 0
+                    and isinstance(spec.shape[0], int)
+                    and spec.shape[0] != self.batch_size
+                ):
                     logger.warning(
                         "Input tensor '%s' shape[0]=%s doesn't match batch_size=%s",
                         spec.name or "unnamed",
@@ -146,7 +246,7 @@ class WinMLExportConfig:
                 if 0 in axes:  # Batch dimension is dynamic
                     logger.warning(
                         "Dynamic batch detected for input '%s'. "
-                        "This prevents MatMulAddFusion and causes BiasGelu!",
+                        "QNN optimizations such as MatMulAddFusion may require static batch.",
                         input_name,
                     )
 
@@ -182,7 +282,7 @@ class WinMLExportConfig:
             return []
         return [spec.name for spec in self.output_tensors if spec.name]
 
-    def get_input_shape(self, name: str | None = None) -> tuple[int, ...] | None:
+    def get_input_shape(self, name: str | None = None) -> tuple[int | str, ...] | None:
         """Get shape for a specific input tensor or the first input.
 
         Args:
@@ -215,7 +315,7 @@ class WinMLExportConfig:
         return self.get_output_names()
 
     @property
-    def input_shape(self) -> tuple[int, ...]:
+    def input_shape(self) -> tuple[int | str, ...]:
         """Backward-compatible property for first input tensor shape.
 
         Returns default (1, 3, 224, 224) if no input tensors specified.

--- a/src/winml/modelkit/export/config.py
+++ b/src/winml/modelkit/export/config.py
@@ -36,18 +36,14 @@ def _normalize_dynamic_axes(dynamic_axes: Any) -> DynamicAxes | None:
     if dynamic_axes is None:
         return None
     if not isinstance(dynamic_axes, dict):
-        raise TypeError(
-            f"dynamic_axes must be a JSON object, got {type(dynamic_axes).__name__}"
-        )
+        raise TypeError(f"dynamic_axes must be a JSON object, got {type(dynamic_axes).__name__}")
 
     normalized: DynamicAxes = {}
     for tensor_name, axes in dynamic_axes.items():
         if not isinstance(tensor_name, str) or not tensor_name:
             raise ValueError("dynamic_axes tensor names must be non-empty strings")
         if not isinstance(axes, dict):
-            raise TypeError(
-                f"dynamic_axes['{tensor_name}'] must be an object mapping axis to name"
-            )
+            raise TypeError(f"dynamic_axes['{tensor_name}'] must be an object mapping axis to name")
 
         normalized_axes: dict[int, str] = {}
         for axis, dim_name in axes.items():
@@ -83,11 +79,16 @@ def _dynamic_axes_from_input_tensors(
     for spec in input_tensors:
         if not spec.name or not spec.shape:
             continue
-        axes = {
-            axis: dim_name
-            for axis, dim_name in enumerate(spec.shape)
-            if isinstance(dim_name, str)
-        }
+        axes: dict[int, str] = {}
+        for axis, dim_name in enumerate(spec.shape):
+            if not isinstance(dim_name, str):
+                continue
+            if not dim_name:
+                raise ValueError(
+                    f"Input tensor '{spec.name}' shape axis {axis} must use a "
+                    "non-empty symbolic dimension name"
+                )
+            axes[axis] = dim_name
         if axes:
             dynamic_axes[spec.name] = axes
 
@@ -240,11 +241,11 @@ class WinMLExportConfig:
                         self.batch_size,
                     )
 
-        # Warn if dynamic batch is detected
+        # Report dynamic batch when explicitly configured.
         if self.dynamic_axes:
             for input_name, axes in self.dynamic_axes.items():
                 if 0 in axes:  # Batch dimension is dynamic
-                    logger.warning(
+                    logger.info(
                         "Dynamic batch detected for input '%s'. "
                         "QNN optimizations such as MatMulAddFusion may require static batch.",
                         input_name,

--- a/src/winml/modelkit/export/htp/exporter.py
+++ b/src/winml/modelkit/export/htp/exporter.py
@@ -264,7 +264,7 @@ class HTPExporter:
                 pre_consolidation_external = []
 
             # Verify ONNX export
-            self._verify_onnx_export(output_path)
+            self._verify_onnx_export(output_path, export_config)
 
             # Update monitor with ONNX export info
             onnx_size_mb = (
@@ -366,16 +366,21 @@ class HTPExporter:
         self._hierarchy_data = summary["module_hierarchy"]
         self._export_stats["hierarchy_modules"] = len(self._hierarchy_data)
 
-    def _verify_onnx_export(self, output_path: str) -> None:
+    def _verify_onnx_export(
+        self,
+        output_path: str,
+        export_config: WinMLExportConfig | None = None,
+    ) -> None:
         """Verify ONNX export succeeded and check for common issues.
 
         Post-export validation:
         1. Load ONNX model
         2. Run ONNX checker
-        3. Verify static batch (warn if dynamic detected)
+        3. Verify batch shape and warn only about unexpected dynamic batch
 
         Args:
-            output_path: Path to exported ONNX file
+            output_path: Path to exported ONNX file.
+            export_config: Export configuration used for the export.
         """
         import logging
 
@@ -388,20 +393,31 @@ class HTPExporter:
             model = load_onnx(output_path)
             logger.info("✅ ONNX verification passed")
 
-            # Check for dynamic batch dimension (should be static)
+            # Check for dynamic batch dimension. Static remains the QNN-safe default,
+            # but dynamic dimensions are valid when explicitly requested.
             graph_inputs = model.graph.input
             has_dynamic_batch = False
+            requested_dynamic_axes = export_config.dynamic_axes if export_config else {}
             for input_tensor in graph_inputs:
                 if input_tensor.type.tensor_type.shape.dim:
                     batch_dim = input_tensor.type.tensor_type.shape.dim[0]
                     if batch_dim.dim_param:  # Has symbolic name (dynamic)
                         has_dynamic_batch = True
-                        logger.warning(
-                            "⚠️  Dynamic batch detected in ONNX for '%s'.\n"
-                            "   This may cause QNN compatibility issues.\n"
-                            "   Recommendation: Remove dynamic_axes from export_config.",
-                            input_tensor.name,
+                        requested_dynamic_batch = (
+                            0 in requested_dynamic_axes.get(input_tensor.name, {})
                         )
+                        if requested_dynamic_batch:
+                            logger.info(
+                                "Dynamic batch confirmed for '%s' as requested.",
+                                input_tensor.name,
+                            )
+                        else:
+                            logger.warning(
+                                "⚠️  Dynamic batch detected in ONNX for '%s'.\n"
+                                "   This may cause QNN compatibility issues.\n"
+                                "   Use static batch for QNN-targeted optimization paths.",
+                                input_tensor.name,
+                            )
 
             if not has_dynamic_batch:
                 logger.info("✅ Static batch confirmed (QNN-compatible)")

--- a/src/winml/modelkit/export/htp/exporter.py
+++ b/src/winml/modelkit/export/htp/exporter.py
@@ -397,14 +397,18 @@ class HTPExporter:
             # but dynamic dimensions are valid when explicitly requested.
             graph_inputs = model.graph.input
             has_dynamic_batch = False
-            requested_dynamic_axes = export_config.dynamic_axes if export_config else {}
+            requested_dynamic_axes: dict[str, dict[int, str]] = (
+                export_config.dynamic_axes
+                if export_config and export_config.dynamic_axes is not None
+                else {}
+            )
             for input_tensor in graph_inputs:
                 if input_tensor.type.tensor_type.shape.dim:
                     batch_dim = input_tensor.type.tensor_type.shape.dim[0]
                     if batch_dim.dim_param:  # Has symbolic name (dynamic)
                         has_dynamic_batch = True
-                        requested_dynamic_batch = (
-                            0 in requested_dynamic_axes.get(input_tensor.name, {})
+                        requested_dynamic_batch = 0 in requested_dynamic_axes.get(
+                            input_tensor.name, {}
                         )
                         if requested_dynamic_batch:
                             logger.info(

--- a/src/winml/modelkit/inspect/types.py
+++ b/src/winml/modelkit/inspect/types.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
+from ..onnx import ShapeDim
+
 
 class SupportLevel(Enum):
     """Support level for each component."""
@@ -24,7 +26,7 @@ class TensorInfo:
 
     name: str
     dtype: str | None = None
-    shape: tuple[int, ...] | None = None
+    shape: tuple[ShapeDim, ...] | None = None
     shape_desc: str | None = None  # Human-readable shape like "[B, 3, 224, 224]"
     dynamic_axes: dict[int, str] | None = None  # {0: "batch", 1: "sequence"}
     value_range: tuple[float, float] | None = None  # e.g., (0.0, 1.0) for pixel values

--- a/src/winml/modelkit/onnx/__init__.py
+++ b/src/winml/modelkit/onnx/__init__.py
@@ -18,7 +18,13 @@ from typing import Any
 from .domains import ONNXDomain
 from .dtypes import SupportedONNXType, remove_optional_from_type_annotation
 from .external_data import copy_onnx_model, get_external_data_files, get_onnx_model_hash
-from .io import InputTensorSpec, OutputTensorSpec, generate_inputs_from_onnx, get_io_config
+from .io import (
+    InputTensorSpec,
+    OutputTensorSpec,
+    ShapeDim,
+    generate_inputs_from_onnx,
+    get_io_config,
+)
 from .metadata import capture_metadata, restore_metadata
 from .persistence import ONNXSaveError, cleanup_onnx, load_onnx, save_onnx
 from .shape import infer_onnx_shapes, infer_shapes
@@ -31,6 +37,7 @@ __all__ = [
     "ONNXDomain",
     "ONNXSaveError",
     "OutputTensorSpec",
+    "ShapeDim",
     "SupportedONNXType",
     "capture_metadata",
     "check_onnx_model",

--- a/src/winml/modelkit/onnx/io.py
+++ b/src/winml/modelkit/onnx/io.py
@@ -100,7 +100,7 @@ class InputTensorSpec:
         }
         torch_dtype = dtype_map.get(self.dtype or "float32", torch.float32)
 
-        concrete_shape = self._concrete_shape()
+        concrete_shape = self.concrete_shape()
 
         if self.value_range is not None:
             lo, hi = self.value_range
@@ -113,7 +113,7 @@ class InputTensorSpec:
             return torch.rand(concrete_shape, dtype=torch_dtype)
         return torch.ones(concrete_shape, dtype=torch_dtype)
 
-    def _concrete_shape(self) -> tuple[int, ...]:
+    def concrete_shape(self) -> tuple[int, ...]:
         """Return a torch-compatible dummy shape, replacing symbolic dims with 1."""
         if self.shape is None:
             raise ValueError(f"Cannot create tensor: shape is None for '{self.name}'")

--- a/src/winml/modelkit/onnx/io.py
+++ b/src/winml/modelkit/onnx/io.py
@@ -30,6 +30,8 @@ import numpy as np
 
 logger = logging.getLogger(__name__)
 
+ShapeDim = int | str
+
 
 # =============================================================================
 # Tensor Specification Dataclasses
@@ -45,7 +47,8 @@ class InputTensorSpec:
     Attributes:
         name: Input tensor name in the ONNX graph (e.g., "pixel_values", "input_ids")
         dtype: Data type (e.g., "float32", "int64", "float16")
-        shape: Tensor shape as tuple (e.g., (1, 3, 224, 224))
+        shape: Tensor shape as tuple (e.g., (1, 3, 224, 224)). String dimensions
+            are symbolic ONNX dimensions and use size 1 for dummy tensor generation.
         value_range: Optional (min, max_exclusive) for dummy tensor generation.
             Populated by resolve_export_config() via Optimum's interceptor.
             Integer semantics: torch.randint(min, max) — max is exclusive.
@@ -64,7 +67,7 @@ class InputTensorSpec:
 
     name: str | None = None
     dtype: str | None = None  # "float32", "float16", "int64", "int32", etc.
-    shape: tuple[int, ...] | None = None
+    shape: tuple[ShapeDim, ...] | None = None
     value_range: tuple[float, float] | None = None  # (min, max_exclusive)
 
     def to_tensor(self) -> Any:
@@ -97,16 +100,38 @@ class InputTensorSpec:
         }
         torch_dtype = dtype_map.get(self.dtype or "float32", torch.float32)
 
+        concrete_shape = self._concrete_shape()
+
         if self.value_range is not None:
             lo, hi = self.value_range
             if torch_dtype.is_floating_point:
-                return torch.rand(self.shape, dtype=torch_dtype) * (hi - lo) + lo
-            return torch.randint(int(lo), int(hi), self.shape, dtype=torch_dtype)
+                return torch.rand(concrete_shape, dtype=torch_dtype) * (hi - lo) + lo
+            return torch.randint(int(lo), int(hi), concrete_shape, dtype=torch_dtype)
 
         # Fallback: no range info (backward compatible)
         if torch_dtype.is_floating_point:
-            return torch.rand(self.shape, dtype=torch_dtype)
-        return torch.ones(self.shape, dtype=torch_dtype)
+            return torch.rand(concrete_shape, dtype=torch_dtype)
+        return torch.ones(concrete_shape, dtype=torch_dtype)
+
+    def _concrete_shape(self) -> tuple[int, ...]:
+        """Return a torch-compatible dummy shape, replacing symbolic dims with 1."""
+        if self.shape is None:
+            raise ValueError(f"Cannot create tensor: shape is None for '{self.name}'")
+
+        concrete: list[int] = []
+        for dim in self.shape:
+            if isinstance(dim, str):
+                if not dim:
+                    raise ValueError(f"Cannot create tensor: empty symbolic dim for '{self.name}'")
+                concrete.append(1)
+            elif isinstance(dim, int):
+                concrete.append(dim)
+            else:
+                raise TypeError(
+                    f"Cannot create tensor: shape for '{self.name}' contains "
+                    f"unsupported dimension {dim!r}"
+                )
+        return tuple(concrete)
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary, excluding None values."""

--- a/tests/unit/commands/test_export.py
+++ b/tests/unit/commands/test_export.py
@@ -122,8 +122,7 @@ class TestExportCLIInterface:
                 args = [str(specs_file) if arg == "inputs.json" else arg for arg in args]
                 args = [str(config_file) if arg == "config.json" else arg for arg in args]
                 args = [
-                    str(dynamic_axes_file) if arg == "dynamic_axes.json" else arg
-                    for arg in args
+                    str(dynamic_axes_file) if arg == "dynamic_axes.json" else arg for arg in args
                 ]
                 args = [str(tmp_path / arg) if arg.endswith(".onnx") else arg for arg in args]
                 saw_input_specs_example |= str(specs_file) in args
@@ -565,7 +564,7 @@ class TestExportConfigFiles:
         )
 
         assert result.exit_code != 0
-        assert "Failed to load export config" in result.output
+        assert "Invalid JSON in --export-config" in result.output
 
 
 class TestExportWarnings:

--- a/tests/unit/commands/test_export.py
+++ b/tests/unit/commands/test_export.py
@@ -74,6 +74,7 @@ class TestExportCLIInterface:
         assert "--torch-module" in result.output
         assert "--input-specs" in result.output
         assert "--export-config" in result.output
+        assert "--dynamic-axes" in result.output
 
     def test_export_help_examples_run(self, runner: CliRunner, tmp_path: Path) -> None:
         """Every command example in export help should execute without crashing."""
@@ -91,6 +92,8 @@ class TestExportCLIInterface:
         specs_file.write_text(json.dumps({"input_ids": {"dtype": "int64", "shape": [1, 8]}}))
         config_file = tmp_path / "config.json"
         config_file.write_text(json.dumps({"opset_version": 17}))
+        dynamic_axes_file = tmp_path / "dynamic_axes.json"
+        dynamic_axes_file.write_text(json.dumps({"input_ids": {"0": "batch"}}))
 
         mock_export_cfg = WinMLExportConfig()
         mock_loader_cfg = WinMLLoaderConfig(task="feature-extraction", model_type="bert")
@@ -118,6 +121,10 @@ class TestExportCLIInterface:
                 args = tokens[2:]  # drop "winml export"
                 args = [str(specs_file) if arg == "inputs.json" else arg for arg in args]
                 args = [str(config_file) if arg == "config.json" else arg for arg in args]
+                args = [
+                    str(dynamic_axes_file) if arg == "dynamic_axes.json" else arg
+                    for arg in args
+                ]
                 args = [str(tmp_path / arg) if arg.endswith(".onnx") else arg for arg in args]
                 saw_input_specs_example |= str(specs_file) in args
                 saw_export_config_example |= str(config_file) in args
@@ -408,6 +415,127 @@ class TestExportConfigFiles:
         config = call_kwargs["export_config"]
         assert config.input_tensors is not None
         assert len(config.input_tensors) == 2
+
+    def test_export_loads_dynamic_axes_json(
+        self,
+        runner: CliRunner,
+        mock_export_onnx: MagicMock,
+        mock_load_hf_model: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Test --dynamic-axes loads and normalizes JSON dynamic axes."""
+        from winml.modelkit.commands.export import export
+
+        dynamic_axes_file = tmp_path / "dynamic_axes.json"
+        dynamic_axes_file.write_text(
+            json.dumps(
+                {
+                    "input_ids": {"0": "batch", "1": "sequence"},
+                    "logits": {"0": "batch"},
+                }
+            )
+        )
+
+        output_path = tmp_path / "model.onnx"
+        result = runner.invoke(
+            export,
+            [
+                "--model",
+                "test-model",
+                "--output",
+                str(output_path),
+                "--dynamic-axes",
+                str(dynamic_axes_file),
+            ],
+            obj={"debug": False},
+        )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = mock_export_onnx.call_args.kwargs
+        config = call_kwargs["export_config"]
+        assert config.dynamic_axes == {
+            "input_ids": {0: "batch", 1: "sequence"},
+            "logits": {0: "batch"},
+        }
+
+    def test_export_input_specs_symbolic_shape_infers_dynamic_axes(
+        self,
+        runner: CliRunner,
+        mock_export_onnx: MagicMock,
+        mock_load_hf_model: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Symbolic dims in --input-specs become dynamic axes."""
+        from winml.modelkit.commands.export import export
+
+        specs_file = tmp_path / "inputs.json"
+        specs_file.write_text(
+            json.dumps(
+                {
+                    "input_ids": {
+                        "dtype": "int64",
+                        "shape": ["batch", "sequence"],
+                    }
+                }
+            )
+        )
+
+        output_path = tmp_path / "model.onnx"
+        result = runner.invoke(
+            export,
+            [
+                "--model",
+                "test-model",
+                "--output",
+                str(output_path),
+                "--input-specs",
+                str(specs_file),
+            ],
+            obj={"debug": False},
+        )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = mock_export_onnx.call_args.kwargs
+        config = call_kwargs["export_config"]
+        assert config.input_tensors is not None
+        assert config.input_tensors[0].shape == ("batch", "sequence")
+        assert config.dynamic_axes == {"input_ids": {0: "batch", 1: "sequence"}}
+
+    def test_export_dynamic_axes_overrides_export_config(
+        self,
+        runner: CliRunner,
+        mock_export_onnx: MagicMock,
+        mock_load_hf_model: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Dedicated --dynamic-axes has CLI precedence over --export-config."""
+        from winml.modelkit.commands.export import export
+
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({"dynamic_axes": {"input_ids": {"0": "old"}}}))
+        dynamic_axes_file = tmp_path / "dynamic_axes.json"
+        dynamic_axes_file.write_text(json.dumps({"input_ids": {"0": "batch"}}))
+
+        output_path = tmp_path / "model.onnx"
+        result = runner.invoke(
+            export,
+            [
+                "--model",
+                "test-model",
+                "--output",
+                str(output_path),
+                "--export-config",
+                str(config_file),
+                "--dynamic-axes",
+                str(dynamic_axes_file),
+            ],
+            obj={"debug": False},
+        )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = mock_export_onnx.call_args.kwargs
+        config = call_kwargs["export_config"]
+        assert config.dynamic_axes == {"input_ids": {0: "batch"}}
 
     def test_export_invalid_export_config_raises(
         self,

--- a/tests/unit/export/test_config_validation.py
+++ b/tests/unit/export/test_config_validation.py
@@ -124,16 +124,16 @@ class TestInputTensorShapeMismatchWarning:
 
 
 # =============================================================================
-# 5. dynamic_axes with axis 0 logs QNN compatibility warning
+# 5. dynamic_axes with axis 0 logs QNN compatibility info
 # =============================================================================
 
 
 class TestDynamicAxesWarning:
-    """dynamic_axes with axis 0 warns about QNN compatibility."""
+    """dynamic_axes with axis 0 reports QNN compatibility context."""
 
-    def test_dynamic_batch_axis_warns(self, caplog):
+    def test_dynamic_batch_axis_logs_info(self, caplog):
         dynamic_axes = {"input_ids": {0: "batch_size"}}
-        with caplog.at_level(logging.WARNING, logger="winml.modelkit.export.config"):
+        with caplog.at_level(logging.INFO, logger="winml.modelkit.export.config"):
             WinMLExportConfig(dynamic_axes=dynamic_axes)
         assert "Dynamic batch detected for input 'input_ids'" in caplog.text
         assert "QNN optimizations" in caplog.text
@@ -144,12 +144,12 @@ class TestDynamicAxesWarning:
             WinMLExportConfig(dynamic_axes=dynamic_axes)
         assert "Dynamic batch detected" not in caplog.text
 
-    def test_multiple_inputs_dynamic_batch(self, caplog):
+    def test_multiple_inputs_dynamic_batch_logs_info(self, caplog):
         dynamic_axes = {
             "input_ids": {0: "batch", 1: "seq"},
             "attention_mask": {0: "batch"},
         }
-        with caplog.at_level(logging.WARNING, logger="winml.modelkit.export.config"):
+        with caplog.at_level(logging.INFO, logger="winml.modelkit.export.config"):
             WinMLExportConfig(dynamic_axes=dynamic_axes)
         assert "input_ids" in caplog.text
         assert "attention_mask" in caplog.text
@@ -170,6 +170,14 @@ class TestDynamicAxesWarning:
             ],
         )
         assert cfg.dynamic_axes == {"input_ids": {0: "batch", 1: "sequence"}}
+
+    def test_empty_symbolic_input_shape_raises(self):
+        with pytest.raises(ValueError, match="non-empty symbolic dimension name"):
+            WinMLExportConfig(
+                input_tensors=[
+                    InputTensorSpec(name="input_ids", dtype="int64", shape=("", 128)),
+                ],
+            )
 
     def test_symbolic_input_shape_conflict_raises(self):
         with pytest.raises(ValueError, match="Conflicting dynamic axis"):

--- a/tests/unit/export/test_config_validation.py
+++ b/tests/unit/export/test_config_validation.py
@@ -124,25 +124,25 @@ class TestInputTensorShapeMismatchWarning:
 
 
 # =============================================================================
-# 5. dynamic_axes with axis 0 logs BiasGelu warning
+# 5. dynamic_axes with axis 0 logs QNN compatibility warning
 # =============================================================================
 
 
 class TestDynamicAxesWarning:
-    """dynamic_axes with axis 0 warns about BiasGelu."""
+    """dynamic_axes with axis 0 warns about QNN compatibility."""
 
     def test_dynamic_batch_axis_warns(self, caplog):
         dynamic_axes = {"input_ids": {0: "batch_size"}}
         with caplog.at_level(logging.WARNING, logger="winml.modelkit.export.config"):
             WinMLExportConfig(dynamic_axes=dynamic_axes)
         assert "Dynamic batch detected for input 'input_ids'" in caplog.text
-        assert "BiasGelu" in caplog.text
+        assert "QNN optimizations" in caplog.text
 
     def test_dynamic_non_batch_axis_no_warning(self, caplog):
         dynamic_axes = {"input_ids": {1: "sequence_length"}}
         with caplog.at_level(logging.WARNING, logger="winml.modelkit.export.config"):
             WinMLExportConfig(dynamic_axes=dynamic_axes)
-        assert "BiasGelu" not in caplog.text
+        assert "Dynamic batch detected" not in caplog.text
 
     def test_multiple_inputs_dynamic_batch(self, caplog):
         dynamic_axes = {
@@ -157,7 +157,28 @@ class TestDynamicAxesWarning:
     def test_no_dynamic_axes_no_warning(self, caplog):
         with caplog.at_level(logging.WARNING, logger="winml.modelkit.export.config"):
             WinMLExportConfig(dynamic_axes=None)
-        assert "BiasGelu" not in caplog.text
+        assert "Dynamic batch detected" not in caplog.text
+
+    def test_dynamic_axes_json_keys_normalized(self):
+        cfg = WinMLExportConfig(dynamic_axes={"input_ids": {"0": "batch", "1": "sequence"}})
+        assert cfg.dynamic_axes == {"input_ids": {0: "batch", 1: "sequence"}}
+
+    def test_symbolic_input_shape_infers_dynamic_axes(self):
+        cfg = WinMLExportConfig(
+            input_tensors=[
+                InputTensorSpec(name="input_ids", dtype="int64", shape=("batch", "sequence")),
+            ],
+        )
+        assert cfg.dynamic_axes == {"input_ids": {0: "batch", 1: "sequence"}}
+
+    def test_symbolic_input_shape_conflict_raises(self):
+        with pytest.raises(ValueError, match="Conflicting dynamic axis"):
+            WinMLExportConfig(
+                input_tensors=[
+                    InputTensorSpec(name="input_ids", dtype="int64", shape=("batch", 128)),
+                ],
+                dynamic_axes={"input_ids": {0: "different_batch"}},
+            )
 
 
 # =============================================================================
@@ -229,6 +250,11 @@ class TestInputTensorSpecRoundtrip:
         assert restored.dtype is None
         assert restored.shape is None
 
+    def test_symbolic_shape_roundtrip(self):
+        original = InputTensorSpec(name="input_ids", dtype="int64", shape=("batch", "sequence"))
+        restored = InputTensorSpec.from_dict(original.to_dict())
+        assert restored.shape == ("batch", "sequence")
+
     def test_name_only_roundtrip(self):
         original = InputTensorSpec(name="input_ids")
         restored = InputTensorSpec.from_dict(original.to_dict())
@@ -261,6 +287,11 @@ class TestInputTensorSpecListToTuple:
         data = {"name": "pixel_values"}
         spec = InputTensorSpec.from_dict(data)
         assert spec.shape is None
+
+    def test_list_symbolic_shape_converted_to_tuple(self):
+        data = {"name": "input_ids", "shape": ["batch", 128]}
+        spec = InputTensorSpec.from_dict(data)
+        assert spec.shape == ("batch", 128)
 
 
 # =============================================================================

--- a/tests/unit/export/test_pytorch_export.py
+++ b/tests/unit/export/test_pytorch_export.py
@@ -132,6 +132,11 @@ class TestInputTensorSpecToTensor:
         with pytest.raises(ValueError, match="shape is None"):
             spec.to_tensor()
 
+    def test_symbolic_shape_uses_dummy_dimension(self) -> None:
+        spec = InputTensorSpec(name="x", dtype="float32", shape=("batch", 10))
+        t = spec.to_tensor()
+        assert t.shape == (1, 10)
+
 
 # =============================================================================
 # TestWinMLExportConfigGenerateDummyInputs
@@ -241,6 +246,18 @@ class TestExportPytorch:
         onnx_model = onnx.load(str(tmp_path / "model.onnx"))
         input_shape = [d.dim_value for d in onnx_model.graph.input[0].type.tensor_type.shape.dim]
         assert input_shape == [1, 10]
+
+    def test_symbolic_input_shape_exports_dynamic_axis(self, tmp_path) -> None:
+        model = SimpleLinear()
+        config = WinMLExportConfig(
+            input_tensors=[InputTensorSpec(name="x", dtype="float32", shape=("batch", 10))],
+        )
+        export_pytorch(model, tmp_path / "model.onnx", config, normalize=False)
+
+        onnx_model = onnx.load(str(tmp_path / "model.onnx"))
+        dims = onnx_model.graph.input[0].type.tensor_type.shape.dim
+        assert dims[0].dim_param == "batch"
+        assert dims[1].dim_value == 10
 
     def test_no_input_tensors_raises(self, tmp_path) -> None:
         model = SimpleLinear()


### PR DESCRIPTION
## Summary

- Add a first-class `--dynamic-axes` option for `winml export`.
- Allow symbolic string dimensions in `--input-specs` and infer matching dynamic ONNX input axes.
- Normalize/validate dynamic axes mappings, including JSON string axis keys.
- Keep static shapes as the QNN-safe default while making requested dynamic batch informational instead of warning-shaped.
- Document dynamic axes, symbolic input specs, and QNN compatibility caveats.

Fixes #929

## Validation

- `uv run ruff check --fix src\winml\modelkit\onnx\io.py src\winml\modelkit\export\config.py src\winml\modelkit\commands\export.py src\winml\modelkit\export\htp\exporter.py tests\unit\export\test_config_validation.py tests\unit\export\test_pytorch_export.py tests\unit\commands\test_export.py`
- `uv run pytest tests\unit\export\test_config_validation.py tests\unit\export\test_pytorch_export.py tests\unit\commands\test_export.py`