### PR TITLE
recipe(opus-mt-fr-en): add CPU fp32 and fp16 recipes

### DIFF
--- a/examples/recipes/Helsinki-NLP_opus-mt-fr-en/cpu/cpu/translation_fp16_decoder_config.json
+++ b/examples/recipes/Helsinki-NLP_opus-mt-fr-en/cpu/cpu/translation_fp16_decoder_config.json
@@ -1,0 +1,76 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {"name": "decoder_input_ids", "dtype": "int32", "shape": [1, 1], "value_range": [0, 59514]},
+      {"name": "encoder_hidden_states", "dtype": "float32", "shape": [1, 512, 512], "value_range": [0, 1]},
+      {"name": "attention_mask", "dtype": "int64", "shape": [1, 512]},
+      {"name": "decoder_attention_mask", "dtype": "int64", "shape": [1, 512]},
+      {"name": "cache_position", "dtype": "int64", "shape": [1]},
+      {"name": "past_0_key", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_0_value", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_1_key", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_1_value", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_2_key", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_2_value", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_3_key", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_3_value", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_4_key", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_4_value", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_5_key", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_5_value", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]}
+    ],
+    "output_tensors": [
+      {"name": "logits"},
+      {"name": "present_0_key"}, {"name": "present_0_value"},
+      {"name": "present_1_key"}, {"name": "present_1_value"},
+      {"name": "present_2_key"}, {"name": "present_2_value"},
+      {"name": "present_3_key"}, {"name": "present_3_value"},
+      {"name": "present_4_key"}, {"name": "present_4_value"},
+      {"name": "present_5_key"}, {"name": "present_5_value"}
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true,
+    "gelu_fusion": true,
+    "matmul_add_fusion": true,
+    "remove_isnan_in_attention_mask": true
+  },
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "text2text-generation",
+    "model_id": "Helsinki-NLP/opus-mt-fr-en",
+    "model_type": "marian",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "text2text-generation",
+    "model_class": "MarianDecoderWrapper",
+    "model_type": "marian"
+  }
+}

--- a/examples/recipes/Helsinki-NLP_opus-mt-fr-en/cpu/cpu/translation_fp16_encoder_config.json
+++ b/examples/recipes/Helsinki-NLP_opus-mt-fr-en/cpu/cpu/translation_fp16_encoder_config.json
@@ -1,0 +1,53 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {"name": "input_ids", "dtype": "int32", "shape": [1, 512], "value_range": [0, 59514]},
+      {"name": "attention_mask", "dtype": "int32", "shape": [1, 512], "value_range": [0, 2]}
+    ],
+    "output_tensors": [{"name": "encoder_hidden_states"}]
+  },
+  "optim": {
+    "clamp_constant_values": true,
+    "gelu_fusion": true,
+    "matmul_add_fusion": true,
+    "remove_isnan_in_attention_mask": true
+  },
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "feature-extraction",
+    "model_id": "Helsinki-NLP/opus-mt-fr-en",
+    "model_type": "marian",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "feature-extraction",
+    "model_class": "MarianEncoderWrapper",
+    "model_type": "marian"
+  }
+}

--- a/examples/recipes/Helsinki-NLP_opus-mt-fr-en/cpu/cpu/translation_fp32_decoder_config.json
+++ b/examples/recipes/Helsinki-NLP_opus-mt-fr-en/cpu/cpu/translation_fp32_decoder_config.json
@@ -1,0 +1,54 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {"name": "decoder_input_ids", "dtype": "int32", "shape": [1, 1], "value_range": [0, 59514]},
+      {"name": "encoder_hidden_states", "dtype": "float32", "shape": [1, 512, 512], "value_range": [0, 1]},
+      {"name": "attention_mask", "dtype": "int64", "shape": [1, 512]},
+      {"name": "decoder_attention_mask", "dtype": "int64", "shape": [1, 512]},
+      {"name": "cache_position", "dtype": "int64", "shape": [1]},
+      {"name": "past_0_key", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_0_value", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_1_key", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_1_value", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_2_key", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_2_value", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_3_key", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_3_value", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_4_key", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_4_value", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_5_key", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_5_value", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]}
+    ],
+    "output_tensors": [
+      {"name": "logits"},
+      {"name": "present_0_key"}, {"name": "present_0_value"},
+      {"name": "present_1_key"}, {"name": "present_1_value"},
+      {"name": "present_2_key"}, {"name": "present_2_value"},
+      {"name": "present_3_key"}, {"name": "present_3_value"},
+      {"name": "present_4_key"}, {"name": "present_4_value"},
+      {"name": "present_5_key"}, {"name": "present_5_value"}
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true,
+    "gelu_fusion": true,
+    "matmul_add_fusion": true,
+    "remove_isnan_in_attention_mask": true
+  },
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "text2text-generation",
+    "model_class": "MarianDecoderWrapper",
+    "model_type": "marian"
+  }
+}

--- a/examples/recipes/Helsinki-NLP_opus-mt-fr-en/cpu/cpu/translation_fp32_encoder_config.json
+++ b/examples/recipes/Helsinki-NLP_opus-mt-fr-en/cpu/cpu/translation_fp32_encoder_config.json
@@ -1,0 +1,45 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [1, 512],
+        "value_range": [0, 59514]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [1, 512],
+        "value_range": [0, 2]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "encoder_hidden_states"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true,
+    "gelu_fusion": true,
+    "matmul_add_fusion": true,
+    "remove_isnan_in_attention_mask": true
+  },
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "feature-extraction",
+    "model_class": "MarianEncoderWrapper",
+    "model_type": "marian"
+  }
+}


### PR DESCRIPTION
# Summary

This recipe-only contribution adds reviewed CPU `fp32` and genuine `fp16` coverage for the `Helsinki-NLP/opus-mt-fr-en` Marian French-to-English translation composite. The model **does work by default on current `main`**; the `fp32` recipes are semantically identical to current auto-config and the `fp16` recipes add an explicit, verified precision policy. Effort/Outcome are L0, the highest reached Goal is L2 PASS on the encoder, and L3 is CLI-BLOCKED because `winml eval` does not register `translation`.

# Model metadata

Model-breakdown: `temp/skill-run-1115/model-breakdown/opus-mt-fr-en.model-breakdown.json`; SHA-256 `3c15048e55223ca7aab6121ca5acdf534b16bb2837a9cd099eb813aec8eaafd9`; checkpoint revision `c4aed37b318c763fd177aa449b44e3b783cc6c02`.

## What the model does

A text-to-text Marian encoder-decoder checkpoint that translates French input text into English output text. The encoder produces contextual hidden states and the autoregressive decoder produces vocabulary logits plus updated key/value cache tensors.
Evidence: Hugging Face model identity opus-mt-fr-en; winml inspect: pipeline_tasks=[translation], architectures=[MarianMTModel]; exported encoder and decoder graph interfaces. Confidence: **verified**.

## Primary user stories

- A user supplies French text to obtain an English translation for cross-language communication or downstream processing. Evidence: checkpoint identity and translation pipeline task. Confidence: **verified**.

## Supported tasks

- `translation` — surfaces: checkpoint, transformers, winml; evidence: winml inspect pipeline_tasks; composite config generation; confidence: **verified**.
- `text2text-generation` — surfaces: transformers, optimum-onnx, winml; evidence: decoder task and Optimum Marian registry; confidence: **verified**.
- `feature-extraction` — surfaces: optimum-onnx, winml; evidence: encoder component task and build config; confidence: **verified**.

These support surfaces describe model loading/export/inference routing. They do not imply task-metric coverage in `winml eval`; the fresh L3 probe below confirms that its eval registry currently excludes `translation`.

## Model architecture

A 6-layer Marian transformer encoder and 6-layer autoregressive Marian decoder, hidden width 512 with 8 attention heads. Each encoder layer contains self-attention and an MLP; each decoder layer contains self-attention, encoder cross-attention, an MLP, normalization/residual paths, and a KV-cache interface. Encoder and decoder export as separate ONNX graphs.
Components: `encoder`, `encoder.embeddings_input`, `encoder.layers[]`, `encoder.layers[].self_attention`, `encoder.layers[].mlp`, `encoder.layers[].normalization_residual`, `decoder`, `decoder.embeddings_input`, `decoder.layers[]`, `decoder.layers[].self_attention`, `decoder.layers[].cross_attention`, `decoder.layers[].mlp`, `decoder.layers[].normalization_residual`, `decoder.kv_cache`, `decoder.lm_head`. Evidence: HTP traced module hierarchies; ONNX node scopes and graph interfaces; winml inspect io_config. Confidence: **mapped**.

# Validation and support evidence

## 1. Baseline

- Current `main`: `76d48ad38f894c3fc5a5e760de67f0a096e438a6`; WinML `0.2.0`.
- Command: `winml build -m Helsinki-NLP/opus-mt-fr-en -o temp/skill-run-1115/baseline/build --ep cpu --device cpu --no-analyze --no-optimize --no-quant --no-compile --rebuild`
- Command: `winml perf -m temp/skill-run-1115/baseline/build/encoder_model.onnx --task feature-extraction --ep cpu --device cpu --iterations 10 --warmup 3 --format json`
- Command: `winml perf -m temp/skill-run-1115/baseline/build/decoder_model.onnx --task text2text-generation --ep cpu --device cpu --iterations 10 --warmup 3 --format json`
- Command: `winml eval --schema --task translation`
- Default/current-main build PASS: Build complete in 37.9s; encoder_model.onnx and decoder_model.onnx emitted.
- Default encoder PASS: mean 71.773 ms, p50 71.038 ms, 14.03 samples/s, RSS delta 140.71 MB.
- Default decoder PASS: mean 21.897 ms, p50 22.274 ms, 45.67 samples/s, RSS delta 243.21 MB.
- Default composite perf PASS: encoder mean/p50 78.319/78.513 ms; decoder mean/p50 24.327/24.283 ms.
- Translation eval CLI-BLOCKED because task translation is absent from the eval registry.
- Optimum probe: vendor tasks are `feature-extraction`, `feature-extraction-with-past`, `text-generation`, `text-generation-with-past`, `text2text-generation`, and `text2text-generation-with-past`; WinML adds no new task key. Starting config is the two-file composite output from `winml config --task translation`.

## 2. Goal

- Frozen charter revision 2: Effort **L0**, Goal ceiling **L2**, Outcome **L0**.
- Success definition: L0 builds and validates CPU fp32/fp16 encoder+decoder artifacts; L1 records component perf; L2 compares encoder ONNX to PyTorch by name at both precisions. Ceiling-independent eval support still requires a task metric or exact independent blocker for every tuple.
- Revision 2 supersedes stale pre-rebase evidence at `74342698e416bd9bc4e5f9b534f943425ce81c62`; no later ceiling change was made.

## 3. Outcome

- Shipped tier: **L0**; highest reached Goal: **L2 PASS**; coverage: **full**; deferred tuples: none.
- Shipped four recipes under `examples/recipes/Helsinki-NLP_opus-mt-fr-en/cpu/cpu/`; no source code and no production recipe README change.
- Appended model finding `marian-007` and methodology finding `_meta-080` in ModelKitArtifacts Lane A commit `be732458`. Methodology friction observed: source-tree analyze reused a central rule tree only after selecting the implemented `WINMLCLI_RULES_DIR` override.

### Goal ladder

| Tier | Verdict | Evidence |
|---|---|---|
| L0 | **PASS** | All four CPU/precision/component builds passed and were structurally validated. |
| L1 | **PASS** | All four component artifacts completed CPU perf with concrete latency, throughput, and memory data. |
| L2 | **PASS** | Encoder named-input PyTorch parity: fp32 cosine=0.9999999999995187, max_abs=3.337860107421875e-06; fp16 cosine=0.999999184734255, max_abs=0.004638791084289551. Decoder parity not claimed: identical DynamicCache/past-KV reconstruction is not provided by the current harness. |

## 4. Per-EP/device/precision results — including perf and eval data

### Perf

Ten measured iterations after three warmups, batch size 1. Component latency is not full autoregressive translation latency.

| Component | EP / Device | Precision | Verdict | Mean | p50 | Throughput | RAM delta | VRAM delta |
|---|---|---|---|---:|---:|---:|---:|---:|
| encoder | CPUExecutionProvider / cpu | fp32 | PASS | 70.032 ms | 70.415 ms | 14.28 samples/s | 140.57 MB | 0.0 MB |
| decoder | CPUExecutionProvider / cpu | fp32 | PASS | 23.607 ms | 23.677 ms | 42.36 samples/s | 243.33 MB | 0.0 MB |
| encoder | CPUExecutionProvider / cpu | fp16 | PASS | 92.095 ms | 92.482 ms | 10.86 samples/s | 291.08 MB | 0.0 MB |
| decoder | CPUExecutionProvider / cpu | fp16 | PASS | 26.441 ms | 26.45 ms | 37.82 samples/s | 252.65 MB | 0.0 MB |

Default composite-path perf also passed at fp32: encoder mean/p50 `78.319/78.513 ms`, decoder `24.327/24.283 ms`. This confirms the model works by default independently of the checked-in recipes.

### Eval

| EP / Device | Precision | Verdict | Dataset / revision / subset | Metric | Exact blocker |
|---|---|---|---|---|---|
| CPUExecutionProvider / cpu | fp32 | **CLI-BLOCKED** | unavailable / unavailable / unavailable | unavailable | `Evaluation failed: Task 'translation' is not supported. Supported tasks: audio-classification, automatic-speech-recognition, depth-estimation, feature-extraction, fill-mask, image-classification, image-feature-extraction, image-to-image, image-to-text, object-detection, question-answering, semantic-segmentation, text-classification, token-classification, zero-shot-classification, zero-shot-image-classification` |
| CPUExecutionProvider / cpu | fp16 | **CLI-BLOCKED** | unavailable / unavailable / unavailable | unavailable | `Evaluation failed: Task 'translation' is not supported. Supported tasks: audio-classification, automatic-speech-recognition, depth-estimation, feature-extraction, fill-mask, image-classification, image-feature-extraction, image-to-image, image-to-text, object-detection, question-answering, semantic-segmentation, text-classification, token-classification, zero-shot-classification, zero-shot-image-classification` |

No dataset or task metric can be reported before the translation eval task and generation loop are registered. Feature gap: add translation dataset/generation-loop support to `winml eval` / `TASK_REGISTRY`.

## 5. Delta

- `examples/recipes/Helsinki-NLP_opus-mt-fr-en/cpu/cpu/translation_fp32_encoder_config.json`
- `examples/recipes/Helsinki-NLP_opus-mt-fr-en/cpu/cpu/translation_fp32_decoder_config.json`
- `examples/recipes/Helsinki-NLP_opus-mt-fr-en/cpu/cpu/translation_fp16_encoder_config.json`
- `examples/recipes/Helsinki-NLP_opus-mt-fr-en/cpu/cpu/translation_fp16_decoder_config.json`
- fp32 encoder and decoder: semantic JSON diff from current-main `winml config` output is **identical** (formatting only).
- fp16 encoder and decoder: JSON pointer `/quant` changes from `null` to the generated fp16 policy; `/quant/mode = "fp16"`, component-specific task/model metadata, `/quant/fp16_keep_io_types = true`, and generated default calibration fields. No export, optimizer, compile, or loader delta exists relative to the matching fp32 config.
- Reducibility: Current metadata and existing Marian registrations already derive a working default composite. No class-wide source defect exists; recipe-only scope is consistent. The fp32 files are filed as explicit reviewed CPU coverage, and fp16 files select a concrete precision policy.
- Code paths/symbols/class-wide changes: none. Recipe-free acceptance: PASS. `examples/recipes/README.md` remains untouched.

## 6. Analyze results — component level and op level

Status: **ANALYZE-PARTIAL-SUCCESS**; exit code `1`. winml analyze exited 1 after emitting complete parseable 11-EP JSON for each artifact because requested all-EP classifications include partial/unsupported/unknown results; exit 2 rule-discovery failures were repaired by setting WINMLCLI_RULES_DIR.

### Component-level analysis

All ten semantic regions map by scoped ONNX node names with mapped confidence. The mapping report lists representative nodes and a full region count; the table uses full region node/operator counts.

| Semantic component | ONNX region / representative nodes | Nodes | Operator counts | Basis / confidence | Relevant per-EP issues |
|---|---|---:|---|---|---|
| `encoder.embeddings_input` — Encoder embedding/input preparation | 65 nodes in encoder_model.onnx; first 20 listed; `/encoder/Reshape`, `/encoder/embed_tokens/Gather` | 65 | Reshape:55, Gather:1, Mul:1, Add:1, Unsqueeze:2, Expand:1, Cast:2, Sub:1, Where:1 | scope-name / mapped | No partial/unsupported rule-backed op type |
| `encoder.layers[].self_attention` — Encoder self-attention | 91 nodes in encoder_model.onnx; first 20 listed; `/encoder/layers.0/self_attn/k_proj/MatMul/MatMulAddFusion`, `/encoder/layers.0/self_attn/Transpose_2` | 91 | Gemm:24, Transpose:24, Mul:12, MatMul:12, Slice:1, Add:6, Softmax:6, Reshape:6 | scope-name / mapped | No partial/unsupported rule-backed op type |
| `encoder.layers[].normalization_residual` — Encoder normalization/residual | 24 nodes in encoder_model.onnx; first 20 listed; `/encoder/layers.0/Add`, `/encoder/layers.0/self_attn_layer_norm/LayerNormalization` | 24 | Add:12, LayerNormalization:12 | scope-name / mapped | No partial/unsupported rule-backed op type |
| `encoder.layers[].mlp` — Encoder feed-forward network | 24 nodes in encoder_model.onnx; first 20 listed; `/encoder/layers.0/fc1/MatMul/MatMulAddFusion`, `/encoder/layers.0/activation_fn/Sigmoid` | 24 | Gemm:12, Sigmoid:6, Mul:6 | scope-name / mapped | No partial/unsupported rule-backed op type |
| `decoder.embeddings_input` — Decoder embedding/input preparation | 114 nodes in decoder_model.onnx; first 20 listed; `gemm_input_reshape_token_212`, `gemm_output_reshape_token_215_new_reshape` | 114 | Reshape:87, Unsqueeze:6, Expand:3, Cast:4, Sub:1, Where:2, Gather:2, Mul:2, Add:3, Greater:1, Slice:1, Equal:1, ScatterND:1 | scope-name / mapped | fp32 NvTensorRTRTXExecutionProvider/gpu: unknown=ScatterND; fp32 QNNExecutionProvider/npu: unknown=ScatterND; fp32 QNNExecutionProvider/gpu: partial=Cast,Expand, unknown=ScatterND; fp32 OpenVINOExecutionProvider/npu: unknown=ScatterND; fp32 OpenVINOExecutionProvider/gpu: unknown=ScatterND; fp32 OpenVINOExecutionProvider/cpu: unknown=ScatterND; fp16 NvTensorRTRTXExecutionProvider/gpu: unknown=ScatterND; fp16 QNNExecutionProvider/npu: partial=Expand, unknown=ScatterND; fp16 QNNExecutionProvider/gpu: partial=Expand, unsupported=Cast, unknown=ScatterND; fp16 OpenVINOExecutionProvider/npu: unknown=ScatterND; fp16 OpenVINOExecutionProvider/gpu: unknown=ScatterND; fp16 OpenVINOExecutionProvider/cpu: unknown=ScatterND |
| `decoder.layers[].cross_attention` — Decoder cross-attention | 91 nodes in decoder_model.onnx; first 20 listed; `/model/model/decoder/layers.5/encoder_attn/v_proj/MatMul/MatMulAddFusion`, `/model/model/decoder/layers.5/encoder_attn/Transpose_1` | 91 | Gemm:24, Transpose:24, Slice:1, Mul:12, MatMul:12, Add:6, Softmax:6, Reshape:6 | scope-name / mapped | No partial/unsupported rule-backed op type |
| `decoder.layers[].self_attention` — Decoder self-attention | 126 nodes in decoder_model.onnx; first 20 listed; `/model/model/decoder/layers.0/self_attn/v_proj/MatMul/MatMulAddFusion`, `/model/model/decoder/layers.0/self_attn/Transpose_2` | 126 | Gemm:24, Transpose:30, Reshape:19, Expand:2, Unsqueeze:1, Concat:1, ScatterND:12, Slice:1, Mul:12, MatMul:12, Add:6, Softmax:6 | scope-name / mapped | fp32 NvTensorRTRTXExecutionProvider/gpu: unknown=ScatterND; fp32 QNNExecutionProvider/npu: unknown=ScatterND; fp32 QNNExecutionProvider/gpu: partial=Concat,Expand, unknown=ScatterND; fp32 OpenVINOExecutionProvider/npu: unknown=ScatterND; fp32 OpenVINOExecutionProvider/gpu: unknown=ScatterND; fp32 OpenVINOExecutionProvider/cpu: unknown=ScatterND; fp16 NvTensorRTRTXExecutionProvider/gpu: unknown=ScatterND; fp16 QNNExecutionProvider/npu: partial=Expand, unknown=ScatterND; fp16 QNNExecutionProvider/gpu: partial=Concat,Expand, unknown=ScatterND; fp16 OpenVINOExecutionProvider/npu: unknown=ScatterND; fp16 OpenVINOExecutionProvider/gpu: unknown=ScatterND; fp16 OpenVINOExecutionProvider/cpu: unknown=ScatterND |
| `decoder.layers[].normalization_residual` — Decoder normalization/residual | 36 nodes in decoder_model.onnx; first 20 listed; `/model/model/decoder/layers.0/Add`, `/model/model/decoder/layers.0/self_attn_layer_norm/LayerNormalization` | 36 | Add:18, LayerNormalization:18 | scope-name / mapped | No partial/unsupported rule-backed op type |
| `decoder.layers[].mlp` — Decoder feed-forward network | 24 nodes in decoder_model.onnx; first 20 listed; `/model/model/decoder/layers.0/fc1/MatMul/MatMulAddFusion`, `/model/model/decoder/layers.0/activation_fn/Sigmoid` | 24 | Gemm:12, Sigmoid:6, Mul:6 | scope-name / mapped | No partial/unsupported rule-backed op type |
| `decoder.lm_head` — Language-model projection | 1 nodes in decoder_model.onnx; first 20 listed; `/model/lm_head/MatMul` | 1 | MatMul:1 | scope-name / mapped | No partial/unsupported rule-backed op type |

Unmapped node count: `0`. Mapping gaps: MLP and normalization/residual are functional regions inferred from scoped node names/topology rather than separate HTP module boundaries; the frozen component map uses current-main fp32 graphs, while fp16 topology/precision is validated by tester artifacts.

### Op-level analysis

#### `fp32_encoder` — 204 operators, 16 unique types

Counts: `Reshape` 61, `Gather` 1, `Mul` 19, `Add` 19, `Gemm` 36, `Transpose` 24, `MatMul` 12, `Unsqueeze` 2, `Expand` 1, `Cast` 2, `Sub` 1, `Where` 1, `Slice` 1, `Softmax` 6, `LayerNormalization` 12, `Sigmoid` 6.

| EP / device | runtime_support | supported | partial | unsupported | unknown |
|---|---:|---:|---|---|---|
| NvTensorRTRTXExecutionProvider/gpu | true | 16 types | none | none | none |
| CUDAExecutionProvider/gpu | false | 0 types | none | none | `Reshape`, `Gather`, `Mul`, `Add`, `Gemm`, `Transpose`, `MatMul`, `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Softmax`, `LayerNormalization`, `Sigmoid` |
| MIGraphXExecutionProvider/gpu | false | 0 types | none | none | `Reshape`, `Gather`, `Mul`, `Add`, `Gemm`, `Transpose`, `MatMul`, `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Softmax`, `LayerNormalization`, `Sigmoid` |
| QNNExecutionProvider/npu | true | 16 types | none | none | none |
| QNNExecutionProvider/gpu | true | 16 types | none | none | none |
| OpenVINOExecutionProvider/npu | true | 16 types | none | none | none |
| OpenVINOExecutionProvider/gpu | true | 16 types | none | none | none |
| OpenVINOExecutionProvider/cpu | true | 16 types | none | none | none |
| DmlExecutionProvider/gpu | false | 0 types | none | none | `Reshape`, `Gather`, `Mul`, `Add`, `Gemm`, `Transpose`, `MatMul`, `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Softmax`, `LayerNormalization`, `Sigmoid` |
| CPUExecutionProvider/cpu | false | 0 types | none | none | `Reshape`, `Gather`, `Mul`, `Add`, `Gemm`, `Transpose`, `MatMul`, `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Softmax`, `LayerNormalization`, `Sigmoid` |
| VitisAIExecutionProvider/npu | false | 0 types | none | none | `Reshape`, `Gather`, `Mul`, `Add`, `Gemm`, `Transpose`, `MatMul`, `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Softmax`, `LayerNormalization`, `Sigmoid` |

#### `fp32_decoder` — 392 operators, 20 unique types

Counts: `Reshape` 112, `Gemm` 60, `Transpose` 54, `Unsqueeze` 7, `Expand` 5, `Cast` 4, `Sub` 1, `Where` 2, `Slice` 3, `Gather` 2, `Mul` 32, `Add` 33, `Concat` 1, `ScatterND` 13, `Greater` 1, `Equal` 1, `MatMul` 25, `Softmax` 12, `LayerNormalization` 18, `Sigmoid` 6.

| EP / device | runtime_support | supported | partial | unsupported | unknown |
|---|---:|---:|---|---|---|
| NvTensorRTRTXExecutionProvider/gpu | false | 20 types | none | none | `ScatterND` |
| CUDAExecutionProvider/gpu | false | 0 types | none | none | `Reshape`, `Gemm`, `Transpose`, `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Gather`, `Mul`, `Add`, `Concat`, `ScatterND`, `Greater`, `Equal`, `MatMul`, `Softmax`, `LayerNormalization`, `Sigmoid` |
| MIGraphXExecutionProvider/gpu | false | 0 types | none | none | `Reshape`, `Gemm`, `Transpose`, `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Gather`, `Mul`, `Add`, `Concat`, `ScatterND`, `Greater`, `Equal`, `MatMul`, `Softmax`, `LayerNormalization`, `Sigmoid` |
| QNNExecutionProvider/npu | false | 20 types | none | none | `ScatterND` |
| QNNExecutionProvider/gpu | false | 19 types | `Expand`, `Cast`, `Concat` | none | `ScatterND` |
| OpenVINOExecutionProvider/npu | false | 20 types | none | none | `ScatterND` |
| OpenVINOExecutionProvider/gpu | false | 20 types | none | none | `ScatterND` |
| OpenVINOExecutionProvider/cpu | false | 20 types | none | none | `ScatterND` |
| DmlExecutionProvider/gpu | false | 0 types | none | none | `Reshape`, `Gemm`, `Transpose`, `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Gather`, `Mul`, `Add`, `Concat`, `ScatterND`, `Greater`, `Equal`, `MatMul`, `Softmax`, `LayerNormalization`, `Sigmoid` |
| CPUExecutionProvider/cpu | false | 0 types | none | none | `Reshape`, `Gemm`, `Transpose`, `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Gather`, `Mul`, `Add`, `Concat`, `ScatterND`, `Greater`, `Equal`, `MatMul`, `Softmax`, `LayerNormalization`, `Sigmoid` |
| VitisAIExecutionProvider/npu | false | 0 types | none | none | `Reshape`, `Gemm`, `Transpose`, `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Gather`, `Mul`, `Add`, `Concat`, `ScatterND`, `Greater`, `Equal`, `MatMul`, `Softmax`, `LayerNormalization`, `Sigmoid` |

#### `fp16_encoder` — 205 operators, 16 unique types

Counts: `Reshape` 61, `Gather` 1, `Mul` 19, `Add` 19, `Gemm` 36, `Transpose` 24, `MatMul` 12, `Unsqueeze` 2, `Expand` 1, `Cast` 3, `Sub` 1, `Where` 1, `Slice` 1, `Softmax` 6, `LayerNormalization` 12, `Sigmoid` 6.

| EP / device | runtime_support | supported | partial | unsupported | unknown |
|---|---:|---:|---|---|---|
| NvTensorRTRTXExecutionProvider/gpu | true | 16 types | none | none | none |
| CUDAExecutionProvider/gpu | false | 0 types | none | none | `Reshape`, `Gather`, `Mul`, `Add`, `Gemm`, `Transpose`, `MatMul`, `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Softmax`, `LayerNormalization`, `Sigmoid` |
| MIGraphXExecutionProvider/gpu | false | 0 types | none | none | `Reshape`, `Gather`, `Mul`, `Add`, `Gemm`, `Transpose`, `MatMul`, `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Softmax`, `LayerNormalization`, `Sigmoid` |
| QNNExecutionProvider/npu | true | 16 types | none | none | none |
| QNNExecutionProvider/gpu | true | 16 types | none | none | none |
| OpenVINOExecutionProvider/npu | true | 16 types | none | none | none |
| OpenVINOExecutionProvider/gpu | true | 16 types | none | none | none |
| OpenVINOExecutionProvider/cpu | true | 16 types | none | none | none |
| DmlExecutionProvider/gpu | false | 0 types | none | none | `Reshape`, `Gather`, `Mul`, `Add`, `Gemm`, `Transpose`, `MatMul`, `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Softmax`, `LayerNormalization`, `Sigmoid` |
| CPUExecutionProvider/cpu | false | 0 types | none | none | `Reshape`, `Gather`, `Mul`, `Add`, `Gemm`, `Transpose`, `MatMul`, `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Softmax`, `LayerNormalization`, `Sigmoid` |
| VitisAIExecutionProvider/npu | false | 0 types | none | none | `Reshape`, `Gather`, `Mul`, `Add`, `Gemm`, `Transpose`, `MatMul`, `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Softmax`, `LayerNormalization`, `Sigmoid` |

#### `fp16_decoder` — 418 operators, 20 unique types

Counts: `Unsqueeze` 7, `Expand` 5, `Cast` 30, `Sub` 1, `Where` 2, `Slice` 3, `Gather` 2, `Mul` 32, `Add` 33, `Reshape` 112, `Gemm` 60, `Transpose` 54, `Concat` 1, `Greater` 1, `Equal` 1, `ScatterND` 13, `MatMul` 25, `Softmax` 12, `LayerNormalization` 18, `Sigmoid` 6.

| EP / device | runtime_support | supported | partial | unsupported | unknown |
|---|---:|---:|---|---|---|
| NvTensorRTRTXExecutionProvider/gpu | false | 20 types | none | none | `ScatterND` |
| CUDAExecutionProvider/gpu | false | 0 types | none | none | `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Gather`, `Mul`, `Add`, `Reshape`, `Gemm`, `Transpose`, `Concat`, `Greater`, `Equal`, `ScatterND`, `MatMul`, `Softmax`, `LayerNormalization`, `Sigmoid` |
| MIGraphXExecutionProvider/gpu | false | 0 types | none | none | `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Gather`, `Mul`, `Add`, `Reshape`, `Gemm`, `Transpose`, `Concat`, `Greater`, `Equal`, `ScatterND`, `MatMul`, `Softmax`, `LayerNormalization`, `Sigmoid` |
| QNNExecutionProvider/npu | false | 20 types | `Expand` | none | `ScatterND` |
| QNNExecutionProvider/gpu | false | 19 types | `Expand`, `Concat` | `Cast` | `ScatterND` |
| OpenVINOExecutionProvider/npu | false | 20 types | none | none | `ScatterND` |
| OpenVINOExecutionProvider/gpu | false | 20 types | none | none | `ScatterND` |
| OpenVINOExecutionProvider/cpu | false | 20 types | none | none | `ScatterND` |
| DmlExecutionProvider/gpu | false | 0 types | none | none | `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Gather`, `Mul`, `Add`, `Reshape`, `Gemm`, `Transpose`, `Concat`, `Greater`, `Equal`, `ScatterND`, `MatMul`, `Softmax`, `LayerNormalization`, `Sigmoid` |
| CPUExecutionProvider/cpu | false | 0 types | none | none | `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Gather`, `Mul`, `Add`, `Reshape`, `Gemm`, `Transpose`, `Concat`, `Greater`, `Equal`, `ScatterND`, `MatMul`, `Softmax`, `LayerNormalization`, `Sigmoid` |
| VitisAIExecutionProvider/npu | false | 0 types | none | none | `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Gather`, `Mul`, `Add`, `Reshape`, `Gemm`, `Transpose`, `Concat`, `Greater`, `Equal`, `ScatterND`, `MatMul`, `Softmax`, `LayerNormalization`, `Sigmoid` |

Artifacts: `temp/skill-run-1115/tester/analyze_fp32_encoder.json`, `temp/skill-run-1115/tester/analyze_fp32_decoder.json`, `temp/skill-run-1115/tester/analyze_fp16_encoder.json`, `temp/skill-run-1115/tester/analyze_fp16_decoder.json`.

## 7. Reproduce commands

```powershell
git rev-parse HEAD; winml --version
winml inspect -m Helsinki-NLP/opus-mt-fr-en --format json --output temp/skill-run-1115/baseline/inspect.json
winml config -m Helsinki-NLP/opus-mt-fr-en --task translation -o temp/skill-run-1115/baseline/config --overwrite
winml build -m Helsinki-NLP/opus-mt-fr-en -c examples/recipes/Helsinki-NLP_opus-mt-fr-en/cpu/cpu/translation_fp32_encoder_config.json -o temp/skill-run-1115/tester/translation_fp32_encoder_config --ep cpu --device cpu --precision fp32 --no-analyze --no-compile --rebuild
winml build -m Helsinki-NLP/opus-mt-fr-en -c examples/recipes/Helsinki-NLP_opus-mt-fr-en/cpu/cpu/translation_fp32_decoder_config.json -o temp/skill-run-1115/tester/translation_fp32_decoder_config --ep cpu --device cpu --precision fp32 --no-analyze --no-compile --rebuild
winml build -m Helsinki-NLP/opus-mt-fr-en -c examples/recipes/Helsinki-NLP_opus-mt-fr-en/cpu/cpu/translation_fp16_encoder_config.json -o temp/skill-run-1115/tester/translation_fp16_encoder_config --ep cpu --device cpu --precision fp16 --no-analyze --no-compile --rebuild
winml build -m Helsinki-NLP/opus-mt-fr-en -c examples/recipes/Helsinki-NLP_opus-mt-fr-en/cpu/cpu/translation_fp16_decoder_config.json -o temp/skill-run-1115/tester/translation_fp16_decoder_config --ep cpu --device cpu --precision fp16 --no-analyze --no-compile --rebuild
winml perf -m temp/skill-run-1115/tester/translation_fp32_encoder_config/model.onnx --task feature-extraction --ep cpu --device cpu --iterations 10 --warmup 3 --format json --output temp/skill-run-1115/tester/perf_fp32_encoder.json --overwrite
winml perf -m temp/skill-run-1115/tester/translation_fp32_decoder_config/model.onnx --task text2text-generation --ep cpu --device cpu --iterations 10 --warmup 3 --format json --output temp/skill-run-1115/tester/perf_fp32_decoder.json --overwrite
winml perf -m temp/skill-run-1115/tester/translation_fp16_encoder_config/model.onnx --task feature-extraction --ep cpu --device cpu --iterations 10 --warmup 3 --format json --output temp/skill-run-1115/tester/perf_fp16_encoder.json --overwrite
winml perf -m temp/skill-run-1115/tester/translation_fp16_decoder_config/model.onnx --task text2text-generation --ep cpu --device cpu --iterations 10 --warmup 3 --format json --output temp/skill-run-1115/tester/perf_fp16_decoder.json --overwrite
python temp/skill-run-1115/tester/compare_encoder.py temp/skill-run-1115/tester/translation_fp32_encoder_config/model.onnx --output temp/skill-run-1115/tester/l2_fp32_encoder.json
python temp/skill-run-1115/tester/compare_encoder.py temp/skill-run-1115/tester/translation_fp16_encoder_config/model.onnx --output temp/skill-run-1115/tester/l2_fp16_encoder.json
winml eval --schema --task translation
$env:WINMLCLI_RULES_DIR='C:\repo\ModelKitArtifacts\rules'; winml analyze -m temp/skill-run-1115/tester/translation_fp32_encoder_config/model.onnx --ep all --device all --format json --output temp/skill-run-1115/tester/analyze_fp32_encoder.json --overwrite
$env:WINMLCLI_RULES_DIR='C:\repo\ModelKitArtifacts\rules'; winml analyze -m temp/skill-run-1115/tester/translation_fp32_decoder_config/model.onnx --ep all --device all --format json --output temp/skill-run-1115/tester/analyze_fp32_decoder.json --overwrite
$env:WINMLCLI_RULES_DIR='C:\repo\ModelKitArtifacts\rules'; winml analyze -m temp/skill-run-1115/tester/translation_fp16_encoder_config/model.onnx --ep all --device all --format json --output temp/skill-run-1115/tester/analyze_fp16_encoder.json --overwrite
$env:WINMLCLI_RULES_DIR='C:\repo\ModelKitArtifacts\rules'; winml analyze -m temp/skill-run-1115/tester/translation_fp16_decoder_config/model.onnx --ep all --device all --format json --output temp/skill-run-1115/tester/analyze_fp16_decoder.json --overwrite
winml perf -m Helsinki-NLP/opus-mt-fr-en --task translation --ep cpu --device cpu --precision fp32 --iterations 10 --warmup 3 --format json --output temp/skill-run-1115/tester/perf_composite_default_fp32.json --overwrite
```
