### PR TITLE
recipe(deberta): add mixedbread-ai/mxbai-rerank-base-v1 (text-classification, reranker)

### DIFF
--- a/examples/recipes/mixedbread-ai_mxbai-rerank-base-v1/cpu/cpu/text-classification_fp16_config.json
+++ b/examples/recipes/mixedbread-ai_mxbai-rerank-base-v1/cpu/cpu/text-classification_fp16_config.json
@@ -1,0 +1,54 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          128100
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "text-classification",
+    "model_class": "AutoModelForSequenceClassification",
+    "model_type": "deberta-v2"
+  }
+}

--- a/examples/recipes/mixedbread-ai_mxbai-rerank-base-v1/cpu/cpu/text-classification_fp32_config.json
+++ b/examples/recipes/mixedbread-ai_mxbai-rerank-base-v1/cpu/cpu/text-classification_fp32_config.json
@@ -1,0 +1,54 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          128100
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "text-classification",
+    "model_class": "AutoModelForSequenceClassification",
+    "model_type": "deberta-v2"
+  }
+}


### PR DESCRIPTION
## Summary

Adds a curated CPU float recipe for **`mixedbread-ai/mxbai-rerank-base-v1`** — a cross-encoder **reranker** that scores `(query, document)` relevance (config `model_type = deberta-v2`, `DebertaV2ForSequenceClassification`, `num_labels = 1` → a single relevance logit). Ships **fp32 + fp16** variants under `cpu/cpu/` (both `quant: null`; no CPU quantized variant per repo convention).

This is a **recipe-only (L0★)** contribution: Optimum already covers `deberta-v2` `text-classification` natively, so `main` builds this model with zero source changes. The delta is the **curated CPU reference recipe** plus an **L2 numeric + ranking parity proof** that the trained reranker head is preserved end-to-end. Notably the recipe is **byte-identical** to the now-merged `cross-encoder/nli-deberta-v3-base` recipe (#1117, on `main` at `e95011d3`) — identical git blob OID `7b36e69520b418c7c86b2d8a39eab741cb9742c5` (git-stored SHA256 `8b587c4b…bec8`; verify with `git rev-parse HEAD:<path>`). The `model_id` is CLI-passed and the output width is config-driven, so one `deberta-v2` text-classification recipe serves the whole task family. Claimed tiers: **Effort L0★ · Goal ceiling L2 · Outcome L0**.

> **Updated after review (#1118):** rebased onto current `origin/main` (`e95011d3`, which now includes the merged #1117 NLI recipe) and corrected the byte-identity evidence to git's canonical blob OID. (An earlier `Get-FileHash` value `59E337…` was the Windows **CRLF** working-tree hash; git normalizes to **LF** on commit, so the on-`main` content hash is `8b587c4b…`.)

---

### 1. Recipe path(s)
- `examples/recipes/mixedbread-ai_mxbai-rerank-base-v1/cpu/cpu/text-classification_fp32_config.json`
- `examples/recipes/mixedbread-ai_mxbai-rerank-base-v1/cpu/cpu/text-classification_fp16_config.json`

Byte-identical (`quant: null` float bucket; on CPU both realize as fp32, fp16 materializes on GPU/NPU). opset 17, batch 1, inputs `input_ids[1,512]` + `attention_mask[1,512]` (int32), output `logits[1,1]`. No `token_type_ids` — `deberta-v2` has `type_vocab_size = 0`.

### 2. README row
None. Recipe-only, CPU-only — deliberately **not** added to the "passes fp16 eval on all 10 (EP, device) buckets" table, which would be a factual overclaim for a CPU-only recipe (consistent with #1084 / #1112 / #1117).

### 3. Build output dir
`temp/mxbai_rerank/` (scratch, gitignored) — `model.onnx` + `model.onnx.data` (786 MB fp32).

### 4. Build log
`✅ Build complete in 633.6s` (Export 369.6s + Optimize 256.9s; **no quantize** — `quant: null`). ONNX IR 8, opset 17, external data co-located, output `logits[1,1]`.

### 5. Appended findings
`model_knowledge/deberta.json` → `deberta-002` (second model in the `deberta` family; `mxbai-rerank-base-v1` added to `models_tested`). Lane A (skill repo); **not** part of this model PR's diff.

### 6. Optimum-coverage probe
`deberta-v2` `text-classification` is **VENDOR-ONLY** (`added_by_winml = []`). Vendor onnx tasks: `[feature-extraction, fill-mask, multiple-choice, question-answering, text-classification, token-classification]`. No winml-added exporter exists or is needed.

### 7. Claimed (Effort, Goal, Outcome)
**L0★ / L2 / L0.** Baseline: `winml build -m mixedbread-ai/mxbai-rerank-base-v1` on `main` (`origin/main = e95011d3` — branch rebased onto current main; winml 0.2.0) already **PASSES** (default pipeline 973.3s incl. quantize → uint8/16 327.5 MB). Contribution = curated CPU float recipe (fp32 + fp16) + L2 relevance-head-preservation proof.

### 8. Goal-ladder verdict table

| Tier | Verdict | Evidence |
|---|---|---|
| L0 (build) | **PASS** | recipe-driven float build exit 0 (633.6 s, no quantize); ONNX opset 17, inputs `input_ids[1,512]`+`attention_mask[1,512]`, output `logits[1,1]`, external data co-located |
| L1 (perf) | **PASS** | CPU/fp32 avg 7027.85 ms, 0.14 samples/s, RAM Δ +624.7 MB (also auto-ran on QNN/NPU at 523.99 ms / 1.91 samples/s) |
| L2 (numeric vs PyTorch) | **PASS** | 4 real `(query, doc)` pairs: cosine **1.000000**, max-abs **1.097e-05**, **ranking order 4/4 identical**, top-1 doc agrees |

Ceiling L2 reached; no downgrade.

### 9. Methodology-evolution declaration
No methodology friction. This is the **second** model in the `deberta` family (added in #1117) — it exercised the self-learning path as designed: `deberta-001` predicted the recipe shape, the recipe came out byte-identical (same git blob OID `7b36e695…`), and `deberta-002` records the reranker-specific ranking-parity check. No skill_meta change needed.

### 10. Perf & eval data

| EP / Device | Precision | Verdict | Mean | p50 | Throughput | RAM Δ | Task metric |
|---|---|---|---|---|---|---|---|
| CPUExecutionProvider / cpu | fp32 | PASS | 7027.85 ms | 6933.79 ms | 0.14 samples/s | +624.7 MB | N/A (L3 not marched — L2 ceiling) |
| QNNExecutionProvider / npu | (auto) | PASS (bonus) | 523.99 ms | 522.76 ms | 1.91 samples/s | +1791.7 MB | — (not a full NPU validation) |

`winml eval` not run (Goal ceiling L2). The NPU row is a bonus data point from `winml perf` auto-selecting QNN — it is **not** a claimed coverage bucket (no NPU-side L2 parity yet), so coverage stays CPU-only/partial.

### 11. Component / op-level data
`winml analyze --ep all`: **568 total operators, 17 unique** (identical op profile to the NLI sibling). Per-EP: **QNN NPU 17/17 supported**, **OpenVINO NPU 17/17 supported** (includes the disentangled-attention `GatherElements` ops); **VitisAI all-unknown** (no rule data — analyze exit 1, expected, not a functional failure). Artifact: `temp/mxbai_rerank/analyze_all.json`.

### 12. Reproducible commands

```powershell
# baseline (main already builds this model, no recipe)
winml build -m mixedbread-ai/mxbai-rerank-base-v1 -o temp\mxbai_rerank_baseline

# recipe-driven float build (this PR)
winml build -m mixedbread-ai/mxbai-rerank-base-v1 `
  -c examples\recipes\mixedbread-ai_mxbai-rerank-base-v1\cpu\cpu\text-classification_fp32_config.json `
  -o temp\mxbai_rerank

# L1 perf (CPU, pinned)
winml perf -m temp\mxbai_rerank\model.onnx --device cpu --ep cpu --iterations 15 --warmup 3 --no-analyze

# op coverage
winml analyze -m temp\mxbai_rerank\model.onnx --ep all -o temp\mxbai_rerank\analyze_all.json

# L2 parity + ranking vs PyTorch: temp\mxbai_rerank_l2.py
#   (tokenizes (query, doc) cross-encoder pairs, pad to 512, int32 ids, drop token_type_ids,
#    runs each pair at batch=1 since the recipe fixes batch_size=1, compares logits + argsort)
python temp\mxbai_rerank_l2.py
```