### PR TITLE
Add ASR fp16 recipe for MahmoudAshraf/mms-300m-1130-forced-aligner

### DIFF
--- a/examples/recipes/MahmoudAshraf_mms-300m-1130-forced-aligner/cpu/cpu/automatic-speech-recognition_fp16_config.json
+++ b/examples/recipes/MahmoudAshraf_mms-300m-1130-forced-aligner/cpu/cpu/automatic-speech-recognition_fp16_config.json
@@ -1,0 +1,58 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          16000
+        ],
+        "value_range": [
+          -1,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "automatic-speech-recognition",
+    "model_type": "wav2vec2"
+  }
+}

--- a/examples/recipes/MahmoudAshraf_mms-300m-1130-forced-aligner/cpu/cpu/automatic-speech-recognition_fp32_config.json
+++ b/examples/recipes/MahmoudAshraf_mms-300m-1130-forced-aligner/cpu/cpu/automatic-speech-recognition_fp32_config.json
@@ -1,0 +1,39 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          16000
+        ],
+        "value_range": [
+          -1,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "automatic-speech-recognition",
+    "model_type": "wav2vec2"
+  }
+}


### PR DESCRIPTION
## Summary

Adds CPU fp32 and fp16 recipes for `MahmoudAshraf/mms-300m-1130-forced-aligner`, a multilingual Wav2Vec2 CTC model used to generate frame emissions for forced alignment and ASR workflows. This is an L0 recipe-only contribution; current `main` already resolves `AutoModelForCTC`, so no source fix is needed. Both required tuples reached L2 PASS for build, perf, and numerical parity; L3 evaluation remains CLI-BLOCKED because WinML has no automatic-speech-recognition evaluator ([#1229](https://github.com/microsoft/winml-cli/issues/1229)).

## Model metadata

### What the model does

This 300M-parameter multilingual audio model consumes raw speech waveforms and emits per-frame logits over a 31-symbol CTC vocabulary. Its advertised use is forced alignment: downstream code combines those emissions with supplied transcript text and a language identifier to produce token/word spans and timestamps; alignment and CTC post-processing are outside the model forward graph.

- Evidence: the [pinned Hugging Face model card](https://huggingface.co/MahmoudAshraf/mms-300m-1130-forced-aligner/tree/49402e9577b1158620820667c218cd494cc44486) identifies a Transformers conversion of MMS-300M trained for forced alignment and demonstrates emissions-to-word-timestamps usage; its pinned config declares `architectures=[Wav2Vec2ForCTC]`, `model_type=wav2vec2`, and `vocab_size=31`. Transformers 5.14.1 `Wav2Vec2ForCTC.forward` sends raw `input_values` through `wav2vec2`, dropout, and `lm_head` to frame logits.
- Confidence: **verified**.

### Primary user stories

- A user supplies a speech recording, its transcript, and an ISO-639-3 language code to obtain scored word timestamps for subtitle, segmentation, or transcript-alignment workflows.
  - Evidence: pinned model-card usage calls `load_audio`, `generate_emissions`, `preprocess_text`, `get_alignments`, `get_spans`, and `postprocess_results` to produce `word_timestamps`.
  - Confidence: **verified**.
- A user supplies raw multilingual speech to obtain CTC frame emissions that another decoder or aligner can consume.
  - Evidence: the checkpoint pipeline tag is `automatic-speech-recognition`; `Wav2Vec2ForCTC.forward` returns logits with vocabulary width `config.vocab_size`.
  - Confidence: **verified**.

### Supported tasks

- **automatic-speech-recognition**
  - Support surfaces: checkpoint, Transformers, Optimum ONNX, and WinML.
  - Evidence: the pinned Hugging Face revision declares `pipeline_tag=automatic-speech-recognition`; Transformers 5.14.1 defines `Wav2Vec2ForCTC` and `AutoModelForCTC` support; the Optimum 2.1.0 / optimum-onnx 0.1.0 registry probe and current-`main` WinML inspection confirm the task surface.
  - Confidence: **verified**.

### Model architecture

```text
Wav2Vec2ForCTC
├── Raw waveform input_values [batch, time]
├── Convolutional feature encoder x 7 (channels 512; total stride 320)
├── Feature projection (512 -> 1024)
├── Stable-LayerNorm encoder
│   ├── Positional convolution (kernel 128, groups 16)
│   └── Transformer layer x 24
│       ├── Pre-LN bidirectional self-attention (16 heads, width 1024)
│       ├── Feed-forward (1024 -> 4096 -> 1024, GELU)
│       └── Residual connections + LayerNorm
└── CTC language-model head (1024 -> 31 frame logits)
```

- Source/confidence: pinned checkpoint config plus Transformers 5.14.1 construction and forward flow for `Wav2Vec2FeatureEncoder`, `Wav2Vec2Model`, `Wav2Vec2EncoderStableLayerNorm`, `Wav2Vec2EncoderLayerStableLayerNorm`, `Wav2Vec2Attention`, `Wav2Vec2FeedForward`, and `Wav2Vec2ForCTC` (**verified**). The checkpoint disables adapters and inference-time masking.

## Validation and support evidence

### Baseline

The frozen baseline is WinML 0.2.0 at `main` commit `57c2cdf2381cc3a55f1ef065d247d838b3c6a0db`. A fresh recipe-free CPU build passed in 142.5 s, selected `AutoModelForCTC` with task `automatic-speech-recognition`, and produced a valid ONNX model with IR 8, opset 17, 967 optimized nodes, `input_values` FLOAT `[1,16000]`, `logits` FLOAT `[1,49,31]`, and 1,261,886,852 bytes of external data. Current `main` therefore already fixes the historical loader mismatch: config, inspect, and recipe-free build resolve `AutoModelForCTC`; no source-code change is required.

Exact baseline provenance and recipe-free build commands:

```powershell
git rev-parse HEAD
winml --version
$BASELINE='temp/mms-forced-aligner-current-main-baseline'
winml build -m MahmoudAshraf/mms-300m-1130-forced-aligner -o $BASELINE --ep cpu --device cpu --no-analyze --no-optimize --no-quant --no-compile --rebuild
```

Observed results were `57c2cdf2381cc3a55f1ef065d247d838b3c6a0db`, WinML `0.2.0`, and recipe-free build PASS in 142.5 s with the structure reported above.

A one-iteration CPU fp32 perf smoke passed with mean/p50 154.973 ms, throughput 6.45 samples/s, and logits `[1,49,31]`. Memory was intentionally disabled, so no baseline memory value is claimed. This establishes the L1 baseline floor.

Starting auto-config behavior selected `automatic-speech-recognition`, `wav2vec2`, and `AutoModelForCTC`; the Optimum registry exposed `audio-classification`, `audio-frame-classification`, `audio-xvector`, `automatic-speech-recognition`, and `feature-extraction` both before and after WinML registration, with no task added by WinML (`VENDOR-ONLY`). The eval schema probe exited 2 because `automatic-speech-recognition` is unsupported by `winml eval`, establishing an independent L3 CLI blocker.

The planner re-issued charter revision 2 solely to refresh this exact-current-`main` baseline. The candidate recipes and measured candidate L0/L1/L2 evidence were unchanged.

### Goal

- **Effort:** L0, per-model recipe-only support for CPU/CPU fp32 and fp16.
- **Committed Goal ceiling:** L2.
- **Outcome target:** L0 shipped support with both required precision tuples covered.
- **Success definition:** fresh CPU fp32/fp16 builds with valid structure, CPU perf, and named-input numerical parity against the same pinned PyTorch checkpoint.
- **Ceiling event:** no downgrade occurred. Charter revision 2 retained the L2 ceiling while refreshing the current-`main` baseline.

### Outcome

- **Shipped tier:** L0.
- **Highest reached Goal verdict:** **L2 PASS**.
- **Coverage:** full; no deferred tuples.
- **Shipped files:**
  - `examples/recipes/MahmoudAshraf_mms-300m-1130-forced-aligner/cpu/cpu/automatic-speech-recognition_fp32_config.json`
  - `examples/recipes/MahmoudAshraf_mms-300m-1130-forced-aligner/cpu/cpu/automatic-speech-recognition_fp16_config.json`
- The final contribution contains only these two recipe files. It includes no source or test changes.
- L3 is **CLI-BLOCKED** for both precisions because WinML has no automatic-speech-recognition evaluator; the feature gap is tracked in [#1229](https://github.com/microsoft/winml-cli/issues/1229).
- Model knowledge finding `wav2vec2-004` was appended separately in learner Lane A ([gim-home/ModelKitArtifacts#182](https://github.com/gim-home/ModelKitArtifacts/pull/182)); no methodology finding was triggered.
- No methodology friction observed.
- Quality gates: insert-license PASS; Ruff PASS; mypy PASS with no issues in 425 source files. Pytest partitions passed as follows: analyze 1,478 passed / 45 skipped in 286.41 s; models 1,451 passed / 6 skipped / 2 xfailed in 59.57 s; optim 547 passed / 16 skipped / 1 xfailed in 35.59 s; commands 3,171 passed / 9 skipped / 1 warning in 259.31 s; remaining 781 passed / 2 skipped / 1 deselected / 2 warnings in 511.68 s.
- This skill-managed PR remains **Draft** after review, as required by the shipment contract.

### Per-EP/device/precision results — including perf and eval data

#### Goal ladder

| Tier | Verdict | Evidence |
|---|---|---|
| L0 | **PASS** | Both required CPU/CPU precisions freshly built and structurally verified. |
| L1 | **PASS** | Both required CPU/CPU precisions produced concrete named-input latency, throughput, and RAM evidence. |
| L2 | **PASS** | Fresh pinned PyTorch reference and identical deterministic named input were used for each ONNX artifact. |

L3 was an above-ceiling supplementary check, not a Goal-ladder row. It is **CLI-BLOCKED** because `automatic-speech-recognition` is not supported by `winml eval`; the evidence is reported in the Eval table below and tracked by [#1229](https://github.com/microsoft/winml-cli/issues/1229).

#### Build and structural validation (L0)

| EP / Device | Precision | Verdict | IR / opset | Nodes | Initializers | I/O | External data |
|---|---|---|---|---:|---|---|---:|
| CPUExecutionProvider / cpu | fp32 | **PASS** | 8 / 17 | 967 | 428 FLOAT, 6 INT64 | `input_values` FLOAT `[1,16000]` → `logits` FLOAT `[1,49,31]` | 1,261,886,852 bytes |
| CPUExecutionProvider / cpu | fp16 | **PASS** | 8 / 17 | 969 | 428 FLOAT16, 6 INT64 | `input_values` FLOAT `[1,16000]` → `logits` FLOAT `[1,49,31]` | 630,943,426 bytes |

Both fresh builds exited 0 and passed ONNX checker/load validation. Persisted final/export graphs contained zero `hierarchy_tag` attributes despite the exporter reporting 1,321/1,321 tags.

#### Perf (L1)

| EP / Device | Precision | Verdict | Mean | p50 | Throughput | RAM Δ | VRAM Δ |
|---|---|---|---:|---:|---:|---:|---:|
| CPUExecutionProvider / cpu | fp32 | **PASS** | 166.081 ms | 166.081 ms | 6.02 samples/s | +1,320,439,808 bytes peak process RSS | — |
| CPUExecutionProvider / cpu | fp16 | **PASS** | 180.291 ms | 180.291 ms | 5.55 samples/s | +2,951,737,344 bytes peak process RSS | — |

The one-iteration, zero-warmup named-input `winml perf` runs exited 0 with memory disabled. After the default memory-enabled baseline command terminated before statistics on this host, a supplementary named-input ORT harness supplied RAM fields:

| Precision | Iterations | Mean | p50 | Throughput | Session RAM Δ | Peak RAM Δ |
|---|---:|---:|---:|---:|---:|---:|
| fp32 | 3 | 135.29466674663126 ms | 130.28870010748506 ms | 7.391274349880456 samples/s | 1,224,876,032 bytes | 1,320,439,808 bytes |
| fp16 | 3 | 357.19733336009085 ms | 346.76560014486313 ms | 2.799572971592986 samples/s | 23,199,744 bytes | 2,951,737,344 bytes |

The supplementary fp32 latencies were 153.93070015124977, 130.28870010748506, and 121.66459998115897 ms; fp16 latencies were 442.2249000053853, 346.76560014486313, and 282.60149993002415 ms. Both sessions used named `input_values`, `ORT_DISABLE_ALL`, and reported no VRAM delta.

#### Numerical parity (L2)

The reference was fresh `AutoModelForCTC` PyTorch inference from checkpoint revision `49402e9577b1158620820667c218cd494cc44486`, using the identical deterministic named input `input_values` FLOAT `[1,16000]`; both ONNX outputs were `logits` `[1,49,31]`.

| EP / Device | Precision | Verdict | Cosine | Max absolute error | Mean absolute error |
|---|---|---|---:|---:|---:|
| CPUExecutionProvider / cpu | fp32 | **PASS** | 0.9999999999993118 | 3.471970558166504e-05 | 5.141229241831354e-06 |
| CPUExecutionProvider / cpu | fp16 | **PASS** | 0.999999914482318 | 0.016648292541503906 | 0.001753806826303553 |

#### Eval (L3, above ceiling)

| EP / Device | Precision | Verdict | Exit | Dataset / revision / subset | Task metric | Blocker |
|---|---|---|---:|---|---|---|
| CPUExecutionProvider / cpu | fp32 | **CLI-BLOCKED** | 1 | — / — / — | — | `automatic-speech-recognition` is not supported by `winml eval`; [#1229](https://github.com/microsoft/winml-cli/issues/1229) |
| CPUExecutionProvider / cpu | fp16 | **CLI-BLOCKED** | 1 | — / — / — | — | `automatic-speech-recognition` is not supported by `winml eval`; [#1229](https://github.com/microsoft/winml-cli/issues/1229) |

The pinned model card names only a “forced alignment dataset” and provides no dataset repository, subset, split, or revision. WinML has no ASR evaluator or default dataset, so no dataset was substituted. WER or forced-alignment timing quality would require a separately specified transcript-and-audio corpus plus an alignment evaluator; neither is registered in `winml eval`.

### Delta

The deliverable is recipe-only and structurally **CHANGED** relative to the generated baseline recipe after recursively stripping `_note` keys:

| Recipe | JSON pointer | Baseline | Shipped | Reason |
|---|---|---|---|---|
| `automatic-speech-recognition_fp32_config.json` | `/loader/model_class` | `"AutoModelForCTC"` | absent | Removes a redundant generated class pin; current `main` derives `AutoModelForCTC` from checkpoint/model-type metadata while the recipe retains task and model type. |
| `automatic-speech-recognition_fp16_config.json` | `/loader/model_class` | `"AutoModelForCTC"` | absent | Same current-`main` derivation; no class pin or source fix is needed. |
| `automatic-speech-recognition_fp16_config.json` | `/quant` | `null` | fp16 conversion object below | Precision-specific intent using the established Wav2Vec2 CPU recipe shape; this is not a metadata-derived class-wide resolution fix. |

The shipped fp16 `/quant` value is exactly:

```json
{
  "mode": "fp16",
  "samples": 10,
  "calibration_method": "minmax",
  "weight_type": "uint8",
  "activation_type": "uint8",
  "per_channel": false,
  "symmetric": false,
  "weight_symmetric": null,
  "activation_symmetric": null,
  "save_calibration": false,
  "distribution": "uniform",
  "seed": null,
  "calibration_load_path": null,
  "calibration_save_path": null,
  "op_types_to_quantize": null,
  "nodes_to_exclude": null,
  "fp16_keep_io_types": true,
  "fp16_op_block_list": null
}
```

There are no code paths, symbols, or class-wide behavior changes. Recipe-free acceptance is not required for this L0 per-model fix, although the frozen current-`main` baseline independently passed recipe-free. Reducibility is consistent with the charter: the only effective model-support delta is the per-model fp16 `quant.mode` intent; omitting `loader.model_class` preserves current-`main` derivation. The production recipe README remains untouched.

### Analyze summary — component level and op level

Static rule analysis **PASS** completed for both artifacts; exit 1 reflects QNN partial operators, not analysis failure. Seven provider classifications were completed per artifact against 1,746 rule parquet files. This is static compatibility analysis, not runtime execution.

#### Component-level summary

| Artifact | Architecture coverage | Mapping | Actionable EP findings |
|---|---|---|---|
| fp32 | 7x convolutional feature encoder; feature projection; positional convolution; 24x attention/FFN encoder; CTC vocabulary head | 965 mapped, 0 partial, 2 unmapped; `mapped+explicit-gaps` | QNN partial: Add, Div, Erf, IsNaN, Mul; unsupported: none |
| fp16 | 7x convolutional feature encoder; feature projection; positional convolution; 24x attention/FFN encoder; CTC vocabulary head | 965 mapped, 0 partial, 4 unmapped; `mapped+explicit-gaps` | QNN partial: Add, Div, Erf, IsNaN, Mul; unsupported: none |

For fp32, 2 nodes carry only broader encoder/model scope names that do not uniquely resolve to a frozen leaf component; for fp16, 4 nodes have that gap. They remain explicitly unmapped rather than guessed.

#### Op-level summary

| Artifact | Graph | Dominant ops | EP roll-up |
|---|---|---|---|
| fp32 | 967 operators / 14 types | Add 251; MatMul 194; Mul 112; Transpose 111; Reshape 96; LayerNormalization 57; Div 32; Erf 32 | NvTensorRTRTX and OpenVINO fully supported; QNN partial for Add, Div, Erf, IsNaN, Mul with none unsupported |
| fp16 | 969 operators / 15 types | Add 251; MatMul 194; Mul 112; Transpose 111; Reshape 96; LayerNormalization 57; Div 32; Erf 32 | NvTensorRTRTX and OpenVINO fully supported; QNN partial for Add, Div, Erf, IsNaN, Mul with none unsupported |

Rule-less CUDA, MIGraphX, TensorRT, and DML classifications report all operator types unknown for both artifacts.

### Reproduce commands

```powershell
$OUT='temp/model-support-repro'
winml build -c examples/recipes/MahmoudAshraf_mms-300m-1130-forced-aligner/cpu/cpu/automatic-speech-recognition_fp32_config.json -m MahmoudAshraf/mms-300m-1130-forced-aligner -o $OUT/fp32 --ep cpu --device cpu --precision fp32 --no-analyze --no-optimize --no-compile --rebuild
winml build -c examples/recipes/MahmoudAshraf_mms-300m-1130-forced-aligner/cpu/cpu/automatic-speech-recognition_fp16_config.json -m MahmoudAshraf/mms-300m-1130-forced-aligner -o $OUT/fp16 --ep cpu --device cpu --precision fp16 --no-analyze --no-optimize --no-compile --rebuild
python -c "import numpy as np,sys; np.savez(sys.argv[1], input_values=np.random.default_rng(1095).uniform(-.25,.25,(1,16000)).astype(np.float32))" $OUT/named_input.npz
winml perf -m $OUT/fp32/model.onnx --device cpu --ep cpu --precision fp32 --iterations 1 --warmup 0 --input-data $OUT/named_input.npz --no-memory
winml perf -m $OUT/fp16/model.onnx --device cpu --ep cpu --precision fp16 --iterations 1 --warmup 0 --input-data $OUT/named_input.npz --no-memory
$L2=@'
import sys
import numpy as np
import onnxruntime as ort
import torch
from transformers import AutoModelForCTC
root=sys.argv[1]
x=np.random.default_rng(1095).uniform(-.25,.25,(1,16000)).astype(np.float32)
model=AutoModelForCTC.from_pretrained('MahmoudAshraf/mms-300m-1130-forced-aligner',revision='49402e9577b1158620820667c218cd494cc44486').eval()
with torch.inference_mode(): ref=model(input_values=torch.from_numpy(x)).logits.detach().cpu().numpy()
for precision in ('fp32','fp16'):
 session=ort.InferenceSession(f'{root}/{precision}/model.onnx',providers=['CPUExecutionProvider'])
 output=session.run(['logits'],{'input_values':x})[0]
 left=output.astype(np.float64).ravel(); right=ref.astype(np.float64).ravel(); delta=output.astype(np.float64)-ref.astype(np.float64)
 print(precision,{'cosine':float(np.dot(left,right)/(np.linalg.norm(left)*np.linalg.norm(right))),'max_abs':float(np.max(np.abs(delta))),'mean_abs':float(np.mean(np.abs(delta)))})
'@
$L2 | Set-Content -Encoding utf8 $OUT/l2_parity.py
python $OUT/l2_parity.py $OUT
$env:WINMLCLI_RULES_DIR='<populated-rules-root>'
winml analyze --model $OUT/fp32/model.onnx --ep all --output $OUT/analyze_fp32_all.json --overwrite
winml analyze --model $OUT/fp16/model.onnx --ep all --output $OUT/analyze_fp16_all.json --overwrite
winml eval -m $OUT/fp32/model.onnx --model-id MahmoudAshraf/mms-300m-1130-forced-aligner --task automatic-speech-recognition --device cpu --ep cpu --precision fp32
winml eval -m $OUT/fp16/model.onnx --model-id MahmoudAshraf/mms-300m-1130-forced-aligner --task automatic-speech-recognition --device cpu --ep cpu --precision fp16
```
