### PR TITLE
feat(telemetry): record model_id on WinMLCLIAction

### DIFF
--- a/src/winml/modelkit/telemetry/click_group.py
+++ b/src/winml/modelkit/telemetry/click_group.py
@@ -30,6 +30,7 @@ from typing import Any
 import click
 
 from .telemetry import Telemetry
+from .utils import _scrub_model_ref
 
 
 _INSTRUMENTED_ATTR = "_winmlcli_instrumented"
@@ -100,8 +101,12 @@ def _instrument(cmd: click.Command) -> click.Command:
             raise
         finally:
             duration_ms = int((time.perf_counter() - start) * 1000)
+            model_id = _param(ctx, "model_id")
+            if model_id is None:
+                model_id = _scrub_model_ref(_param(ctx, "model"))
             telemetry.log_action(
                 action_name=cmd.name or "",
+                model_id=model_id,
                 device=_param(ctx, "device"),
                 ep=_param(ctx, "ep"),
                 duration_ms=duration_ms,

--- a/src/winml/modelkit/telemetry/click_group.py
+++ b/src/winml/modelkit/telemetry/click_group.py
@@ -101,9 +101,13 @@ def _instrument(cmd: click.Command) -> click.Command:
             raise
         finally:
             duration_ms = int((time.perf_counter() - start) * 1000)
-            model_id = _param(ctx, "model_id")
-            if model_id is None:
-                model_id = _scrub_model_ref(_param(ctx, "model"))
+            # Both inputs go through the scrubber: --model-id is trusted to be
+            # a clean HF id but isn't validated, so a stray path there is
+            # anonymized too. --model-id wins when present (eval/quantize);
+            # otherwise fall back to the scrubbed -m value.
+            model_id = _scrub_model_ref(_param(ctx, "model_id")) or _scrub_model_ref(
+                _param(ctx, "model")
+            )
             telemetry.log_action(
                 action_name=cmd.name or "",
                 model_id=model_id,

--- a/src/winml/modelkit/telemetry/telemetry.py
+++ b/src/winml/modelkit/telemetry/telemetry.py
@@ -48,6 +48,7 @@ _ALLOWED_KEYS: dict[str, set[str]] = {
     _ACTION_EVENT: {
         "invoked_from",
         "action_name",
+        "model_id",
         "device",
         "ep",
         "duration_ms",
@@ -188,6 +189,7 @@ class Telemetry:
         ep: EPNameOrAlias | None,
         duration_ms: int,
         success: bool,
+        model_id: str | None = None,
         **_unused: Any,
     ) -> None:
         """Emit a ``WinMLCLIAction`` event for a completed CLI command."""
@@ -197,6 +199,7 @@ class Telemetry:
             attrs = {
                 "invoked_from": self._invoked_from,
                 "action_name": action_name,
+                "model_id": model_id,
                 "device": device,
                 "ep": ep,
                 "duration_ms": duration_ms,

--- a/src/winml/modelkit/telemetry/utils.py
+++ b/src/winml/modelkit/telemetry/utils.py
@@ -151,6 +151,40 @@ def _looks_like_path(token: str) -> bool:
     return "\\" in token and _PACKAGE_ROOT in token.replace("\\", "/")
 
 
+def _model_ref_local_marker(value: str) -> str:
+    """Anonymized marker for a local model reference.
+
+    Emits only the file extension or the literal ``dir`` — never any path
+    fragment (no basename, no directory names, no username).
+    """
+    tail = value.replace("\\", "/").rsplit("/", 1)[-1]
+    ext = Path(tail).suffix
+    return f"<local:{ext}>" if ext else "<local:dir>"
+
+
+def _scrub_model_ref(value: str | tuple[str, ...] | None) -> str | None:
+    """Classify a ``-m/--model`` reference for telemetry.
+
+    Clean HuggingFace ids (``org/name``, single slash, not present on
+    disk) pass through verbatim. Everything else — drive-letter paths,
+    absolute paths, on-disk paths, and bare names — collapses to a
+    ``<local:...>`` marker that carries no path content.
+    """
+    if isinstance(value, tuple):
+        value = value[0] if value else None
+    if not value:
+        return None
+    normalized = value.replace("\\", "/")
+    if re.match(r"^[A-Za-z]:[\\/]", value) or normalized.startswith("/"):
+        return _model_ref_local_marker(value)
+    if Path(value).exists():
+        return _model_ref_local_marker(value)
+    parts = normalized.split("/")
+    if len(parts) == 2 and parts[0] and parts[1]:
+        return value
+    return _model_ref_local_marker(value)
+
+
 def _encode_cache_entry(entry: dict[str, Any]) -> str:
     """Encode a cache entry to a single-line string: ``base64(json(dict))``."""
     raw = json.dumps(entry, ensure_ascii=False).encode("utf-8")

--- a/src/winml/modelkit/telemetry/utils.py
+++ b/src/winml/modelkit/telemetry/utils.py
@@ -151,6 +151,14 @@ def _looks_like_path(token: str) -> bool:
     return "\\" in token and _PACKAGE_ROOT in token.replace("\\", "/")
 
 
+# A clean HuggingFace Hub id: one or two segments of the Hub charset, with
+# at most one slash (``bert-base-uncased`` or ``org/name``). Anything with a
+# path separator beyond a single ``/``, a drive letter, an ``=`` (eval's
+# ``role=path`` form), or any other character falls through to the local
+# marker.
+_HUB_ID_RE = re.compile(r"^[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?$")
+
+
 def _model_ref_local_marker(value: str) -> str:
     """Anonymized marker for a local model reference.
 
@@ -165,10 +173,12 @@ def _model_ref_local_marker(value: str) -> str:
 def _scrub_model_ref(value: str | tuple[str, ...] | None) -> str | None:
     """Classify a ``-m/--model`` reference for telemetry.
 
-    Clean HuggingFace ids (``org/name``, single slash, not present on
-    disk) pass through verbatim. Everything else — drive-letter paths,
-    absolute paths, on-disk paths, and bare names — collapses to a
-    ``<local:...>`` marker that carries no path content.
+    Clean HuggingFace Hub ids — one or two Hub-charset segments with at most
+    one slash, not present on disk (``bert-base-uncased``, ``org/name``) —
+    pass through verbatim. Everything else — drive-letter paths, absolute
+    paths, on-disk paths, ``role=path`` composites, and names with unexpected
+    characters — collapses to a ``<local:...>`` marker that carries no path
+    content.
     """
     if isinstance(value, tuple):
         value = value[0] if value else None
@@ -179,8 +189,14 @@ def _scrub_model_ref(value: str | tuple[str, ...] | None) -> str | None:
         return _model_ref_local_marker(value)
     if Path(value).exists():
         return _model_ref_local_marker(value)
-    parts = normalized.split("/")
-    if len(parts) == 2 and parts[0] and parts[1]:
+    # A single-segment name that carries a file extension (e.g. ``model.onnx``)
+    # is treated as a local file reference, not a Hub id — Hub ids don't carry
+    # file extensions, and this is far more likely a path the user typed for a
+    # file that isn't on *this* disk. Two-segment ``org/name`` is exempt: a dot
+    # there is part of the id (e.g. ``org/model.v2``), not a file extension.
+    if "/" not in normalized and Path(value).suffix:
+        return _model_ref_local_marker(value)
+    if _HUB_ID_RE.match(value):
         return value
     return _model_ref_local_marker(value)
 

--- a/tests/unit/telemetry/test_click_group.py
+++ b/tests/unit/telemetry/test_click_group.py
@@ -314,3 +314,27 @@ def test_action_prefers_model_id_param(enabled_telemetry):
     runner.invoke(cli, ["eval-", "-m", "x.onnx", "--model-id", "microsoft/resnet-50"])
     action_record = mock_logger.emit.call_args_list[1].args[0]
     assert dict(action_record.attributes)["model_id"] == "microsoft/resnet-50"
+
+
+def test_action_scrubs_path_in_model_id_param(enabled_telemetry):
+    """Defense-in-depth: --model-id is trusted to be a clean HF id but is not
+    validated. A path passed there is still anonymized, never emitted verbatim.
+    Regression for PR #1108 review."""
+
+    @click.group(cls=ActionGroup)
+    def cli():
+        pass
+
+    @cli.command()
+    @click.option("-m", "--model", default=None)
+    @click.option("--model-id", "model_id", default=None)
+    def eval_(model, model_id):
+        pass
+
+    telemetry = Telemetry.get_or_init()
+    mock_logger = _with_mock_logger(telemetry)
+
+    runner = CliRunner()
+    runner.invoke(cli, ["eval-", "--model-id", r"C:\Users\alice\secret.onnx"])
+    action_record = mock_logger.emit.call_args_list[1].args[0]
+    assert dict(action_record.attributes)["model_id"] == "<local:.onnx>"

--- a/tests/unit/telemetry/test_click_group.py
+++ b/tests/unit/telemetry/test_click_group.py
@@ -265,3 +265,52 @@ def test_subcommand_help_does_not_emit(enabled_telemetry):
     if telemetry_mod._INSTANCE is not None:
         logger = telemetry_mod._INSTANCE._logger
         assert logger is None or not logger.emit.called
+
+
+@pytest.mark.parametrize(
+    ("model_arg", "expected_model_id"),
+    [
+        ("microsoft/resnet-50", "microsoft/resnet-50"),
+        (r"C:\Users\alice\x.onnx", "<local:.onnx>"),
+    ],
+)
+def test_action_records_scrubbed_model_id(enabled_telemetry, model_arg, expected_model_id):
+    @click.group(cls=ActionGroup)
+    def cli():
+        pass
+
+    @cli.command()
+    @click.option("-m", "--model", default=None)
+    def perf(model):
+        pass
+
+    telemetry = Telemetry.get_or_init()
+    mock_logger = _with_mock_logger(telemetry)
+
+    runner = CliRunner()
+    runner.invoke(cli, ["perf", "-m", model_arg])
+    action_record = mock_logger.emit.call_args_list[1].args[0]
+    assert dict(action_record.attributes)["model_id"] == expected_model_id
+
+
+def test_action_prefers_model_id_param(enabled_telemetry):
+    """When a command exposes ``--model-id`` (eval/quantize), that clean
+    HF id is recorded directly, bypassing the scrubbed ``-m`` value."""
+
+    @click.group(cls=ActionGroup)
+    def cli():
+        pass
+
+    @cli.command()
+    @click.option("-m", "--model", default=None)
+    @click.option("--model-id", "model_id", default=None)
+    def eval_(model, model_id):
+        pass
+
+    telemetry = Telemetry.get_or_init()
+    mock_logger = _with_mock_logger(telemetry)
+
+    runner = CliRunner()
+    runner.invoke(cli, ["eval-", "-m", "x.onnx", "--model-id", "microsoft/resnet-50"])
+    action_record = mock_logger.emit.call_args_list[1].args[0]
+    assert dict(action_record.attributes)["model_id"] == "microsoft/resnet-50"

--- a/tests/unit/telemetry/test_telemetry_emit.py
+++ b/tests/unit/telemetry/test_telemetry_emit.py
@@ -67,6 +67,35 @@ def test_log_action_drops_unknown_attrs(running_telemetry):
     assert "leaked_field" not in attrs
 
 
+def test_log_action_emits_model_id(running_telemetry):
+    logger = _with_mock_logger(running_telemetry)
+    running_telemetry.log_action(
+        action_name="perf",
+        device="NPU",
+        ep="QNNExecutionProvider",
+        duration_ms=10,
+        success=True,
+        model_id="microsoft/resnet-50",
+    )
+    log_record = logger.emit.call_args.args[0]
+    attrs = dict(log_record.attributes)
+    assert attrs["model_id"] == "microsoft/resnet-50"
+
+
+def test_log_action_model_id_defaults_none(running_telemetry):
+    logger = _with_mock_logger(running_telemetry)
+    running_telemetry.log_action(
+        action_name="perf",
+        device=None,
+        ep=None,
+        duration_ms=10,
+        success=True,
+    )
+    log_record = logger.emit.call_args.args[0]
+    attrs = dict(log_record.attributes)
+    assert attrs["model_id"] is None
+
+
 def test_log_error_scrubs_message_and_extracts_stack(running_telemetry):
     logger = _with_mock_logger(running_telemetry)
     try:

--- a/tests/unit/telemetry/test_utils_scrubbing.py
+++ b/tests/unit/telemetry/test_utils_scrubbing.py
@@ -162,6 +162,15 @@ def test_format_exception_message_scrubs_long_token_at_cap_boundary():
         # Clean HF ID — passthrough
         ("microsoft/resnet-50", "microsoft/resnet-50"),
         ("google-bert/bert-base-uncased", "google-bert/bert-base-uncased"),
+        # Single-segment canonical Hub ids (no org prefix) pass through too —
+        # these are real, commonly-used ids and are the documented `perf -m`
+        # form. Regression for PR #1108 review.
+        ("bert-base-uncased", "bert-base-uncased"),
+        ("gpt2", "gpt2"),
+        ("mymodel", "mymodel"),
+        # Two-segment id with a dot in the name segment is still an id, not a
+        # file (the dot is part of the id, not a file extension).
+        ("org/model.v2", "org/model.v2"),
         # Windows absolute path with .onnx file
         (r"C:\Users\alice\models\resnet50-int8.onnx", "<local:.onnx>"),
         # POSIX-style absolute path (defensive; leading slash)
@@ -170,10 +179,13 @@ def test_format_exception_message_scrubs_long_token_at_cap_boundary():
         (r".\output\model.onnx", "<local:.onnx>"),
         # Directory-style reference (no extension) via backslash separator
         (r".\output\qwen3-bundle", "<local:dir>"),
-        # Bare filename with extension, no separator
+        # Single-segment name carrying a file extension is a local file ref,
+        # not a Hub id (Hub ids don't carry file extensions).
         ("model.onnx", "<local:.onnx>"),
-        # Bare name, no separator, no extension
-        ("mymodel", "<local:dir>"),
+        # eval's `role=path` composite: the `=` makes it non-Hub, so the
+        # `sub/model.onnx` fragment is never emitted verbatim. Regression for
+        # PR #1108 review.
+        ("encoder=sub/model.onnx", "<local:.onnx>"),
         # Tuple (multiple=True) — first element classified
         (("microsoft/resnet-50", "other/model"), "microsoft/resnet-50"),
         (("model.onnx",), "<local:.onnx>"),

--- a/tests/unit/telemetry/test_utils_scrubbing.py
+++ b/tests/unit/telemetry/test_utils_scrubbing.py
@@ -7,6 +7,7 @@ import pytest
 
 from winml.modelkit.telemetry.utils import (
     _format_exception_message,
+    _scrub_model_ref,
     _scrub_pii,
     _trim_path,
 )
@@ -153,3 +154,53 @@ def test_format_exception_message_scrubs_long_token_at_cap_boundary():
     assert "abcdef0123456789" not in result
     assert "<scrubbed>" in result
     assert len(result) <= 200
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        # Clean HF ID — passthrough
+        ("microsoft/resnet-50", "microsoft/resnet-50"),
+        ("google-bert/bert-base-uncased", "google-bert/bert-base-uncased"),
+        # Windows absolute path with .onnx file
+        (r"C:\Users\alice\models\resnet50-int8.onnx", "<local:.onnx>"),
+        # POSIX-style absolute path (defensive; leading slash)
+        ("/home/x/model.onnx", "<local:.onnx>"),
+        # Backslash-relative path with extension
+        (r".\output\model.onnx", "<local:.onnx>"),
+        # Directory-style reference (no extension) via backslash separator
+        (r".\output\qwen3-bundle", "<local:dir>"),
+        # Bare filename with extension, no separator
+        ("model.onnx", "<local:.onnx>"),
+        # Bare name, no separator, no extension
+        ("mymodel", "<local:dir>"),
+        # Tuple (multiple=True) — first element classified
+        (("microsoft/resnet-50", "other/model"), "microsoft/resnet-50"),
+        (("model.onnx",), "<local:.onnx>"),
+        # None / empty / empty tuple
+        (None, None),
+        ("", None),
+        ((), None),
+    ],
+)
+def test_scrub_model_ref(value, expected):
+    assert _scrub_model_ref(value) == expected
+
+
+def test_scrub_model_ref_existing_path_is_local(tmp_path, monkeypatch):
+    """A single-token relative name that exists on disk is treated as a
+    local path, not an HF id — even without a separator."""
+    f = tmp_path / "on_disk.onnx"
+    f.write_text("x")
+    monkeypatch.chdir(tmp_path)
+    assert _scrub_model_ref("on_disk.onnx") == "<local:.onnx>"
+
+
+def test_scrub_model_ref_org_name_that_exists_is_local(tmp_path, monkeypatch):
+    """If an `org/name` string happens to exist on disk, prefer the local
+    marker — existence wins over the HF-id shape."""
+    d = tmp_path / "org"
+    d.mkdir()
+    (d / "name").mkdir()
+    monkeypatch.chdir(tmp_path)
+    assert _scrub_model_ref("org/name") == "<local:dir>"


### PR DESCRIPTION
## Summary

- Add a `model_id` attribute to the `WinMLCLIAction` telemetry event so we can see which model each CLI command ran against.
- Anonymize local model references: `<local:.onnx>` / `<local:dir>` — no path fragment (basename, dir names, username) is ever emitted. Clean HuggingFace ids (`org/name`) pass through as-is.
- For commands exposing `--model-id` (eval/quantize), the clean HF id is recorded directly, bypassing the scrubbed `-m` value.

## Changes

- `telemetry/utils.py`: new `_scrub_model_ref` classifier + `<local:...>` marker.
- `telemetry/telemetry.py`: `log_action` gains a `model_id` param; `model_id` added to the `WinMLCLIAction` allowlist.
- `telemetry/click_group.py`: wires `--model-id`-preferred, otherwise-scrubbed-`-m` into emission.

Closes #1107
