### PR TITLE
recipe(cross-encoder/ms-marco-MiniLM-L4-v2): add text-classification fp32/fp16 recipes

### DIFF
--- a/examples/recipes/cross-encoder_ms-marco-MiniLM-L4-v2/cpu/cpu/text-classification_fp16_config.json
+++ b/examples/recipes/cross-encoder_ms-marco-MiniLM-L4-v2/cpu/cpu/text-classification_fp16_config.json
@@ -1,0 +1,65 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [1, 512],
+        "value_range": [0, 30522]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [1, 512],
+        "value_range": [0, 2]
+      },
+      {
+        "name": "token_type_ids",
+        "dtype": "int32",
+        "shape": [1, 512],
+        "value_range": [0, 2]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "text-classification",
+    "model_class": "AutoModelForSequenceClassification",
+    "model_type": "bert"
+  }
+}

--- a/examples/recipes/cross-encoder_ms-marco-MiniLM-L4-v2/cpu/cpu/text-classification_fp32_config.json
+++ b/examples/recipes/cross-encoder_ms-marco-MiniLM-L4-v2/cpu/cpu/text-classification_fp32_config.json
@@ -1,0 +1,46 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [1, 512],
+        "value_range": [0, 30522]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [1, 512],
+        "value_range": [0, 2]
+      },
+      {
+        "name": "token_type_ids",
+        "dtype": "int32",
+        "shape": [1, 512],
+        "value_range": [0, 2]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "text-classification",
+    "model_class": "AutoModelForSequenceClassification",
+    "model_type": "bert"
+  }
+}

--- a/examples/recipes/cross-encoder_ms-marco-MiniLM-L4-v2/dml/gpu/text-classification_fp16_config.json
+++ b/examples/recipes/cross-encoder_ms-marco-MiniLM-L4-v2/dml/gpu/text-classification_fp16_config.json
@@ -1,0 +1,65 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [1, 512],
+        "value_range": [0, 30522]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [1, 512],
+        "value_range": [0, 2]
+      },
+      {
+        "name": "token_type_ids",
+        "dtype": "int32",
+        "shape": [1, 512],
+        "value_range": [0, 2]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "text-classification",
+    "model_class": "AutoModelForSequenceClassification",
+    "model_type": "bert"
+  }
+}

--- a/examples/recipes/cross-encoder_ms-marco-MiniLM-L4-v2/dml/gpu/text-classification_fp32_config.json
+++ b/examples/recipes/cross-encoder_ms-marco-MiniLM-L4-v2/dml/gpu/text-classification_fp32_config.json
@@ -1,0 +1,46 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [1, 512],
+        "value_range": [0, 30522]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [1, 512],
+        "value_range": [0, 2]
+      },
+      {
+        "name": "token_type_ids",
+        "dtype": "int32",
+        "shape": [1, 512],
+        "value_range": [0, 2]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "text-classification",
+    "model_class": "AutoModelForSequenceClassification",
+    "model_type": "bert"
+  }
+}


### PR DESCRIPTION
Recipe-only contribution (Effort L0). Adds fp32 and fp16 recipe configs for
**cross-encoder/ms-marco-MiniLM-L4-v2** (`BertForSequenceClassification`, 4 layers, task `text-classification`)
on two verified EP/device combinations: **CPU** and **DML (GPU)**. Goal L1 (perf) PASS on all 4 configs.

---

### 1. Recipe path(s)

- `examples/recipes/cross-encoder_ms-marco-MiniLM-L4-v2/cpu/cpu/text-classification_fp32_config.json`
- `examples/recipes/cross-encoder_ms-marco-MiniLM-L4-v2/cpu/cpu/text-classification_fp16_config.json`
- `examples/recipes/cross-encoder_ms-marco-MiniLM-L4-v2/dml/gpu/text-classification_fp32_config.json`
- `examples/recipes/cross-encoder_ms-marco-MiniLM-L4-v2/dml/gpu/text-classification_fp16_config.json`

### 2. README row

N/A — README not modified in this PR.

### 3. Build output dir

- `temp/minilm4_cpu_fp32/`
- `temp/minilm4_cpu_fp16/`
- `temp/minilm4_dml_fp32/`
- `temp/minilm4_dml_fp16/`

### 4. Build log

- cpu/cpu fp32: `✅ Build complete in 16.2s` (Export 3.8s, Optimize 12.0s)
- cpu/cpu fp16: `✅ Build complete in 16.9s` (Export 3.5s, Optimize 12.2s, FP16 0.7s)
- dml/gpu fp32: `✅ Build complete in 16.5s` (Export 3.7s, Optimize 12.3s)
- dml/gpu fp16: `✅ Build complete in 17.3s` (Export 3.8s, Optimize 12.5s, FP16 0.7s)

### 5. Appended findings

N/A — recipe-only L0 contribution.

### 6. Optimum-coverage probe

`bert` architecture fully supported by Optimum and winml. `winml inspect` confirms all components at "Default" status.

### 7. Claimed (Effort, Goal, Outcome)

| Axis | Tier |
|---|---|
| Effort | L0 (recipe-only) |
| Goal | L1 (build + perf) |
| Outcome | L0 (recipe + report) |

### 8. Goal-ladder verdict table

| Tier | Verdict | Evidence |
|---|---|---|
| L0 (build) | **PASS** | All 4 configs build successfully |
| L1 (perf) | **PASS** | All 4 configs produce valid latency/throughput (see item 10) |
| L2 | N/A | Goal ceiling = L1 |
| L3 | N/A | Goal ceiling = L1 |

### 9. Methodology-evolution declaration

No methodology friction observed.

### 10. Perf & eval data

| EP / Device | Precision | Verdict | Throughput | RAM Δ | VRAM Δ (local) |
|---|---|---|---|---|---|
| OpenVINOExecutionProvider / cpu | fp32 | PASS | 82.69 samples/s | +159.30 MB | — |
| OpenVINOExecutionProvider / cpu | fp16 | PASS | 85.10 samples/s | +160.10 MB | — |
| DmlExecutionProvider / gpu | fp32 | PASS | 81.25 samples/s | +283.00 MB | +171.30 MB |
| DmlExecutionProvider / gpu | fp16 | PASS | 31.42 samples/s | +243.20 MB | +101.00 MB |
| QNNExecutionProvider / npu | * | HOST-BLOCKED | — | — | No NPU hardware |

### 11. Component / op-level data

- **Architecture**: 4 hidden layers, 12 attention heads, hidden size 384
- **Fusion patterns applied**: `gelu_fusion`, `matmul_add_fusion`

### 12. Reproducible commands

```powershell
# Build (cpu/cpu fp32)
winml build -c examples/recipes/cross-encoder_ms-marco-MiniLM-L4-v2/cpu/cpu/text-classification_fp32_config.json -m cross-encoder/ms-marco-MiniLM-L4-v2 -o temp/minilm4_cpu_fp32

# Build (cpu/cpu fp16)
winml build -c examples/recipes/cross-encoder_ms-marco-MiniLM-L4-v2/cpu/cpu/text-classification_fp16_config.json -m cross-encoder/ms-marco-MiniLM-L4-v2 -o temp/minilm4_cpu_fp16 --precision fp16

# Build (dml/gpu fp32)
winml build -c examples/recipes/cross-encoder_ms-marco-MiniLM-L4-v2/dml/gpu/text-classification_fp32_config.json -m cross-encoder/ms-marco-MiniLM-L4-v2 -o temp/minilm4_dml_fp32 --ep dml --device gpu

# Build (dml/gpu fp16)
winml build -c examples/recipes/cross-encoder_ms-marco-MiniLM-L4-v2/dml/gpu/text-classification_fp16_config.json -m cross-encoder/ms-marco-MiniLM-L4-v2 -o temp/minilm4_dml_fp16 --ep dml --device gpu --precision fp16

# Perf
winml perf -m temp/minilm4_cpu_fp32/model.onnx --device cpu --iterations 20
winml perf -m temp/minilm4_cpu_fp16/model.onnx --device cpu --iterations 20
winml perf -m temp/minilm4_dml_fp32/model.onnx --device gpu --ep dml --iterations 20
winml perf -m temp/minilm4_dml_fp16/model.onnx --device gpu --ep dml --iterations 20
```
