### PR TITLE
feat(loader): add pipeline_tag fallback to task detection

### DIFF
--- a/src/winml/modelkit/loader/resolution.py
+++ b/src/winml/modelkit/loader/resolution.py
@@ -24,7 +24,6 @@ from typing import TYPE_CHECKING, cast
 
 from .task import (
     HF_TASK_DEFAULTS,
-    KNOWN_TASKS,
     get_default_task_for_model_id,
     get_supported_tasks,
     normalize_task,
@@ -556,7 +555,7 @@ def resolve_task(
     if opt_task is None and not getattr(config, "architectures", None) and model_type:
         # Populate Optimum's ONNX export-config registry before querying it;
         # get_supported_tasks returns [] if this hasn't been imported.
-        import optimum.exporters.onnx.model_configs  # noqa: F401
+        import optimum.exporters.onnx.model_configs
 
         supported = get_supported_tasks(model_type, resolve_optimum_library(model_type))
         if supported:
@@ -574,18 +573,29 @@ def resolve_task(
         except ValueError:
             opt_task = None
 
-    # 1e. Hub pipeline_tag fallback
-    if opt_task is None and model_id:
+    # 1d. Hub pipeline_tag fallback
+    if opt_task is None and model_id and model_type:
         from ..utils.hub_utils import get_pipeline_tag
 
         tag = get_pipeline_tag(model_id)
         if tag:
             normalized_tag = normalize_task(tag)
-            if normalized_tag in KNOWN_TASKS:
+            # Gate on the model-type's ONNX-exportable set, NOT the full KNOWN_TASKS
+            # display taxonomy. A Hub pipeline_tag is a HuggingFace *pipeline* label and
+            # may name a task with no export path (e.g. text-to-image,
+            # reinforcement-learning, time-series-forecasting). Admitting one would flow a
+            # non-exportable task into Stage 2 (model-class) / Stage 3 instead of degrading
+            # to the last-resort default. Populate Optimum's ONNX export-config registry
+            # first (as Stage 1b does) so get_supported_tasks doesn't return [].
+            import optimum.exporters.onnx.model_configs  # noqa: F401
+
+            if normalized_tag in get_supported_tasks(
+                model_type, resolve_optimum_library(model_type)
+            ):
                 opt_task = normalized_tag
                 source = TaskSource.PIPELINE_TAG
 
-    # 1d. last-resort default
+    # 1e. last-resort default
     if opt_task is None:
         opt_task = next(iter(HF_TASK_DEFAULTS))
         source = TaskSource.HF_TASK_DEFAULT

--- a/src/winml/modelkit/loader/resolution.py
+++ b/src/winml/modelkit/loader/resolution.py
@@ -442,8 +442,8 @@ def resolve_task(
     """Resolve a single model's task + class from an HF config.
 
     Stages: 0 user override -> 1 detect (override / no-architectures /
-    TasksManager / default) -> 2 model class -> 3 modality upgrade
-    (detection path only) -> 4 composite tag.
+    TasksManager / pipeline-tag / default) -> 2 model class -> 3 modality
+    upgrade (detection path only) -> 4 composite tag.
 
     ``model_type_override`` lets a caller drive resolution with a build variant
     (e.g. ``qwen3_transformer_only``) without mutating the loaded HF config; when
@@ -576,20 +576,14 @@ def resolve_task(
 
     # 1e. Hub pipeline_tag fallback
     if opt_task is None and model_id:
-        try:
-            from ..utils.hub_utils import _is_local_path
+        from ..utils.hub_utils import get_pipeline_tag
 
-            if not _is_local_path(model_id):
-                from huggingface_hub import HfApi
-
-                tag = HfApi().model_info(model_id).pipeline_tag
-                if tag:
-                    normalized_tag = normalize_task(tag)
-                    if normalized_tag in KNOWN_TASKS:
-                        opt_task = normalized_tag
-                        source = TaskSource.PIPELINE_TAG
-        except Exception:  # graceful fallthrough: network errors, invalid model_id, etc.
-            pass
+        tag = get_pipeline_tag(model_id)
+        if tag:
+            normalized_tag = normalize_task(tag)
+            if normalized_tag in KNOWN_TASKS:
+                opt_task = normalized_tag
+                source = TaskSource.PIPELINE_TAG
 
     # 1d. last-resort default
     if opt_task is None:

--- a/src/winml/modelkit/loader/resolution.py
+++ b/src/winml/modelkit/loader/resolution.py
@@ -588,7 +588,7 @@ def resolve_task(
                     if normalized_tag in KNOWN_TASKS:
                         opt_task = normalized_tag
                         source = TaskSource.PIPELINE_TAG
-        except Exception:
+        except Exception:  # graceful fallthrough: network errors, invalid model_id, etc.
             pass
 
     # 1d. last-resort default

--- a/src/winml/modelkit/loader/resolution.py
+++ b/src/winml/modelkit/loader/resolution.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, cast
 
 from .task import (
     HF_TASK_DEFAULTS,
+    KNOWN_TASKS,
     get_default_task_for_model_id,
     get_supported_tasks,
     normalize_task,
@@ -253,6 +254,7 @@ class TaskSource(str, Enum):
     SENTINEL_DEFAULT = "sentinel-default"  # (model_type, None) sentinel
     TASKS_MANAGER = "tasks-manager"  # Optimum inference (incl. fill-mask upgrade)
     WRAPPED_LIBRARY = "wrapped-library"  # no architectures -> first supported task
+    PIPELINE_TAG = "pipeline-tag"  # Hub pipeline_tag fallback
     HF_TASK_DEFAULT = "hf-task-default"  # last-resort default
 
 
@@ -571,6 +573,23 @@ def resolve_task(
             source = TaskSource.TASKS_MANAGER
         except ValueError:
             opt_task = None
+
+    # 1e. Hub pipeline_tag fallback
+    if opt_task is None and model_id:
+        try:
+            from ..utils.hub_utils import _is_local_path
+
+            if not _is_local_path(model_id):
+                from huggingface_hub import HfApi
+
+                tag = HfApi().model_info(model_id).pipeline_tag
+                if tag:
+                    normalized_tag = normalize_task(tag)
+                    if normalized_tag in KNOWN_TASKS:
+                        opt_task = normalized_tag
+                        source = TaskSource.PIPELINE_TAG
+        except Exception:
+            pass
 
     # 1d. last-resort default
     if opt_task is None:

--- a/src/winml/modelkit/utils/__init__.py
+++ b/src/winml/modelkit/utils/__init__.py
@@ -7,6 +7,7 @@
 from .config_utils import merge_config
 from .constants import normalize_ep_name
 from .hub_utils import (
+    get_pipeline_tag,
     inject_hub_metadata,
     is_hub_model,
     load_hf_components_from_onnx,
@@ -28,6 +29,7 @@ __all__ = [
     "ModelInputKind",
     "WinMLManifest",
     "classify_model_input",
+    "get_pipeline_tag",
     "inject_hub_metadata",
     "is_hub_model",
     "load_hf_components_from_onnx",

--- a/src/winml/modelkit/utils/hub_utils.py
+++ b/src/winml/modelkit/utils/hub_utils.py
@@ -144,6 +144,28 @@ def is_hub_model(model_name_or_path: str) -> tuple[bool, dict]:
         return False, {"type": "local", "path": model_name_or_path}
 
 
+_PIPELINE_TAG_TIMEOUT = 10  # seconds
+
+
+def get_pipeline_tag(model_id: str) -> str | None:
+    """Return the Hub ``pipeline_tag`` for *model_id*, or ``None``.
+
+    Lightweight helper that skips the full metadata extraction of
+    ``is_hub_model``. Returns ``None`` (never raises) when *model_id* is a
+    local path, the Hub is unreachable, or the model has no tag.
+    """
+    if _is_local_path(model_id):
+        return None
+    try:
+        from huggingface_hub import HfApi
+
+        info = HfApi().model_info(model_id, timeout=_PIPELINE_TAG_TIMEOUT)
+        return getattr(info, "pipeline_tag", None)
+    except Exception:
+        logger.debug("pipeline_tag lookup failed for '%s'", model_id, exc_info=True)
+        return None
+
+
 def inject_hub_metadata(onnx_model: Any, model_name_or_path: str, metadata: dict) -> None:
     """Inject HuggingFace Hub metadata into ONNX model.
 

--- a/src/winml/modelkit/utils/hub_utils.py
+++ b/src/winml/modelkit/utils/hub_utils.py
@@ -144,7 +144,7 @@ def is_hub_model(model_name_or_path: str) -> tuple[bool, dict]:
         return False, {"type": "local", "path": model_name_or_path}
 
 
-_PIPELINE_TAG_TIMEOUT = 10  # seconds
+_PIPELINE_TAG_TIMEOUT = 5  # seconds
 
 
 def get_pipeline_tag(model_id: str) -> str | None:

--- a/tests/unit/loader/test_detect_task.py
+++ b/tests/unit/loader/test_detect_task.py
@@ -231,31 +231,37 @@ def test_resolve_task_case1_surfaces_modality_aware_task() -> None:
 
 
 # =============================================================================
-# Stage 1e — Hub pipeline_tag fallback
+# Stage 1d — Hub pipeline_tag fallback
 # =============================================================================
 
 _GET_PIPELINE_TAG = "winml.modelkit.utils.hub_utils.get_pipeline_tag"
+_GET_SUPPORTED = "winml.modelkit.loader.resolution.get_supported_tasks"
 
 
 def test_resolve_task_uses_pipeline_tag_when_architecture_fails() -> None:
     """When config.architectures contains a generic name (e.g. 'Model') that
-    TasksManager cannot resolve, the Hub pipeline_tag is used as fallback."""
+    TasksManager cannot resolve, an exportable Hub pipeline_tag is used as fallback."""
     cfg = _FakeConfig("faketype", name_or_path="audeering/wav2vec2-large-robust-24-ft-age-gender")
     with (
         patch(_INFER, side_effect=ValueError("unknown arch")),
         patch(_GET_PIPELINE_TAG, return_value="audio-classification"),
+        patch(_GET_SUPPORTED, return_value=["feature-extraction", "audio-classification"]),
     ):
         r = resolve_task(cfg)
     assert r.task == "audio-classification"
     assert r.source == TaskSource.PIPELINE_TAG
 
 
-def test_resolve_task_pipeline_tag_skips_invalid_task() -> None:
-    """When pipeline_tag is not a recognized task, falls through to last-resort default."""
+def test_resolve_task_pipeline_tag_skips_non_exportable_task() -> None:
+    """A pipeline_tag that is not in the model-type's ONNX-exportable set (e.g. a
+    HuggingFace pipeline label like text-to-image with no export path) is rejected and
+    resolution falls through to the last-resort default rather than surfacing a task
+    Stage 2 can't build."""
     cfg = _FakeConfig("faketype", name_or_path="someone/some-model")
     with (
         patch(_INFER, side_effect=ValueError("unknown arch")),
-        patch(_GET_PIPELINE_TAG, return_value="not-a-real-task"),
+        patch(_GET_PIPELINE_TAG, return_value="text-to-image"),
+        patch(_GET_SUPPORTED, return_value=["feature-extraction", "audio-classification"]),
     ):
         r = resolve_task(cfg)
     assert r.source == TaskSource.HF_TASK_DEFAULT

--- a/tests/unit/loader/test_detect_task.py
+++ b/tests/unit/loader/test_detect_task.py
@@ -234,28 +234,16 @@ def test_resolve_task_case1_surfaces_modality_aware_task() -> None:
 # Stage 1e — Hub pipeline_tag fallback
 # =============================================================================
 
-_IS_LOCAL = "winml.modelkit.utils.hub_utils._is_local_path"
-_HF_API = "huggingface_hub.HfApi"
-
-
-def _fake_model_info(pipeline_tag: str | None):
-    """Return a mock model_info object with a ``pipeline_tag`` attribute."""
-    return type("FakeModelInfo", (), {"pipeline_tag": pipeline_tag})()
+_GET_PIPELINE_TAG = "winml.modelkit.utils.hub_utils.get_pipeline_tag"
 
 
 def test_resolve_task_uses_pipeline_tag_when_architecture_fails() -> None:
     """When config.architectures contains a generic name (e.g. 'Model') that
     TasksManager cannot resolve, the Hub pipeline_tag is used as fallback."""
     cfg = _FakeConfig("faketype", name_or_path="audeering/wav2vec2-large-robust-24-ft-age-gender")
-    mock_api = type(
-        "MockApi",
-        (),
-        {"model_info": lambda self, _: _fake_model_info("audio-classification")},
-    )()
     with (
         patch(_INFER, side_effect=ValueError("unknown arch")),
-        patch(_IS_LOCAL, return_value=False),
-        patch(_HF_API, return_value=mock_api),
+        patch(_GET_PIPELINE_TAG, return_value="audio-classification"),
     ):
         r = resolve_task(cfg)
     assert r.task == "audio-classification"
@@ -265,44 +253,33 @@ def test_resolve_task_uses_pipeline_tag_when_architecture_fails() -> None:
 def test_resolve_task_pipeline_tag_skips_invalid_task() -> None:
     """When pipeline_tag is not a recognized task, falls through to last-resort default."""
     cfg = _FakeConfig("faketype", name_or_path="someone/some-model")
-    mock_api = type(
-        "MockApi",
-        (),
-        {"model_info": lambda self, _: _fake_model_info("not-a-real-task")},
-    )()
     with (
         patch(_INFER, side_effect=ValueError("unknown arch")),
-        patch(_IS_LOCAL, return_value=False),
-        patch(_HF_API, return_value=mock_api),
+        patch(_GET_PIPELINE_TAG, return_value="not-a-real-task"),
     ):
         r = resolve_task(cfg)
     assert r.source == TaskSource.HF_TASK_DEFAULT
 
 
 def test_resolve_task_pipeline_tag_handles_api_failure() -> None:
-    """When the Hub API call fails (network error, etc.), falls through gracefully."""
+    """When the Hub API call fails (network error, etc.), get_pipeline_tag returns None."""
     cfg = _FakeConfig("faketype", name_or_path="someone/some-model")
-    mock_api = type(
-        "MockApi",
-        (),
-        {"model_info": lambda self, _: (_ for _ in ()).throw(ConnectionError("offline"))},
-    )()
     with (
         patch(_INFER, side_effect=ValueError("unknown arch")),
-        patch(_IS_LOCAL, return_value=False),
-        patch(_HF_API, return_value=mock_api),
+        patch(_GET_PIPELINE_TAG, return_value=None),
     ):
         r = resolve_task(cfg)
     assert r.source == TaskSource.HF_TASK_DEFAULT
 
 
 def test_resolve_task_pipeline_tag_skips_local_path() -> None:
-    """When model_id is a local path, the Hub API is not called."""
+    """When model_id is a local path, get_pipeline_tag is still called but returns None
+    (local-path rejection is internal to get_pipeline_tag)."""
     cfg = _FakeConfig("faketype", name_or_path="./local-model")
     with (
         patch(_INFER, side_effect=ValueError("unknown arch")),
-        patch(_IS_LOCAL, return_value=True),
-        patch(_HF_API, side_effect=AssertionError("must not call HfApi for local paths")),
+        patch(_GET_PIPELINE_TAG, return_value=None) as mock_tag,
     ):
         r = resolve_task(cfg)
+    mock_tag.assert_called_once_with("./local-model")
     assert r.source == TaskSource.HF_TASK_DEFAULT

--- a/tests/unit/loader/test_detect_task.py
+++ b/tests/unit/loader/test_detect_task.py
@@ -228,3 +228,81 @@ def test_resolve_task_case1_surfaces_modality_aware_task() -> None:
         r = resolve_task(cfg)
     assert r.task == "image-feature-extraction"
     assert r.optimum_task == "feature-extraction"
+
+
+# =============================================================================
+# Stage 1e — Hub pipeline_tag fallback
+# =============================================================================
+
+_IS_LOCAL = "winml.modelkit.utils.hub_utils._is_local_path"
+_HF_API = "huggingface_hub.HfApi"
+
+
+def _fake_model_info(pipeline_tag: str | None):
+    """Return a mock model_info object with a ``pipeline_tag`` attribute."""
+    return type("FakeModelInfo", (), {"pipeline_tag": pipeline_tag})()
+
+
+def test_resolve_task_uses_pipeline_tag_when_architecture_fails() -> None:
+    """When config.architectures contains a generic name (e.g. 'Model') that
+    TasksManager cannot resolve, the Hub pipeline_tag is used as fallback."""
+    cfg = _FakeConfig("faketype", name_or_path="audeering/wav2vec2-large-robust-24-ft-age-gender")
+    mock_api = type(
+        "MockApi",
+        (),
+        {"model_info": lambda self, _: _fake_model_info("audio-classification")},
+    )()
+    with (
+        patch(_INFER, side_effect=ValueError("unknown arch")),
+        patch(_IS_LOCAL, return_value=False),
+        patch(_HF_API, return_value=mock_api),
+    ):
+        r = resolve_task(cfg)
+    assert r.task == "audio-classification"
+    assert r.source == TaskSource.PIPELINE_TAG
+
+
+def test_resolve_task_pipeline_tag_skips_invalid_task() -> None:
+    """When pipeline_tag is not a recognized task, falls through to last-resort default."""
+    cfg = _FakeConfig("faketype", name_or_path="someone/some-model")
+    mock_api = type(
+        "MockApi",
+        (),
+        {"model_info": lambda self, _: _fake_model_info("not-a-real-task")},
+    )()
+    with (
+        patch(_INFER, side_effect=ValueError("unknown arch")),
+        patch(_IS_LOCAL, return_value=False),
+        patch(_HF_API, return_value=mock_api),
+    ):
+        r = resolve_task(cfg)
+    assert r.source == TaskSource.HF_TASK_DEFAULT
+
+
+def test_resolve_task_pipeline_tag_handles_api_failure() -> None:
+    """When the Hub API call fails (network error, etc.), falls through gracefully."""
+    cfg = _FakeConfig("faketype", name_or_path="someone/some-model")
+    mock_api = type(
+        "MockApi",
+        (),
+        {"model_info": lambda self, _: (_ for _ in ()).throw(ConnectionError("offline"))},
+    )()
+    with (
+        patch(_INFER, side_effect=ValueError("unknown arch")),
+        patch(_IS_LOCAL, return_value=False),
+        patch(_HF_API, return_value=mock_api),
+    ):
+        r = resolve_task(cfg)
+    assert r.source == TaskSource.HF_TASK_DEFAULT
+
+
+def test_resolve_task_pipeline_tag_skips_local_path() -> None:
+    """When model_id is a local path, the Hub API is not called."""
+    cfg = _FakeConfig("faketype", name_or_path="./local-model")
+    with (
+        patch(_INFER, side_effect=ValueError("unknown arch")),
+        patch(_IS_LOCAL, return_value=True),
+        patch(_HF_API, side_effect=AssertionError("must not call HfApi for local paths")),
+    ):
+        r = resolve_task(cfg)
+    assert r.source == TaskSource.HF_TASK_DEFAULT

--- a/tests/unit/utils/test_hub_utils.py
+++ b/tests/unit/utils/test_hub_utils.py
@@ -1,0 +1,56 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Tests for winml.modelkit.utils.hub_utils.
+
+Focused coverage of :func:`get_pipeline_tag` — the lightweight Hub helper used
+by the Stage 1d ``pipeline_tag`` fallback in loader task resolution. These tests
+exercise the helper directly (local-path short-circuit, API failure, tag
+extraction) rather than through a mocked stand-in, so the real ``_is_local_path``
+guard and ``except`` fallthrough are covered.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from winml.modelkit.utils import get_pipeline_tag
+
+
+_HF_API = "huggingface_hub.HfApi"
+
+
+def test_get_pipeline_tag_local_path_returns_none_without_network() -> None:
+    """A local path is rejected up front — the Hub API is never constructed."""
+    with patch(_HF_API) as mock_api:
+        assert get_pipeline_tag("./local-model") is None
+    mock_api.assert_not_called()
+
+
+def test_get_pipeline_tag_returns_tag_for_hub_model() -> None:
+    """A reachable Hub model returns its pipeline_tag."""
+    info = MagicMock(pipeline_tag="audio-classification")
+    api = MagicMock()
+    api.model_info.return_value = info
+    with patch(_HF_API, return_value=api):
+        assert get_pipeline_tag("audeering/wav2vec2-large-robust-24-ft-age-gender") == (
+            "audio-classification"
+        )
+    api.model_info.assert_called_once()
+
+
+def test_get_pipeline_tag_none_when_model_has_no_tag() -> None:
+    """A model without a pipeline_tag yields None."""
+    api = MagicMock()
+    api.model_info.return_value = MagicMock(pipeline_tag=None)
+    with patch(_HF_API, return_value=api):
+        assert get_pipeline_tag("someone/some-model") is None
+
+
+def test_get_pipeline_tag_swallows_api_error_and_returns_none() -> None:
+    """A network/Hub error is caught — the helper returns None instead of raising."""
+    api = MagicMock()
+    api.model_info.side_effect = ConnectionError("offline")
+    with patch(_HF_API, return_value=api):
+        assert get_pipeline_tag("someone/some-model") is None


### PR DESCRIPTION
## Summary

When architecture-based task detection (Stage 1c) fails because `config.architectures` contains a generic name like `'Model'` that doesn't map to any real transformers class, task resolution falls through to the last-resort `feature-extraction` default. However, HuggingFace Hub knows the correct task via `pipeline_tag` (e.g. `audio-classification` for `audeering/wav2vec2-large-robust-24-ft-age-gender`).

This PR adds a **Stage 1e** between Stage 1c (TasksManager architecture detection) and Stage 1d (last-resort default) that queries the Hub's `pipeline_tag` as a fallback.

## Changes

### `src/winml/modelkit/loader/resolution.py`
- Added `TaskSource.PIPELINE_TAG = "pipeline-tag"` enum value for provenance tracking
- Added `KNOWN_TASKS` to imports from `.task`
- Added Stage 1e block in `resolve_task()`:
  - Only runs when `opt_task is None` (architecture detection failed) and `model_id` exists
  - Checks `model_id` is not a local path via `_is_local_path` from `hub_utils`
  - Queries `HfApi().model_info(model_id).pipeline_tag`
  - Normalizes the tag and validates against `KNOWN_TASKS`
  - Wrapped in `try/except Exception` for graceful fallthrough on network errors or invalid model IDs

### `tests/unit/loader/test_detect_task.py`
Added 4 tests:
- Valid pipeline_tag is used when architecture detection fails
- Invalid/unknown pipeline_tag falls through to default
- API failure (network error) falls through gracefully
- Local path model_id skips the Hub API call entirely