### PR TITLE
feat(telemetry): record root cause on WinMLCLIError

### DIFF
--- a/src/winml/modelkit/telemetry/telemetry.py
+++ b/src/winml/modelkit/telemetry/telemetry.py
@@ -24,7 +24,12 @@ from typing import TYPE_CHECKING, Any
 from . import consent as consent_mod
 from . import constants
 from .deviceid import get_or_create_device_id
-from .utils import _extract_exception_stack, _format_exception_message
+from .utils import (
+    _ROOT_CAUSE_MESSAGE_CAP,
+    _extract_exception_stack,
+    _format_exception_message,
+    _root_cause,
+)
 
 
 if TYPE_CHECKING:
@@ -57,6 +62,8 @@ _ALLOWED_KEYS: dict[str, set[str]] = {
         "exception_type",
         "exception_message",
         "exception_stack",
+        "root_cause_type",
+        "root_cause_message",
     },
 }
 
@@ -211,10 +218,18 @@ class Telemetry:
         try:
             if self._logger is None:
                 return
+            root = _root_cause(exc)
+            has_root = root is not exc
             attrs = {
                 "exception_type": type(exc).__name__,
                 "exception_message": _format_exception_message(str(exc)),
                 "exception_stack": _extract_exception_stack(exc.__traceback__),
+                "root_cause_type": type(root).__name__ if has_root else None,
+                "root_cause_message": (
+                    _format_exception_message(str(root), cap=_ROOT_CAUSE_MESSAGE_CAP)
+                    if has_root
+                    else None
+                ),
             }
             self._emit(_ERROR_EVENT, attrs)
         except Exception:

--- a/src/winml/modelkit/telemetry/telemetry.py
+++ b/src/winml/modelkit/telemetry/telemetry.py
@@ -25,7 +25,6 @@ from . import consent as consent_mod
 from . import constants
 from .deviceid import get_or_create_device_id
 from .utils import (
-    _ROOT_CAUSE_MESSAGE_CAP,
     _extract_exception_stack,
     _format_exception_message,
     _root_cause,
@@ -47,6 +46,12 @@ _INSTANCE: Telemetry | None = None
 _HEARTBEAT_EVENT = "WinMLCLIHeartbeat"
 _ACTION_EVENT = "WinMLCLIAction"
 _ERROR_EVENT = "WinMLCLIError"
+
+# Root-cause messages get a larger cap than the outer exception message
+# (``_MESSAGE_CAP``): the root cause is the diagnostic payload, whereas the
+# outer message is often just a wrapper prefix. Initial value; tune from
+# real telemetry once truncation rates are known.
+_ROOT_CAUSE_MESSAGE_CAP = 500
 
 _ALLOWED_KEYS: dict[str, set[str]] = {
     _HEARTBEAT_EVENT: set(),

--- a/src/winml/modelkit/telemetry/utils.py
+++ b/src/winml/modelkit/telemetry/utils.py
@@ -300,14 +300,19 @@ def _root_cause(exc: BaseException) -> BaseException:
 
     Follows ``__cause__`` (explicit ``raise ... from e``) in preference to
     ``__context__`` (implicit, set when raising inside an ``except`` block),
-    repeatedly, until neither is set. Returns ``exc`` itself when there is
-    no chain. Cycle-safe: a chain that loops back on itself terminates
-    rather than spinning forever.
+    repeatedly, until neither is set. A ``__context__`` explicitly suppressed
+    by ``raise ... from None`` (``__suppress_context__``) is honored — the
+    walk stops there, matching Python's own traceback printing and respecting
+    the developer's intent to hide that inner error. Returns ``exc`` itself
+    when there is no chain. Cycle-safe: a chain that loops back on itself
+    terminates rather than spinning forever.
     """
     seen: set[int] = {id(exc)}
     current = exc
     while True:
-        nxt = current.__cause__ or current.__context__
+        nxt = current.__cause__
+        if nxt is None and not current.__suppress_context__:
+            nxt = current.__context__
         if nxt is None or id(nxt) in seen:
             return current
         seen.add(id(nxt))

--- a/src/winml/modelkit/telemetry/utils.py
+++ b/src/winml/modelkit/telemetry/utils.py
@@ -242,3 +242,22 @@ def _extract_exception_stack(tb: Any) -> list[dict[str, Any]]:
         }
         for frame in frames
     ]
+
+
+def _root_cause(exc: BaseException) -> BaseException:
+    """Return the innermost cause of an exception chain.
+
+    Follows ``__cause__`` (explicit ``raise ... from e``) in preference to
+    ``__context__`` (implicit, set when raising inside an ``except`` block),
+    repeatedly, until neither is set. Returns ``exc`` itself when there is
+    no chain. Cycle-safe: a chain that loops back on itself terminates
+    rather than spinning forever.
+    """
+    seen: set[int] = {id(exc)}
+    current = exc
+    while True:
+        nxt = current.__cause__ or current.__context__
+        if nxt is None or id(nxt) in seen:
+            return current
+        seen.add(id(nxt))
+        current = nxt

--- a/src/winml/modelkit/telemetry/utils.py
+++ b/src/winml/modelkit/telemetry/utils.py
@@ -114,16 +114,18 @@ def _scrub_pii(text: str) -> str:
 
 
 _MESSAGE_CAP = 200
+_ROOT_CAUSE_MESSAGE_CAP = 500
 
 
-def _format_exception_message(message: str | None) -> str:
+def _format_exception_message(message: str | None, cap: int = _MESSAGE_CAP) -> str:
     """Run the scrubbing pipeline: path trim -> PII scrub -> length cap.
 
     Scrub runs *before* the length cap so PII straddling the cap boundary
     is still recognized by the regexes. Capping first would split a token
     or email mid-string and leak the surviving prefix (e.g. ``alice@exa…``
     leaves ``alice`` exposed because the cropped fragment no longer
-    matches the email pattern).
+    matches the email pattern). ``cap`` is parameterized so the root-cause
+    message can use a larger limit than the outer message.
     """
     if not message:
         return ""
@@ -134,8 +136,8 @@ def _format_exception_message(message: str | None) -> str:
     result = _scrub_pii(result)
     # Cap last - bounds final size even if scrub expanded the string
     # (each match becomes the 11-char ``<scrubbed>`` placeholder).
-    if len(result) > _MESSAGE_CAP:
-        result = result[: _MESSAGE_CAP - 1] + "…"
+    if len(result) > cap:
+        result = result[: cap - 1] + "…"
     return result
 
 

--- a/src/winml/modelkit/telemetry/utils.py
+++ b/src/winml/modelkit/telemetry/utils.py
@@ -114,7 +114,6 @@ def _scrub_pii(text: str) -> str:
 
 
 _MESSAGE_CAP = 200
-_ROOT_CAUSE_MESSAGE_CAP = 500
 
 
 def _format_exception_message(message: str | None, cap: int = _MESSAGE_CAP) -> str:

--- a/tests/unit/telemetry/test_telemetry_emit.py
+++ b/tests/unit/telemetry/test_telemetry_emit.py
@@ -94,6 +94,53 @@ def test_log_error_scrubs_message_and_extracts_stack(running_telemetry):
         assert set(frame.keys()) == {"file", "line", "function"}
 
 
+def test_log_error_records_root_cause_for_chained(running_telemetry):
+    logger = _with_mock_logger(running_telemetry)
+    try:
+        try:
+            raise ValueError("qwen3_5 not recognized")
+        except ValueError as e:
+            raise RuntimeError("Inspection error") from e
+    except RuntimeError as outer:
+        running_telemetry.log_error(outer)
+
+    log_record = logger.emit.call_args.args[0]
+    attrs = dict(log_record.attributes)
+    assert attrs["exception_type"] == "RuntimeError"
+    assert attrs["root_cause_type"] == "ValueError"
+    assert "qwen3_5 not recognized" in attrs["root_cause_message"]
+
+
+def test_log_error_unchained_has_null_root_cause(running_telemetry):
+    logger = _with_mock_logger(running_telemetry)
+    try:
+        raise RuntimeError("Quantization failed")
+    except RuntimeError as exc:
+        running_telemetry.log_error(exc)
+
+    log_record = logger.emit.call_args.args[0]
+    attrs = dict(log_record.attributes)
+    assert attrs["exception_type"] == "RuntimeError"
+    assert attrs["root_cause_type"] is None
+    assert attrs["root_cause_message"] is None
+
+
+def test_log_error_scrubs_root_cause_message(running_telemetry):
+    logger = _with_mock_logger(running_telemetry)
+    try:
+        try:
+            raise ValueError("leaked alice@example.com in root")
+        except ValueError as e:
+            raise RuntimeError("wrapper") from e
+    except RuntimeError as outer:
+        running_telemetry.log_error(outer)
+
+    log_record = logger.emit.call_args.args[0]
+    attrs = dict(log_record.attributes)
+    assert "alice@example.com" not in attrs["root_cause_message"]
+    assert "<scrubbed>" in attrs["root_cause_message"]
+
+
 def test_disabled_telemetry_noops_all_emits(monkeypatch):
     monkeypatch.setattr("winml.modelkit.telemetry.constants.INSTRUMENTATION_KEY", "")
     t = Telemetry.get_or_init()

--- a/tests/unit/telemetry/test_telemetry_emit.py
+++ b/tests/unit/telemetry/test_telemetry_emit.py
@@ -94,6 +94,12 @@ def test_log_error_scrubs_message_and_extracts_stack(running_telemetry):
         assert set(frame.keys()) == {"file", "line", "function"}
 
 
+def test_root_cause_message_cap_is_500():
+    from winml.modelkit.telemetry.telemetry import _ROOT_CAUSE_MESSAGE_CAP
+
+    assert _ROOT_CAUSE_MESSAGE_CAP == 500
+
+
 def test_log_error_records_root_cause_for_chained(running_telemetry):
     logger = _with_mock_logger(running_telemetry)
     try:

--- a/tests/unit/telemetry/test_utils_scrubbing.py
+++ b/tests/unit/telemetry/test_utils_scrubbing.py
@@ -6,7 +6,6 @@
 import pytest
 
 from winml.modelkit.telemetry.utils import (
-    _ROOT_CAUSE_MESSAGE_CAP,
     _format_exception_message,
     _scrub_pii,
     _trim_path,
@@ -156,10 +155,6 @@ def test_format_exception_message_scrubs_long_token_at_cap_boundary():
     assert len(result) <= 200
 
 
-def test_root_cause_message_cap_value_is_500():
-    assert _ROOT_CAUSE_MESSAGE_CAP == 500
-
-
 def test_format_exception_message_default_cap_is_200():
     msg = "y" * 400
     result = _format_exception_message(msg)
@@ -168,7 +163,7 @@ def test_format_exception_message_default_cap_is_200():
 
 def test_format_exception_message_custom_cap_allows_longer():
     msg = "y" * 400
-    result = _format_exception_message(msg, cap=_ROOT_CAUSE_MESSAGE_CAP)
+    result = _format_exception_message(msg, cap=500)
     # 400 < 500, so nothing is truncated.
     assert result == msg
     assert not result.endswith("…")
@@ -176,7 +171,7 @@ def test_format_exception_message_custom_cap_allows_longer():
 
 def test_format_exception_message_custom_cap_still_truncates_beyond():
     msg = "y" * 600
-    result = _format_exception_message(msg, cap=_ROOT_CAUSE_MESSAGE_CAP)
+    result = _format_exception_message(msg, cap=500)
     assert len(result) <= 500
     assert result.endswith("…")
 
@@ -185,7 +180,7 @@ def test_format_exception_message_custom_cap_scrubs_pii_before_cap():
     # Email lands just before the 500 boundary; must be scrubbed, not split.
     prefix = "y" * 495
     msg = prefix + " alice@example.com"
-    result = _format_exception_message(msg, cap=_ROOT_CAUSE_MESSAGE_CAP)
+    result = _format_exception_message(msg, cap=500)
     assert "alice" not in result
     assert "@" not in result
     assert len(result) <= 500

--- a/tests/unit/telemetry/test_utils_scrubbing.py
+++ b/tests/unit/telemetry/test_utils_scrubbing.py
@@ -6,6 +6,7 @@
 import pytest
 
 from winml.modelkit.telemetry.utils import (
+    _ROOT_CAUSE_MESSAGE_CAP,
     _format_exception_message,
     _scrub_pii,
     _trim_path,
@@ -153,3 +154,38 @@ def test_format_exception_message_scrubs_long_token_at_cap_boundary():
     assert "abcdef0123456789" not in result
     assert "<scrubbed>" in result
     assert len(result) <= 200
+
+
+def test_root_cause_message_cap_value_is_500():
+    assert _ROOT_CAUSE_MESSAGE_CAP == 500
+
+
+def test_format_exception_message_default_cap_is_200():
+    msg = "y" * 400
+    result = _format_exception_message(msg)
+    assert len(result) <= 200
+
+
+def test_format_exception_message_custom_cap_allows_longer():
+    msg = "y" * 400
+    result = _format_exception_message(msg, cap=_ROOT_CAUSE_MESSAGE_CAP)
+    # 400 < 500, so nothing is truncated.
+    assert result == msg
+    assert not result.endswith("…")
+
+
+def test_format_exception_message_custom_cap_still_truncates_beyond():
+    msg = "y" * 600
+    result = _format_exception_message(msg, cap=_ROOT_CAUSE_MESSAGE_CAP)
+    assert len(result) <= 500
+    assert result.endswith("…")
+
+
+def test_format_exception_message_custom_cap_scrubs_pii_before_cap():
+    # Email lands just before the 500 boundary; must be scrubbed, not split.
+    prefix = "y" * 495
+    msg = prefix + " alice@example.com"
+    result = _format_exception_message(msg, cap=_ROOT_CAUSE_MESSAGE_CAP)
+    assert "alice" not in result
+    assert "@" not in result
+    assert len(result) <= 500

--- a/tests/unit/telemetry/test_utils_stack.py
+++ b/tests/unit/telemetry/test_utils_stack.py
@@ -89,6 +89,20 @@ def test_root_cause_follows_implicit_context():
         assert _root_cause(outer) is root
 
 
+def test_root_cause_honors_suppressed_context():
+    # `raise ... from None` sets __suppress_context__=True and __cause__=None.
+    # The suppressed inner exception must NOT be walked into — matching
+    # Python's own traceback printing and the developer's intent to hide it.
+    try:
+        try:
+            raise ValueError("suppressed inner")
+        except ValueError:
+            raise RuntimeError("clean outer") from None
+    except RuntimeError as outer:
+        # No chain surfaces: the outer exception is its own root cause.
+        assert _root_cause(outer) is outer
+
+
 def test_root_cause_walks_multiple_levels_to_innermost():
     innermost = OSError("disk full")
     try:

--- a/tests/unit/telemetry/test_utils_stack.py
+++ b/tests/unit/telemetry/test_utils_stack.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
-from winml.modelkit.telemetry.utils import _extract_exception_stack
+from winml.modelkit.telemetry.utils import _extract_exception_stack, _root_cause
 
 
 def _raise_chain():
@@ -58,3 +58,66 @@ def test_extract_exception_stack_contains_no_message_or_locals():
 
 def test_extract_exception_stack_on_none_returns_empty():
     assert _extract_exception_stack(None) == []
+
+
+def test_root_cause_no_chain_returns_self():
+    exc = ValueError("boom")
+    assert _root_cause(exc) is exc
+
+
+def test_root_cause_follows_explicit_cause():
+    root = ValueError("root")
+    try:
+        try:
+            raise root
+        except ValueError as e:
+            raise RuntimeError("wrapper") from e
+    except RuntimeError as outer:
+        assert _root_cause(outer) is root
+
+
+def test_root_cause_follows_implicit_context():
+    root = ValueError("root")
+    try:
+        try:
+            raise root
+        except ValueError:
+            # No `from` — Python sets __context__ implicitly. B904 is the
+            # exact pattern under test here, so the lint is suppressed.
+            raise RuntimeError("wrapper")  # noqa: B904
+    except RuntimeError as outer:
+        assert _root_cause(outer) is root
+
+
+def test_root_cause_walks_multiple_levels_to_innermost():
+    innermost = OSError("disk full")
+    try:
+        try:
+            try:
+                raise innermost
+            except OSError as e1:
+                raise RuntimeError("mid") from e1
+        except RuntimeError as e2:
+            raise ValueError("top") from e2
+    except ValueError as outer:
+        assert _root_cause(outer) is innermost
+
+
+def test_root_cause_prefers_cause_over_context():
+    cause = ValueError("the cause")
+    context = KeyError("the context")
+    outer = RuntimeError("outer")
+    # Simulate: raised inside handling `context`, but `from cause`.
+    outer.__context__ = context
+    outer.__cause__ = cause
+    assert _root_cause(outer) is cause
+
+
+def test_root_cause_cycle_guard_terminates():
+    a = ValueError("a")
+    b = RuntimeError("b")
+    a.__cause__ = b
+    b.__cause__ = a  # cycle
+    # Must terminate and return one of the two, not loop forever.
+    result = _root_cause(a)
+    assert result in (a, b)


### PR DESCRIPTION
## Summary

- Record the innermost root cause of an exception chain on `WinMLCLIError`, so wrapped errors (e.g. `ClickException` around a `ValueError`) become analyzable instead of collapsing to `ErrorType=ClickException`.
- New attributes `root_cause_type` (for grouping) and `root_cause_message` (scrubbed, capped at 500 — larger than the outer 200 cap since the root cause is the diagnostic payload). Both are `None` when the outer exception has no deeper cause, so "no chain" is visually distinct from a real root cause.

## Changes

- `telemetry/utils.py`: new `_root_cause` chain-walker (prefers `__cause__` over `__context__`, walks to innermost, cycle-safe via `id()`); `_format_exception_message` gains a `cap` param; new `_ROOT_CAUSE_MESSAGE_CAP = 500`.
- `telemetry/telemetry.py`: `log_error` resolves the root cause and emits the two new attributes; both added to the `WinMLCLIError` allowlist.

## Notes

- This is **Part 1 (telemetry layer)** of #1110. Part 2 (fixing command-layer sites that drop the cause, e.g. `commands/quantize.py:327`) is intentionally out of scope — the plan is to use the new telemetry data to prioritize the highest-frequency offenders.
- The 500-char cap is an initial value; it can be tuned once real telemetry shows how often root-cause messages are truncated.

Part of #1110
