### PR TITLE
feat: Add ONNX data to QNN profiler metrics

### DIFF
--- a/src/winml/modelkit/_env.py
+++ b/src/winml/modelkit/_env.py
@@ -1,0 +1,17 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Environment variable helpers used during early package initialization."""
+
+from __future__ import annotations
+
+import os
+
+
+_TRUE_ENV_VALUES = frozenset({"1", "true", "yes", "on"})
+
+
+def env_flag_enabled(name: str) -> bool:
+    """Return whether an environment variable is set to a truthy flag value."""
+    return os.environ.get(name, "").strip().lower() in _TRUE_ENV_VALUES

--- a/src/winml/modelkit/_warnings.py
+++ b/src/winml/modelkit/_warnings.py
@@ -12,7 +12,8 @@ Usage:
     from . import _warnings  # Filters are configured automatically
 
 Environment Variables:
-    WINMLCLI_SHOW_ALL_WARNINGS: Set to "1" or "true" to disable warning suppression
+    WINMLCLI_SHOW_ALL_WARNINGS: Set to "1", "true", "yes", or "on" to disable
+        warning suppression.
 """
 
 from __future__ import annotations
@@ -20,6 +21,8 @@ from __future__ import annotations
 import logging
 import os
 import warnings
+
+from ._env import env_flag_enabled
 
 
 def _configure() -> None:
@@ -34,7 +37,7 @@ def _configure() -> None:
     os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
 
     # Allow users to see all warnings if they want
-    if os.environ.get("WINMLCLI_SHOW_ALL_WARNINGS", "").lower() in ("1", "true", "yes"):
+    if env_flag_enabled("WINMLCLI_SHOW_ALL_WARNINGS"):
         return
 
     # =========================================================================

--- a/src/winml/modelkit/analyze/utils/timing_utils.py
+++ b/src/winml/modelkit/analyze/utils/timing_utils.py
@@ -6,8 +6,9 @@
 
 from __future__ import annotations
 
-import os
 from typing import TYPE_CHECKING
+
+from ..._env import env_flag_enabled
 
 
 if TYPE_CHECKING:
@@ -15,12 +16,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-_TIMING_LOG_ENABLED = os.environ.get("WINMLCLI_TIMING_LOG", "").strip().lower() in {
-    "1",
-    "true",
-    "yes",
-    "on",
-}
+_TIMING_LOG_ENABLED = env_flag_enabled("WINMLCLI_TIMING_LOG")
 
 
 def make_timing_logger(logger: logging.Logger) -> Callable[..., None]:

--- a/src/winml/modelkit/optracing/qnn/profiler.py
+++ b/src/winml/modelkit/optracing/qnn/profiler.py
@@ -105,6 +105,7 @@ def _csv_operator_metrics(
                 onnx_op_type=op_data.get("onnx_op_type"),
                 onnx_attributes=op_data.get("onnx_attributes"),
                 onnx_inputs=op_data.get("onnx_inputs"),
+                onnx_outputs=op_data.get("onnx_outputs"),
             )
         )
     # duration is the headline metric; percent breaks ties when US timing is
@@ -136,6 +137,7 @@ def _load_onnx_operator_data(onnx_path: Path) -> dict[str, dict[str, Any]]:
             "onnx_op_type": node.op_type,
             "onnx_attributes": {attr.name: _serialize_attribute(attr) for attr in node.attribute},
             "onnx_inputs": _node_input_metadata(node, opset_versions, value_info, initializers),
+            "onnx_outputs": _node_output_metadata(node, opset_versions, value_info, initializers),
         }
     return operator_data
 
@@ -160,30 +162,60 @@ def _node_input_metadata(
     initializers: dict[str, Any],
 ) -> dict[str, dict[str, Any]]:
     """Return input metadata keyed by ONNX schema formal input name."""
+    return _node_value_metadata(node, node.input, "input", opset_versions, value_info, initializers)
+
+
+def _node_output_metadata(
+    node: Any,
+    opset_versions: dict[str, int],
+    value_info: dict[str, Any],
+    initializers: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    """Return output metadata keyed by ONNX schema formal output name."""
+    return _node_value_metadata(
+        node, node.output, "output", opset_versions, value_info, initializers
+    )
+
+
+def _node_value_metadata(
+    node: Any,
+    value_names: Any,
+    value_kind: str,
+    opset_versions: dict[str, int],
+    value_info: dict[str, Any],
+    initializers: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    """Return input/output metadata keyed by ONNX schema formal parameter name."""
     metadata: dict[str, dict[str, Any]] = {}
-    for index, value_name in enumerate(node.input):
+    for index, value_name in enumerate(value_names):
         if not value_name:
             continue
-        schema_name = _schema_input_name(node, index, opset_versions)
-        key = _unique_input_key(schema_name, index, metadata)
+        schema_name = _schema_value_name(node, index, value_kind, opset_versions)
+        key = _unique_value_key(schema_name, index, metadata)
         metadata[key] = _input_tensor_metadata(value_name, value_info, initializers)
     return metadata
 
 
-def _schema_input_name(node: Any, input_index: int, opset_versions: dict[str, int]) -> str:
-    """Resolve a node input index to its ONNX schema formal parameter name."""
+def _schema_value_name(
+    node: Any,
+    value_index: int,
+    value_kind: str,
+    opset_versions: dict[str, int],
+) -> str:
+    """Resolve a node input/output index to its ONNX schema formal parameter name."""
     from onnx import defs
 
     domain = node.domain
     opset_version = opset_versions.get(domain)
     if opset_version is None:
         logger.debug(
-            "Could not resolve ONNX opset version for %s domain=%r input=%d",
+            "Could not resolve ONNX opset version for %s domain=%r %s=%d",
             node.op_type,
             domain,
-            input_index,
+            value_kind,
+            value_index,
         )
-        return f"input_{input_index}"
+        return f"{value_kind}_{value_index}"
 
     try:
         schema = defs.get_schema(
@@ -193,30 +225,32 @@ def _schema_input_name(node: Any, input_index: int, opset_versions: dict[str, in
         )
     except defs.SchemaError:
         logger.debug(
-            "Could not resolve ONNX schema for %s domain=%r input=%d",
+            "Could not resolve ONNX schema for %s domain=%r %s=%d",
             node.op_type,
             domain,
-            input_index,
+            value_kind,
+            value_index,
             exc_info=True,
         )
-        return f"input_{input_index}"
+        return f"{value_kind}_{value_index}"
 
-    if input_index < len(schema.inputs):
-        return schema.inputs[input_index].name
-    if schema.inputs:
-        return schema.inputs[-1].name
-    return f"input_{input_index}"
+    schema_values = schema.inputs if value_kind == "input" else schema.outputs
+    if value_index < len(schema_values):
+        return schema_values[value_index].name
+    if schema_values:
+        return schema_values[-1].name
+    return f"{value_kind}_{value_index}"
 
 
-def _unique_input_key(
+def _unique_value_key(
     schema_name: str,
-    input_index: int,
+    value_index: int,
     existing: dict[str, dict[str, Any]],
 ) -> str:
     """Keep schema names as keys while disambiguating repeated variadic inputs."""
     if schema_name not in existing:
         return schema_name
-    return f"{schema_name}[{input_index}]"
+    return f"{schema_name}[{value_index}]"
 
 
 def _input_tensor_metadata(
@@ -283,7 +317,37 @@ def _serialize_attribute(attr: Any) -> Any:
         return _sparse_tensor_attribute_metadata(value)
     if attr_type == AttributeProto.SPARSE_TENSORS:
         return [_sparse_tensor_attribute_metadata(tensor) for tensor in value]
-    return value
+    if attr_type == AttributeProto.TYPE_PROTO:
+        return _protobuf_attribute_metadata(value)
+    if attr_type == AttributeProto.TYPE_PROTOS:
+        return [_protobuf_attribute_metadata(type_proto) for type_proto in value]
+    return _json_safe_attribute_value(value)
+
+
+def _protobuf_attribute_metadata(value: Any) -> dict[str, Any] | str:
+    """Convert protobuf attribute payloads to JSON-safe metadata."""
+    from google.protobuf import json_format
+
+    try:
+        return json_format.MessageToDict(value, preserving_proto_field_name=True)
+    except Exception:
+        logger.debug("Could not convert protobuf attribute payload to JSON", exc_info=True)
+        return str(value)
+
+
+def _json_safe_attribute_value(value: Any) -> Any:
+    """Return a JSON-safe fallback for unsupported ONNX attribute payloads."""
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    if isinstance(value, list | tuple):
+        return [_json_safe_attribute_value(item) for item in value]
+    if isinstance(value, dict):
+        return {str(k): _json_safe_attribute_value(v) for k, v in value.items()}
+    if hasattr(value, "DESCRIPTOR"):
+        return _protobuf_attribute_metadata(value)
+    return str(value)
 
 
 def _tensor_attribute_metadata(tensor: Any) -> dict[str, Any]:
@@ -628,9 +692,16 @@ class QNNProfiler(OpTracer):
                 f"warmup, got {len(measured)} from {len(samples)} total."
             )
 
-        onnx_operator_data = (
-            _load_onnx_operator_data(self.onnx_path) if _is_op_add_data_enabled() else None
-        )
+        onnx_operator_data = None
+        if _is_op_add_data_enabled():
+            try:
+                onnx_operator_data = _load_onnx_operator_data(self.onnx_path)
+            except Exception as error:
+                logger.warning(
+                    "Could not enrich QNN profiler metrics with ONNX metadata: %s",
+                    error,
+                    exc_info=True,
+                )
         operators = _csv_operator_metrics(measured, onnx_operator_data)
 
         return OpTraceResult(

--- a/src/winml/modelkit/optracing/qnn/profiler.py
+++ b/src/winml/modelkit/optracing/qnn/profiler.py
@@ -20,7 +20,7 @@ import contextlib
 import logging
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 
@@ -177,9 +177,9 @@ def _input_tensor_metadata(
 def _shape_dim_to_value(dim: Any) -> int | str | None:
     """Convert an ONNX TensorShapeProto dimension into a JSON-safe value."""
     if dim.HasField("dim_value"):
-        return dim.dim_value
+        return cast("int", dim.dim_value)
     if dim.HasField("dim_param"):
-        return dim.dim_param
+        return cast("str", dim.dim_param)
     return None
 
 
@@ -193,9 +193,8 @@ def _tensor_data_type_name(data_type: int) -> str:
 def _serialize_attribute(attr: Any) -> Any:
     """Convert an ONNX AttributeProto value into compact JSON-safe metadata."""
     import onnx
-    from onnx import helper
 
-    value = helper.get_attribute_value(attr)
+    value = onnx.helper.get_attribute_value(attr)
     attr_type = attr.type
     if attr_type == onnx.AttributeProto.STRING:
         return value.decode("utf-8", errors="replace")

--- a/src/winml/modelkit/optracing/qnn/profiler.py
+++ b/src/winml/modelkit/optracing/qnn/profiler.py
@@ -185,34 +185,34 @@ def _shape_dim_to_value(dim: Any) -> int | str | None:
 
 def _tensor_data_type_name(data_type: int) -> str:
     """Return the ONNX TensorProto datatype name for an enum value."""
-    import onnx
+    from onnx import TensorProto
 
-    return onnx.TensorProto.DataType.Name(data_type)
+    return TensorProto.DataType.Name(data_type)
 
 
 def _serialize_attribute(attr: Any) -> Any:
     """Convert an ONNX AttributeProto value into compact JSON-safe metadata."""
-    import onnx
+    from onnx import AttributeProto, helper
 
-    value = onnx.helper.get_attribute_value(attr)
+    value = helper.get_attribute_value(attr)
     attr_type = attr.type
-    if attr_type == onnx.AttributeProto.STRING:
+    if attr_type == AttributeProto.STRING:
         return value.decode("utf-8", errors="replace")
-    if attr_type == onnx.AttributeProto.STRINGS:
+    if attr_type == AttributeProto.STRINGS:
         return [item.decode("utf-8", errors="replace") for item in value]
-    if attr_type == onnx.AttributeProto.TENSOR:
+    if attr_type == AttributeProto.TENSOR:
         return _tensor_attribute_metadata(value)
-    if attr_type == onnx.AttributeProto.TENSORS:
+    if attr_type == AttributeProto.TENSORS:
         return [_tensor_attribute_metadata(tensor) for tensor in value]
-    if attr_type in (onnx.AttributeProto.INTS, onnx.AttributeProto.FLOATS):
+    if attr_type in (AttributeProto.INTS, AttributeProto.FLOATS):
         return list(value)
-    if attr_type == onnx.AttributeProto.GRAPH:
+    if attr_type == AttributeProto.GRAPH:
         return _graph_attribute_metadata(value)
-    if attr_type == onnx.AttributeProto.GRAPHS:
+    if attr_type == AttributeProto.GRAPHS:
         return [_graph_attribute_metadata(graph) for graph in value]
-    if attr_type == onnx.AttributeProto.SPARSE_TENSOR:
+    if attr_type == AttributeProto.SPARSE_TENSOR:
         return _sparse_tensor_attribute_metadata(value)
-    if attr_type == onnx.AttributeProto.SPARSE_TENSORS:
+    if attr_type == AttributeProto.SPARSE_TENSORS:
         return [_sparse_tensor_attribute_metadata(tensor) for tensor in value]
     return value
 

--- a/src/winml/modelkit/optracing/qnn/profiler.py
+++ b/src/winml/modelkit/optracing/qnn/profiler.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 
+from ..._env import env_flag_enabled
 from ...winml import add_ep_for_device
 from ..base import OpTracer
 from ..result import OperatorMetrics, OpTraceResult
@@ -114,7 +115,7 @@ def _csv_operator_metrics(
 
 def _is_op_add_data_enabled() -> bool:
     """Return whether basic QNN op metrics should include ONNX node metadata."""
-    return os.getenv(_OP_ADD_DATA_ENV) is not None
+    return env_flag_enabled(_OP_ADD_DATA_ENV)
 
 
 def _load_onnx_operator_data(onnx_path: Path) -> dict[str, dict[str, Any]]:

--- a/src/winml/modelkit/optracing/qnn/profiler.py
+++ b/src/winml/modelkit/optracing/qnn/profiler.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+_OP_ADD_DATA_ENV = "WINMLCLI_OP_ADD_DATA"
 
 
 def _ort_type_to_numpy(ort_type: str) -> np.dtype:
@@ -58,7 +59,10 @@ def _resolve_shape(shape: list, default_dim: int = 1) -> list[int]:
     return [default_dim if not isinstance(d, int) or d <= 0 else d for d in shape]
 
 
-def _csv_operator_metrics(samples: list[dict[str, Any]]) -> list[OperatorMetrics]:
+def _csv_operator_metrics(
+    samples: list[dict[str, Any]],
+    onnx_operator_data: dict[str, dict[str, Any]] | None = None,
+) -> list[OperatorMetrics]:
     """Aggregate per-sample CSV operator records into ``OperatorMetrics``.
 
     Each operator's duration and percentage are computed against the metadata
@@ -86,20 +90,154 @@ def _csv_operator_metrics(samples: list[dict[str, Any]]) -> list[OperatorMetrics
             entry["percent"] += op["cycles"] / total_cycles * 100 if total_cycles > 0 else 0.0
             entry["count"] += 1
 
-    metrics = [
-        OperatorMetrics(
-            name=entry["name"],
-            op_path=entry["name"],
-            op_id=entry["op_id"],
-            duration_us=entry["duration_us"] / entry["count"],
-            percent_of_total=entry["percent"] / entry["count"],
+    metrics: list[OperatorMetrics] = []
+    onnx_operator_data = onnx_operator_data or {}
+    for entry in acc.values():
+        op_data = onnx_operator_data.get(entry["name"], {})
+        metrics.append(
+            OperatorMetrics(
+                name=entry["name"],
+                op_path=entry["name"],
+                op_id=entry["op_id"],
+                duration_us=entry["duration_us"] / entry["count"],
+                percent_of_total=entry["percent"] / entry["count"],
+                onnx_op_type=op_data.get("onnx_op_type"),
+                onnx_attributes=op_data.get("onnx_attributes"),
+                onnx_inputs=op_data.get("onnx_inputs"),
+            )
         )
-        for entry in acc.values()
-    ]
     # duration is the headline metric; percent breaks ties when US timing is
     # absent (so durations collapse to 0 but cycle shares still differ).
     metrics.sort(key=lambda m: (m.duration_us, m.percent_of_total), reverse=True)
     return metrics
+
+
+def _is_op_add_data_enabled() -> bool:
+    """Return whether basic QNN op metrics should include ONNX node metadata."""
+    return os.getenv(_OP_ADD_DATA_ENV) is not None
+
+
+def _load_onnx_operator_data(onnx_path: Path) -> dict[str, dict[str, Any]]:
+    """Load ONNX node metadata keyed by node name for profiler enrichment."""
+    from ...onnx import infer_shapes, load_onnx
+
+    model = load_onnx(onnx_path, load_weights=False, validate=False)
+    model = infer_shapes(model)
+    value_info = _collect_value_info(model)
+    initializers = {init.name: init for init in model.graph.initializer}
+
+    operator_data: dict[str, dict[str, Any]] = {}
+    for node in model.graph.node:
+        if not node.name:
+            continue
+        operator_data[node.name] = {
+            "onnx_op_type": node.op_type,
+            "onnx_attributes": {attr.name: _serialize_attribute(attr) for attr in node.attribute},
+            "onnx_inputs": {
+                name: _input_tensor_metadata(name, value_info, initializers)
+                for name in node.input
+                if name
+            },
+        }
+    return operator_data
+
+
+def _collect_value_info(model: Any) -> dict[str, Any]:
+    """Collect graph tensor type/shape entries by tensor name."""
+    return {
+        vi.name: vi
+        for vi in list(model.graph.input) + list(model.graph.output) + list(model.graph.value_info)
+    }
+
+
+def _input_tensor_metadata(
+    name: str,
+    value_info: dict[str, Any],
+    initializers: dict[str, Any],
+) -> dict[str, Any]:
+    """Return JSON-safe shape and type metadata for a node input tensor."""
+    metadata: dict[str, Any] = {}
+    if name in initializers:
+        initializer = initializers[name]
+        metadata["dims"] = list(initializer.dims)
+        metadata["data_type"] = _tensor_data_type_name(initializer.data_type)
+        return metadata
+
+    vi = value_info.get(name)
+    if vi is None or not vi.type.HasField("tensor_type"):
+        return metadata
+
+    tensor_type = vi.type.tensor_type
+    metadata["data_type"] = _tensor_data_type_name(tensor_type.elem_type)
+    if tensor_type.HasField("shape"):
+        metadata["dims"] = [_shape_dim_to_value(dim) for dim in tensor_type.shape.dim]
+    return metadata
+
+
+def _shape_dim_to_value(dim: Any) -> int | str | None:
+    """Convert an ONNX TensorShapeProto dimension into a JSON-safe value."""
+    if dim.HasField("dim_value"):
+        return dim.dim_value
+    if dim.HasField("dim_param"):
+        return dim.dim_param
+    return None
+
+
+def _tensor_data_type_name(data_type: int) -> str:
+    """Return the ONNX TensorProto datatype name for an enum value."""
+    import onnx
+
+    return onnx.TensorProto.DataType.Name(data_type)
+
+
+def _serialize_attribute(attr: Any) -> Any:
+    """Convert an ONNX AttributeProto value into compact JSON-safe metadata."""
+    import onnx
+    from onnx import helper
+
+    value = helper.get_attribute_value(attr)
+    attr_type = attr.type
+    if attr_type == onnx.AttributeProto.STRING:
+        return value.decode("utf-8", errors="replace")
+    if attr_type == onnx.AttributeProto.STRINGS:
+        return [item.decode("utf-8", errors="replace") for item in value]
+    if attr_type == onnx.AttributeProto.TENSOR:
+        return _tensor_attribute_metadata(value)
+    if attr_type == onnx.AttributeProto.TENSORS:
+        return [_tensor_attribute_metadata(tensor) for tensor in value]
+    if attr_type in (onnx.AttributeProto.INTS, onnx.AttributeProto.FLOATS):
+        return list(value)
+    if attr_type == onnx.AttributeProto.GRAPH:
+        return _graph_attribute_metadata(value)
+    if attr_type == onnx.AttributeProto.GRAPHS:
+        return [_graph_attribute_metadata(graph) for graph in value]
+    if attr_type == onnx.AttributeProto.SPARSE_TENSOR:
+        return _sparse_tensor_attribute_metadata(value)
+    if attr_type == onnx.AttributeProto.SPARSE_TENSORS:
+        return [_sparse_tensor_attribute_metadata(tensor) for tensor in value]
+    return value
+
+
+def _tensor_attribute_metadata(tensor: Any) -> dict[str, Any]:
+    """Summarize tensor attributes without embedding raw tensor data."""
+    return {
+        "name": tensor.name,
+        "dims": list(tensor.dims),
+        "data_type": _tensor_data_type_name(tensor.data_type),
+    }
+
+
+def _sparse_tensor_attribute_metadata(tensor: Any) -> dict[str, Any]:
+    """Summarize sparse tensor attributes without embedding raw tensor data."""
+    return {
+        "dims": list(tensor.dims),
+        "values": _tensor_attribute_metadata(tensor.values),
+    }
+
+
+def _graph_attribute_metadata(graph: Any) -> dict[str, Any]:
+    """Summarize graph attributes without recursively dumping subgraphs."""
+    return {"name": graph.name, "node_count": len(graph.node)}
 
 
 def _csv_summary(samples: list[dict[str, Any]]) -> dict[str, Any]:
@@ -422,7 +560,10 @@ class QNNProfiler(OpTracer):
                 f"warmup, got {len(measured)} from {len(samples)} total."
             )
 
-        operators = _csv_operator_metrics(measured)
+        onnx_operator_data = (
+            _load_onnx_operator_data(self.onnx_path) if _is_op_add_data_enabled() else None
+        )
+        operators = _csv_operator_metrics(measured, onnx_operator_data)
 
         return OpTraceResult(
             model=self.onnx_path.name,

--- a/src/winml/modelkit/optracing/qnn/profiler.py
+++ b/src/winml/modelkit/optracing/qnn/profiler.py
@@ -126,6 +126,7 @@ def _load_onnx_operator_data(onnx_path: Path) -> dict[str, dict[str, Any]]:
     model = infer_shapes(model)
     value_info = _collect_value_info(model)
     initializers = {init.name: init for init in model.graph.initializer}
+    opset_versions = _collect_opset_versions(model)
 
     operator_data: dict[str, dict[str, Any]] = {}
     for node in model.graph.node:
@@ -134,13 +135,14 @@ def _load_onnx_operator_data(onnx_path: Path) -> dict[str, dict[str, Any]]:
         operator_data[node.name] = {
             "onnx_op_type": node.op_type,
             "onnx_attributes": {attr.name: _serialize_attribute(attr) for attr in node.attribute},
-            "onnx_inputs": {
-                name: _input_tensor_metadata(name, value_info, initializers)
-                for name in node.input
-                if name
-            },
+            "onnx_inputs": _node_input_metadata(node, opset_versions, value_info, initializers),
         }
     return operator_data
+
+
+def _collect_opset_versions(model: Any) -> dict[str, int]:
+    """Collect imported ONNX opset versions by domain."""
+    return {opset.domain: opset.version for opset in model.opset_import}
 
 
 def _collect_value_info(model: Any) -> dict[str, Any]:
@@ -151,13 +153,79 @@ def _collect_value_info(model: Any) -> dict[str, Any]:
     }
 
 
+def _node_input_metadata(
+    node: Any,
+    opset_versions: dict[str, int],
+    value_info: dict[str, Any],
+    initializers: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    """Return input metadata keyed by ONNX schema formal input name."""
+    metadata: dict[str, dict[str, Any]] = {}
+    for index, value_name in enumerate(node.input):
+        if not value_name:
+            continue
+        schema_name = _schema_input_name(node, index, opset_versions)
+        key = _unique_input_key(schema_name, index, metadata)
+        metadata[key] = _input_tensor_metadata(value_name, value_info, initializers)
+    return metadata
+
+
+def _schema_input_name(node: Any, input_index: int, opset_versions: dict[str, int]) -> str:
+    """Resolve a node input index to its ONNX schema formal parameter name."""
+    from onnx import defs
+
+    domain = node.domain
+    opset_version = opset_versions.get(domain)
+    if opset_version is None:
+        logger.debug(
+            "Could not resolve ONNX opset version for %s domain=%r input=%d",
+            node.op_type,
+            domain,
+            input_index,
+        )
+        return f"input_{input_index}"
+
+    try:
+        schema = defs.get_schema(
+            node.op_type,
+            max_inclusive_version=opset_version,
+            domain=domain,
+        )
+    except defs.SchemaError:
+        logger.debug(
+            "Could not resolve ONNX schema for %s domain=%r input=%d",
+            node.op_type,
+            domain,
+            input_index,
+            exc_info=True,
+        )
+        return f"input_{input_index}"
+
+    if input_index < len(schema.inputs):
+        return schema.inputs[input_index].name
+    if schema.inputs:
+        return schema.inputs[-1].name
+    return f"input_{input_index}"
+
+
+def _unique_input_key(
+    schema_name: str,
+    input_index: int,
+    existing: dict[str, dict[str, Any]],
+) -> str:
+    """Keep schema names as keys while disambiguating repeated variadic inputs."""
+    if schema_name not in existing:
+        return schema_name
+    return f"{schema_name}[{input_index}]"
+
+
 def _input_tensor_metadata(
     name: str,
     value_info: dict[str, Any],
     initializers: dict[str, Any],
 ) -> dict[str, Any]:
     """Return JSON-safe shape and type metadata for a node input tensor."""
-    metadata: dict[str, Any] = {}
+    metadata: dict[str, Any] = {"name": name}
     if name in initializers:
         initializer = initializers[name]
         metadata["dims"] = list(initializer.dims)

--- a/src/winml/modelkit/optracing/result.py
+++ b/src/winml/modelkit/optracing/result.py
@@ -49,6 +49,7 @@ class OperatorMetrics:
     onnx_op_type: str | None = None
     onnx_attributes: dict[str, Any] | None = None
     onnx_inputs: dict[str, dict[str, Any]] | None = None
+    onnx_outputs: dict[str, dict[str, Any]] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to dict, omitting fields left unset (``None``).

--- a/src/winml/modelkit/optracing/result.py
+++ b/src/winml/modelkit/optracing/result.py
@@ -46,6 +46,9 @@ class OperatorMetrics:
     num_htp_ops: int | None = None
     data_type: str | None = None
     dims: list[int] | None = None
+    onnx_op_type: str | None = None
+    onnx_attributes: dict[str, Any] | None = None
+    onnx_inputs: dict[str, dict[str, Any]] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to dict, omitting fields left unset (``None``).

--- a/tests/unit/optracing/test_qnn_profiler.py
+++ b/tests/unit/optracing/test_qnn_profiler.py
@@ -12,7 +12,6 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import onnx
 import pytest
-from onnx import TensorProto, helper
 
 from winml.modelkit.optracing.qnn.profiler import (
     QNNProfiler,
@@ -292,21 +291,21 @@ def _make_csv_sample(cycles: int, us: int, conv_cycles: int, add_cycles: int) ->
 
 def _write_transpose_model(path: Path) -> None:
     """Write a generated ONNX model with node input and attribute metadata."""
-    input_info = helper.make_tensor_value_info(
-        "input", TensorProto.FLOAT, [1, 3, "height", "width"]
+    input_info = onnx.helper.make_tensor_value_info(
+        "input", onnx.TensorProto.FLOAT, [1, 3, "height", "width"]
     )
-    output_info = helper.make_tensor_value_info(
-        "output", TensorProto.FLOAT, [1, "height", "width", 3]
+    output_info = onnx.helper.make_tensor_value_info(
+        "output", onnx.TensorProto.FLOAT, [1, "height", "width", 3]
     )
-    node = helper.make_node(
+    node = onnx.helper.make_node(
         "Transpose",
         ["input"],
         ["output"],
         name="transpose_node",
         perm=[0, 2, 3, 1],
     )
-    graph = helper.make_graph([node], "transpose_graph", [input_info], [output_info])
-    onnx.save_model(helper.make_model(graph), path)
+    graph = onnx.helper.make_graph([node], "transpose_graph", [input_info], [output_info])
+    onnx.save_model(onnx.helper.make_model(graph), path)
 
 
 def _make_node_csv_sample(node_name: str) -> str:
@@ -394,7 +393,7 @@ def test_qnn_profiler_from_csv_adds_onnx_data_when_env_is_set(tmp_path, monkeypa
     assert operator["onnx_attributes"] == {"perm": list(node.attribute[0].ints)}
     assert operator["onnx_inputs"] == {
         graph_input.name: {
-            "data_type": TensorProto.DataType.Name(graph_input.type.tensor_type.elem_type),
+            "data_type": onnx.TensorProto.DataType.Name(graph_input.type.tensor_type.elem_type),
             "dims": [
                 dim.dim_value if dim.HasField("dim_value") else dim.dim_param
                 for dim in graph_input.type.tensor_type.shape.dim

--- a/tests/unit/optracing/test_qnn_profiler.py
+++ b/tests/unit/optracing/test_qnn_profiler.py
@@ -10,7 +10,9 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import numpy as np
+import onnx
 import pytest
+from onnx import TensorProto, helper
 
 from winml.modelkit.optracing.qnn.profiler import (
     QNNProfiler,
@@ -288,6 +290,35 @@ def _make_csv_sample(cycles: int, us: int, conv_cycles: int, add_cycles: int) ->
     )
 
 
+def _write_transpose_model(path: Path) -> None:
+    """Write a generated ONNX model with node input and attribute metadata."""
+    input_info = helper.make_tensor_value_info(
+        "input", TensorProto.FLOAT, [1, 3, "height", "width"]
+    )
+    output_info = helper.make_tensor_value_info(
+        "output", TensorProto.FLOAT, [1, "height", "width", 3]
+    )
+    node = helper.make_node(
+        "Transpose",
+        ["input"],
+        ["output"],
+        name="transpose_node",
+        perm=[0, 2, 3, 1],
+    )
+    graph = helper.make_graph([node], "transpose_graph", [input_info], [output_info])
+    onnx.save_model(helper.make_model(graph), path)
+
+
+def _make_node_csv_sample(node_name: str) -> str:
+    """Build one inference sample block for a named ONNX node."""
+    return (
+        '0,ROOT,4,COUNT,HW,ROOT,"Number of HVX threads used"\n'
+        '1,ROOT,100,CYCLES,HW,ROOT,"Accelerator (execute) time (cycles)"\n'
+        f'2,NODE,25,CYCLES,HW,SUB-EVENT,"{node_name}:OpId_7 (cycles)"\n'
+        '3,ROOT,10,US,HW,ROOT,"Accelerator (execute) time"\n'
+    )
+
+
 def test_qnn_profiler_from_csv_skips_warmup(tmp_path):
     """The first ``warmup`` samples are dropped before computing metrics."""
     # One warmup sample with outlier timing, then two measured samples.
@@ -319,6 +350,57 @@ def test_qnn_profiler_from_csv_sample_count_mismatch(tmp_path):
     profiler = QNNProfiler(tmp_path / "model.onnx", output_dir=tmp_path, level="basic")
     with pytest.raises(ValueError):
         profiler._from_csv(csv_path, iterations=5, warmup=0, artifacts={})
+
+
+def test_qnn_profiler_from_csv_omits_onnx_data_without_env(tmp_path, monkeypatch):
+    """Basic profiling output is unchanged unless WINMLCLI_OP_ADD_DATA is set."""
+    model_path = tmp_path / "model.onnx"
+    csv_path = tmp_path / "profiling_output.csv"
+    _write_transpose_model(model_path)
+    csv_path.write_text(
+        _CSV_HEADER + _make_node_csv_sample("transpose_node"),
+        encoding="utf-8",
+    )
+
+    monkeypatch.delenv("WINMLCLI_OP_ADD_DATA", raising=False)
+    profiler = QNNProfiler(model_path, output_dir=tmp_path, level="basic")
+    result = profiler._from_csv(csv_path, iterations=1, warmup=0, artifacts={})
+
+    operator = result.to_dict()["operators"][0]
+    assert "onnx_op_type" not in operator
+    assert "onnx_attributes" not in operator
+    assert "onnx_inputs" not in operator
+
+
+def test_qnn_profiler_from_csv_adds_onnx_data_when_env_is_set(tmp_path, monkeypatch):
+    """Basic profiling can include ONNX node type, attributes, and input specs."""
+    model_path = tmp_path / "model.onnx"
+    csv_path = tmp_path / "profiling_output.csv"
+    _write_transpose_model(model_path)
+    csv_path.write_text(
+        _CSV_HEADER + _make_node_csv_sample("transpose_node"),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("WINMLCLI_OP_ADD_DATA", "1")
+    profiler = QNNProfiler(model_path, output_dir=tmp_path, level="basic")
+    result = profiler._from_csv(csv_path, iterations=1, warmup=0, artifacts={})
+
+    operator = result.to_dict()["operators"][0]
+    model = onnx.load(model_path)
+    node = model.graph.node[0]
+    graph_input = model.graph.input[0]
+    assert operator["onnx_op_type"] == node.op_type
+    assert operator["onnx_attributes"] == {"perm": list(node.attribute[0].ints)}
+    assert operator["onnx_inputs"] == {
+        graph_input.name: {
+            "data_type": TensorProto.DataType.Name(graph_input.type.tensor_type.elem_type),
+            "dims": [
+                dim.dim_value if dim.HasField("dim_value") else dim.dim_param
+                for dim in graph_input.type.tensor_type.shape.dim
+            ],
+        }
+    }
 
 
 def test_qnn_profiler_empty_artifacts(tmp_path):

--- a/tests/unit/optracing/test_qnn_profiler.py
+++ b/tests/unit/optracing/test_qnn_profiler.py
@@ -6,17 +6,19 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
-from onnx import TensorProto, helper, load, save_model
+from onnx import AttributeProto, TensorProto, TypeProto, helper, load, save_model
 
 from winml.modelkit.optracing.qnn.profiler import (
     QNNProfiler,
     _ort_type_to_numpy,
     _resolve_shape,
+    _serialize_attribute,
 )
 from winml.modelkit.optracing.qnn.viewer import (
     _DEFAULT_CONFIG,
@@ -389,6 +391,7 @@ def test_qnn_profiler_from_csv_adds_onnx_data_when_env_is_set(tmp_path, monkeypa
     model = load(model_path)
     node = model.graph.node[0]
     graph_input = model.graph.input[0]
+    graph_output = model.graph.output[0]
     assert operator["onnx_op_type"] == node.op_type
     assert operator["onnx_attributes"] == {"perm": list(node.attribute[0].ints)}
     assert operator["onnx_inputs"] == {
@@ -401,6 +404,51 @@ def test_qnn_profiler_from_csv_adds_onnx_data_when_env_is_set(tmp_path, monkeypa
             ],
         }
     }
+    assert operator["onnx_outputs"] == {
+        "transposed": {
+            "name": graph_output.name,
+            "data_type": TensorProto.DataType.Name(graph_output.type.tensor_type.elem_type),
+            "dims": [
+                dim.dim_value if dim.HasField("dim_value") else dim.dim_param
+                for dim in graph_output.type.tensor_type.shape.dim
+            ],
+        }
+    }
+
+
+def test_qnn_profiler_from_csv_falls_back_when_onnx_metadata_fails(tmp_path, monkeypatch, caplog):
+    """ONNX enrichment failures do not discard otherwise valid profiling metrics."""
+    csv_path = tmp_path / "profiling_output.csv"
+    csv_path.write_text(
+        _CSV_HEADER + _make_node_csv_sample("transpose_node"),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("WINMLCLI_OP_ADD_DATA", "1")
+    profiler = QNNProfiler(tmp_path / "missing.onnx", output_dir=tmp_path, level="basic")
+    result = profiler._from_csv(csv_path, iterations=1, warmup=0, artifacts={})
+
+    operator = result.to_dict()["operators"][0]
+    assert operator["name"] == "transpose_node"
+    assert "onnx_op_type" not in operator
+    assert "onnx_inputs" not in operator
+    assert "onnx_outputs" not in operator
+    assert "Could not enrich QNN profiler metrics with ONNX metadata" in caplog.text
+
+
+def test_serialize_type_proto_attribute_is_json_safe():
+    """Unsupported protobuf-valued attributes are converted to JSON-safe metadata."""
+    type_proto = TypeProto()
+    type_proto.tensor_type.elem_type = TensorProto.FLOAT
+    attr = AttributeProto()
+    attr.name = "type_proto"
+    attr.type = AttributeProto.TYPE_PROTO
+    attr.tp.CopyFrom(type_proto)
+
+    value = _serialize_attribute(attr)
+
+    json.dumps(value)
+    assert value == {"tensor_type": {"elem_type": TensorProto.FLOAT}}
 
 
 def test_qnn_profiler_empty_artifacts(tmp_path):

--- a/tests/unit/optracing/test_qnn_profiler.py
+++ b/tests/unit/optracing/test_qnn_profiler.py
@@ -392,7 +392,8 @@ def test_qnn_profiler_from_csv_adds_onnx_data_when_env_is_set(tmp_path, monkeypa
     assert operator["onnx_op_type"] == node.op_type
     assert operator["onnx_attributes"] == {"perm": list(node.attribute[0].ints)}
     assert operator["onnx_inputs"] == {
-        graph_input.name: {
+        "data": {
+            "name": graph_input.name,
             "data_type": TensorProto.DataType.Name(graph_input.type.tensor_type.elem_type),
             "dims": [
                 dim.dim_value if dim.HasField("dim_value") else dim.dim_param

--- a/tests/unit/optracing/test_qnn_profiler.py
+++ b/tests/unit/optracing/test_qnn_profiler.py
@@ -10,8 +10,8 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import numpy as np
-import onnx
 import pytest
+from onnx import TensorProto, helper, load, save_model
 
 from winml.modelkit.optracing.qnn.profiler import (
     QNNProfiler,
@@ -291,21 +291,21 @@ def _make_csv_sample(cycles: int, us: int, conv_cycles: int, add_cycles: int) ->
 
 def _write_transpose_model(path: Path) -> None:
     """Write a generated ONNX model with node input and attribute metadata."""
-    input_info = onnx.helper.make_tensor_value_info(
-        "input", onnx.TensorProto.FLOAT, [1, 3, "height", "width"]
+    input_info = helper.make_tensor_value_info(
+        "input", TensorProto.FLOAT, [1, 3, "height", "width"]
     )
-    output_info = onnx.helper.make_tensor_value_info(
-        "output", onnx.TensorProto.FLOAT, [1, "height", "width", 3]
+    output_info = helper.make_tensor_value_info(
+        "output", TensorProto.FLOAT, [1, "height", "width", 3]
     )
-    node = onnx.helper.make_node(
+    node = helper.make_node(
         "Transpose",
         ["input"],
         ["output"],
         name="transpose_node",
         perm=[0, 2, 3, 1],
     )
-    graph = onnx.helper.make_graph([node], "transpose_graph", [input_info], [output_info])
-    onnx.save_model(onnx.helper.make_model(graph), path)
+    graph = helper.make_graph([node], "transpose_graph", [input_info], [output_info])
+    save_model(helper.make_model(graph), path)
 
 
 def _make_node_csv_sample(node_name: str) -> str:
@@ -386,14 +386,14 @@ def test_qnn_profiler_from_csv_adds_onnx_data_when_env_is_set(tmp_path, monkeypa
     result = profiler._from_csv(csv_path, iterations=1, warmup=0, artifacts={})
 
     operator = result.to_dict()["operators"][0]
-    model = onnx.load(model_path)
+    model = load(model_path)
     node = model.graph.node[0]
     graph_input = model.graph.input[0]
     assert operator["onnx_op_type"] == node.op_type
     assert operator["onnx_attributes"] == {"perm": list(node.attribute[0].ints)}
     assert operator["onnx_inputs"] == {
         graph_input.name: {
-            "data_type": onnx.TensorProto.DataType.Name(graph_input.type.tensor_type.elem_type),
+            "data_type": TensorProto.DataType.Name(graph_input.type.tensor_type.elem_type),
             "dims": [
                 dim.dim_value if dim.HasField("dim_value") else dim.dim_param
                 for dim in graph_input.type.tensor_type.shape.dim

--- a/tests/unit/test_env.py
+++ b/tests/unit/test_env.py
@@ -1,0 +1,34 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Tests for environment variable helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from winml.modelkit._env import env_flag_enabled
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on", " on "])
+def test_env_flag_enabled_truthy_values(value: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Truthy environment flag spellings are accepted consistently."""
+    monkeypatch.setenv("WINMLCLI_TEST_FLAG", value)
+
+    assert env_flag_enabled("WINMLCLI_TEST_FLAG") is True
+
+
+@pytest.mark.parametrize("value", ["", "0", "false", "no", "off", "anything"])
+def test_env_flag_enabled_falsey_values(value: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unset and non-truthy environment flag values are disabled."""
+    monkeypatch.setenv("WINMLCLI_TEST_FLAG", value)
+
+    assert env_flag_enabled("WINMLCLI_TEST_FLAG") is False
+
+
+def test_env_flag_enabled_missing_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing environment flags are disabled."""
+    monkeypatch.delenv("WINMLCLI_TEST_FLAG", raising=False)
+
+    assert env_flag_enabled("WINMLCLI_TEST_FLAG") is False


### PR DESCRIPTION
## Summary
- Add env-gated ONNX metadata enrichment for QNN basic profiler metrics via WINMLCLI_OP_ADD_DATA
- Include ONNX node type, attributes, and input tensor metadata keyed by input name
- Add focused unit coverage for default and env-enabled output shapes

## Verification
- uv run ruff check --fix src\winml\modelkit\optracing\result.py src\winml\modelkit\optracing\qnn\profiler.py tests\unit\optracing\test_qnn_profiler.py
- uv run pytest tests\unit\optracing\test_qnn_profiler.py