### PR TITLE
recipe(deberta): add cross-encoder/nli-deberta-v3-base (text-classification, NLI)

### DIFF
--- a/examples/recipes/cross-encoder_nli-deberta-v3-base/cpu/cpu/text-classification_fp16_config.json
+++ b/examples/recipes/cross-encoder_nli-deberta-v3-base/cpu/cpu/text-classification_fp16_config.json
@@ -1,0 +1,54 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          128100
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "text-classification",
+    "model_class": "AutoModelForSequenceClassification",
+    "model_type": "deberta-v2"
+  }
+}

--- a/examples/recipes/cross-encoder_nli-deberta-v3-base/cpu/cpu/text-classification_fp32_config.json
+++ b/examples/recipes/cross-encoder_nli-deberta-v3-base/cpu/cpu/text-classification_fp32_config.json
@@ -1,0 +1,54 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          128100
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "text-classification",
+    "model_class": "AutoModelForSequenceClassification",
+    "model_type": "deberta-v2"
+  }
+}


### PR DESCRIPTION
## Summary

Adds a curated CPU float recipe for **`cross-encoder/nli-deberta-v3-base`** — a DeBERTa-v3 cross-encoder for natural-language inference (3-way sequence classification: contradiction / entailment / neutral; config `model_type = deberta-v2`). Ships **fp32 + fp16** variants under `cpu/cpu/` (both `quant: null`; no CPU quantized variant per repo convention).

This is a **recipe-only (L0★)** contribution: Optimum already covers `deberta-v2` `text-classification` natively, so `main` builds this model with zero source changes. The delta this PR adds is the **curated CPU reference recipe** plus an **L2 numeric-parity proof** that the trained 3-way NLI head is preserved end-to-end (which a plain build does not demonstrate). Claimed tiers: **Effort L0★ · Goal ceiling L2 · Outcome L0**.

---

### 1. Recipe path(s)
- `examples/recipes/cross-encoder_nli-deberta-v3-base/cpu/cpu/text-classification_fp32_config.json`
- `examples/recipes/cross-encoder_nli-deberta-v3-base/cpu/cpu/text-classification_fp16_config.json`

Both are byte-identical (`quant: null` float bucket; on CPU both realize as fp32, fp16 materializes on GPU/NPU). opset 17, batch 1, inputs `input_ids[1,512]` + `attention_mask[1,512]` (int32), output `logits`. No `token_type_ids` — `deberta-v2` has `type_vocab_size = 0`.

### 2. README row
None. Recipe-only, CPU-only — deliberately **not** added to the "Total: N (model, task) tuples that pass fp16 eval on all 10 (EP, device) buckets" table, which would be a factual overclaim for a CPU-only recipe (consistent with the reviewed outcome on #1084 / #1112).

### 3. Build output dir
`temp/nli_deberta_v3/` (scratch, gitignored) — `model.onnx` + `model.onnx.data` (786 MB fp32).

### 4. Build log
`✅ Build complete` — recipe-driven `winml build` exit 0 (269.5 s). ONNX IR 8, opset 17, external data co-located, output `logits[1,3]`.

### 5. Appended findings
`model_knowledge/deberta.json` → `deberta-001` (new family). Lane A (skill repo); **not** part of this model PR's diff.

### 6. Optimum-coverage probe
`deberta-v2` `text-classification` is **VENDOR-ONLY** (`added_by_winml = []`). Vendor onnx tasks: `[feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification]`. No winml-added exporter exists or is needed.

### 7. Claimed (Effort, Goal, Outcome)
**L0★ / L2 / L0.** Baseline: `winml build -m cross-encoder/nli-deberta-v3-base` on `main` (`origin/main = 74342698`, winml 0.2.0) already **PASSES** build-only. Contribution = curated CPU float recipe (fp32 + fp16) + L2 trained-head-preservation proof.

### 8. Goal-ladder verdict table

| Tier | Verdict | Evidence |
|---|---|---|
| L0 (build) | **PASS** | recipe-driven build exit 0 (269.5 s); ONNX opset 17, inputs `input_ids[1,512]`+`attention_mask[1,512]`, output `logits[1,3]`, external data co-located |
| L1 (perf) | **PASS** | CPU/fp32 avg 5951 ms, throughput 0.17 samples/s, RAM Δ +618 MB (slow but deterministic; ContextPooler pools fixed position 0, so random-dummy perf is safe) |
| L2 (numeric vs PyTorch) | **PASS** | 4 real NLI pairs: cosine **1.000000**, max-abs **1.9e-6**, argmax agreement **4/4** — trained 3-way NLI head + disentangled attention export losslessly |

Ceiling L2 reached; no downgrade.

### 9. Methodology-evolution declaration
No methodology friction this cycle. `deberta` is a new model family (new `model_knowledge/deberta.json`), but the existing pipeline handled it without a skill_meta change.

### 10. Perf & eval data

| EP / Device | Precision | Verdict | Mean | p50 | Throughput | RAM Δ | Task metric |
|---|---|---|---|---|---|---|---|
| CPUExecutionProvider / cpu | fp32 | PASS | 5951 ms | — | 0.17 samples/s | +618 MB | N/A (L3 not marched — L2 ceiling) |

`winml eval` not run (Goal ceiling L2). NLI label order for this checkpoint is `{0:contradiction, 1:entailment, 2:neutral}`, which differs from the GLUE/MNLI dataset order — an eval would need a label remap, so no eval block is shipped (mirrors `facebook/bart-large-mnli`).

### 11. Component / op-level data
`winml analyze --ep all`: **568 total operators, 17 unique**. Per-EP op classification: **QNN NPU 17/17 supported**, **OpenVINO NPU 17/17 supported** (includes the disentangled-attention `GatherElements` ops); **VitisAI all-unknown** (no rule data — analyze exit 1, expected, not a functional failure). Artifact: `temp/nli_deberta_v3/analyze_all.json`.

### 12. Reproducible commands

```powershell
# baseline (main already builds this model, no recipe)
winml build -m cross-encoder/nli-deberta-v3-base -o temp\nli_deberta_v3_baseline

# recipe-driven build (this PR)
winml build -m cross-encoder/nli-deberta-v3-base `
  -c examples\recipes\cross-encoder_nli-deberta-v3-base\cpu\cpu\text-classification_fp32_config.json `
  -o temp\nli_deberta_v3

# L1 perf (CPU)
winml perf -m temp\nli_deberta_v3\model.onnx --iterations 20 --warmup 5 --no-analyze

# op coverage
winml analyze -m temp\nli_deberta_v3\model.onnx --ep all -o temp\nli_deberta_v3\analyze_all.json

# L2 parity vs PyTorch: temp\nli_deberta_v3_l2.py (4 real NLI pairs, pad to 512, int32 inputs, drop token_type_ids)
python temp\nli_deberta_v3_l2.py
```
