### PR TITLE
recipe(google/owlv2-base-patch16-ensemble): add zero-shot-object-detection recipes

### DIFF
--- a/examples/recipes/google_owlv2-base-patch16-ensemble/cpu/cpu/zero-shot-object-detection_fp16_config.json
+++ b/examples/recipes/google_owlv2-base-patch16-ensemble/cpu/cpu/zero-shot-object-detection_fp16_config.json
@@ -1,0 +1,74 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [1, 3, 960, 960],
+        "value_range": [0, 1]
+      },
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [1, 16],
+        "value_range": [0, 49408]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [1, 16],
+        "value_range": [0, 2]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      },
+      {
+        "name": "pred_boxes"
+      },
+      {
+        "name": "text_embeds"
+      },
+      {
+        "name": "image_embeds"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "zero-shot-object-detection",
+    "model_class": "AutoModelForZeroShotObjectDetection",
+    "model_type": "owlv2"
+  }
+}

--- a/examples/recipes/google_owlv2-base-patch16-ensemble/cpu/cpu/zero-shot-object-detection_fp32_config.json
+++ b/examples/recipes/google_owlv2-base-patch16-ensemble/cpu/cpu/zero-shot-object-detection_fp32_config.json
@@ -1,0 +1,55 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [1, 3, 960, 960],
+        "value_range": [0, 1]
+      },
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [1, 16],
+        "value_range": [0, 49408]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [1, 16],
+        "value_range": [0, 2]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      },
+      {
+        "name": "pred_boxes"
+      },
+      {
+        "name": "text_embeds"
+      },
+      {
+        "name": "image_embeds"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "zero-shot-object-detection",
+    "model_class": "AutoModelForZeroShotObjectDetection",
+    "model_type": "owlv2"
+  }
+}

--- a/examples/recipes/google_owlv2-base-patch16-ensemble/dml/gpu/zero-shot-object-detection_fp16_config.json
+++ b/examples/recipes/google_owlv2-base-patch16-ensemble/dml/gpu/zero-shot-object-detection_fp16_config.json
@@ -1,0 +1,74 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [1, 3, 960, 960],
+        "value_range": [0, 1]
+      },
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [1, 16],
+        "value_range": [0, 49408]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [1, 16],
+        "value_range": [0, 2]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      },
+      {
+        "name": "pred_boxes"
+      },
+      {
+        "name": "text_embeds"
+      },
+      {
+        "name": "image_embeds"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "zero-shot-object-detection",
+    "model_class": "AutoModelForZeroShotObjectDetection",
+    "model_type": "owlv2"
+  }
+}

--- a/examples/recipes/google_owlv2-base-patch16-ensemble/dml/gpu/zero-shot-object-detection_fp32_config.json
+++ b/examples/recipes/google_owlv2-base-patch16-ensemble/dml/gpu/zero-shot-object-detection_fp32_config.json
@@ -1,0 +1,55 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [1, 3, 960, 960],
+        "value_range": [0, 1]
+      },
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [1, 16],
+        "value_range": [0, 49408]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [1, 16],
+        "value_range": [0, 2]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      },
+      {
+        "name": "pred_boxes"
+      },
+      {
+        "name": "text_embeds"
+      },
+      {
+        "name": "image_embeds"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "zero-shot-object-detection",
+    "model_class": "AutoModelForZeroShotObjectDetection",
+    "model_type": "owlv2"
+  }
+}


### PR DESCRIPTION
## Summary

Recipe-only contribution (Effort L0). Adds fp32 and fp16 recipe configs for
**google/owlv2-base-patch16-ensemble** (`Owlv2ForObjectDetection`, task `zero-shot-object-detection`)
on two verified EP/device combinations: **CPU** and **DML (GPU)**. Goal L1 (perf) PASS on all 4 configs.

---

### 1. Recipe path(s)

- `examples/recipes/google_owlv2-base-patch16-ensemble/cpu/cpu/zero-shot-object-detection_fp32_config.json`
- `examples/recipes/google_owlv2-base-patch16-ensemble/cpu/cpu/zero-shot-object-detection_fp16_config.json`
- `examples/recipes/google_owlv2-base-patch16-ensemble/dml/gpu/zero-shot-object-detection_fp32_config.json`
- `examples/recipes/google_owlv2-base-patch16-ensemble/dml/gpu/zero-shot-object-detection_fp16_config.json`

### 2. README row

N/A — README not modified in this PR. The model has not yet passed fp16 eval on all 10 (EP, device) buckets; only cpu/cpu and dml/gpu are verified.

### 3. Build output dir

- `temp/owlv2_cpu_fp32/` (cpu/cpu fp32)
- `temp/owlv2_cpu_fp16/` (cpu/cpu fp16)
- `temp/owlv2_dml_fp32/` (dml/gpu fp32)
- `temp/owlv2_dml_fp16/` (dml/gpu fp16)

### 4. Build log

All 4 configs completed successfully:

- cpu/cpu fp32: `✅ Build complete in 46.4s` (Export 24.0s, Optimize 21.7s)
- cpu/cpu fp16: `✅ Build complete in 51.6s` (Export 23.3s, Optimize 22.6s, FP16 5.1s)
- dml/gpu fp32: `✅ Build complete in 47.2s` (Export 23.9s, Optimize 22.6s)
- dml/gpu fp16: `✅ Build complete in 46.2s` (Export 23.2s, Optimize 22.3s)

Note: Einsum op in `class_head` triggers `OpUnsupportedError` during optimize analysis but does not block the build.

### 5. Appended findings

N/A — no `model_knowledge/` or `skill_meta/` entries added (recipe-only L0 contribution; skill repo is separate from this working repo).

### 6. Optimum-coverage probe

N/A — `owlv2` architecture is already supported by HuggingFace transformers. No custom OnnxConfig was needed.

### 7. Claimed (Effort, Goal, Outcome)

| Axis | Tier |
|---|---|
| Effort | L0 (recipe-only, no per-architecture code) |
| Goal | L1 (build + perf) |
| Outcome | L0 (recipe + report) |

### 8. Goal-ladder verdict table

| Tier | Verdict | Evidence |
|---|---|---|
| L0 (build) | **PASS** | All 4 configs (cpu/cpu fp32, cpu/cpu fp16, dml/gpu fp32, dml/gpu fp16) build successfully with `winml build` |
| L1 (perf) | **PASS** | All 4 configs produce valid latency/throughput numbers via `winml perf` (see item 10) |
| L2 (numeric vs PyTorch) | N/A | Not attempted (Goal ceiling = L1) |
| L3 (task metric) | N/A | Not attempted (Goal ceiling = L1) |

### 9. Methodology-evolution declaration

No methodology friction observed during this contribution.

### 10. Perf & eval data

| EP / Device | Precision | Verdict | Mean | p50 | p90 | Throughput | RAM Δ | VRAM Δ (local) |
|---|---|---|---|---|---|---|---|---|
| OpenVINOExecutionProvider / cpu | fp32 | PASS | 1615.230 ms | 1624.474 ms | 1648.833 ms | 0.62 samples/s | +1312.20 MB | — |
| OpenVINOExecutionProvider / cpu | fp16 | PASS | 1326.320 ms | 1323.640 ms | 1355.230 ms | 0.75 samples/s | +1337.40 MB | — |
| DmlExecutionProvider / gpu | fp32 | PASS | 1087.511 ms | 1087.774 ms | 1089.853 ms | 0.92 samples/s | +1466.77 MB | +1701.40 MB |
| DmlExecutionProvider / gpu | fp16 | PASS | 2619.240 ms | 2609.730 ms | 2641.840 ms | 0.38 samples/s | +575.80 MB | +884.00 MB |
| QNNExecutionProvider / npu | * | HOST-BLOCKED | — | — | — | — | — | No NPU hardware available on test host |

Model size: fp32 = 585.55 MB (export); fp16 = 293.0 MB (quantized, 50% size reduction).

### 11. Component / op-level data

From `winml analyze` (post-optimization):

- **Total operators**: 1025 (after fusion)
- **Unique operator types**: 28
- **Top operators**: Reshape (411), Gemm (150), Transpose (121), Add (79), Mul (77), LayerNormalization (52), MatMul (49), Sigmoid (25), Softmax (24)
- **Notable ops**: Einsum (1, triggers OpUnsupportedError during analysis but does not block build), ArgMax (1), Gelu (2)
- **Fusion patterns applied**: `gelu_fusion`, `matmul_add_fusion` (autoconf converged in 2 iterations, 1007 → 1025 nodes)
- **Artifact**: `temp/owlv2_cpu_fp32/analyze_result.json`

### 12. Reproducible commands

```powershell
# Build (cpu/cpu fp32)
winml build -c examples/recipes/google_owlv2-base-patch16-ensemble/cpu/cpu/zero-shot-object-detection_fp32_config.json -m google/owlv2-base-patch16-ensemble -o temp/owlv2_cpu_fp32

# Build (cpu/cpu fp16) — --precision fp16 required to override auto-precision when --device is passed
winml build -c examples/recipes/google_owlv2-base-patch16-ensemble/cpu/cpu/zero-shot-object-detection_fp16_config.json -m google/owlv2-base-patch16-ensemble -o temp/owlv2_cpu_fp16 --precision fp16

# Build (dml/gpu fp32)
winml build -c examples/recipes/google_owlv2-base-patch16-ensemble/dml/gpu/zero-shot-object-detection_fp32_config.json -m google/owlv2-base-patch16-ensemble -o temp/owlv2_dml_fp32 --ep dml --device gpu

# Build (dml/gpu fp16) — --precision fp16 required to override auto-precision when --device is passed
winml build -c examples/recipes/google_owlv2-base-patch16-ensemble/dml/gpu/zero-shot-object-detection_fp16_config.json -m google/owlv2-base-patch16-ensemble -o temp/owlv2_dml_fp16 --ep dml --device gpu --precision fp16

# Perf (cpu fp32)
winml perf -m temp/owlv2_cpu_fp32/model.onnx --device cpu --iterations 5

# Perf (cpu fp16)
winml perf -m temp/owlv2_cpu_fp16/model.onnx --device cpu --iterations 5

# Perf (dml/gpu fp32)
winml perf -m temp/owlv2_dml_fp32/model.onnx --device gpu --ep dml --iterations 5

# Perf (dml/gpu fp16)
winml perf -m temp/owlv2_dml_fp16/model.onnx --device gpu --ep dml --iterations 5
```
