### PR TITLE
recipe(owlv2-base-patch16): add CPU fp32 and fp16 support

### DIFF
--- a/examples/recipes/google_owlv2-base-patch16/cpu/cpu/zero-shot-object-detection_fp16_config.json
+++ b/examples/recipes/google_owlv2-base-patch16/cpu/cpu/zero-shot-object-detection_fp16_config.json
@@ -1,0 +1,74 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [1, 3, 960, 960],
+        "value_range": [0, 1]
+      },
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [1, 16],
+        "value_range": [0, 49408]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [1, 16],
+        "value_range": [0, 2]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      },
+      {
+        "name": "pred_boxes"
+      },
+      {
+        "name": "text_embeds"
+      },
+      {
+        "name": "image_embeds"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "zero-shot-object-detection",
+    "model_class": "AutoModelForZeroShotObjectDetection",
+    "model_type": "owlv2"
+  }
+}

--- a/examples/recipes/google_owlv2-base-patch16/cpu/cpu/zero-shot-object-detection_fp32_config.json
+++ b/examples/recipes/google_owlv2-base-patch16/cpu/cpu/zero-shot-object-detection_fp32_config.json
@@ -1,0 +1,55 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [1, 3, 960, 960],
+        "value_range": [0, 1]
+      },
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [1, 16],
+        "value_range": [0, 49408]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [1, 16],
+        "value_range": [0, 2]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      },
+      {
+        "name": "pred_boxes"
+      },
+      {
+        "name": "text_embeds"
+      },
+      {
+        "name": "image_embeds"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "zero-shot-object-detection",
+    "model_class": "AutoModelForZeroShotObjectDetection",
+    "model_type": "owlv2"
+  }
+}


### PR DESCRIPTION
## Summary

This recipe-only contribution adds verified CPU fp32 and fp16 build coverage for `google/owlv2-base-patch16`, a text-conditioned zero-shot object detector. Effort and shipped Outcome are **L0**, and the highest honestly reached Goal verdict is **L0 PASS** for both required precision tuples. Supplementary L1 perf commands produced metrics but authoritatively **FAIL** on native teardown exit `0xC0000005`; L2 is therefore non-finalizable, and L3 is CLI-BLOCKED.

## Model metadata

### What the model does

OWLv2 is a text-conditioned open-vocabulary object detector. It accepts an image plus one or more text queries and returns query-conditioned class logits and normalized bounding boxes, together with text and image embeddings.

- Evidence/confidence: pinned [`google/owlv2-base-patch16`](https://huggingface.co/google/owlv2-base-patch16/tree/2a1560802f8cf3c408fec9b809d705f56a2f7146) model card/config and concrete `Owlv2ForObjectDetection.forward`; **verified**.

### Primary user stories

- A user supplies an image and natural-language object queries to obtain boxes and confidence scores for locating queried categories without a checkpoint-specific fixed label vocabulary. Evidence: pinned model card and example; **verified**.
- A researcher supplies images and text queries to study zero-shot text-conditioned localization, including categories whose labels were unavailable during detector training. Evidence: pinned model card Intended Use; **verified**.

### Supported tasks

| Task | Support surfaces | Evidence | Confidence |
|---|---|---|---|
| `zero-shot-object-detection` | checkpoint, Transformers, Optimum ONNX, WinML | pinned pipeline tag; `Owlv2ForObjectDetection`; Optimum vendor registry; `winml inspect` resolving `OwlV2OnnxConfig` and `WinMLModelForGenericTask` | verified |

### Model architecture

```text
Owlv2ForObjectDetection
├── Owlv2Model multimodal backbone
│   ├── Text embeddings (vocab 49,408; max length 16; hidden 512)
│   ├── Text encoder layers x 12 (8-head self-attention; MLP 512→2048→512)
│   ├── Vision patch embedding (960×960 image; 16×16 patches; 60×60 grid; hidden 768)
│   ├── Vision encoder layers x 12 (12-head self-attention; MLP 768→3072→768)
│   └── Text/vision projections and normalized embeddings (projection 512)
├── Patch/class-token feature fusion + LayerNorm
├── Query-conditioned class prediction head
├── Objectness prediction head
└── Bounding-box prediction head + grid bias + sigmoid
```

- Source/confidence: pinned checkpoint revision `2a1560802f8cf3c408fec9b809d705f56a2f7146`, pinned Transformers `Owlv2ForObjectDetection`/`Owlv2Model` source, and recipe-free current-main export hierarchy; **verified**.

## Validation and support evidence

### 1. Baseline

The frozen baseline is exact current `main` commit `3a2b2f7db5e70bb1f9039dd9037697ef92b2bc2a` with WinML CLI `0.2.0`.

- **Auto-config / Optimum:** `winml config -m google/owlv2-base-patch16 -t zero-shot-object-detection` resolves `AutoModelForZeroShotObjectDetection`, model type `owlv2`, task `zero-shot-object-detection`, and the same export contract used by the fp32 recipe. Optimum's vendor registry exposes `feature-extraction` and `zero-shot-object-detection`; WinML adds no task (`VENDOR-ONLY`).
- **Recipe-free build floor — PASS:** `winml build -m google/owlv2-base-patch16 --ep cpu --device cpu --no-analyze --no-optimize --no-quant --no-compile --rebuild` exited 0 and completed in **111.5 s**. The pre-optimization export has **1,199 nodes** and correct bindings: `input_ids` INT32 `[1,16]`, `pixel_values` FLOAT `[1,3,960,960]`, and `attention_mask` INT32 `[1,16]`.
- **Recipe-free perf floor — FAIL:** `winml perf --ep cpu --device cpu` completed 10 warmups and 100 timed iterations and persisted Avg **4156.21 ms**, P50 **4157.49 ms**, throughput **0.24 samples/s**, and total RAM delta **+643.1 MB**, then exited non-zero during WindowsML teardown. The native exit is `-1073741819` / `0xC0000005` in `Microsoft.Windows.AI.MachineLearning.dll` `2.0.300.41724`, fault offset `0x26f5`, WER bucket `53def927dd6c2a0e007b5c91617a7da5`; [#1233](https://github.com/microsoft/winml-cli/issues/1233) tracks the shared lifecycle defect.
- **Eval floor — CLI-BLOCKED:** `winml eval --schema --task zero-shot-object-detection` exited 2 because the task is not registered. No dataset or task metric is claimed.

The historical OWLv2 input-binding patch is no longer necessary: current `main` already contains the generalized forward-signature keyword binding repair merged through [#1155](https://github.com/microsoft/winml-cli/pull/1155). Recipe-free current-main export proves the correct semantic bindings, so this PR intentionally does not reintroduce exporter or test changes.

### 2. Goal

- **Effort:** L0 recipe-only.
- **Original Goal (charter revision 1):** L2, with L0 as the measured baseline floor.
- **Re-issued Goal (charter revision 2):** L0. Both exact L1 commands crash after persisting results because of the shared lifecycle defect in [#1233](https://github.com/microsoft/winml-cli/issues/1233), outside the per-model L0 recipe repair class.
- **L0 success definition:** fresh CPU/cpu fp32 and fp16 builds are structurally and precision-valid. L1 perf, L2 numerical comparison, and L3 evaluator probes remain supplementary above the revised ceiling and cannot raise the final outcome above L0.
- **Outcome commitment:** L0.

### 3. Outcome

- **Shipped tier / highest Goal verdict:** L0 / **L0 PASS**.
- **Coverage:** full; no deferred required tuples.
- **Required tuples:** `CPUExecutionProvider / cpu / fp32` and `CPUExecutionProvider / cpu / fp16`, both L0 PASS.
- **Shipped paths:**
  - `examples/recipes/google_owlv2-base-patch16/cpu/cpu/zero-shot-object-detection_fp32_config.json`
  - `examples/recipes/google_owlv2-base-patch16/cpu/cpu/zero-shot-object-detection_fp16_config.json`
- **Code paths:** none. The generalized binding fix and its tests are already on `main` through #1155.
- **Support outcome:** L1 FAIL on both tuples with persisted metrics and exact native exit `0xC0000005`; L2 values are measured but `NOT-FINALIZABLE-ABOVE-L1-FAIL`; L3 is CLI-BLOCKED by the unsupported evaluator task.
- **Model finding:** current `main` binds OWLv2 keyword inputs by forward signature, falsifying the old need for a model-specific reorder while preserving that historical finding for pre-#1155 revisions.
- **Methodology finding:** no new methodology finding is warranted. Existing crash-exit and ladder short-circuit rules handled the case without friction; the learner recorded `no_friction: true`.

### 4. Per-EP/device/precision results — including perf and eval data

#### Goal ladder

| Tier | Verdict | Evidence |
|---|---|---|
| L0 | **PASS** | Both builds exited 0; ONNX load/checker, exact names/shapes/dtypes, and precision checks passed. fp32 has 418 FLOAT and 0 FLOAT16 initializers; fp16 has 418 FLOAT16 and 0 FLOAT initializers. Sidecars are 613,624,064 and 306,812,032 bytes respectively (ratio 0.5). |
| L1 | **FAIL** (supplementary above ceiling) | Both commands completed 10 warmups and 100/100 timed iterations and persisted metrics, then exited `-1073741819` / `0xC0000005`. A non-zero crash exit is authoritative; shared defect: #1233. |
| L2 | **NOT-FINALIZABLE-ABOVE-L1-FAIL** (supplementary) | Named-output comparison values were measured, but cannot become a Goal PASS above the authoritative L1 FAIL. |
| L3 | **CLI-BLOCKED** (supplementary above ceiling) | `zero-shot-object-detection` is absent from the `winml eval` task registry; no metric was fabricated. |

#### Build and perf tuples

| Tier | EP / Device | Precision | Verdict | Nodes | Mean | p50 | Throughput | RAM Δ | VRAM local/shared Δ |
|---|---|---|---|---:|---:|---:|---:|---:|---:|
| L0 | CPUExecutionProvider / cpu | fp32 | PASS | 881 | — | — | — | — | — |
| L0 | CPUExecutionProvider / cpu | fp16 | PASS | 886 | — | — | — | — | — |
| L1 | CPUExecutionProvider / cpu | fp32 | **FAIL — command exit `0xC0000005`** | — | 4225.334 ms | 4157.492 ms | 0.24 samples/s | +600.0 MB | 0.0 / 0.0 MB |
| L1 | CPUExecutionProvider / cpu | fp16 | **FAIL — command exit `0xC0000005`** | — | 6299.19 ms | 6292.885 ms | 0.16 samples/s | +887.52 MB | 0.0 / 0.0 MB |

For fp32, the failed command also measured P90 **4275.569 ms**, P95 **4800.294 ms**, P99 **5971.344 ms**, min **4091.217 ms**, max **5971.344 ms**, std **260.214 ms**, warmup mean **4217.315 ms**, model-load RAM **+10.93 MB**, and inference RAM **+589.07 MB**. For fp16, it measured P90 **6404.35 ms**, P95 **6466.769 ms**, P99 **6604.894 ms**, min **6126.252 ms**, max **6604.894 ms**, std **85.975 ms**, warmup mean **6502.936 ms**, model-load RAM **+10.91 MB**, and inference RAM **+876.61 MB**. These concrete metrics do not convert either crashing command to PASS.

#### Supplementary L2 named-output comparison

All values below are explicitly **measured but non-finalizable above L1 FAIL**.

| Precision | Output | Cosine | Max abs | Mean abs |
|---|---|---:|---:|---:|
| fp32 | `logits` | 0.9999999999440868 | 0.00164031982421875 | 6.423128975762262e-05 |
| fp32 | `pred_boxes` | 0.9999999999960476 | 3.2007694244384766e-05 | 5.260669988476567e-07 |
| fp32 | `text_embeds` | 0.9999999999996807 | 1.2665987014770508e-07 | 2.8033980470354436e-08 |
| fp32 | `image_embeds` | 0.9999999999924271 | 0.00027114152908325195 | 2.0609060718764e-06 |
| fp16 | `logits` | 0.9999813545917369 | 0.7349939346313477 | 0.03942612515555488 |
| fp16 | `pred_boxes` | 0.9999983875543323 | 0.0154954195022583 | 0.00037615584888650724 |
| fp16 | `text_embeds` | 0.9999996069777055 | 0.00012337416410446167 | 3.151061315520565e-05 |
| fp16 | `image_embeds` | 0.9999968549499252 | 0.19051861763000488 | 0.0014261186358107947 |

#### Eval tuples

| EP / Device | Precision | Verdict | Dataset / revision / subset | Task metric |
|---|---|---|---|---|
| CPUExecutionProvider / cpu | fp32 | **CLI-BLOCKED** (exit 1) | none | none |
| CPUExecutionProvider / cpu | fp16 | **CLI-BLOCKED** (exit 1) | none | none |

Exact schema error (exit 2):

> Error: Task 'zero-shot-object-detection' is not supported by `winml eval`. Supported tasks: depth-estimation, feature-extraction, fill-mask, image-classification, image-feature-extraction, image-segmentation, image-to-text, keypoint-detection, mask-generation, next-sentence-prediction, object-detection, question-answering, sentence-similarity, sequence-classification, text-classification, token-classification, zero-shot-classification, zero-shot-image-classification.

Exact artifact-attempt error (exit 1 for each precision):

> Error: Evaluation failed: Task 'zero-shot-object-detection' is not supported. Supported tasks: compare-tensor, depth-estimation, feature-extraction, fill-mask, image-classification, image-feature-extraction, image-segmentation, image-to-text, keypoint-detection, mask-generation, next-sentence-prediction, object-detection, question-answering, sentence-similarity, sequence-classification, text-classification, token-classification, zero-shot-classification, zero-shot-image-classification.

Feature-gap status is **FILED-LOCALLY-FOR-OWNER-TRIAGE**; no external evaluator issue was created. The requested capability is a registered zero-shot-object-detection evaluator with a published schema, image-plus-text-query inputs, and a pinned-dataset metric for ONNX artifacts.

### 5. Delta

This is a reducibility-consistent, recipe-only L0 declaration. Recipe-free acceptance already passes on current `main`; no checkpoint-specific architecture field is overridden.

- **fp32 recipe:** parsed content is **IDENTICAL** to auto-config after ignoring formatting (`0` JSON-pointer deltas). It preserves loader task/class/type, input shapes/ranges, opset, output names, `optim: {}`, `quant: null`, and `compile: null`.
- **fp16 recipe:** exactly one structural delta from auto-config:
  - JSON pointer: `/quant`
  - old value: `null`
  - new value:

```json
{
  "mode": "fp16",
  "samples": 10,
  "calibration_method": "minmax",
  "weight_type": "uint8",
  "activation_type": "uint8",
  "per_channel": false,
  "symmetric": false,
  "weight_symmetric": null,
  "activation_symmetric": null,
  "save_calibration": false,
  "distribution": "uniform",
  "seed": null,
  "calibration_load_path": null,
  "calibration_save_path": null,
  "op_types_to_quantize": null,
  "nodes_to_exclude": null,
  "fp16_keep_io_types": true,
  "fp16_op_block_list": null
}
```

`mode: fp16` selects the required human precision intent, while `fp16_keep_io_types: true` preserves the baseline external I/O contract. There are no source-symbol or class-wide behavior changes. The production recipe README remains untouched.

### 6. Analyze summary — component level and op level

**ANALYZE-PARTIAL-SUCCESS:** both static `--ep all` analyses emitted complete JSON classification arrays but exited 1 after an ONNX Runtime provider-bridge warning. This is static rule analysis, not runtime execution or proof of provider availability.

#### Component-level summary

| Artifact | Architecture coverage | Mapping | Actionable EP findings |
|---|---|---|---|
| fp32 | 12x text encoder; 12x vision encoder; patch/class-token fusion; query class head; box head; objectness head pruned | 880 mapped, 1 partial, 1 unmapped; partial confidence | QNNExecutionProvider partial: Gather, IsNaN; unsupported: none |
| fp16 | 12x text encoder; 12x vision encoder; patch/class-token fusion; query class head; box head; objectness head pruned | 885 mapped, 1 partial, 1 unmapped; partial confidence | QNNExecutionProvider partial: Gather, IsNaN, Expand; unsupported: none |

One optimizer-generated `Reshape` remains unmapped in each artifact. Mappings cite tagged pre-optimization scopes/topology because optimization changes final graph nodes; exhaustive ordered-input-signature grouping was outside overview depth.

#### Op-level summary

| Artifact | Graph | Dominant ops | EP roll-up |
|---|---|---|---|
| fp32 | 881 ops / 29 types | Reshape 256; Gemm 150; Mul 101; Transpose 97; Add 67; LayerNormalization 52 | QNN partial Gather, IsNaN; no unsupported types |
| fp16 | 886 ops / 29 types | Reshape 256; Gemm 150; Mul 101; Transpose 97; Add 67; LayerNormalization 52 | QNN partial Gather, IsNaN, Expand; no unsupported types |

CUDAExecutionProvider, MIGraphXExecutionProvider, TensorrtExecutionProvider, and DmlExecutionProvider have all operator types unknown under the available static rules. No fully-supported EP group is claimed.

#### Quality gates

| Gate | Result |
|---|---|
| Ruff: `ruff check src/ tests/` | PASS — all checks passed |
| mypy: `mypy -p winml.modelkit` | PASS — no issues in 426 source files |
| Models workflow partition | PASS — 1,451 passed, 6 skipped, 2 xfailed in 77.87 s |
| Commands workflow partition | PASS — 3,187 passed, 9 skipped, 1 warning in 314.31 s |

These are the affected current-workflow non-hardware partitions for a recipe-only model loading/export and command-surface delta. No shared analyzer, optimizer, registry, or source file changed.

### 7. Reproduce commands

Run from a checkout of this PR with repository dependencies installed. The first block reproduces the frozen current-main baseline command forms at commit `3a2b2f7db5e70bb1f9039dd9037697ef92b2bc2a`; output paths are portable.

```powershell
$BASELINE = Join-Path (Get-Location) 'temp/owlv2-current-main-baseline'
uv run winml config -m google/owlv2-base-patch16 -t zero-shot-object-detection -o (Join-Path $BASELINE 'config')
uv run winml build -m google/owlv2-base-patch16 -o (Join-Path $BASELINE 'build') --ep cpu --device cpu --no-analyze --no-optimize --no-quant --no-compile --rebuild
uv run winml perf -m (Join-Path $BASELINE 'build/model.onnx') --ep cpu --device cpu
uv run winml eval --schema --task zero-shot-object-detection
```

Tester-supplied portable contribution commands:

```powershell
$OUT = Join-Path (Get-Location) 'temp/owlv2-support-repro'
$FP32 = Join-Path $OUT 'cpu/fp32'
$FP16 = Join-Path $OUT 'cpu/fp16'
uv run winml build -c examples/recipes/google_owlv2-base-patch16/cpu/cpu/zero-shot-object-detection_fp32_config.json -m google/owlv2-base-patch16 -o $FP32 --ep cpu --device cpu --precision fp32 --rebuild
uv run winml build -c examples/recipes/google_owlv2-base-patch16/cpu/cpu/zero-shot-object-detection_fp16_config.json -m google/owlv2-base-patch16 -o $FP16 --ep cpu --device cpu --precision fp16 --rebuild
uv run winml perf -m (Join-Path $FP32 'model.onnx') --ep cpu --device cpu
uv run winml perf -m (Join-Path $FP16 'model.onnx') --ep cpu --device cpu
if (-not $env:WINMLCLI_RULES_DIR) { throw 'Set WINMLCLI_RULES_DIR to a populated runtime-check rules directory before analyze.' }
uv run winml analyze --model (Join-Path $FP32 'model.onnx') --ep all --output (Join-Path $FP32 'analyze_all.json')
uv run winml analyze --model (Join-Path $FP16 'model.onnx') --ep all --output (Join-Path $FP16 'analyze_all.json')
uv run winml eval --schema --task zero-shot-object-detection
uv run winml eval -m (Join-Path $FP32 'model.onnx') --model-id google/owlv2-base-patch16 --task zero-shot-object-detection --ep cpu --device cpu
uv run winml eval -m (Join-Path $FP16 'model.onnx') --model-id google/owlv2-base-patch16 --task zero-shot-object-detection --ep cpu --device cpu
```
