### PR TITLE
feat(perf): auto-build a genai bundle from a model id for --runtime winml-genai

### DIFF
--- a/docs/commands/perf.md
+++ b/docs/commands/perf.md
@@ -16,7 +16,8 @@ $ winml perf [options]
 
 | Flag | Short | Type | Default | Description |
 |---|---|---|---|---|
-| `--model` | `-m` | `TEXT` | — | HuggingFace model ID or path to a local `.onnx` file. Required. |
+| `--model` | `-m` | `TEXT` | — | HuggingFace model ID or path to a local `.onnx` file. Required. With `--runtime winml-genai`, also accepts a prebuilt genai **bundle directory**, or a HuggingFace model ID that is auto-built into a bundle on demand. |
+| `--runtime` | | `winml\|winml-genai` | `winml` | Inference runtime. `winml` benchmarks single-shot ONNX inference; `winml-genai` benchmarks an onnxruntime-genai bundle (LLM generation: time-to-first-token + decode tokens/sec). With `winml-genai`, a model ID that is not a bundle directory is auto-built into one (cached under `~/.cache/winml/`, targeting the NPU HTP via QNN) before benchmarking; pass `--rebuild` to force a fresh build. |
 | `--task` | | `TEXT` | auto-detected | Explicit task override (e.g., `image-classification`). Inferred from the model if omitted. |
 | `--iterations` | | `INTEGER` | `100` | Number of timed inference iterations used to compute statistics. |
 | `--warmup` | | `INTEGER` | `10` | Number of warm-up iterations run before timing begins; excluded from statistics. |
@@ -36,6 +37,11 @@ $ winml perf [options]
 | `--ignore-cache/--no-ignore-cache` | | flag | `false` | Build from scratch in a temporary folder and discard the artifact after benchmarking. Implies `--rebuild`. |
 | `--module` | | `TEXT` | — | PyTorch module class name for per-module benchmarking (e.g., `BertAttention`). Builds and times each matching instance separately. See [Load and export](../concepts/load-and-export.md). |
 | `--monitor/--no-monitor` | | flag | `false` | Show a live NPU/CPU utilization chart while the benchmark runs and include hardware metrics in the JSON report. |
+| `--compile` / `--no-compile` | | flag | `false` | Compile the model to EPContext binaries during build. For `--runtime winml-genai` on the NPU, `--compile` pre-compiles each QNN stage (in an isolated subprocess) before generation. |
+| `--compile-timeout` | | `INTEGER` | `300` | *(winml-genai)* Max seconds to compile each EPContext stage before falling back to the original ONNX. Requires `--compile`. |
+| `--prompt` | | `TEXT` | `Explain the theory of relativity in simple terms.` | *(winml-genai)* Prompt text to generate from. Wrapped in the bundle's chat template unless `--no-apply-template`. |
+| `--apply-template/--no-apply-template` | | flag | `true` | *(winml-genai)* Wrap `--prompt` in the bundle's chat template before timing. |
+| `--max-new-tokens` | | `INTEGER` | `128` | *(winml-genai)* Number of new tokens to generate per iteration. |
 
 ## How it works
 

--- a/docs/commands/perf.md
+++ b/docs/commands/perf.md
@@ -17,7 +17,7 @@ $ winml perf [options]
 | Flag | Short | Type | Default | Description |
 |---|---|---|---|---|
 | `--model` | `-m` | `TEXT` | — | HuggingFace model ID or path to a local `.onnx` file. Required. With `--runtime winml-genai`, also accepts a prebuilt genai **bundle directory**, or a HuggingFace model ID that is auto-built into a bundle on demand. |
-| `--runtime` | | `winml\|winml-genai` | `winml` | Inference runtime. `winml` benchmarks single-shot ONNX inference; `winml-genai` benchmarks an onnxruntime-genai bundle (LLM generation: time-to-first-token + decode tokens/sec). With `winml-genai`, a model ID that is not a bundle directory is auto-built into one (cached under `~/.cache/winml/`, targeting the NPU HTP via QNN) before benchmarking; pass `--rebuild` to force a fresh build. |
+| `--runtime` | | `winml\|winml-genai` | `winml` | Inference runtime. `winml` benchmarks single-shot ONNX inference; `winml-genai` benchmarks an onnxruntime-genai bundle (LLM generation: time-to-first-token + decode tokens/sec). With `winml-genai`, a model ID that is not a bundle directory is auto-built into one (cached under `~/.cache/winml/`, targeting the NPU HTP via QNN) before benchmarking. Cache handling matches the `winml` runtime: `--rebuild` overwrites the cached bundle, and `--ignore-cache` builds a throwaway bundle in a temp folder and leaves the cache untouched. |
 | `--task` | | `TEXT` | auto-detected | Explicit task override (e.g., `image-classification`). Inferred from the model if omitted. |
 | `--iterations` | | `INTEGER` | `100` | Number of timed inference iterations used to compute statistics. |
 | `--warmup` | | `INTEGER` | `10` | Number of warm-up iterations run before timing begins; excluded from statistics. |

--- a/docs/samples/qwen3-genai-bundle.md
+++ b/docs/samples/qwen3-genai-bundle.md
@@ -103,6 +103,22 @@ CPU companions handle the embedding lookup and vocab projection. The command rep
 time-to-first-token (prefill) and decode throughput, and writes a results JSON under
 `~/.cache/winml/perf/`.
 
+!!! tip "One command from a model id (auto-build)"
+    `winml perf --runtime winml-genai` also accepts a HuggingFace **model id** directly.
+    When `-m` is not a prebuilt bundle directory, it builds the genai bundle on demand
+    (into `~/.cache/winml/`, reused on later runs) and then benchmarks it — no separate
+    `winml build` step:
+
+    ```bash
+    winml perf -m Qwen/Qwen3-0.6B --runtime winml-genai --compile \
+      --compile-timeout 600 --max-new-tokens 20 --prompt "What is the capital of France?"
+    ```
+
+    The auto-build always targets the NPU HTP via QNN (the only supported genai bundle
+    target today). `-o/--output` stays the results-JSON path, and `--rebuild` forces a
+    fresh bundle. To persist the bundle at a specific directory instead, run `winml build`
+    (Step 1) and point `perf -m` at that folder.
+
 !!! warning "`--compile` is required on the NPU"
     The genai NPU path needs `--compile` (EPContext pre-compilation): each QNN stage is
     compiled once to a context binary before generation. Without `--compile`,

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -1754,26 +1754,40 @@ _GENAI_IGNORED_FLAGS: dict[str, str] = {
     "batch_size": "--batch-size",
 }
 
-# Subset of the above that the model-id auto-build path *does* honor (they drive
-# the on-the-fly build). Excluded from the ignored-flags warning when a bundle
-# was auto-built; a prebuilt bundle still ignores them all.
-_GENAI_AUTOBUILD_FLAGS: frozenset[str] = frozenset({"task", "precision", "rebuild", "ignore_cache"})
+# Subsets of the above that the model-id auto-build path honors, so they are
+# excluded from the ignored-flags warning when a bundle is auto-built. A prebuilt
+# bundle still ignores them all.
+#
+# * Cache-behavior flags force the build path (the reuse fast-path is never taken
+#   when they are set), so they are honored whenever an auto-build runs.
+# * Artifact-shaping flags only take effect when a build actually runs; a cache
+#   hit reuses a bundle keyed by the model id alone and silently drops them, so
+#   they are still reported as ignored in that case.
+_GENAI_BUILD_CONTROL_FLAGS: frozenset[str] = frozenset({"rebuild", "ignore_cache"})
+_GENAI_BUILD_INPUT_FLAGS: frozenset[str] = frozenset({"task", "precision"})
 
 
 def _warn_ignored_genai_flags(
-    ctx: click.Context, console: Console, *, autobuilt: bool = False
+    ctx: click.Context, console: Console, *, autobuilt: bool = False, built_fresh: bool = False
 ) -> None:
     """Warn about WinML-only flags the user passed that genai ignores.
 
     When the bundle was auto-built from a model id (``autobuilt``), the
-    build-driving flags (task/precision/rebuild/ignore-cache) are honored by the
-    build, so they are not reported as ignored. A prebuilt bundle ignores them.
+    cache-behavior flags (rebuild/ignore-cache) are always honored by the build.
+    The artifact-shaping flags (task/precision) are honored only when a fresh
+    build actually ran (``built_fresh``); on a cache hit the model-id-keyed bundle
+    is reused as-is, so those flags are reported as ignored. A prebuilt bundle
+    ignores them all.
     """
+    honored: set[str] = set()
+    if autobuilt:
+        honored |= _GENAI_BUILD_CONTROL_FLAGS
+        if built_fresh:
+            honored |= _GENAI_BUILD_INPUT_FLAGS
     ignored = [
         flag
         for param, flag in _GENAI_IGNORED_FLAGS.items()
-        if cli_utils.is_cli_provided(ctx, param)
-        and not (autobuilt and param in _GENAI_AUTOBUILD_FLAGS)
+        if cli_utils.is_cli_provided(ctx, param) and param not in honored
     ]
     if ignored:
         console.print(
@@ -1784,7 +1798,7 @@ def _warn_ignored_genai_flags(
 
 def _autobuild_genai_bundle(
     ctx: click.Context, *, model: str, console: Console, stack: contextlib.ExitStack
-) -> Path:
+) -> tuple[Path, bool]:
     """Build (or reuse) a genai bundle for a HuggingFace model id.
 
     Mirrors the winml runtime's on-the-fly build: when ``-m`` is a model id
@@ -1804,6 +1818,10 @@ def _autobuild_genai_bundle(
 
     The imports are function-local so ``winml perf --help`` does not pay their
     cost and so a bundle-directory run never imports the build stack.
+
+    Returns a ``(bundle_dir, built_fresh)`` pair. ``built_fresh`` is ``True`` when
+    a build actually ran and ``False`` when the managed-cache fast-path reused an
+    existing bundle (in which case task/precision were not applied to it).
     """
     import tempfile
 
@@ -1835,7 +1853,7 @@ def _autobuild_genai_bundle(
         force_rebuild = bool(p.get("rebuild"))
         if (bundle_dir / "genai_config.json").exists() and not force_rebuild:
             console.print(f"[dim]Reusing cached genai bundle:[/dim] {bundle_dir}")
-            return bundle_dir
+            return bundle_dir, False
 
     # Cache miss (or forced rebuild): resolve the model family so its
     # genai-bundle recipe can drive the build.
@@ -1876,7 +1894,7 @@ def _autobuild_genai_bundle(
         cache_dir=build_cache_dir,
         emit=lambda msg: console.print(msg, markup=False),
     )
-    return bundle_dir
+    return bundle_dir, True
 
 
 def _run_genai_runtime(ctx: click.Context, *, console: Console, json_mode: bool) -> None:
@@ -1911,6 +1929,7 @@ def _run_genai_runtime(ctx: click.Context, *, console: Console, json_mode: bool)
         # the same way the winml runtime auto-builds an ONNX from a model id.
         bundle_dir = Path(model)
         autobuilt_from: str | None = None
+        built_fresh = False
         if bundle_dir.is_dir():
             if not (bundle_dir / "genai_config.json").exists():
                 raise click.UsageError(
@@ -1922,10 +1941,14 @@ def _run_genai_runtime(ctx: click.Context, *, console: Console, json_mode: bool)
                 f"--runtime winml-genai requires a genai bundle *directory*, got '{model}'."
             )
         else:
-            bundle_dir = _autobuild_genai_bundle(ctx, model=model, console=console, stack=stack)
+            bundle_dir, built_fresh = _autobuild_genai_bundle(
+                ctx, model=model, console=console, stack=stack
+            )
             autobuilt_from = model
 
-        _warn_ignored_genai_flags(ctx, console, autobuilt=autobuilt_from is not None)
+        _warn_ignored_genai_flags(
+            ctx, console, autobuilt=autobuilt_from is not None, built_fresh=built_fresh
+        )
 
         # A full generation is far costlier than one session.run(): default to
         # fewer iterations/warmup unless the user set them explicitly.

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -1767,6 +1767,80 @@ def _warn_ignored_genai_flags(ctx: click.Context, console: Console) -> None:
         )
 
 
+def _autobuild_genai_bundle(ctx: click.Context, *, model: str, console: Console) -> Path:
+    """Build (or reuse) a genai bundle for a HuggingFace model id.
+
+    Mirrors the winml runtime's on-the-fly build: when ``-m`` is a model id
+    rather than a prebuilt bundle directory, emit a genai bundle into a managed
+    cache directory and benchmark that. A prior build is reused unless
+    ``--rebuild`` / ``--ignore-cache`` forces a fresh one. genai bundles target
+    the NPU HTP via QNN, so the build pins ``ep=qnn`` / ``device=npu`` regardless
+    of the benchmark's ``--device`` (which still selects the runtime EP).
+
+    The imports are function-local so ``winml perf --help`` does not pay their
+    cost and so a bundle-directory run never imports the build stack.
+    """
+    from ..cache import get_cache_dir, get_model_dir
+    from ..loader import resolve_loader_config
+    from ..models.winml import build_genai_bundle, resolve_genai_bundle
+
+    p = ctx.params
+    cache_dir = get_cache_dir()
+    bundle_dir = get_model_dir(model, cache_dir=cache_dir) / "genai-bundle"
+    # --ignore-cache and --rebuild both force a fresh bundle. (For the genai
+    # auto-build the fresh build lands in the same cache dir rather than a
+    # throwaway temp folder; the expensive component builds are cache-keyed.)
+    force_rebuild = bool(p.get("rebuild") or p.get("ignore_cache"))
+
+    # Fast path: reuse a previously built bundle (keyed by model id) unless a
+    # rebuild was requested. Checked before any model resolution so a cache hit
+    # never touches the network.
+    if (bundle_dir / "genai_config.json").exists() and not force_rebuild:
+        console.print(f"[dim]Reusing cached genai bundle:[/dim] {bundle_dir}")
+        return bundle_dir
+
+    # Cache miss (or forced rebuild): resolve the model family so its
+    # genai-bundle recipe can drive the build.
+    try:
+        loader_cfg, hf_config, *_rest = resolve_loader_config(model_id=model, task=p.get("task"))
+    except click.ClickException:
+        raise
+    except Exception as exc:
+        raise click.UsageError(
+            f"Could not resolve '{model}' for a genai bundle build ({exc}). Pass a "
+            "prebuilt genai bundle *directory* produced by a winml-cli export instead."
+        ) from exc
+
+    model_type = getattr(hf_config, "model_type", None) or loader_cfg.model_type
+    recipe = resolve_genai_bundle(model_type)
+    if recipe is None:
+        raise click.UsageError(
+            f"--runtime winml-genai cannot auto-build '{model}': no genai bundle recipe "
+            f"is registered for model type '{model_type or 'unknown'}'. Pass a prebuilt "
+            "genai bundle *directory* (e.g. from "
+            f"'winml build -m {model} -o <dir> --device npu --ep qnn')."
+        )
+
+    precision = p["precision"] if cli_utils.is_cli_provided(ctx, "precision") else None
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    console.print(
+        f"[dim]Building genai bundle for[/dim] {model} "
+        f"[dim](model_type={model_type}) ->[/dim] {bundle_dir}"
+    )
+    build_genai_bundle(
+        model,
+        bundle_dir,
+        recipe,
+        ep="qnn",
+        device="npu",
+        precision=precision,
+        force_rebuild=force_rebuild,
+        cache_dir=cache_dir,
+        emit=lambda msg: console.print(msg, markup=False),
+    )
+    return bundle_dir
+
+
 def _run_genai_runtime(ctx: click.Context, *, console: Console, json_mode: bool) -> None:
     """Validate folder input and dispatch to the winml-genai benchmark path.
 
@@ -1787,16 +1861,25 @@ def _run_genai_runtime(ctx: click.Context, *, console: Console, json_mode: bool)
     if p.get("module_class"):
         raise click.UsageError("--module is not supported with --runtime winml-genai.")
 
+    # Resolve the bundle. A local directory is used as-is (it must be a real
+    # genai bundle); an ``.onnx`` file is rejected; anything else is treated as
+    # a HuggingFace model id and a genai bundle is auto-built on demand -- the
+    # same way the winml runtime auto-builds an ONNX from a model id.
     bundle_dir = Path(model)
-    if bundle_dir.suffix.lower() == ".onnx" or not bundle_dir.is_dir():
+    autobuilt_from: str | None = None
+    if bundle_dir.is_dir():
+        if not (bundle_dir / "genai_config.json").exists():
+            raise click.UsageError(
+                f"No genai_config.json found in '{model}'. Point --model at a bundle "
+                "folder produced by a winml-cli export."
+            )
+    elif bundle_dir.suffix.lower() == ".onnx":
         raise click.UsageError(
             f"--runtime winml-genai requires a genai bundle *directory*, got '{model}'."
         )
-    if not (bundle_dir / "genai_config.json").exists():
-        raise click.UsageError(
-            f"No genai_config.json found in '{model}'. Point --model at a bundle "
-            "folder produced by a winml-cli export."
-        )
+    else:
+        bundle_dir = _autobuild_genai_bundle(ctx, model=model, console=console)
+        autobuilt_from = model
 
     _warn_ignored_genai_flags(ctx, console)
 
@@ -1809,7 +1892,14 @@ def _run_genai_runtime(ctx: click.Context, *, console: Console, json_mode: bool)
     # The shared --device default is "auto" (the ONNX default), so an omitted
     # flag is treated as "config"; an explicit --device is a deliberate override.
     device = p["device"].lower() if cli_utils.is_cli_provided(ctx, "device") else "config"
-    output = p.get("output") or genai_output_path(bundle_dir)
+    if p.get("output"):
+        output = p["output"]
+    elif autobuilt_from is not None:
+        # The auto-built bundle lives in a cache dir whose name is not a
+        # meaningful slug, so derive the report path from the model id instead.
+        output = generate_output_path(autobuilt_from)
+    else:
+        output = genai_output_path(bundle_dir)
     cli_utils.guard_output(output, p["overwrite"])
 
     # EP override precedence: an explicit ``--ep`` wins over the ``--device``

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -36,6 +36,8 @@ from ._live_chart import LiveMonitorDisplay
 
 
 if TYPE_CHECKING:
+    import contextlib
+
     from ..models.winml.base import WinMLPreTrainedModel
     from ..models.winml.composite_model import WinMLCompositeModel
     from ..session.stats import PerfStats
@@ -1752,13 +1754,26 @@ _GENAI_IGNORED_FLAGS: dict[str, str] = {
     "batch_size": "--batch-size",
 }
 
+# Subset of the above that the model-id auto-build path *does* honor (they drive
+# the on-the-fly build). Excluded from the ignored-flags warning when a bundle
+# was auto-built; a prebuilt bundle still ignores them all.
+_GENAI_AUTOBUILD_FLAGS: frozenset[str] = frozenset({"task", "precision", "rebuild", "ignore_cache"})
 
-def _warn_ignored_genai_flags(ctx: click.Context, console: Console) -> None:
-    """Warn about WinML-only flags the user passed that genai ignores."""
+
+def _warn_ignored_genai_flags(
+    ctx: click.Context, console: Console, *, autobuilt: bool = False
+) -> None:
+    """Warn about WinML-only flags the user passed that genai ignores.
+
+    When the bundle was auto-built from a model id (``autobuilt``), the
+    build-driving flags (task/precision/rebuild/ignore-cache) are honored by the
+    build, so they are not reported as ignored. A prebuilt bundle ignores them.
+    """
     ignored = [
         flag
         for param, flag in _GENAI_IGNORED_FLAGS.items()
         if cli_utils.is_cli_provided(ctx, param)
+        and not (autobuilt and param in _GENAI_AUTOBUILD_FLAGS)
     ]
     if ignored:
         console.print(
@@ -1767,37 +1782,60 @@ def _warn_ignored_genai_flags(ctx: click.Context, console: Console) -> None:
         )
 
 
-def _autobuild_genai_bundle(ctx: click.Context, *, model: str, console: Console) -> Path:
+def _autobuild_genai_bundle(
+    ctx: click.Context, *, model: str, console: Console, stack: contextlib.ExitStack
+) -> Path:
     """Build (or reuse) a genai bundle for a HuggingFace model id.
 
     Mirrors the winml runtime's on-the-fly build: when ``-m`` is a model id
-    rather than a prebuilt bundle directory, emit a genai bundle into a managed
-    cache directory and benchmark that. A prior build is reused unless
-    ``--rebuild`` / ``--ignore-cache`` forces a fresh one. genai bundles target
-    the NPU HTP via QNN, so the build pins ``ep=qnn`` / ``device=npu`` regardless
-    of the benchmark's ``--device`` (which still selects the runtime EP).
+    rather than a prebuilt bundle directory, emit a genai bundle and benchmark
+    it. Cache handling matches the single-model path:
+
+    * a plain run reuses a previously built bundle keyed by the model id;
+    * ``--rebuild`` overwrites that cached bundle in place;
+    * ``--ignore-cache`` builds fresh in a throwaway temp dir -- both the
+      assembled bundle and its component build cache -- and leaves the managed
+      cache untouched. The temp dir is entered on *stack* so it outlives the
+      benchmark and is removed afterwards.
+
+    genai bundles target the NPU HTP via QNN, so the build pins ``ep=qnn`` /
+    ``device=npu`` regardless of the benchmark's ``--device`` (which still
+    selects the runtime EP).
 
     The imports are function-local so ``winml perf --help`` does not pay their
     cost and so a bundle-directory run never imports the build stack.
     """
+    import tempfile
+
     from ..cache import get_cache_dir, get_model_dir
     from ..loader import resolve_loader_config
     from ..models.winml import build_genai_bundle, resolve_genai_bundle
 
     p = ctx.params
-    cache_dir = get_cache_dir()
-    bundle_dir = get_model_dir(model, cache_dir=cache_dir) / "genai-bundle"
-    # --ignore-cache and --rebuild both force a fresh bundle. (For the genai
-    # auto-build the fresh build lands in the same cache dir rather than a
-    # throwaway temp folder; the expensive component builds are cache-keyed.)
-    force_rebuild = bool(p.get("rebuild") or p.get("ignore_cache"))
 
-    # Fast path: reuse a previously built bundle (keyed by model id) unless a
-    # rebuild was requested. Checked before any model resolution so a cache hit
-    # never touches the network.
-    if (bundle_dir / "genai_config.json").exists() and not force_rebuild:
-        console.print(f"[dim]Reusing cached genai bundle:[/dim] {bundle_dir}")
-        return bundle_dir
+    if p.get("ignore_cache"):
+        # Mirror the winml runtime's use_cache=False path: build everything
+        # fresh in a throwaway temp dir and neither read from nor write to the
+        # managed cache. The assembled bundle and the component build cache both
+        # live under the temp root; the ExitStack removes it after benchmarking.
+        tmp_root = Path(
+            stack.enter_context(
+                tempfile.TemporaryDirectory(prefix="winml-genai-perf-", ignore_cleanup_errors=True)
+            )
+        )
+        bundle_dir = tmp_root / "genai-bundle"
+        build_cache_dir: Path = tmp_root / "cache"
+        force_rebuild = True
+    else:
+        cache_dir = get_cache_dir()
+        bundle_dir = get_model_dir(model, cache_dir=cache_dir) / "genai-bundle"
+        build_cache_dir = cache_dir
+        # --rebuild overwrites the cached bundle; a plain run reuses it. Checked
+        # before any model resolution so a cache hit never touches the network.
+        force_rebuild = bool(p.get("rebuild"))
+        if (bundle_dir / "genai_config.json").exists() and not force_rebuild:
+            console.print(f"[dim]Reusing cached genai bundle:[/dim] {bundle_dir}")
+            return bundle_dir
 
     # Cache miss (or forced rebuild): resolve the model family so its
     # genai-bundle recipe can drive the build.
@@ -1835,7 +1873,7 @@ def _autobuild_genai_bundle(ctx: click.Context, *, model: str, console: Console)
         device="npu",
         precision=precision,
         force_rebuild=force_rebuild,
-        cache_dir=cache_dir,
+        cache_dir=build_cache_dir,
         emit=lambda msg: console.print(msg, markup=False),
     )
     return bundle_dir
@@ -1847,6 +1885,8 @@ def _run_genai_runtime(ctx: click.Context, *, console: Console, json_mode: bool)
     The genai imports are function-local so ``winml perf --help`` does not pay
     their import cost (see tests/cli/test_import_time.py).
     """
+    import contextlib
+
     from ._perf_genai import (
         GenaiPerfConfig,
         genai_output_path,
@@ -1861,68 +1901,72 @@ def _run_genai_runtime(ctx: click.Context, *, console: Console, json_mode: bool)
     if p.get("module_class"):
         raise click.UsageError("--module is not supported with --runtime winml-genai.")
 
-    # Resolve the bundle. A local directory is used as-is (it must be a real
-    # genai bundle); an ``.onnx`` file is rejected; anything else is treated as
-    # a HuggingFace model id and a genai bundle is auto-built on demand -- the
-    # same way the winml runtime auto-builds an ONNX from a model id.
-    bundle_dir = Path(model)
-    autobuilt_from: str | None = None
-    if bundle_dir.is_dir():
-        if not (bundle_dir / "genai_config.json").exists():
+    # The ExitStack keeps an --ignore-cache auto-build's throwaway temp dir alive
+    # across the benchmark below, then removes it on exit. A bundle dir or a
+    # cached auto-build registers nothing, so it is a no-op.
+    with contextlib.ExitStack() as stack:
+        # Resolve the bundle. A local directory is used as-is (it must be a real
+        # genai bundle); an ``.onnx`` file is rejected; anything else is treated
+        # as a HuggingFace model id and a genai bundle is auto-built on demand --
+        # the same way the winml runtime auto-builds an ONNX from a model id.
+        bundle_dir = Path(model)
+        autobuilt_from: str | None = None
+        if bundle_dir.is_dir():
+            if not (bundle_dir / "genai_config.json").exists():
+                raise click.UsageError(
+                    f"No genai_config.json found in '{model}'. Point --model at a bundle "
+                    "folder produced by a winml-cli export."
+                )
+        elif bundle_dir.suffix.lower() == ".onnx":
             raise click.UsageError(
-                f"No genai_config.json found in '{model}'. Point --model at a bundle "
-                "folder produced by a winml-cli export."
+                f"--runtime winml-genai requires a genai bundle *directory*, got '{model}'."
             )
-    elif bundle_dir.suffix.lower() == ".onnx":
-        raise click.UsageError(
-            f"--runtime winml-genai requires a genai bundle *directory*, got '{model}'."
+        else:
+            bundle_dir = _autobuild_genai_bundle(ctx, model=model, console=console, stack=stack)
+            autobuilt_from = model
+
+        _warn_ignored_genai_flags(ctx, console, autobuilt=autobuilt_from is not None)
+
+        # A full generation is far costlier than one session.run(): default to
+        # fewer iterations/warmup unless the user set them explicitly.
+        iterations = p["iterations"] if cli_utils.is_cli_provided(ctx, "iterations") else 10
+        warmup = p["warmup"] if cli_utils.is_cli_provided(ctx, "warmup") else 2
+
+        # genai defaults to "config" (respect the bundle's own per-stage routing).
+        # The shared --device default is "auto" (the ONNX default), so an omitted
+        # flag is treated as "config"; an explicit --device is a deliberate override.
+        device = p["device"].lower() if cli_utils.is_cli_provided(ctx, "device") else "config"
+        if p.get("output"):
+            output = p["output"]
+        elif autobuilt_from is not None:
+            # The auto-built bundle lives in a cache dir whose name is not a
+            # meaningful slug, so derive the report path from the model id instead.
+            output = generate_output_path(autobuilt_from)
+        else:
+            output = genai_output_path(bundle_dir)
+        cli_utils.guard_output(output, p["overwrite"])
+
+        # EP override precedence: an explicit ``--ep`` wins over the ``--device``
+        # resolution, which in turn wins over the default ("config" = respect the
+        # bundle's genai_config.json routing).  GenaiSession validates the value.
+        ep: EPNameOrAlias | None = (
+            p["ep"] if cli_utils.is_cli_provided(ctx, "ep") else resolve_genai_ep(device)
         )
-    else:
-        bundle_dir = _autobuild_genai_bundle(ctx, model=model, console=console)
-        autobuilt_from = model
 
-    _warn_ignored_genai_flags(ctx, console)
-
-    # A full generation is far costlier than one session.run(): default to
-    # fewer iterations/warmup unless the user set them explicitly.
-    iterations = p["iterations"] if cli_utils.is_cli_provided(ctx, "iterations") else 10
-    warmup = p["warmup"] if cli_utils.is_cli_provided(ctx, "warmup") else 2
-
-    # genai defaults to "config" (respect the bundle's own per-stage routing).
-    # The shared --device default is "auto" (the ONNX default), so an omitted
-    # flag is treated as "config"; an explicit --device is a deliberate override.
-    device = p["device"].lower() if cli_utils.is_cli_provided(ctx, "device") else "config"
-    if p.get("output"):
-        output = p["output"]
-    elif autobuilt_from is not None:
-        # The auto-built bundle lives in a cache dir whose name is not a
-        # meaningful slug, so derive the report path from the model id instead.
-        output = generate_output_path(autobuilt_from)
-    else:
-        output = genai_output_path(bundle_dir)
-    cli_utils.guard_output(output, p["overwrite"])
-
-    # EP override precedence: an explicit ``--ep`` wins over the ``--device``
-    # resolution, which in turn wins over the default ("config" = respect the
-    # bundle's genai_config.json routing).  GenaiSession validates the value.
-    ep: EPNameOrAlias | None = (
-        p["ep"] if cli_utils.is_cli_provided(ctx, "ep") else resolve_genai_ep(device)
-    )
-
-    config = GenaiPerfConfig(
-        bundle_dir=bundle_dir,
-        ep=ep,
-        device=device,
-        prompt=p["prompt"],
-        apply_template=p["apply_template"],
-        max_new_tokens=p["max_new_tokens"],
-        iterations=iterations,
-        warmup=warmup,
-        compile=not p["no_compile"],
-        compile_timeout=p["compile_timeout"],
-        output_path=output,
-    )
-    run_genai_perf(config, console=console, json_mode=json_mode)
+        config = GenaiPerfConfig(
+            bundle_dir=bundle_dir,
+            ep=ep,
+            device=device,
+            prompt=p["prompt"],
+            apply_template=p["apply_template"],
+            max_new_tokens=p["max_new_tokens"],
+            iterations=iterations,
+            warmup=warmup,
+            compile=not p["no_compile"],
+            compile_timeout=p["compile_timeout"],
+            output_path=output,
+        )
+        run_genai_perf(config, console=console, json_mode=json_mode)
 
 
 @click.command("perf")

--- a/tests/unit/commands/test_perf_genai.py
+++ b/tests/unit/commands/test_perf_genai.py
@@ -959,6 +959,88 @@ class TestCliDispatch:
         assert result.exit_code == 0, result.output
         assert build_calls["build"]["force_rebuild"] is True
 
+    def test_ignore_cache_builds_in_tempdir(
+        self, runner: CliRunner, tmp_path: Path, capture_run: dict, monkeypatch
+    ) -> None:
+        # --ignore-cache mirrors the winml runtime: build fresh in a throwaway
+        # temp dir and never touch the managed cache. Both the assembled bundle
+        # and its component build cache land outside WINML_CACHE_DIR, and the
+        # managed bundle dir is never written.
+        import winml.modelkit.loader as loader_mod
+        import winml.modelkit.models.winml as winml_models
+        from winml.modelkit.cache import get_model_dir
+
+        monkeypatch.setenv("WINML_CACHE_DIR", str(tmp_path))
+        monkeypatch.setattr(
+            loader_mod, "resolve_loader_config", _fake_resolve_loader_config("qwen3")
+        )
+        monkeypatch.setattr(winml_models, "resolve_genai_bundle", lambda _mt: object())
+        build_calls: dict = {}
+        monkeypatch.setattr(
+            winml_models, "build_genai_bundle", _fake_build_genai_bundle(build_calls)
+        )
+
+        result = runner.invoke(
+            perf, ["-m", "Qwen/Qwen3-0.6B", "--runtime", "winml-genai", "--ignore-cache"]
+        )
+
+        assert result.exit_code == 0, result.output
+        build = build_calls["build"]
+        # Forced fresh build, isolated from the managed cache on both axes.
+        assert build["force_rebuild"] is True
+        assert not build["output_dir"].is_relative_to(tmp_path)
+        assert not Path(build["cache_dir"]).is_relative_to(tmp_path)
+        # The managed bundle dir is never populated.
+        managed = get_model_dir("Qwen/Qwen3-0.6B", cache_dir=tmp_path) / "genai-bundle"
+        assert not (managed / "genai_config.json").exists()
+        # The benchmark ran against the temp bundle that was built.
+        assert capture_run["config"].bundle_dir == build["output_dir"]
+
+    def test_autobuild_honored_flags_not_warned_as_ignored(
+        self, runner: CliRunner, tmp_path: Path, capture_run: dict, monkeypatch
+    ) -> None:
+        # The build-driving flags (--rebuild/--task) steer the auto-build, so
+        # they must NOT appear in the "options are ignored" warning when a bundle
+        # is built from a model id. A genuinely ignored flag (--memory) still is.
+        import winml.modelkit.loader as loader_mod
+        import winml.modelkit.models.winml as winml_models
+
+        monkeypatch.setenv("WINML_CACHE_DIR", str(tmp_path))
+        monkeypatch.setattr(
+            loader_mod, "resolve_loader_config", _fake_resolve_loader_config("qwen3")
+        )
+        monkeypatch.setattr(winml_models, "resolve_genai_bundle", lambda _mt: object())
+        monkeypatch.setattr(winml_models, "build_genai_bundle", _fake_build_genai_bundle({}))
+
+        result = runner.invoke(
+            perf,
+            [
+                "-m",
+                "Qwen/Qwen3-0.6B",
+                "--runtime",
+                "winml-genai",
+                "--rebuild",
+                "--task",
+                "text-generation",
+                "--memory",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "--rebuild" not in result.output
+        assert "--task" not in result.output
+        assert "--memory" in result.output  # still ignored -> still warned
+
+    def test_prebuilt_bundle_still_warns_build_flags(
+        self, runner: CliRunner, tmp_path: Path, capture_run: dict
+    ) -> None:
+        # A prebuilt bundle dir ignores the build-driving flags, so --rebuild is
+        # reported as ignored (no auto-build happened).
+        bundle = _make_bundle(tmp_path)
+        result = runner.invoke(perf, ["-m", str(bundle), "--runtime", "winml-genai", "--rebuild"])
+        assert result.exit_code == 0, result.output
+        assert "--rebuild" in result.output
+
     def test_autobuild_without_recipe_rejected(
         self, runner: CliRunner, tmp_path: Path, capture_run: dict, monkeypatch
     ) -> None:

--- a/tests/unit/commands/test_perf_genai.py
+++ b/tests/unit/commands/test_perf_genai.py
@@ -116,6 +116,34 @@ def _make_bundle(tmp_path: Path, name: str = "bundle") -> Path:
     return bundle
 
 
+def _fake_resolve_loader_config(model_type: str):
+    """Return a ``resolve_loader_config`` stand-in yielding *model_type*.
+
+    Keeps the auto-build tests offline (no HF-hub access).
+    """
+    from types import SimpleNamespace
+
+    def _resolve(model_id: object = None, *, task: object = None, **_kw: object):
+        cfg = SimpleNamespace(model_type=model_type)
+        hf = SimpleNamespace(model_type=model_type)
+        return cfg, hf, object, None
+
+    return _resolve
+
+
+def _fake_build_genai_bundle(captured: dict):
+    """A ``build_genai_bundle`` stand-in that writes a stub bundle and records kwargs."""
+
+    def _build(model_id: str, output_dir: object, recipe: object, **kwargs: object) -> Path:
+        out = Path(output_dir)
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "genai_config.json").write_text("{}", encoding="utf-8")
+        captured["build"] = {"model_id": model_id, "output_dir": out, **kwargs}
+        return out / "genai_config.json"
+
+    return _build
+
+
 # ---------------------------------------------------------------------------
 # resolve_genai_ep
 # ---------------------------------------------------------------------------
@@ -821,9 +849,19 @@ class TestCliDispatch:
         assert "directory" in result.output.lower()
         assert "config" not in capture_run
 
-    def test_missing_directory_rejected(
-        self, runner: CliRunner, tmp_path: Path, capture_run: dict
+    def test_unresolvable_model_id_rejected(
+        self, runner: CliRunner, tmp_path: Path, capture_run: dict, monkeypatch
     ) -> None:
+        # A -m that is neither a bundle dir nor an .onnx is treated as a model
+        # id; an unresolvable one surfaces a clean UsageError, not a traceback.
+        import winml.modelkit.loader as loader_mod
+
+        monkeypatch.setenv("WINML_CACHE_DIR", str(tmp_path))
+
+        def _boom(*_a: object, **_k: object):
+            raise ValueError("nope")
+
+        monkeypatch.setattr(loader_mod, "resolve_loader_config", _boom)
         result = runner.invoke(perf, ["-m", str(tmp_path / "nope"), "--runtime", "winml-genai"])
         assert result.exit_code != 0
         assert "config" not in capture_run
@@ -836,6 +874,111 @@ class TestCliDispatch:
         result = runner.invoke(perf, ["-m", str(empty), "--runtime", "winml-genai"])
         assert result.exit_code != 0
         assert "genai_config.json" in result.output
+        assert "config" not in capture_run
+
+    def test_hf_model_id_autobuilds_and_dispatches(
+        self, runner: CliRunner, tmp_path: Path, capture_run: dict, monkeypatch
+    ) -> None:
+        # -m is a model id (not a bundle dir): a genai bundle is built on the
+        # fly into the cache and then benchmarked -- one command, no prior build.
+        import winml.modelkit.loader as loader_mod
+        import winml.modelkit.models.winml as winml_models
+
+        monkeypatch.setenv("WINML_CACHE_DIR", str(tmp_path))
+        monkeypatch.setattr(
+            loader_mod, "resolve_loader_config", _fake_resolve_loader_config("qwen3")
+        )
+        monkeypatch.setattr(winml_models, "resolve_genai_bundle", lambda _mt: object())
+        build_calls: dict = {}
+        monkeypatch.setattr(
+            winml_models, "build_genai_bundle", _fake_build_genai_bundle(build_calls)
+        )
+
+        result = runner.invoke(perf, ["-m", "Qwen/Qwen3-0.6B", "--runtime", "winml-genai"])
+
+        assert result.exit_code == 0, result.output
+        # Built once, pinned to the NPU HTP via QNN regardless of --device.
+        assert build_calls["build"]["ep"] == "qnn"
+        assert build_calls["build"]["device"] == "npu"
+        assert build_calls["build"]["force_rebuild"] is False
+        # Benchmarked the freshly built cache bundle.
+        cfg = capture_run["config"]
+        assert cfg.bundle_dir == build_calls["build"]["output_dir"]
+        assert (cfg.bundle_dir / "genai_config.json").exists()
+        # Omitting --device keeps the "respect the bundle" default.
+        assert cfg.device == "config"
+        assert cfg.ep is None
+
+    def test_autobuild_reuses_cached_bundle(
+        self, runner: CliRunner, tmp_path: Path, capture_run: dict, monkeypatch
+    ) -> None:
+        import winml.modelkit.models.winml as winml_models
+        from winml.modelkit.cache import get_model_dir
+
+        monkeypatch.setenv("WINML_CACHE_DIR", str(tmp_path))
+        cached = get_model_dir("Qwen/Qwen3-0.6B", cache_dir=tmp_path) / "genai-bundle"
+        cached.mkdir(parents=True)
+        (cached / "genai_config.json").write_text("{}", encoding="utf-8")
+
+        build_calls: dict = {}
+        monkeypatch.setattr(
+            winml_models, "build_genai_bundle", _fake_build_genai_bundle(build_calls)
+        )
+
+        result = runner.invoke(perf, ["-m", "Qwen/Qwen3-0.6B", "--runtime", "winml-genai"])
+
+        assert result.exit_code == 0, result.output
+        assert "build" not in build_calls  # cache hit: never rebuilt
+        assert capture_run["config"].bundle_dir == cached
+
+    def test_rebuild_forces_autobuild(
+        self, runner: CliRunner, tmp_path: Path, capture_run: dict, monkeypatch
+    ) -> None:
+        import winml.modelkit.loader as loader_mod
+        import winml.modelkit.models.winml as winml_models
+        from winml.modelkit.cache import get_model_dir
+
+        monkeypatch.setenv("WINML_CACHE_DIR", str(tmp_path))
+        cached = get_model_dir("Qwen/Qwen3-0.6B", cache_dir=tmp_path) / "genai-bundle"
+        cached.mkdir(parents=True)
+        (cached / "genai_config.json").write_text("{}", encoding="utf-8")
+
+        monkeypatch.setattr(
+            loader_mod, "resolve_loader_config", _fake_resolve_loader_config("qwen3")
+        )
+        monkeypatch.setattr(winml_models, "resolve_genai_bundle", lambda _mt: object())
+        build_calls: dict = {}
+        monkeypatch.setattr(
+            winml_models, "build_genai_bundle", _fake_build_genai_bundle(build_calls)
+        )
+
+        result = runner.invoke(
+            perf, ["-m", "Qwen/Qwen3-0.6B", "--runtime", "winml-genai", "--rebuild"]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert build_calls["build"]["force_rebuild"] is True
+
+    def test_autobuild_without_recipe_rejected(
+        self, runner: CliRunner, tmp_path: Path, capture_run: dict, monkeypatch
+    ) -> None:
+        # A model id with no registered genai-bundle recipe cannot be auto-built:
+        # surface a clear UsageError pointing at a prebuilt bundle directory.
+        import winml.modelkit.loader as loader_mod
+        import winml.modelkit.models.winml as winml_models
+
+        monkeypatch.setenv("WINML_CACHE_DIR", str(tmp_path))
+        monkeypatch.setattr(
+            loader_mod, "resolve_loader_config", _fake_resolve_loader_config("bert")
+        )
+        monkeypatch.setattr(winml_models, "resolve_genai_bundle", lambda _mt: None)
+
+        result = runner.invoke(
+            perf, ["-m", "google-bert/bert-base-uncased", "--runtime", "winml-genai"]
+        )
+
+        assert result.exit_code != 0
+        assert "recipe" in result.output.lower()
         assert "config" not in capture_run
 
     def test_winml_runtime_unaffected(

--- a/tests/unit/commands/test_perf_genai.py
+++ b/tests/unit/commands/test_perf_genai.py
@@ -1041,6 +1041,47 @@ class TestCliDispatch:
         assert result.exit_code == 0, result.output
         assert "--rebuild" in result.output
 
+    def test_cache_hit_warns_dropped_build_input_flags(
+        self, runner: CliRunner, tmp_path: Path, capture_run: dict, monkeypatch
+    ) -> None:
+        # On a cache hit the model-id-keyed bundle is reused as-is, so the
+        # artifact-shaping flags (--precision/--task) were NOT applied to it and
+        # must be reported as ignored -- unlike a fresh build, which honors them.
+        # (--rebuild/--ignore-cache always force a build, so they never reach here.)
+        import winml.modelkit.models.winml as winml_models
+        from winml.modelkit.cache import get_model_dir
+
+        monkeypatch.setenv("WINML_CACHE_DIR", str(tmp_path))
+        cached = get_model_dir("Qwen/Qwen3-0.6B", cache_dir=tmp_path) / "genai-bundle"
+        cached.mkdir(parents=True)
+        (cached / "genai_config.json").write_text("{}", encoding="utf-8")
+
+        build_calls: dict = {}
+        monkeypatch.setattr(
+            winml_models, "build_genai_bundle", _fake_build_genai_bundle(build_calls)
+        )
+
+        result = runner.invoke(
+            perf,
+            [
+                "-m",
+                "Qwen/Qwen3-0.6B",
+                "--runtime",
+                "winml-genai",
+                "--precision",
+                "w8a16",
+                "--task",
+                "text-generation",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "build" not in build_calls  # cache hit: reused, never built
+        assert capture_run["config"].bundle_dir == cached
+        # The reused bundle did not honor the build-input flags -> warned.
+        assert "--precision" in result.output
+        assert "--task" in result.output
+
     def test_autobuild_without_recipe_rejected(
         self, runner: CliRunner, tmp_path: Path, capture_run: dict, monkeypatch
     ) -> None:


### PR DESCRIPTION
## What

`winml perf -m <hf-model-id> --runtime winml-genai` now auto-builds a genai bundle from a HuggingFace model id instead of requiring a prebuilt bundle directory.

## Why

The `winml` runtime already auto-builds an ONNX from a model id on demand. The `winml-genai` runtime forced users to first run `winml build ... --device npu --ep qnn` and then point `perf` at the output directory. This mirrors the winml behavior so a bare model id "just works".

## How

- New `_autobuild_genai_bundle` helper: resolves the model family, looks up its genai-bundle recipe, and builds into the managed cache dir (`get_model_dir(model)/genai-bundle`), pinning `ep=qnn` / `device=npu` (genai bundles target the NPU HTP via QNN). A prior build is reused unless `--rebuild` / `--ignore-cache` forces a fresh one.
- `_run_genai_runtime` now distinguishes inputs: a directory is used as-is (must contain `genai_config.json`), an `.onnx` path is rejected, anything else is treated as a model id and auto-built on demand.
- When auto-built, the report path is derived from the model id (the cache dir name is not a meaningful slug).
- Docs: `perf.md` and the `qwen3-genai-bundle.md` sample updated with the one-command flow.

Unblocks `winml perf -m Qwen/Qwen3-0.6B --runtime winml-genai`.
