### PR TITLE
Standardize WinML CLI naming across code and docs (#510)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![License](https://img.shields.io/badge/license-MIT-green)
 [![Model Accuracy Report](https://img.shields.io/badge/docs-model%20accuracy%20report-blue)](https://microsoft.github.io/winml-cli/latest/reports/model_accuracy_report.html)
 
-**Windows ML CLI** is a command line tool for building **portable, performant, and high-quality** AI models for Windows ML. It takes you from a source model — whether from Hugging Face or your own pipeline — to a hardware-optimized artifact in a reproducible workflow.
+**WinML CLI** is a command line tool for building **portable, performant, and high-quality** AI models for Windows ML. It takes you from a source model — whether from Hugging Face or your own pipeline — to a hardware-optimized artifact in a reproducible workflow.
 
 Purpose-built for Windows hardware diversity, the CLI handles conversion, graph optimization, and compilation across AMD, Intel, NVIDIA, and Qualcomm targets. The CLI fits naturally into CI/CD pipelines so teams can validate and ship models easily.
 
@@ -90,7 +90,7 @@ uv run winml inspect -m microsoft/resnet-50
 uv run winml build -m microsoft/resnet-50 -o resnet_out/ --no-quant
 ```
 
-`winml build` runs all pipeline steps in sequence — export, optimize, quantize. You can start a model build without a config file, or provide one to configure each step in the sequence (see [`winml config`](https://microsoft.github.io/winml-cli/latest/commands/config/) to customize). All intermediate artifacts land in `resnet_out/`. For more details, see [Output Layout - Windows ML CLI](https://microsoft.github.io/winml-cli/latest/reference/output-layout/#file-categories).
+`winml build` runs all pipeline steps in sequence — export, optimize, quantize. You can start a model build without a config file, or provide one to configure each step in the sequence (see [`winml config`](https://microsoft.github.io/winml-cli/latest/commands/config/) to customize). All intermediate artifacts land in `resnet_out/`. For more details, see [Output Layout - WinML CLI](https://microsoft.github.io/winml-cli/latest/reference/output-layout/#file-categories).
 
 ### Benchmark the model
 
@@ -104,8 +104,8 @@ uv run winml perf -m resnet_out/model.onnx --device auto --iterations 50 --monit
 
 ## 🔀 Try Other Ways
 
-- **Use with AI Agent** — See details at [Use with AI Agent - Windows ML CLI](https://microsoft.github.io/winml-cli/latest/getting-started/agent-skill/).
-- **UI Quickstart** — See also [UI Quickstart - Windows ML CLI](https://microsoft.github.io/winml-cli/latest/getting-started/ui-quickstart/).
+- **Use with AI Agent** — See details at [Use with AI Agent - WinML CLI](https://microsoft.github.io/winml-cli/latest/getting-started/agent-skill/).
+- **UI Quickstart** — See also [UI Quickstart - WinML CLI](https://microsoft.github.io/winml-cli/latest/getting-started/ui-quickstart/).
 
 ---
 

--- a/docs/getting-started/ui-quickstart.md
+++ b/docs/getting-started/ui-quickstart.md
@@ -1,13 +1,13 @@
-# Try Windows ML CLI with a UI
+# Try WinML CLI with a UI
 
-If you prefer a graphical interface, you can use the **Foundry Toolkit** extension for VS Code to run Windows ML CLI model conversion without typing commands.
+If you prefer a graphical interface, you can use the **Foundry Toolkit** extension for VS Code to run WinML CLI model conversion without typing commands.
 
 ## Quick reference
 
 1. **Install [Visual Studio Code](https://code.visualstudio.com/)**
 2. **Install the Foundry Toolkit extension** — search for `Foundry Toolkit` in the VS Code Extensions view
 3. **Open the Model Conversion tool** — in the Foundry Toolkit panel, select **Model Conversion**
-4. **Choose your model** — pick a model from Hugging Face, provide a local path, or select from the built-in model catalog filtered by Windows ML CLI
-5. **Run the build** — the extension invokes Windows ML CLI and streams the output to the VS Code terminal
+4. **Choose your model** — pick a model from Hugging Face, provide a local path, or select from the built-in model catalog filtered by WinML CLI
+5. **Run the build** — the extension invokes WinML CLI and streams the output to the VS Code terminal
 
-For a full walkthrough, see [Build with Windows ML CLI (Preview)](https://code.visualstudio.com/docs/intelligentapps/modelconversion#_build-with-windows-ml-cli-preview) in the VS Code documentation.
+For a full walkthrough, see [Build with WinML CLI (Preview)](https://code.visualstudio.com/docs/intelligentapps/modelconversion#_build-with-windows-ml-cli-preview) in the VS Code documentation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # winml-cli
 
-Windows ML CLI is a command line tool for building portable, performant, and high-quality AI models for Windows ML. It takes you from a source model — whether from Hugging Face or your own pipeline — to a hardware-optimized artifact in a reproducible workflow.
+WinML CLI is a command line tool for building portable, performant, and high-quality AI models for Windows ML. It takes you from a source model — whether from Hugging Face or your own pipeline — to a hardware-optimized artifact in a reproducible workflow.
 
 Purpose-built for Windows hardware diversity, the CLI handles conversion, graph optimization, and compilation across AMD, Intel, NVIDIA, and Qualcomm targets. The CLI fits naturally into CI/CD pipelines so teams can validate and ship models easily.
 
@@ -29,7 +29,7 @@ Purpose-built for Windows hardware diversity, the CLI handles conversion, graph 
 
 ## Repository access
 
-To request access to the Windows ML CLI repository, visit [aka.ms/winml-cli](https://aka.ms/winml-cli).
+To request access to the WinML CLI repository, visit [aka.ms/winml-cli](https://aka.ms/winml-cli).
 
 ## License
 

--- a/docs/reference/supported-models.md
+++ b/docs/reference/supported-models.md
@@ -1,6 +1,6 @@
 # Supported Models
 
-Windows ML CLI has validated a set of models for compatibility across all
+WinML CLI has validated a set of models for compatibility across all
 Execution Providers (EPs)—see the full
 [Model Accuracy Report](../reports/model_accuracy_report.html).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Windows ML CLI
+site_name: WinML CLI
 site_description: A CLI toolkit to build portable, performant, and high-quality models for Windows ML.
 site_url: https://microsoft.github.io/winml-cli/
 repo_url: https://github.com/microsoft/winml-cli

--- a/scripts/e2e_eval/run_sa_eval.py
+++ b/scripts/e2e_eval/run_sa_eval.py
@@ -97,7 +97,7 @@ def _count_onnx_nodes(path: Path) -> int | None:
 
 
 def _run_cli(args: list[str]) -> tuple[int, str]:
-    """Run a winml CLI command via subprocess. Returns (rc, combined_output)."""
+    """Run a WinML CLI command via subprocess. Returns (rc, combined_output)."""
     result = subprocess.run(  # noqa: S603
         [sys.executable, "-m", "winml.modelkit.cli", *args],
         capture_output=True,
@@ -138,7 +138,7 @@ def _normalize_ep(ep: str) -> str:
 
 
 def _resolve_ep_arg(ep: str) -> str:
-    """Resolve full ORT EP name to the short form accepted by winml CLI --ep."""
+    """Resolve full ORT EP name to the short form accepted by WinML CLI --ep."""
     try:
         return _EP_TO_PERF_ARG[ep]
     except KeyError:

--- a/skills/use-winml-cli/SKILL.md
+++ b/skills/use-winml-cli/SKILL.md
@@ -3,7 +3,7 @@ name: use-winml-cli
 description: Build, optimize, quantize, compile, and benchmark ONNX models for Windows ML using the `winml` CLI. Covers the Build-Your-Own-Model (BYOM) pipeline across NPU (Qualcomm QNN, Intel OpenVINO, AMD VitisAI), GPU, and CPU execution providers. Use this skill whenever the user wants to run a Hugging Face or ONNX model on a Windows AI PC, target an NPU, prepare a model for on-device inference, benchmark latency on Snapdragon X Elite / Intel Core Ultra / AMD Ryzen AI, or troubleshoot operator/EP compatibility — even when they don't say "winml" by name. If a user mentions running models on Windows hardware, NPU acceleration, or low-latency on-device inference, this skill applies. **Skip for generative models** — LLMs (GPT, LLaMA, Phi, Mistral), Stable Diffusion, Whisper, or any decoder-only / seq2seq architecture are out of scope (planned for late 2026).
 ---
 
-# winml CLI
+# WinML CLI
 
 `winml` is a CLI that turns a source model — a Hugging Face ID or a local ONNX file — into a portable, performant artifact that runs on any Windows execution provider. This skill teaches you the *shape* of that workflow. The CLI is the source of truth for current commands and flags.
 

--- a/src/winml/modelkit/analyze/core/runtime_checker_query.py
+++ b/src/winml/modelkit/analyze/core/runtime_checker_query.py
@@ -402,7 +402,7 @@ def _normalize_table_path(path_like: str | Path) -> str:
     """Normalize table path for debug output.
 
     - Resolve '..' segments when possible.
-    - If the path includes a workspace folder marker (e.g., ModelKit),
+    - If the path includes a workspace folder marker (e.g., winml-cli),
       return a path starting from that marker.
     """
     p = Path(path_like)
@@ -412,7 +412,7 @@ def _normalize_table_path(path_like: str | Path) -> str:
         pass
 
     parts = list(p.parts)
-    for marker in ("ModelKit",):
+    for marker in ("winml-cli",):
         if marker in parts:
             idx = parts.index(marker)
             return "\\".join(parts[idx:])

--- a/src/winml/modelkit/cli.py
+++ b/src/winml/modelkit/cli.py
@@ -247,7 +247,7 @@ class LazyGroup(ActionGroup):
     invoke_without_command=True,
     context_settings={"help_option_names": ["-h", "--help"]},
 )
-@click.version_option(version=__version__, prog_name="winml")
+@click.version_option(version=__version__, prog_name="WinML CLI")
 @verbosity_options()
 @no_color_option()
 @click.option(

--- a/src/winml/modelkit/commands/analyze.py
+++ b/src/winml/modelkit/commands/analyze.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-"""Analyze command for winml CLI.
+"""Analyze command for WinML CLI.
 
 Analyzes ONNX models for runtime support with Rich Live stacked bar
 visualization, showing real-time per-node progress display.

--- a/src/winml/modelkit/commands/compile.py
+++ b/src/winml/modelkit/commands/compile.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-"""Compile command for winml CLI.
+"""Compile command for WinML CLI.
 
 This module provides the compile command that compiles ONNX models to
 EP-specific formats (e.g., QNN EPContext).

--- a/src/winml/modelkit/commands/export.py
+++ b/src/winml/modelkit/commands/export.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-"""Export command for winml CLI.
+"""Export command for WinML CLI.
 
 This module provides the export command that uses export_onnx() as the single
 implementation path for HuggingFace to ONNX model conversion.

--- a/src/winml/modelkit/commands/optimize.py
+++ b/src/winml/modelkit/commands/optimize.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-"""Optimize command for winml CLI.
+"""Optimize command for WinML CLI.
 
 This module provides the optimize command that uses the capability-driven
 optimizer for ONNX model optimization with fusion and graph optimizations.

--- a/src/winml/modelkit/commands/quantize.py
+++ b/src/winml/modelkit/commands/quantize.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-"""Quantize command for winml CLI.
+"""Quantize command for WinML CLI.
 
 This module provides the quantize command that inserts QDQ (Quantize-Dequantize)
 nodes into ONNX models for quantization-aware inference.

--- a/src/winml/modelkit/serve/app.py
+++ b/src/winml/modelkit/serve/app.py
@@ -726,7 +726,7 @@ def _register_routes(app: FastAPI, *, mode: str) -> None:
         "/v1/cli/{command}",
         response_model=CliResponse,
         tags=["cli"],
-        summary="Run any winml CLI command",
+        summary="Run any WinML CLI command",
     )
     async def cli_command(command: str, request: CliRequest) -> CliResponse:
         """Proxy to the CLI wrapper — available in all server modes."""

--- a/src/winml/modelkit/serve/cli_api.py
+++ b/src/winml/modelkit/serve/cli_api.py
@@ -5,7 +5,7 @@
 
 """Phase 0: CLI-as-API FastAPI application.
 
-Wraps every winml CLI command as a REST endpoint using Click's CliRunner.
+Wraps every WinML CLI command as a REST endpoint using Click's CliRunner.
 Each request is stateless — the model loads, runs, and unloads within a
 single CliRunner.invoke() call.
 
@@ -225,7 +225,7 @@ def _extract_json_from_stdout(stdout: str) -> dict[str, Any] | list[Any] | None:
 
 
 def _invoke(command: str, args: dict[str, Any]) -> CliResponse:
-    """Invoke a winml CLI command via CliRunner and return a CliResponse.
+    """Invoke a WinML CLI command via CliRunner and return a CliResponse.
 
     Applies the per-command JSON extraction strategy to populate ``result``.
     """
@@ -336,7 +336,7 @@ async def health() -> HealthResponse:
     "/v1/cli/{command}",
     response_model=CliResponse,
     tags=["CLI"],
-    summary="Invoke a winml CLI command",
+    summary="Invoke a WinML CLI command",
     responses={
         200: {"description": "Command invoked (check exit_code for success/failure)"},
         404: {"description": "Unknown command name"},

--- a/src/winml/modelkit/serve/static/index.html
+++ b/src/winml/modelkit/serve/static/index.html
@@ -823,7 +823,7 @@ canvas.spark{width:100%;height:60px;display:block}
             <code>GET /v1/resources</code> &mdash; Memory and request stats<br>
             <code>GET /v1/models/{id}/stats</code> &mdash; Live latency stats for a model<br>
             <code>GET /v1/logs</code> &mdash; Poll recent log lines<br>
-            <code>POST /v1/cli/{command}</code> &mdash; Run any winml CLI command
+            <code>POST /v1/cli/{command}</code> &mdash; Run any WinML CLI command
           </div>
         </div>
 

--- a/src/winml/modelkit/utils/console.py
+++ b/src/winml/modelkit/utils/console.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
-"""Shared console output utilities for winml CLI commands.
+"""Shared console output utilities for WinML CLI commands.
 
 Provides consistent Rich-based formatting for:
 - Config command: headers, I/O specs, resolution summary

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-"""Shared test helpers for winml CLI invocation.
+"""Shared test helpers for WinML CLI invocation.
 
 Provides ``run_inspect``, a thin wrapper around ``CliRunner.invoke`` used
 by both ``tests/cli/test_inspect_cli.py`` and ``tests/e2e/test_inspect_e2e.py``


### PR DESCRIPTION
Standardizes the product name to **WinML CLI** for #510, resolving the mixed user-facing spellings (`winml CLI`, `Windows ML CLI`).

**Code** (8b5e1443)
- Normalize lowercase `winml CLI` -> `WinML CLI` in command/serve/utils docstrings, scripts, the use-winml-cli skill, the serve static demo, and the test helper (15 spots).
- Brand `winml --version` via prog_name (now `WinML CLI, version X`).
- Replace the stale hardcoded `ModelKit` workspace-folder marker with `winml-cli` in analyze debug path normalization.

**Docs** (19e53bde)
- Rename product display name `Windows ML CLI` -> `WinML CLI` across README, mkdocs site_name, and docs pages (index, ui-quickstart, supported-models).

Platform references (`Windows ML`) and the CLI command name (`winml`) are intentionally left unchanged.

Addresses #510.