### PR TITLE
recipe(opus-mt-en-ru): add verified CPU fp32/fp16 recipes

### DIFF
--- a/examples/recipes/Helsinki-NLP_opus-mt-en-ru/cpu/cpu/translation_fp16_decoder_config.json
+++ b/examples/recipes/Helsinki-NLP_opus-mt-en-ru/cpu/cpu/translation_fp16_decoder_config.json
@@ -1,0 +1,76 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {"name": "decoder_input_ids", "dtype": "int32", "shape": [1, 1], "value_range": [0, 62518]},
+      {"name": "encoder_hidden_states", "dtype": "float32", "shape": [1, 512, 512], "value_range": [0, 1]},
+      {"name": "attention_mask", "dtype": "int64", "shape": [1, 512]},
+      {"name": "decoder_attention_mask", "dtype": "int64", "shape": [1, 512]},
+      {"name": "cache_position", "dtype": "int64", "shape": [1]},
+      {"name": "past_0_key", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_0_value", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_1_key", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_1_value", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_2_key", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_2_value", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_3_key", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_3_value", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_4_key", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_4_value", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_5_key", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_5_value", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]}
+    ],
+    "output_tensors": [
+      {"name": "logits"},
+      {"name": "present_0_key"}, {"name": "present_0_value"},
+      {"name": "present_1_key"}, {"name": "present_1_value"},
+      {"name": "present_2_key"}, {"name": "present_2_value"},
+      {"name": "present_3_key"}, {"name": "present_3_value"},
+      {"name": "present_4_key"}, {"name": "present_4_value"},
+      {"name": "present_5_key"}, {"name": "present_5_value"}
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true,
+    "gelu_fusion": true,
+    "matmul_add_fusion": true,
+    "remove_isnan_in_attention_mask": true
+  },
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "text2text-generation",
+    "model_id": "Helsinki-NLP/opus-mt-en-ru",
+    "model_type": "marian",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "text2text-generation",
+    "model_class": "MarianDecoderWrapper",
+    "model_type": "marian"
+  }
+}

--- a/examples/recipes/Helsinki-NLP_opus-mt-en-ru/cpu/cpu/translation_fp16_encoder_config.json
+++ b/examples/recipes/Helsinki-NLP_opus-mt-en-ru/cpu/cpu/translation_fp16_encoder_config.json
@@ -1,0 +1,53 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {"name": "input_ids", "dtype": "int32", "shape": [1, 512], "value_range": [0, 62518]},
+      {"name": "attention_mask", "dtype": "int32", "shape": [1, 512], "value_range": [0, 2]}
+    ],
+    "output_tensors": [{"name": "encoder_hidden_states"}]
+  },
+  "optim": {
+    "clamp_constant_values": true,
+    "gelu_fusion": true,
+    "matmul_add_fusion": true,
+    "remove_isnan_in_attention_mask": true
+  },
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "feature-extraction",
+    "model_id": "Helsinki-NLP/opus-mt-en-ru",
+    "model_type": "marian",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "feature-extraction",
+    "model_class": "MarianEncoderWrapper",
+    "model_type": "marian"
+  }
+}

--- a/examples/recipes/Helsinki-NLP_opus-mt-en-ru/cpu/cpu/translation_fp32_decoder_config.json
+++ b/examples/recipes/Helsinki-NLP_opus-mt-en-ru/cpu/cpu/translation_fp32_decoder_config.json
@@ -1,0 +1,54 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {"name": "decoder_input_ids", "dtype": "int32", "shape": [1, 1], "value_range": [0, 62518]},
+      {"name": "encoder_hidden_states", "dtype": "float32", "shape": [1, 512, 512], "value_range": [0, 1]},
+      {"name": "attention_mask", "dtype": "int64", "shape": [1, 512]},
+      {"name": "decoder_attention_mask", "dtype": "int64", "shape": [1, 512]},
+      {"name": "cache_position", "dtype": "int64", "shape": [1]},
+      {"name": "past_0_key", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_0_value", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_1_key", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_1_value", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_2_key", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_2_value", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_3_key", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_3_value", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_4_key", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_4_value", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_5_key", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]},
+      {"name": "past_5_value", "dtype": "float32", "shape": [1, 8, 512, 64], "value_range": [0, 1]}
+    ],
+    "output_tensors": [
+      {"name": "logits"},
+      {"name": "present_0_key"}, {"name": "present_0_value"},
+      {"name": "present_1_key"}, {"name": "present_1_value"},
+      {"name": "present_2_key"}, {"name": "present_2_value"},
+      {"name": "present_3_key"}, {"name": "present_3_value"},
+      {"name": "present_4_key"}, {"name": "present_4_value"},
+      {"name": "present_5_key"}, {"name": "present_5_value"}
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true,
+    "gelu_fusion": true,
+    "matmul_add_fusion": true,
+    "remove_isnan_in_attention_mask": true
+  },
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "text2text-generation",
+    "model_class": "MarianDecoderWrapper",
+    "model_type": "marian"
+  }
+}

--- a/examples/recipes/Helsinki-NLP_opus-mt-en-ru/cpu/cpu/translation_fp32_encoder_config.json
+++ b/examples/recipes/Helsinki-NLP_opus-mt-en-ru/cpu/cpu/translation_fp32_encoder_config.json
@@ -1,0 +1,31 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {"name": "input_ids", "dtype": "int32", "shape": [1, 512], "value_range": [0, 62518]},
+      {"name": "attention_mask", "dtype": "int32", "shape": [1, 512], "value_range": [0, 2]}
+    ],
+    "output_tensors": [{"name": "encoder_hidden_states"}]
+  },
+  "optim": {
+    "clamp_constant_values": true,
+    "gelu_fusion": true,
+    "matmul_add_fusion": true,
+    "remove_isnan_in_attention_mask": true
+  },
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "feature-extraction",
+    "model_class": "MarianEncoderWrapper",
+    "model_type": "marian"
+  }
+}


### PR DESCRIPTION
# Summary

This recipe-only contribution records reproducible CPU fp32 and genuine fp16 coverage for the composite Helsinki-NLP/opus-mt-en-ru Marian English-to-Russian translation model. It ships Effort L0 / Outcome L0 through four encoder/decoder recipes; all required CPU tuples have full coverage. The frozen Goal ceiling is L2, and the highest reached verdict is L2 PASS for encoder numerical parity with the decoder constraint explicit. Translation task-metric evaluation remains supplementary CLI-BLOCKED evidence and is not promoted above the L2 ceiling.

# Model metadata

Frozen model-breakdown report: `temp/skill-run-1116/planner/model-breakdown-opus-mt-en-ru.json`; SHA-256 `7e67dca09132704e1800045b6a73df65fb3166ae707f3180d15a4782752a0522`. Claims below retain the frozen evidence and confidence labels.

## What the model does

A text-to-text Marian encoder-decoder checkpoint that translates normalized, SentencePiece-tokenized English text into Russian token logits and generated Russian text.
- Evidence: Hugging Face model card for Helsinki-NLP/opus-mt-en-ru at revision bb09c99d180016eac6819df3dae68edb1690fdee: source language en, target language ru, dataset OPUS, model transformer-align, preprocessing normalization + SentencePiece; Pinned config: architectures=['MarianMTModel'], model_type='marian', is_encoder_decoder=true, vocab_size=62518
- Confidence: `verified`

## Primary user stories

- A user supplies English text to obtain a Russian translation for cross-language reading or communication.
  - Evidence: Hugging Face model card for Helsinki-NLP/opus-mt-en-ru at revision bb09c99d180016eac6819df3dae68edb1690fdee: source languages en; target languages ru; translation tag
  - Confidence: `verified`

## Supported tasks

- `translation` - support surfaces: `checkpoint`, `winml`
  - Evidence: Hugging Face pipeline_tag=translation and model-card translation metadata; winml inspect: pipeline_tasks=['translation']; composite encoder=feature-extraction, decoder=text2text-generation
  - Confidence: `verified`
- `text2text-generation` - support surfaces: `transformers`, `optimum-onnx`, `winml`
  - Evidence: Pinned architecture MarianMTModel and is_encoder_decoder=true; Optimum Marian registry includes text2text-generation; WinML replaces the same registry cell with MarianDecoderIOConfig; winml inspect resolves task=text2text-generation from tasks-manager
  - Confidence: `verified`
- `feature-extraction` - support surfaces: `optimum-onnx`, `winml`
  - Evidence: Optimum Marian registry includes feature-extraction; WinML replaces the same registry cell with MarianEncoderIOConfig; winml inspect composite maps encoder to feature-extraction
  - Confidence: `verified`

## Model architecture

MarianMTModel is a 76,672,000-parameter encoder-decoder Transformer with a shared 62,518x512 token embedding, learned/frozen sinusoidal positional embeddings, six 512-wide 8-head encoder layers, six 512-wide 8-head decoder layers, 2,048-wide swish feed-forward blocks, decoder cross-attention, a tied vocabulary projection, and runtime autoregressive KV-cache/generation orchestration. WinML exports it as separate encoder and decoder components.
- Component IDs: `model.shared_embedding`, `model.encoder`, `model.encoder.layers[]`, `model.decoder`, `model.decoder.layers[]`, `model.lm_head`, `runtime.generation_and_kv_cache`
- Evidence: Pinned config at bb09c99d180016eac6819df3dae68edb1690fdee: d_model=512, encoder_layers=6, decoder_layers=6, attention_heads=8, ffn_dim=2048, activation=swish, shared embeddings=true, tied embeddings=true; Transformers 4.57.6 concrete source: MarianMTModel -> MarianModel(shared, encoder, decoder) + lm_head; MarianEncoderLayer has self-attention/FFN; MarianDecoderLayer has self-attention/cross-attention/FFN; Config-only architecture probe: total_parameters=76672000; WinML inspect and fresh composite config: separate MarianEncoderWrapper and MarianDecoderWrapper components
- Confidence: `verified`

# Validation and support evidence

## 1. Baseline

- Pinned main commit: `76d48ad38f894c3fc5a5e760de67f0a096e438a6`
- WinML version: `0.2.0`
- Build: **PASS**. Composite recipe-free build emitted encoder and decoder; Build complete in 28.7s and 40.5s.
  - Command: `uv run winml build -m Helsinki-NLP/opus-mt-en-ru -o temp/skill-run-1116/baseline_opus_mt_en_ru --ep cpu --device cpu --no-analyze --no-optimize --no-quant --no-compile --rebuild`
  - Log/output evidence: `temp/skill-run-1116/planner/baseline_build_utf8.log`; encoder `Build complete in 28.7s`; decoder `Build complete in 40.5s`.
- Perf: **PASS**. CPU fp32 encoder avg/P50=74.91/74.51ms, throughput=13.35/s, RAM total delta=139.7MB; decoder avg/P50=22.98/22.90ms, throughput=43.51/s, RAM total delta=249.0MB.
  - Command: `uv run winml perf -m temp/skill-run-1116/baseline_opus_mt_en_ru/encoder_model.onnx --ep cpu --device cpu ; uv run winml perf -m temp/skill-run-1116/baseline_opus_mt_en_ru/decoder_model.onnx --ep cpu --device cpu`
  - Scope: These are component/first-token benchmarks, not full autoregressive English-to-Russian translation latency.
- Eval floor: **CLI-BLOCKED**, exit 2: `Task 'translation' is not supported by winml eval`.
  - Command: `uv run winml eval --schema --task translation`
  - Log: `temp/skill-run-1116/planner/baseline_eval_translation_utf8.log`
- Starting auto-config recipe: `temp/skill-run-1116/starting_config_opus_mt_en_ru_{encoder,decoder}`
  - Command: `uv run winml config -m Helsinki-NLP/opus-mt-en-ru --task translation -o temp/skill-run-1116/starting_config_opus_mt_en_ru`
  - Result: PR fp32 encoder/decoder are semantically identical; fp16 encoder/decoder differ only at quant.mode=fp16 configuration.
- Build/perf/eval floor: `L1`; baseline proves L0 build and L1 component perf, while translation eval is CLI-BLOCKED and retained only as supplementary evidence.
- Optimum probe: **VENDOR+OVERRIDE**. Vendor tasks: `feature-extraction`, `feature-extraction-with-past`, `text-generation`, `text-generation-with-past`, `text2text-generation`, `text2text-generation-with-past`; after WinML: `feature-extraction`, `feature-extraction-with-past`, `text-generation`, `text-generation-with-past`, `text2text-generation`, `text2text-generation-with-past`; added by WinML: none.

## 2. Goal

- Committed Effort: **L0**
- Committed Goal ceiling: **L2**
- Committed Outcome: **L0**
- Success definition: fresh CPU fp32/fp16 encoder+decoder L0 and L1 plus meaningful encoder PyTorch parity at L2; decoder parity constraint explicit
- Charter revision 1 froze L2 from the outset; no ceiling change or re-issued charter occurred.

## 3. Outcome

- Shipped tier: **L0**
- Highest reached Goal verdict: **L2 PASS (encoder numerical scope; decoder constraint explicit)**
- Coverage: **full**
- Deferred tuples: none
- Shipped recipe paths:
  - `examples/recipes/Helsinki-NLP_opus-mt-en-ru/cpu/cpu/translation_fp32_encoder_config.json`
  - `examples/recipes/Helsinki-NLP_opus-mt-en-ru/cpu/cpu/translation_fp32_decoder_config.json`
  - `examples/recipes/Helsinki-NLP_opus-mt-en-ru/cpu/cpu/translation_fp16_encoder_config.json`
  - `examples/recipes/Helsinki-NLP_opus-mt-en-ru/cpu/cpu/translation_fp16_decoder_config.json`
- Shipped code paths: none
- Appended model finding: `marian-008` in `model_knowledge/marian.json`.
- Appended methodology findings: none.
- No methodology friction observed.

## 4. Per-EP/device/precision results including concrete perf and eval data/exact blockers

### Goal ladder

| Tier | Verdict | Evidence |
|---|---|---|
| L0 | PASS | all two precision tuples and four component artifacts independently rebuilt and structurally validated |
| L1 | PASS | all four component artifacts ran on CPU with concrete latency/throughput/RAM |
| L2 | PASS | real tokenized named-input PyTorch parity for both encoder precisions; decoder parity is explicitly constrained and not claimed |

### L0 build and structure

| EP / device | Precision | Component | Verdict | Build | Structural evidence |
|---|---|---|---|---:|---|
| cpu / cpu | fp32 | encoder | PASS | 24.2 s | IR 8; opset 17; initializers `FLOAT`=102, `INT64`=32; external data adjacent=true; artifact `temp/skill-run-1116/tester/build/cpu_cpu_fp32_encoder/model.onnx` |
| cpu / cpu | fp32 | decoder | PASS | 40.8 s | IR 8; opset 17; initializers `FLOAT`=166, `INT64`=43; external data adjacent=true; artifact `temp/skill-run-1116/tester/build/cpu_cpu_fp32_decoder/model.onnx` |
| cpu / cpu | fp16 | encoder | PASS | 28.3 s | IR 8; opset 17; initializers `FLOAT16`=102, `INT64`=32; external data adjacent=true; artifact `temp/skill-run-1116/tester/build/cpu_cpu_fp16_encoder/model.onnx` |
| cpu / cpu | fp16 | decoder | PASS | 48.9 s | IR 8; opset 17; initializers `FLOAT16`=166, `INT64`=43; external data adjacent=true; artifact `temp/skill-run-1116/tester/build/cpu_cpu_fp16_decoder/model.onnx` |

### L1 perf

These are component measurements, not end-to-end autoregressive translation latency. VRAM delta was not reported by the frozen CPU evidence.

| EP / device | Precision | Component | Verdict | Mean | p50 | Throughput | RAM load | RAM inference | RAM total delta | VRAM delta | Scope |
|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---|
| cpu / cpu | fp32 | encoder | PASS | 74.79 ms | 74.71 ms | 13.37 samples/s | 79.3 MB | 60.2 MB | 139.6 MB | not reported | single encoder component |
| cpu / cpu | fp32 | decoder | PASS | 23.69 ms | 23.61 ms | 42.22 samples/s | 241.0 MB | 7.8 MB | 248.8 MB | not reported | single decoder step with synthetic named inputs; not full autoregressive translation |
| cpu / cpu | fp16 | encoder | PASS | 95.37 ms | 95.42 ms | 10.49 samples/s | 218.0 MB | 78.6 MB | 296.7 MB | not reported | single encoder component |
| cpu / cpu | fp16 | decoder | PASS | 28.14 ms | 27.9 ms | 35.53 samples/s | 245.1 MB | 14.2 MB | 259.4 MB | not reported | single decoder step with synthetic named inputs; not full autoregressive translation |

### L2 numerical parity

| EP / device | Precision | Component | Verdict | Reference/input | Cosine | Max abs | Mean abs | RMSE |
|---|---|---|---|---|---:|---:|---:|---:|
| cpu / cpu | fp32 | encoder | PASS | transformers MarianMTModel.get_encoder() @ bb09c99d180016eac6819df3dae68edb1690fdee; text `The quick brown fox jumps over the lazy dog.`; shape `[1, 512, 512]` | 0.9999999999994811 | 6.198883056640625e-06 | 2.7017895465331065e-07 | 3.5698963661937196e-07 |
| cpu / cpu | fp32 | decoder | CONSTRAINT-DOCUMENTED-NOT-CLAIMED | The ONNX decoder is a static-cache single-token wrapper with 12 full [1,8,512,64] past-KV inputs plus cache_position and 12 captured present-KV outputs. Meaningful PT parity requires constructing an identical WinMLStaticCache state and comparing the same decoder step or full generation loop; zero-KV ONNX versus stock PT prefill is not apples-to-apples. No decoder numerical parity is claimed. | not claimed | not claimed | not claimed | not claimed |
| cpu / cpu | fp16 | encoder | PASS | transformers MarianMTModel.get_encoder() @ bb09c99d180016eac6819df3dae68edb1690fdee; text `The quick brown fox jumps over the lazy dog.`; shape `[1, 512, 512]` | 0.9999989143104122 | 0.0061779022216796875 | 0.0003867089235389254 | 0.0005159687928534306 |
| cpu / cpu | fp16 | decoder | CONSTRAINT-DOCUMENTED-NOT-CLAIMED | The ONNX decoder is a static-cache single-token wrapper with 12 full [1,8,512,64] past-KV inputs plus cache_position and 12 captured present-KV outputs. Meaningful PT parity requires constructing an identical WinMLStaticCache state and comparing the same decoder step or full generation loop; zero-KV ONNX versus stock PT prefill is not apples-to-apples. No decoder numerical parity is claimed. | not claimed | not claimed | not claimed | not claimed |

### Supplementary eval evidence

Because the committed ceiling is L2, this eval evidence is supplementary and does not create or imply an L3 verdict.

| EP / device | Precision | Component | Verdict | Dataset / revision / subset | Metric | Exit | Exact blocker |
|---|---|---|---|---|---|---:|---|
| cpu / cpu | fp32 | encoder | CLI-BLOCKED | not produced because CLI-BLOCKED | not produced because CLI-BLOCKED | 1 | Evaluation failed: Task 'translation' is not supported. Supported tasks: compare-tensor, depth-estimation, feature-extraction, fill-mask, image-classification, image-feature-extraction, image-segmentation, image-to-text, keypoint-detection, mask-generation, next-sentence-prediction, object-detection, question-answering, sentence-similarity, sequence-classification, text-classification, token-classification, zero-shot-classification, zero-shot-image-classification. Feature gap: `temp/skill-run-1116/tester/feature-gap-translation-eval.json`. |
| cpu / cpu | fp32 | decoder | CLI-BLOCKED | not produced because CLI-BLOCKED | not produced because CLI-BLOCKED | 1 | Evaluation failed: Task 'translation' is not supported. Supported tasks: compare-tensor, depth-estimation, feature-extraction, fill-mask, image-classification, image-feature-extraction, image-segmentation, image-to-text, keypoint-detection, mask-generation, next-sentence-prediction, object-detection, question-answering, sentence-similarity, sequence-classification, text-classification, token-classification, zero-shot-classification, zero-shot-image-classification. Feature gap: `temp/skill-run-1116/tester/feature-gap-translation-eval.json`. |
- cpu/cpu/fp32 schema probe: exit 2; Task 'translation' is not supported by `winml eval`. Supported tasks: depth-estimation, feature-extraction, fill-mask, image-classification, image-feature-extraction, image-segmentation, image-to-text, keypoint-detection, mask-generation, next-sentence-prediction, object-detection, question-answering, sentence-similarity, sequence-classification, text-classification, token-classification, zero-shot-classification, zero-shot-image-classification.
| cpu / cpu | fp16 | encoder | CLI-BLOCKED | not produced because CLI-BLOCKED | not produced because CLI-BLOCKED | 1 | Evaluation failed: Task 'translation' is not supported. Supported tasks: compare-tensor, depth-estimation, feature-extraction, fill-mask, image-classification, image-feature-extraction, image-segmentation, image-to-text, keypoint-detection, mask-generation, next-sentence-prediction, object-detection, question-answering, sentence-similarity, sequence-classification, text-classification, token-classification, zero-shot-classification, zero-shot-image-classification. Feature gap: `temp/skill-run-1116/tester/feature-gap-translation-eval.json`. |
| cpu / cpu | fp16 | decoder | CLI-BLOCKED | not produced because CLI-BLOCKED | not produced because CLI-BLOCKED | 1 | Evaluation failed: Task 'translation' is not supported. Supported tasks: compare-tensor, depth-estimation, feature-extraction, fill-mask, image-classification, image-feature-extraction, image-segmentation, image-to-text, keypoint-detection, mask-generation, next-sentence-prediction, object-detection, question-answering, sentence-similarity, sequence-classification, text-classification, token-classification, zero-shot-classification, zero-shot-image-classification. Feature gap: `temp/skill-run-1116/tester/feature-gap-translation-eval.json`. |
- cpu/cpu/fp16 schema probe: exit 2; Task 'translation' is not supported by `winml eval`. Supported tasks: depth-estimation, feature-extraction, fill-mask, image-classification, image-feature-extraction, image-segmentation, image-to-text, keypoint-detection, mask-generation, next-sentence-prediction, object-detection, question-answering, sentence-similarity, sequence-classification, text-classification, token-classification, zero-shot-classification, zero-shot-image-classification.

## 5. Delta

- Baseline recipe: `temp/skill-run-1116/starting_config_opus_mt_en_ru_{encoder,decoder}`
- Overall comparison: **CHANGED**. Producer semantic JSON comparison in temp/skill-run-1116/producer/recipe_verification.json: fp32 encoder/decoder are identical to fresh configs; fp16 encoder/decoder differ only at /quant.
  - `translation_fp32_encoder_config.json`: **IDENTICAL**
  - `translation_fp32_decoder_config.json`: **IDENTICAL**
  - `translation_fp16_encoder_config.json`: **CHANGED_ONLY_AT_/quant**
  - `translation_fp16_decoder_config.json`: **CHANGED_ONLY_AT_/quant**
- `examples/recipes/Helsinki-NLP_opus-mt-en-ru/cpu/cpu/translation_fp16_encoder_config.json` at JSON pointer `/quant`: old value `null`; new value `{"mode":"fp16","samples":10,"calibration_method":"minmax","weight_type":"uint8","activation_type":"uint8","per_channel":false,"symmetric":false,"weight_symmetric":null,"activation_symmetric":null,"save_calibration":false,"distribution":"uniform","seed":null,"calibration_load_path":null,"calibration_save_path":null,"op_types_to_quantize":null,"nodes_to_exclude":null,"task":"feature-extraction","model_id":"Helsinki-NLP/opus-mt-en-ru","model_type":"marian","fp16_keep_io_types":true,"fp16_op_block_list":null}`. Reason: Charter-required explicit fp16 coverage; build also passed --precision fp16 and artifact inspection found genuine FLOAT16 initializers.
- `examples/recipes/Helsinki-NLP_opus-mt-en-ru/cpu/cpu/translation_fp16_decoder_config.json` at JSON pointer `/quant`: old value `null`; new value `{"mode":"fp16","samples":10,"calibration_method":"minmax","weight_type":"uint8","activation_type":"uint8","per_channel":false,"symmetric":false,"weight_symmetric":null,"activation_symmetric":null,"save_calibration":false,"distribution":"uniform","seed":null,"calibration_load_path":null,"calibration_save_path":null,"op_types_to_quantize":null,"nodes_to_exclude":null,"task":"text2text-generation","model_id":"Helsinki-NLP/opus-mt-en-ru","model_type":"marian","fp16_keep_io_types":true,"fp16_op_block_list":null}`. Reason: Charter-required explicit fp16 coverage; build also passed --precision fp16 and artifact inspection found genuine FLOAT16 initializers.
- Code paths/symbols and class-wide behavior changes: none; no code changes and no class-wide behavior changes.
- Reducibility consistent with charter: true.
- Recipe-free acceptance was required and is **PASS**: Frozen planner baseline at current origin/main 76d48ad38f894c3fc5a5e760de67f0a096e438a6; temp/skill-run-1116/planner/baseline_build_utf8.log.
  - Command: `uv run winml build -m Helsinki-NLP/opus-mt-en-ru -o temp/skill-run-1116/baseline_opus_mt_en_ru --ep cpu --device cpu --no-analyze --no-optimize --no-quant --no-compile --rebuild`
- The production recipe README remains untouched.

## 6. Analyze results containing both full component-level and op-level analysis

Overall status: **ANALYZE-PARTIAL-SUCCESS**. All four commands exited 1 because support is partial/unknown, not setup failure. Each emitted parseable JSON with metadata and six complete requested EP result rows. No exit 2 setup failure occurred. Rules environment: `WINMLCLI_RULES_DIR=C:\repo\ModelKitArtifacts\rules`; forbidden WINML_RULES_PATH used=false. Static analyze is rule-based graph analysis and is not runtime execution evidence.

### Component-level analysis

#### fp32 encoder

- Status: **ANALYZE-PARTIAL-SUCCESS**; exit code 1; artifact `temp/skill-run-1116/tester/analyze_cpu_cpu_fp32_encoder.json`; SHA-256 `8e046ffc826fe555e1633e01fa7941e18383121b1a19972d299064b154d16a23`.
- Command: `$env:WINMLCLI_RULES_DIR='C:\repo\ModelKitArtifacts\rules'; uv run winml analyze --model temp/skill-run-1116/tester/build/cpu_cpu_fp32_encoder/model.onnx --ep all --output temp/skill-run-1116/tester/analyze_cpu_cpu_fp32_encoder.json`
- Exact error/status: exit 1 denotes partial operator coverage; emitted JSON is complete for every requested EP and is parsed fail-closed
- Mapping totals: mapped=150; partial=54; unmapped=0.

| Semantic component | ONNX regions or nodes | Nodes | Operator counts | Mapping basis | Confidence | Per-EP partial/unsupported/unknown issues |
|---|---|---:|---|---|---|---|
| `model.encoder` | `/encoder/*`, `/encoder/Reshape`, `/encoder/Mul`, `/encoder/Add` | 10 | `Add`=1, `Cast`=2, `Expand`=1, `Mul`=1, `Reshape`=1, `Sub`=1, `Unsqueeze`=2, `Where`=1 | hierarchy-tagged ONNX node scope | mapped | CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |
| `model.encoder.layers[0]` | `/encoder/layers.N/*`, `/encoder/layers.0/self_attn/k_proj/MatMul/MatMulAddFusion`, `/encoder/layers.0/self_attn/Transpose_2`, `/encoder/layers.0/self_attn/Mul_1` | 24 | `Add`=3, `Gemm`=6, `LayerNormalization`=2, `MatMul`=2, `Mul`=3, `Reshape`=1, `Sigmoid`=1, `Slice`=1, `Softmax`=1, `Transpose`=4 | hierarchy-tagged ONNX node scope | mapped | CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |
| `model.encoder.layers[1]` | `/encoder/layers.N/*`, `/encoder/layers.1/self_attn/k_proj/MatMul/MatMulAddFusion`, `/encoder/layers.1/self_attn/Transpose_2`, `/encoder/layers.1/self_attn/Mul_1` | 23 | `Add`=3, `Gemm`=6, `LayerNormalization`=2, `MatMul`=2, `Mul`=3, `Reshape`=1, `Sigmoid`=1, `Softmax`=1, `Transpose`=4 | hierarchy-tagged ONNX node scope | mapped | CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |
| `model.encoder.layers[2]` | `/encoder/layers.N/*`, `/encoder/layers.2/self_attn/k_proj/MatMul/MatMulAddFusion`, `/encoder/layers.2/self_attn/Transpose_2`, `/encoder/layers.2/self_attn/Mul_1` | 23 | `Add`=3, `Gemm`=6, `LayerNormalization`=2, `MatMul`=2, `Mul`=3, `Reshape`=1, `Sigmoid`=1, `Softmax`=1, `Transpose`=4 | hierarchy-tagged ONNX node scope | mapped | CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |
| `model.encoder.layers[3]` | `/encoder/layers.N/*`, `/encoder/layers.3/self_attn/k_proj/MatMul/MatMulAddFusion`, `/encoder/layers.3/self_attn/Transpose_2`, `/encoder/layers.3/self_attn/Mul_1` | 23 | `Add`=3, `Gemm`=6, `LayerNormalization`=2, `MatMul`=2, `Mul`=3, `Reshape`=1, `Sigmoid`=1, `Softmax`=1, `Transpose`=4 | hierarchy-tagged ONNX node scope | mapped | CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |
| `model.encoder.layers[4]` | `/encoder/layers.N/*`, `/encoder/layers.4/self_attn/k_proj/MatMul/MatMulAddFusion`, `/encoder/layers.4/self_attn/Transpose_2`, `/encoder/layers.4/self_attn/Mul_1` | 23 | `Add`=3, `Gemm`=6, `LayerNormalization`=2, `MatMul`=2, `Mul`=3, `Reshape`=1, `Sigmoid`=1, `Softmax`=1, `Transpose`=4 | hierarchy-tagged ONNX node scope | mapped | CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |
| `model.encoder.layers[5]` | `/encoder/layers.N/*`, `/encoder/layers.5/self_attn/k_proj/MatMul/MatMulAddFusion`, `/encoder/layers.5/self_attn/Transpose_2`, `/encoder/layers.5/self_attn/Mul_1` | 23 | `Add`=3, `Gemm`=6, `LayerNormalization`=2, `MatMul`=2, `Mul`=3, `Reshape`=1, `Sigmoid`=1, `Softmax`=1, `Transpose`=4 | hierarchy-tagged ONNX node scope | mapped | CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |
| `model.encoder.optimizer_inserted` | `/encoder/*`, `gemm_input_reshape_token_8`, `gemm_output_reshape_token_11_new_reshape`, `gemm_output_reshape_token_5_new_reshape` | 54 | `Reshape`=54 | exported graph ownership only; optimizer-generated node names lack module scope | partial | CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |
| `model.shared_embedding` | `/encoder/*`, `/encoder/embed_tokens/Gather` | 1 | `Gather`=1 | hierarchy-tagged ONNX node scope | mapped | CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |

Mapping gaps:
- Optimizer-inserted Reshape nodes without hierarchy scope map only to the exported encoder/decoder component.
- Runtime generation/KV orchestration is outside each ONNX graph.
- Shared embedding weights are duplicated into separate exported artifacts; mapping reflects graph execution, not storage ownership.

#### fp32 decoder

- Status: **ANALYZE-PARTIAL-SUCCESS**; exit code 1; artifact `temp/skill-run-1116/tester/analyze_cpu_cpu_fp32_decoder.json`; SHA-256 `62846ffbf0ae2a68033c932d79bff956227c32c9f067952e95a42c90816bf055`.
- Command: `$env:WINMLCLI_RULES_DIR='C:\repo\ModelKitArtifacts\rules'; uv run winml analyze --model temp/skill-run-1116/tester/build/cpu_cpu_fp32_decoder/model.onnx --ep all --output temp/skill-run-1116/tester/analyze_cpu_cpu_fp32_decoder.json`
- Exact error/status: exit 1 denotes partial operator coverage; emitted JSON is complete for every requested EP and is parsed fail-closed
- Mapping totals: mapped=278; partial=114; unmapped=0.

| Semantic component | ONNX regions or nodes | Nodes | Operator counts | Mapping basis | Confidence | Per-EP partial/unsupported/unknown issues |
|---|---|---:|---|---|---|---|
| `model.decoder.layers[0]` | `/decoder/layers.N/*`, `/model/model/decoder/layers.0/encoder_attn/v_proj/MatMul/MatMulAddFusion`, `/model/model/decoder/layers.0/encoder_attn/Transpose_1`, `/model/model/decoder/layers.0/encoder_attn/Slice` | 50 | `Add`=5, `Concat`=1, `Expand`=1, `Gemm`=10, `LayerNormalization`=3, `MatMul`=4, `Mul`=5, `Reshape`=4, `ScatterND`=2, `Sigmoid`=1, `Slice`=2, `Softmax`=2, `Transpose`=9, `Unsqueeze`=1 | hierarchy-tagged ONNX node scope | mapped | NvTensorRTRTXExecutionProvider: `unknown`; CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; QNNExecutionProvider: `partial`, `unknown`; OpenVINOExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |
| `model.decoder.layers[1]` | `/decoder/layers.N/*`, `/model/model/decoder/layers.1/encoder_attn/v_proj/MatMul/MatMulAddFusion`, `/model/model/decoder/layers.1/encoder_attn/Transpose_1`, `/model/model/decoder/layers.1/self_attn/v_proj/MatMul/MatMulAddFusion` | 45 | `Add`=5, `Gemm`=10, `LayerNormalization`=3, `MatMul`=4, `Mul`=5, `Reshape`=4, `ScatterND`=2, `Sigmoid`=1, `Softmax`=2, `Transpose`=9 | hierarchy-tagged ONNX node scope | mapped | NvTensorRTRTXExecutionProvider: `unknown`; CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; QNNExecutionProvider: `unknown`; OpenVINOExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |
| `model.decoder.layers[2]` | `/decoder/layers.N/*`, `/model/model/decoder/layers.2/encoder_attn/v_proj/MatMul/MatMulAddFusion`, `/model/model/decoder/layers.2/encoder_attn/Transpose_1`, `/model/model/decoder/layers.2/self_attn/v_proj/MatMul/MatMulAddFusion` | 45 | `Add`=5, `Gemm`=10, `LayerNormalization`=3, `MatMul`=4, `Mul`=5, `Reshape`=4, `ScatterND`=2, `Sigmoid`=1, `Softmax`=2, `Transpose`=9 | hierarchy-tagged ONNX node scope | mapped | NvTensorRTRTXExecutionProvider: `unknown`; CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; QNNExecutionProvider: `unknown`; OpenVINOExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |
| `model.decoder.layers[3]` | `/decoder/layers.N/*`, `/model/model/decoder/layers.3/encoder_attn/v_proj/MatMul/MatMulAddFusion`, `/model/model/decoder/layers.3/encoder_attn/Transpose_1`, `/model/model/decoder/layers.3/self_attn/v_proj/MatMul/MatMulAddFusion` | 45 | `Add`=5, `Gemm`=10, `LayerNormalization`=3, `MatMul`=4, `Mul`=5, `Reshape`=4, `ScatterND`=2, `Sigmoid`=1, `Softmax`=2, `Transpose`=9 | hierarchy-tagged ONNX node scope | mapped | NvTensorRTRTXExecutionProvider: `unknown`; CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; QNNExecutionProvider: `unknown`; OpenVINOExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |
| `model.decoder.layers[4]` | `/decoder/layers.N/*`, `/model/model/decoder/layers.4/encoder_attn/v_proj/MatMul/MatMulAddFusion`, `/model/model/decoder/layers.4/encoder_attn/Transpose_1`, `/model/model/decoder/layers.4/self_attn/v_proj/MatMul/MatMulAddFusion` | 45 | `Add`=5, `Gemm`=10, `LayerNormalization`=3, `MatMul`=4, `Mul`=5, `Reshape`=4, `ScatterND`=2, `Sigmoid`=1, `Softmax`=2, `Transpose`=9 | hierarchy-tagged ONNX node scope | mapped | NvTensorRTRTXExecutionProvider: `unknown`; CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; QNNExecutionProvider: `unknown`; OpenVINOExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |
| `model.decoder.layers[5]` | `/decoder/layers.N/*`, `/model/model/decoder/layers.5/encoder_attn/v_proj/MatMul/MatMulAddFusion`, `/model/model/decoder/layers.5/encoder_attn/Transpose_1`, `/model/model/decoder/layers.5/self_attn/Reshape_3` | 47 | `Add`=5, `Expand`=1, `Gemm`=10, `LayerNormalization`=3, `MatMul`=4, `Mul`=5, `Reshape`=5, `ScatterND`=2, `Sigmoid`=1, `Softmax`=2, `Transpose`=9 | hierarchy-tagged ONNX node scope | mapped | NvTensorRTRTXExecutionProvider: `unknown`; CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; QNNExecutionProvider: `partial`, `unknown`; OpenVINOExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |
| `model.decoder.optimizer_inserted` | `/decoder/*`, `gemm_input_reshape_token_212`, `gemm_output_reshape_token_215_new_reshape`, `gemm_output_reshape_token_185_new_reshape` | 114 | `Add`=3, `Cast`=4, `Equal`=1, `Expand`=3, `Gather`=2, `Greater`=1, `Mul`=2, `Reshape`=87, `ScatterND`=1, `Slice`=1, `Sub`=1, `Unsqueeze`=6, `Where`=2 | exported graph ownership only; optimizer-generated node names lack module scope | partial | NvTensorRTRTXExecutionProvider: `unknown`; CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; QNNExecutionProvider: `partial`, `unknown`; OpenVINOExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |
| `model.lm_head` | `/decoder/*`, `/model/lm_head/MatMul` | 1 | `MatMul`=1 | hierarchy-tagged ONNX node scope | mapped | CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |

Mapping gaps:
- Optimizer-inserted Reshape nodes without hierarchy scope map only to the exported encoder/decoder component.
- Runtime generation/KV orchestration is outside each ONNX graph.
- Shared embedding weights are duplicated into separate exported artifacts; mapping reflects graph execution, not storage ownership.

#### fp16 encoder

- Status: **ANALYZE-PARTIAL-SUCCESS**; exit code 1; artifact `temp/skill-run-1116/tester/analyze_cpu_cpu_fp16_encoder.json`; SHA-256 `a4801b73f962b7fc75bc6b236955b2d1add0cbd998d0dc814be1af64da6a7e07`.
- Command: `$env:WINMLCLI_RULES_DIR='C:\repo\ModelKitArtifacts\rules'; uv run winml analyze --model temp/skill-run-1116/tester/build/cpu_cpu_fp16_encoder/model.onnx --ep all --output temp/skill-run-1116/tester/analyze_cpu_cpu_fp16_encoder.json`
- Exact error/status: exit 1 denotes partial operator coverage; emitted JSON is complete for every requested EP and is parsed fail-closed
- Mapping totals: mapped=150; partial=55; unmapped=0.

| Semantic component | ONNX regions or nodes | Nodes | Operator counts | Mapping basis | Confidence | Per-EP partial/unsupported/unknown issues |
|---|---|---:|---|---|---|---|
| `model.encoder` | `/encoder/*`, `/encoder/Reshape`, `/encoder/Mul`, `/encoder/Add` | 10 | `Add`=1, `Cast`=2, `Expand`=1, `Mul`=1, `Reshape`=1, `Sub`=1, `Unsqueeze`=2, `Where`=1 | hierarchy-tagged ONNX node scope | mapped | CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |
| `model.encoder.layers[0]` | `/encoder/layers.N/*`, `/encoder/layers.0/self_attn/k_proj/MatMul/MatMulAddFusion`, `/encoder/layers.0/self_attn/Transpose_2`, `/encoder/layers.0/self_attn/Mul_1` | 24 | `Add`=3, `Gemm`=6, `LayerNormalization`=2, `MatMul`=2, `Mul`=3, `Reshape`=1, `Sigmoid`=1, `Slice`=1, `Softmax`=1, `Transpose`=4 | hierarchy-tagged ONNX node scope | mapped | CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |
| `model.encoder.layers[1]` | `/encoder/layers.N/*`, `/encoder/layers.1/self_attn/k_proj/MatMul/MatMulAddFusion`, `/encoder/layers.1/self_attn/Transpose_2`, `/encoder/layers.1/self_attn/Mul_1` | 23 | `Add`=3, `Gemm`=6, `LayerNormalization`=2, `MatMul`=2, `Mul`=3, `Reshape`=1, `Sigmoid`=1, `Softmax`=1, `Transpose`=4 | hierarchy-tagged ONNX node scope | mapped | CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |
| `model.encoder.layers[2]` | `/encoder/layers.N/*`, `/encoder/layers.2/self_attn/k_proj/MatMul/MatMulAddFusion`, `/encoder/layers.2/self_attn/Transpose_2`, `/encoder/layers.2/self_attn/Mul_1` | 23 | `Add`=3, `Gemm`=6, `LayerNormalization`=2, `MatMul`=2, `Mul`=3, `Reshape`=1, `Sigmoid`=1, `Softmax`=1, `Transpose`=4 | hierarchy-tagged ONNX node scope | mapped | CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |
| `model.encoder.layers[3]` | `/encoder/layers.N/*`, `/encoder/layers.3/self_attn/k_proj/MatMul/MatMulAddFusion`, `/encoder/layers.3/self_attn/Transpose_2`, `/encoder/layers.3/self_attn/Mul_1` | 23 | `Add`=3, `Gemm`=6, `LayerNormalization`=2, `MatMul`=2, `Mul`=3, `Reshape`=1, `Sigmoid`=1, `Softmax`=1, `Transpose`=4 | hierarchy-tagged ONNX node scope | mapped | CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |
| `model.encoder.layers[4]` | `/encoder/layers.N/*`, `/encoder/layers.4/self_attn/k_proj/MatMul/MatMulAddFusion`, `/encoder/layers.4/self_attn/Transpose_2`, `/encoder/layers.4/self_attn/Mul_1` | 23 | `Add`=3, `Gemm`=6, `LayerNormalization`=2, `MatMul`=2, `Mul`=3, `Reshape`=1, `Sigmoid`=1, `Softmax`=1, `Transpose`=4 | hierarchy-tagged ONNX node scope | mapped | CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |
| `model.encoder.layers[5]` | `/encoder/layers.N/*`, `/encoder/layers.5/self_attn/k_proj/MatMul/MatMulAddFusion`, `/encoder/layers.5/self_attn/Transpose_2`, `/encoder/layers.5/self_attn/Mul_1` | 23 | `Add`=3, `Gemm`=6, `LayerNormalization`=2, `MatMul`=2, `Mul`=3, `Reshape`=1, `Sigmoid`=1, `Softmax`=1, `Transpose`=4 | hierarchy-tagged ONNX node scope | mapped | CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |
| `model.encoder.optimizer_inserted` | `/encoder/*`, `gemm_input_reshape_token_8`, `gemm_output_reshape_token_11_new_reshape`, `gemm_output_reshape_token_5_new_reshape` | 55 | `Cast`=1, `Reshape`=54 | exported graph ownership only; optimizer-generated node names lack module scope | partial | CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |
| `model.shared_embedding` | `/encoder/*`, `/encoder/embed_tokens/Gather` | 1 | `Gather`=1 | hierarchy-tagged ONNX node scope | mapped | CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |

Mapping gaps:
- Optimizer-inserted Reshape nodes without hierarchy scope map only to the exported encoder/decoder component.
- Runtime generation/KV orchestration is outside each ONNX graph.
- Shared embedding weights are duplicated into separate exported artifacts; mapping reflects graph execution, not storage ownership.

#### fp16 decoder

- Status: **ANALYZE-PARTIAL-SUCCESS**; exit code 1; artifact `temp/skill-run-1116/tester/analyze_cpu_cpu_fp16_decoder.json`; SHA-256 `7e4c2cc7088bc463f01b9f3dd88570d4cfee9dfb996f27b39c3b6da8625a3398`.
- Command: `$env:WINMLCLI_RULES_DIR='C:\repo\ModelKitArtifacts\rules'; uv run winml analyze --model temp/skill-run-1116/tester/build/cpu_cpu_fp16_decoder/model.onnx --ep all --output temp/skill-run-1116/tester/analyze_cpu_cpu_fp16_decoder.json`
- Exact error/status: exit 1 denotes partial operator coverage; emitted JSON is complete for every requested EP and is parsed fail-closed
- Mapping totals: mapped=278; partial=140; unmapped=0.

| Semantic component | ONNX regions or nodes | Nodes | Operator counts | Mapping basis | Confidence | Per-EP partial/unsupported/unknown issues |
|---|---|---:|---|---|---|---|
| `model.decoder.layers[0]` | `/decoder/layers.N/*`, `/model/model/decoder/layers.0/encoder_attn/Slice`, `/model/model/decoder/layers.0/self_attn/v_proj/MatMul/MatMulAddFusion`, `/model/model/decoder/layers.0/self_attn/Transpose_2` | 50 | `Add`=5, `Concat`=1, `Expand`=1, `Gemm`=10, `LayerNormalization`=3, `MatMul`=4, `Mul`=5, `Reshape`=4, `ScatterND`=2, `Sigmoid`=1, `Slice`=2, `Softmax`=2, `Transpose`=9, `Unsqueeze`=1 | hierarchy-tagged ONNX node scope | mapped | NvTensorRTRTXExecutionProvider: `unknown`; CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; QNNExecutionProvider: `partial`, `unknown`; OpenVINOExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |
| `model.decoder.layers[1]` | `/decoder/layers.N/*`, `/model/model/decoder/layers.1/encoder_attn/v_proj/MatMul/MatMulAddFusion`, `/model/model/decoder/layers.1/encoder_attn/Transpose_1`, `/model/model/decoder/layers.1/self_attn/v_proj/MatMul/MatMulAddFusion` | 45 | `Add`=5, `Gemm`=10, `LayerNormalization`=3, `MatMul`=4, `Mul`=5, `Reshape`=4, `ScatterND`=2, `Sigmoid`=1, `Softmax`=2, `Transpose`=9 | hierarchy-tagged ONNX node scope | mapped | NvTensorRTRTXExecutionProvider: `unknown`; CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; QNNExecutionProvider: `unknown`; OpenVINOExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |
| `model.decoder.layers[2]` | `/decoder/layers.N/*`, `/model/model/decoder/layers.2/encoder_attn/v_proj/MatMul/MatMulAddFusion`, `/model/model/decoder/layers.2/encoder_attn/Transpose_1`, `/model/model/decoder/layers.2/self_attn/v_proj/MatMul/MatMulAddFusion` | 45 | `Add`=5, `Gemm`=10, `LayerNormalization`=3, `MatMul`=4, `Mul`=5, `Reshape`=4, `ScatterND`=2, `Sigmoid`=1, `Softmax`=2, `Transpose`=9 | hierarchy-tagged ONNX node scope | mapped | NvTensorRTRTXExecutionProvider: `unknown`; CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; QNNExecutionProvider: `unknown`; OpenVINOExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |
| `model.decoder.layers[3]` | `/decoder/layers.N/*`, `/model/model/decoder/layers.3/encoder_attn/v_proj/MatMul/MatMulAddFusion`, `/model/model/decoder/layers.3/encoder_attn/Transpose_1`, `/model/model/decoder/layers.3/self_attn/v_proj/MatMul/MatMulAddFusion` | 45 | `Add`=5, `Gemm`=10, `LayerNormalization`=3, `MatMul`=4, `Mul`=5, `Reshape`=4, `ScatterND`=2, `Sigmoid`=1, `Softmax`=2, `Transpose`=9 | hierarchy-tagged ONNX node scope | mapped | NvTensorRTRTXExecutionProvider: `unknown`; CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; QNNExecutionProvider: `unknown`; OpenVINOExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |
| `model.decoder.layers[4]` | `/decoder/layers.N/*`, `/model/model/decoder/layers.4/encoder_attn/v_proj/MatMul/MatMulAddFusion`, `/model/model/decoder/layers.4/encoder_attn/Transpose_1`, `/model/model/decoder/layers.4/self_attn/v_proj/MatMul/MatMulAddFusion` | 45 | `Add`=5, `Gemm`=10, `LayerNormalization`=3, `MatMul`=4, `Mul`=5, `Reshape`=4, `ScatterND`=2, `Sigmoid`=1, `Softmax`=2, `Transpose`=9 | hierarchy-tagged ONNX node scope | mapped | NvTensorRTRTXExecutionProvider: `unknown`; CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; QNNExecutionProvider: `unknown`; OpenVINOExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |
| `model.decoder.layers[5]` | `/decoder/layers.N/*`, `/model/model/decoder/layers.5/self_attn/Reshape_3`, `/model/model/decoder/layers.5/self_attn/Expand_2`, `/model/model/decoder/layers.5/encoder_attn/v_proj/MatMul/MatMulAddFusion` | 47 | `Add`=5, `Expand`=1, `Gemm`=10, `LayerNormalization`=3, `MatMul`=4, `Mul`=5, `Reshape`=5, `ScatterND`=2, `Sigmoid`=1, `Softmax`=2, `Transpose`=9 | hierarchy-tagged ONNX node scope | mapped | NvTensorRTRTXExecutionProvider: `unknown`; CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; QNNExecutionProvider: `partial`, `unknown`; OpenVINOExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |
| `model.decoder.optimizer_inserted` | `/decoder/*`, `/model/model/decoder/Unsqueeze_8`, `/model/model/decoder/Unsqueeze_9`, `/model/model/decoder/Expand_6` | 140 | `Add`=3, `Cast`=30, `Equal`=1, `Expand`=3, `Gather`=2, `Greater`=1, `Mul`=2, `Reshape`=87, `ScatterND`=1, `Slice`=1, `Sub`=1, `Unsqueeze`=6, `Where`=2 | exported graph ownership only; optimizer-generated node names lack module scope | partial | NvTensorRTRTXExecutionProvider: `unknown`; CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; QNNExecutionProvider: `partial`, `unsupported`, `unknown`; OpenVINOExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |
| `model.lm_head` | `/decoder/*`, `/model/lm_head/MatMul` | 1 | `MatMul`=1 | hierarchy-tagged ONNX node scope | mapped | CUDAExecutionProvider: `unknown`; MIGraphXExecutionProvider: `unknown`; DmlExecutionProvider: `unknown` |

Mapping gaps:
- Optimizer-inserted Reshape nodes without hierarchy scope map only to the exported encoder/decoder component.
- Runtime generation/KV orchestration is outside each ONNX graph.
- Shared embedding weights are duplicated into separate exported artifacts; mapping reflects graph execution, not storage ownership.

### Op-level analysis

#### fp32 encoder

- Total operators: **204**; unique operator types: **16**.
- Operator counts: `Reshape`=61, `Gather`=1, `Mul`=19, `Add`=19, `Gemm`=36, `Transpose`=24, `MatMul`=12, `Unsqueeze`=2, `Expand`=1, `Cast`=2, `Sub`=1, `Where`=1, `Slice`=1, `Softmax`=6, `LayerNormalization`=12, `Sigmoid`=6.

| EP | Runtime support | Supported | Partial | Unsupported | Unknown |
|---|---|---|---|---|---|
| NvTensorRTRTXExecutionProvider | true | `Reshape`, `Gather`, `Mul`, `Add`, `Gemm`, `Transpose`, `MatMul`, `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Softmax`, `LayerNormalization`, `Sigmoid` | none | none | none |
| CUDAExecutionProvider | false | none | none | none | `Reshape`, `Gather`, `Mul`, `Add`, `Gemm`, `Transpose`, `MatMul`, `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Softmax`, `LayerNormalization`, `Sigmoid` |
| MIGraphXExecutionProvider | false | none | none | none | `Reshape`, `Gather`, `Mul`, `Add`, `Gemm`, `Transpose`, `MatMul`, `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Softmax`, `LayerNormalization`, `Sigmoid` |
| QNNExecutionProvider | true | `Reshape`, `Gather`, `Mul`, `Add`, `Gemm`, `Transpose`, `MatMul`, `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Softmax`, `LayerNormalization`, `Sigmoid` | none | none | none |
| OpenVINOExecutionProvider | true | `Reshape`, `Gather`, `Mul`, `Add`, `Gemm`, `Transpose`, `MatMul`, `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Softmax`, `LayerNormalization`, `Sigmoid` | none | none | none |
| DmlExecutionProvider | false | none | none | none | `Reshape`, `Gather`, `Mul`, `Add`, `Gemm`, `Transpose`, `MatMul`, `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Softmax`, `LayerNormalization`, `Sigmoid` |

#### fp32 decoder

- Total operators: **392**; unique operator types: **20**.
- Operator counts: `Reshape`=112, `Gemm`=60, `Transpose`=54, `Unsqueeze`=7, `Expand`=5, `Cast`=4, `Sub`=1, `Where`=2, `Slice`=3, `Gather`=2, `Mul`=32, `Add`=33, `Concat`=1, `ScatterND`=13, `Greater`=1, `Equal`=1, `MatMul`=25, `Softmax`=12, `LayerNormalization`=18, `Sigmoid`=6.

| EP | Runtime support | Supported | Partial | Unsupported | Unknown |
|---|---|---|---|---|---|
| NvTensorRTRTXExecutionProvider | false | `Reshape`, `Gemm`, `Transpose`, `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Gather`, `Mul`, `Add`, `Concat`, `Greater`, `Equal`, `ScatterND`, `MatMul`, `Softmax`, `LayerNormalization`, `Sigmoid` | none | none | `ScatterND` |
| CUDAExecutionProvider | false | none | none | none | `Reshape`, `Gemm`, `Transpose`, `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Gather`, `Mul`, `Add`, `Concat`, `ScatterND`, `Greater`, `Equal`, `MatMul`, `Softmax`, `LayerNormalization`, `Sigmoid` |
| MIGraphXExecutionProvider | false | none | none | none | `Reshape`, `Gemm`, `Transpose`, `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Gather`, `Mul`, `Add`, `Concat`, `ScatterND`, `Greater`, `Equal`, `MatMul`, `Softmax`, `LayerNormalization`, `Sigmoid` |
| QNNExecutionProvider | false | `Reshape`, `Gemm`, `Transpose`, `Unsqueeze`, `Sub`, `Cast`, `Where`, `Slice`, `Gather`, `Mul`, `Add`, `Expand`, `Greater`, `Equal`, `ScatterND`, `MatMul`, `Softmax`, `LayerNormalization`, `Sigmoid` | `Expand`, `Cast`, `Concat` | none | `ScatterND` |
| OpenVINOExecutionProvider | false | `Reshape`, `Gemm`, `Transpose`, `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Gather`, `Mul`, `Add`, `Concat`, `Greater`, `Equal`, `ScatterND`, `MatMul`, `Softmax`, `LayerNormalization`, `Sigmoid` | none | none | `ScatterND` |
| DmlExecutionProvider | false | none | none | none | `Reshape`, `Gemm`, `Transpose`, `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Gather`, `Mul`, `Add`, `Concat`, `ScatterND`, `Greater`, `Equal`, `MatMul`, `Softmax`, `LayerNormalization`, `Sigmoid` |

#### fp16 encoder

- Total operators: **205**; unique operator types: **16**.
- Operator counts: `Reshape`=61, `Gather`=1, `Mul`=19, `Add`=19, `Gemm`=36, `Transpose`=24, `MatMul`=12, `Unsqueeze`=2, `Expand`=1, `Cast`=3, `Sub`=1, `Where`=1, `Slice`=1, `Softmax`=6, `LayerNormalization`=12, `Sigmoid`=6.

| EP | Runtime support | Supported | Partial | Unsupported | Unknown |
|---|---|---|---|---|---|
| NvTensorRTRTXExecutionProvider | true | `Reshape`, `Gather`, `Mul`, `Add`, `Gemm`, `Transpose`, `MatMul`, `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Softmax`, `LayerNormalization`, `Sigmoid` | none | none | none |
| CUDAExecutionProvider | false | none | none | none | `Reshape`, `Gather`, `Mul`, `Add`, `Gemm`, `Transpose`, `MatMul`, `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Softmax`, `LayerNormalization`, `Sigmoid` |
| MIGraphXExecutionProvider | false | none | none | none | `Reshape`, `Gather`, `Mul`, `Add`, `Gemm`, `Transpose`, `MatMul`, `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Softmax`, `LayerNormalization`, `Sigmoid` |
| QNNExecutionProvider | true | `Reshape`, `Gather`, `Mul`, `Add`, `Gemm`, `Transpose`, `MatMul`, `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Softmax`, `LayerNormalization`, `Sigmoid` | none | none | none |
| OpenVINOExecutionProvider | true | `Reshape`, `Gather`, `Mul`, `Add`, `Gemm`, `Transpose`, `MatMul`, `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Softmax`, `LayerNormalization`, `Sigmoid` | none | none | none |
| DmlExecutionProvider | false | none | none | none | `Reshape`, `Gather`, `Mul`, `Add`, `Gemm`, `Transpose`, `MatMul`, `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Softmax`, `LayerNormalization`, `Sigmoid` |

#### fp16 decoder

- Total operators: **418**; unique operator types: **20**.
- Operator counts: `Unsqueeze`=7, `Expand`=5, `Cast`=30, `Sub`=1, `Where`=2, `Slice`=3, `Gather`=2, `Mul`=32, `Add`=33, `Reshape`=112, `Gemm`=60, `Transpose`=54, `Concat`=1, `Greater`=1, `Equal`=1, `ScatterND`=13, `MatMul`=25, `Softmax`=12, `LayerNormalization`=18, `Sigmoid`=6.

| EP | Runtime support | Supported | Partial | Unsupported | Unknown |
|---|---|---|---|---|---|
| NvTensorRTRTXExecutionProvider | false | `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Gather`, `Mul`, `Add`, `Reshape`, `Gemm`, `Transpose`, `Concat`, `Greater`, `Equal`, `ScatterND`, `MatMul`, `Softmax`, `LayerNormalization`, `Sigmoid` | none | none | `ScatterND` |
| CUDAExecutionProvider | false | none | none | none | `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Gather`, `Mul`, `Add`, `Reshape`, `Gemm`, `Transpose`, `Concat`, `Greater`, `Equal`, `ScatterND`, `MatMul`, `Softmax`, `LayerNormalization`, `Sigmoid` |
| MIGraphXExecutionProvider | false | none | none | none | `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Gather`, `Mul`, `Add`, `Reshape`, `Gemm`, `Transpose`, `Concat`, `Greater`, `Equal`, `ScatterND`, `MatMul`, `Softmax`, `LayerNormalization`, `Sigmoid` |
| QNNExecutionProvider | false | `Unsqueeze`, `Sub`, `Cast`, `Where`, `Slice`, `Gather`, `Mul`, `Add`, `Reshape`, `Gemm`, `Transpose`, `Expand`, `Greater`, `Equal`, `ScatterND`, `MatMul`, `Softmax`, `LayerNormalization`, `Sigmoid` | `Expand`, `Concat` | `Cast` | `ScatterND` |
| OpenVINOExecutionProvider | false | `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Gather`, `Mul`, `Add`, `Reshape`, `Gemm`, `Transpose`, `Concat`, `Greater`, `Equal`, `ScatterND`, `MatMul`, `Softmax`, `LayerNormalization`, `Sigmoid` | none | none | `ScatterND` |
| DmlExecutionProvider | false | none | none | none | `Unsqueeze`, `Expand`, `Cast`, `Sub`, `Where`, `Slice`, `Gather`, `Mul`, `Add`, `Reshape`, `Gemm`, `Transpose`, `Concat`, `Greater`, `Equal`, `ScatterND`, `MatMul`, `Softmax`, `LayerNormalization`, `Sigmoid` |

## 7. Reproduce commands

```powershell
uv run winml build -c examples/recipes/Helsinki-NLP_opus-mt-en-ru/cpu/cpu/translation_fp32_encoder_config.json -m Helsinki-NLP/opus-mt-en-ru -o temp/skill-run-1116/tester/build/cpu_cpu_fp32_encoder --ep cpu --device cpu --precision fp32 --no-analyze --no-compile --rebuild
uv run winml build -c examples/recipes/Helsinki-NLP_opus-mt-en-ru/cpu/cpu/translation_fp32_decoder_config.json -m Helsinki-NLP/opus-mt-en-ru -o temp/skill-run-1116/tester/build/cpu_cpu_fp32_decoder --ep cpu --device cpu --precision fp32 --no-analyze --no-compile --rebuild
uv run winml build -c examples/recipes/Helsinki-NLP_opus-mt-en-ru/cpu/cpu/translation_fp16_encoder_config.json -m Helsinki-NLP/opus-mt-en-ru -o temp/skill-run-1116/tester/build/cpu_cpu_fp16_encoder --ep cpu --device cpu --precision fp16 --no-analyze --no-compile --rebuild
uv run winml build -c examples/recipes/Helsinki-NLP_opus-mt-en-ru/cpu/cpu/translation_fp16_decoder_config.json -m Helsinki-NLP/opus-mt-en-ru -o temp/skill-run-1116/tester/build/cpu_cpu_fp16_decoder --ep cpu --device cpu --precision fp16 --no-analyze --no-compile --rebuild
uv run winml perf -m temp/skill-run-1116/tester/build/cpu_cpu_fp32_encoder/model.onnx --ep cpu --device cpu
uv run winml perf -m temp/skill-run-1116/tester/build/cpu_cpu_fp32_decoder/model.onnx --ep cpu --device cpu
uv run winml perf -m temp/skill-run-1116/tester/build/cpu_cpu_fp16_encoder/model.onnx --ep cpu --device cpu
uv run winml perf -m temp/skill-run-1116/tester/build/cpu_cpu_fp16_decoder/model.onnx --ep cpu --device cpu
uv run python temp/skill-run-1116/tester/l2_encoder_parity.py
uv run winml eval --schema --task translation
uv run winml eval -m temp/skill-run-1116/tester/build/cpu_cpu_fp32_encoder/model.onnx --model-id Helsinki-NLP/opus-mt-en-ru --task translation --ep cpu --device cpu
uv run winml eval -m temp/skill-run-1116/tester/build/cpu_cpu_fp32_decoder/model.onnx --model-id Helsinki-NLP/opus-mt-en-ru --task translation --ep cpu --device cpu
uv run winml eval -m temp/skill-run-1116/tester/build/cpu_cpu_fp16_encoder/model.onnx --model-id Helsinki-NLP/opus-mt-en-ru --task translation --ep cpu --device cpu
uv run winml eval -m temp/skill-run-1116/tester/build/cpu_cpu_fp16_decoder/model.onnx --model-id Helsinki-NLP/opus-mt-en-ru --task translation --ep cpu --device cpu
$env:WINMLCLI_RULES_DIR='C:\repo\ModelKitArtifacts\rules'; uv run winml analyze --model temp/skill-run-1116/tester/build/cpu_cpu_fp32_encoder/model.onnx --ep all --output temp/skill-run-1116/tester/analyze_cpu_cpu_fp32_encoder.json
$env:WINMLCLI_RULES_DIR='C:\repo\ModelKitArtifacts\rules'; uv run winml analyze --model temp/skill-run-1116/tester/build/cpu_cpu_fp32_decoder/model.onnx --ep all --output temp/skill-run-1116/tester/analyze_cpu_cpu_fp32_decoder.json
$env:WINMLCLI_RULES_DIR='C:\repo\ModelKitArtifacts\rules'; uv run winml analyze --model temp/skill-run-1116/tester/build/cpu_cpu_fp16_encoder/model.onnx --ep all --output temp/skill-run-1116/tester/analyze_cpu_cpu_fp16_encoder.json
$env:WINMLCLI_RULES_DIR='C:\repo\ModelKitArtifacts\rules'; uv run winml analyze --model temp/skill-run-1116/tester/build/cpu_cpu_fp16_decoder/model.onnx --ep all --output temp/skill-run-1116/tester/analyze_cpu_cpu_fp16_decoder.json
```
