### PR TITLE
recipe(wav2vec2): add jakeBland/wav2vec-vm-finetune (audio-classification)

### DIFF
--- a/examples/recipes/jakeBland_wav2vec-vm-finetune/cpu/cpu/audio-classification_fp16_config.json
+++ b/examples/recipes/jakeBland_wav2vec-vm-finetune/cpu/cpu/audio-classification_fp16_config.json
@@ -1,0 +1,54 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_values",
+        "dtype": "float32",
+        "shape": [1, 16000],
+        "value_range": [-1, 1]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "audio-classification",
+    "model_class": "AutoModelForAudioClassification",
+    "model_type": "wav2vec2",
+    "trust_remote_code": true
+  }
+}

--- a/examples/recipes/jakeBland_wav2vec-vm-finetune/cpu/cpu/audio-classification_fp32_config.json
+++ b/examples/recipes/jakeBland_wav2vec-vm-finetune/cpu/cpu/audio-classification_fp32_config.json
@@ -1,0 +1,35 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_values",
+        "dtype": "float32",
+        "shape": [1, 16000],
+        "value_range": [-1, 1]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "audio-classification",
+    "model_class": "AutoModelForAudioClassification",
+    "model_type": "wav2vec2",
+    "trust_remote_code": true
+  }
+}

--- a/examples/recipes/jakeBland_wav2vec-vm-finetune/dml/gpu/audio-classification_fp16_config.json
+++ b/examples/recipes/jakeBland_wav2vec-vm-finetune/dml/gpu/audio-classification_fp16_config.json
@@ -1,0 +1,54 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_values",
+        "dtype": "float32",
+        "shape": [1, 16000],
+        "value_range": [-1, 1]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "audio-classification",
+    "model_class": "AutoModelForAudioClassification",
+    "model_type": "wav2vec2",
+    "trust_remote_code": true
+  }
+}

--- a/examples/recipes/jakeBland_wav2vec-vm-finetune/dml/gpu/audio-classification_fp32_config.json
+++ b/examples/recipes/jakeBland_wav2vec-vm-finetune/dml/gpu/audio-classification_fp32_config.json
@@ -1,0 +1,35 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_values",
+        "dtype": "float32",
+        "shape": [1, 16000],
+        "value_range": [-1, 1]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "audio-classification",
+    "model_class": "AutoModelForAudioClassification",
+    "model_type": "wav2vec2",
+    "trust_remote_code": true
+  }
+}


### PR DESCRIPTION
Recipe-only contribution (Effort L0). Adds fp32 and fp16 recipe configs for
**jakeBland/wav2vec-vm-finetune** (`Wav2Vec2ForSequenceClassification`, task `audio-classification`)
on two verified EP/device combinations: **CPU** and **DML (GPU)**. Goal L1 (perf) PASS on all 4 configs.

---

### 1. Recipe path(s)

- `examples/recipes/jakeBland_wav2vec-vm-finetune/cpu/cpu/audio-classification_fp32_config.json`
- `examples/recipes/jakeBland_wav2vec-vm-finetune/cpu/cpu/audio-classification_fp16_config.json`
- `examples/recipes/jakeBland_wav2vec-vm-finetune/dml/gpu/audio-classification_fp32_config.json`
- `examples/recipes/jakeBland_wav2vec-vm-finetune/dml/gpu/audio-classification_fp16_config.json`

### 2. README row

N/A — README not modified in this PR. The model has not yet passed fp16 eval on all 10 (EP, device) buckets; only cpu/cpu and dml/gpu are verified.

### 3. Build output dir

- `temp/wav2vec_cpu_fp32/` (cpu/cpu fp32)
- `temp/wav2vec_cpu_fp16/` (cpu/cpu fp16)
- `temp/wav2vec_dml_fp32/` (dml/gpu fp32)
- `temp/wav2vec_dml_fp16/` (dml/gpu fp16)

### 4. Build log

All 4 configs completed successfully:

- cpu/cpu fp32: `✅ Build complete in 56.2s` (Export 29.7s, Optimize 25.5s)
- cpu/cpu fp16: `✅ Build complete in 64.0s` (Export 28.8s, Optimize 24.3s, FP16 10.3s)
- dml/gpu fp32: `✅ Build complete in 53.2s` (Export 28.2s, Optimize 24.2s)
- dml/gpu fp16: `✅ Build complete in 54.0s` (Export 28.5s, Optimize 24.7s)

### 5. Appended findings

N/A — no `model_knowledge/` or `skill_meta/` entries added (recipe-only L0 contribution; skill repo is separate from this working repo).

### 6. Optimum-coverage probe

N/A — `wav2vec2` architecture is already supported by Optimum's `Wav2Vec2OnnxConfig`. No custom OnnxConfig was needed.

### 7. Claimed (Effort, Goal, Outcome)

| Axis | Tier |
|---|---|
| Effort | L0 (recipe-only, no per-architecture code) |
| Goal | L1 (build + perf) |
| Outcome | L0 (recipe + report) |

### 8. Goal-ladder verdict table

| Tier | Verdict | Evidence |
|---|---|---|
| L0 (build) | **PASS** | All 4 configs (cpu/cpu fp32, cpu/cpu fp16, dml/gpu fp32, dml/gpu fp16) build successfully with `winml build` |
| L1 (perf) | **PASS** | All 4 configs produce valid latency/throughput numbers via `winml perf` (see item 10) |
| L2 (numeric vs PyTorch) | N/A | Not attempted (Goal ceiling = L1) |
| L3 (task metric) | N/A | Not attempted (Goal ceiling = L1) |

### 9. Methodology-evolution declaration

No methodology friction observed during this contribution.

### 10. Perf & eval data

| EP / Device | Precision | Verdict | Mean | p50 | p90 | Throughput | RAM Δ | VRAM Δ (local) |
|---|---|---|---|---|---|---|---|---|
| OpenVINOExecutionProvider / cpu | fp32 | PASS | 128.478 ms | 127.733 ms | 137.807 ms | 7.78 samples/s | +2511.28 MB | — |
| OpenVINOExecutionProvider / cpu | fp16 | PASS | 128.124 ms | 127.399 ms | 134.016 ms | 7.80 samples/s | +2514.16 MB | — |
| DmlExecutionProvider / gpu | fp32 | PASS | 35.032 ms | 34.790 ms | 36.966 ms | 28.54 samples/s | +1437.18 MB | +1273.35 MB |
| DmlExecutionProvider / gpu | fp16 | PASS | 35.047 ms | 35.078 ms | 36.145 ms | 28.53 samples/s | +1420.45 MB | +1273.35 MB |
| QNNExecutionProvider / npu | * | HOST-BLOCKED | — | — | — | — | — | No NPU hardware available on test host |

Model size: fp32 = 1204.57 MB (export) → 1.2 GB (optimized); fp16 = 602.4 MB (quantized, 50% size reduction).

### 11. Component / op-level data

From `winml analyze` (post-optimization):

- **Total operators**: 771 (after fusion)
- **Unique operator types**: 13
- **Operator breakdown**: Reshape (244), Gemm (147), Transpose (111), LayerNormalization (57), Add (49), Mul (48), MatMul (48), Gelu (32), Softmax (24), Conv (8), Unsqueeze (1), Slice (1), ReduceMean (1)
- **Fusion patterns applied**: `gelu_fusion`, `matmul_add_fusion` (autoconf converged in 2 iterations, 897 → 771 nodes)
- **Per-EP op classification**: all 13 op types classified as `unknown` (no per-EP support matrix available in current analyze data)
- **Artifact**: `temp/wav2vec_cpu_fp32/analyze_result.json`

### 12. Reproducible commands

```powershell
# Build (cpu/cpu fp32)
winml build -c examples/recipes/jakeBland_wav2vec-vm-finetune/cpu/cpu/audio-classification_fp32_config.json -m jakeBland/wav2vec-vm-finetune -o temp/wav2vec_cpu_fp32

# Build (cpu/cpu fp16)
winml build -c examples/recipes/jakeBland_wav2vec-vm-finetune/cpu/cpu/audio-classification_fp16_config.json -m jakeBland/wav2vec-vm-finetune -o temp/wav2vec_cpu_fp16

# Build (dml/gpu fp32)
winml build -c examples/recipes/jakeBland_wav2vec-vm-finetune/dml/gpu/audio-classification_fp32_config.json -m jakeBland/wav2vec-vm-finetune -o temp/wav2vec_dml_fp32 --ep dml --device gpu

# Build (dml/gpu fp16)
winml build -c examples/recipes/jakeBland_wav2vec-vm-finetune/dml/gpu/audio-classification_fp16_config.json -m jakeBland/wav2vec-vm-finetune -o temp/wav2vec_dml_fp16 --ep dml --device gpu

# Perf (cpu fp32)
winml perf -m temp/wav2vec_cpu_fp32/model.onnx --device cpu --iterations 10

# Perf (cpu fp16)
winml perf -m temp/wav2vec_cpu_fp16/model.onnx --device cpu --iterations 10

# Perf (dml/gpu fp32)
winml perf -m temp/wav2vec_dml_fp32/model.onnx --device gpu --ep dml --iterations 10

# Perf (dml/gpu fp16)
winml perf -m temp/wav2vec_dml_fp16/model.onnx --device gpu --ep dml --iterations 10
```
