### PR TITLE
feat(vit-gpt2): add CPU image-captioning recipes

### DIFF
--- a/examples/recipes/nlpconnect_vit-gpt2-image-captioning/cpu/cpu/image-to-text_fp16_config_decoder.json
+++ b/examples/recipes/nlpconnect_vit-gpt2-image-captioning/cpu/cpu/image-to-text_fp16_config_decoder.json
@@ -1,0 +1,507 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "decoder_input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          1
+        ],
+        "value_range": [
+          0,
+          50257
+        ]
+      },
+      {
+        "name": "encoder_hidden_states",
+        "dtype": "float32",
+        "shape": [
+          1,
+          197,
+          768
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "decoder_attention_mask",
+        "dtype": "int64",
+        "shape": [
+          1,
+          1024
+        ]
+      },
+      {
+        "name": "cache_position",
+        "dtype": "int64",
+        "shape": [
+          1
+        ]
+      },
+      {
+        "name": "past_0_key",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_0_value",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_1_key",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_1_value",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_2_key",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_2_value",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_3_key",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_3_value",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_4_key",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_4_value",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_5_key",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_5_value",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_6_key",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_6_value",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_7_key",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_7_value",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_8_key",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_8_value",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_9_key",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_9_value",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_10_key",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_10_value",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_11_key",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_11_value",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      },
+      {
+        "name": "present_0_key"
+      },
+      {
+        "name": "present_0_value"
+      },
+      {
+        "name": "present_1_key"
+      },
+      {
+        "name": "present_1_value"
+      },
+      {
+        "name": "present_2_key"
+      },
+      {
+        "name": "present_2_value"
+      },
+      {
+        "name": "present_3_key"
+      },
+      {
+        "name": "present_3_value"
+      },
+      {
+        "name": "present_4_key"
+      },
+      {
+        "name": "present_4_value"
+      },
+      {
+        "name": "present_5_key"
+      },
+      {
+        "name": "present_5_value"
+      },
+      {
+        "name": "present_6_key"
+      },
+      {
+        "name": "present_6_value"
+      },
+      {
+        "name": "present_7_key"
+      },
+      {
+        "name": "present_7_value"
+      },
+      {
+        "name": "present_8_key"
+      },
+      {
+        "name": "present_8_value"
+      },
+      {
+        "name": "present_9_key"
+      },
+      {
+        "name": "present_9_value"
+      },
+      {
+        "name": "present_10_key"
+      },
+      {
+        "name": "present_10_value"
+      },
+      {
+        "name": "present_11_key"
+      },
+      {
+        "name": "present_11_value"
+      }
+    ],
+    "compatibility": {
+      "transformers_attention": "eager"
+    }
+  },
+  "optim": {
+    "gelu_fusion": true,
+    "layer_norm_fusion": true,
+    "matmul_add_fusion": true,
+    "remove_isnan_in_attention_mask": true,
+    "reshape_mergedreshape": true
+  },
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "text2text-generation",
+    "model_id": "nlpconnect/vit-gpt2-image-captioning",
+    "model_type": "vision-encoder-decoder",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "text2text-generation",
+    "model_class": "VisionDecoderWrapper",
+    "model_type": "vision-encoder-decoder"
+  }
+}

--- a/examples/recipes/nlpconnect_vit-gpt2-image-captioning/cpu/cpu/image-to-text_fp16_config_encoder.json
+++ b/examples/recipes/nlpconnect_vit-gpt2-image-captioning/cpu/cpu/image-to-text_fp16_config_encoder.json
@@ -1,0 +1,73 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          224,
+          224
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "encoder_hidden_states"
+      }
+    ],
+    "compatibility": {
+      "transformers_attention": "eager"
+    }
+  },
+  "optim": {
+    "gelu_fusion": true,
+    "layer_norm_fusion": true,
+    "matmul_add_fusion": true,
+    "remove_isnan_in_attention_mask": true,
+    "reshape_mergedreshape": true
+  },
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "image-feature-extraction",
+    "model_id": "nlpconnect/vit-gpt2-image-captioning",
+    "model_type": "vision-encoder-decoder",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "image-feature-extraction",
+    "model_class": "VisionEncoderWrapper",
+    "model_type": "vision-encoder-decoder"
+  }
+}

--- a/examples/recipes/nlpconnect_vit-gpt2-image-captioning/cpu/cpu/image-to-text_fp32_config_decoder.json
+++ b/examples/recipes/nlpconnect_vit-gpt2-image-captioning/cpu/cpu/image-to-text_fp32_config_decoder.json
@@ -1,0 +1,485 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "decoder_input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          1
+        ],
+        "value_range": [
+          0,
+          50257
+        ]
+      },
+      {
+        "name": "encoder_hidden_states",
+        "dtype": "float32",
+        "shape": [
+          1,
+          197,
+          768
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "decoder_attention_mask",
+        "dtype": "int64",
+        "shape": [
+          1,
+          1024
+        ]
+      },
+      {
+        "name": "cache_position",
+        "dtype": "int64",
+        "shape": [
+          1
+        ]
+      },
+      {
+        "name": "past_0_key",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_0_value",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_1_key",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_1_value",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_2_key",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_2_value",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_3_key",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_3_value",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_4_key",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_4_value",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_5_key",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_5_value",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_6_key",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_6_value",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_7_key",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_7_value",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_8_key",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_8_value",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_9_key",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_9_value",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_10_key",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_10_value",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_11_key",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "past_11_value",
+        "dtype": "float32",
+        "shape": [
+          1,
+          12,
+          1024,
+          64
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      },
+      {
+        "name": "present_0_key"
+      },
+      {
+        "name": "present_0_value"
+      },
+      {
+        "name": "present_1_key"
+      },
+      {
+        "name": "present_1_value"
+      },
+      {
+        "name": "present_2_key"
+      },
+      {
+        "name": "present_2_value"
+      },
+      {
+        "name": "present_3_key"
+      },
+      {
+        "name": "present_3_value"
+      },
+      {
+        "name": "present_4_key"
+      },
+      {
+        "name": "present_4_value"
+      },
+      {
+        "name": "present_5_key"
+      },
+      {
+        "name": "present_5_value"
+      },
+      {
+        "name": "present_6_key"
+      },
+      {
+        "name": "present_6_value"
+      },
+      {
+        "name": "present_7_key"
+      },
+      {
+        "name": "present_7_value"
+      },
+      {
+        "name": "present_8_key"
+      },
+      {
+        "name": "present_8_value"
+      },
+      {
+        "name": "present_9_key"
+      },
+      {
+        "name": "present_9_value"
+      },
+      {
+        "name": "present_10_key"
+      },
+      {
+        "name": "present_10_value"
+      },
+      {
+        "name": "present_11_key"
+      },
+      {
+        "name": "present_11_value"
+      }
+    ],
+    "compatibility": {
+      "transformers_attention": "eager"
+    }
+  },
+  "optim": {
+    "gelu_fusion": true,
+    "layer_norm_fusion": true,
+    "matmul_add_fusion": true,
+    "remove_isnan_in_attention_mask": true,
+    "reshape_mergedreshape": true
+  },
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "text2text-generation",
+    "model_class": "VisionDecoderWrapper",
+    "model_type": "vision-encoder-decoder"
+  }
+}

--- a/examples/recipes/nlpconnect_vit-gpt2-image-captioning/cpu/cpu/image-to-text_fp32_config_encoder.json
+++ b/examples/recipes/nlpconnect_vit-gpt2-image-captioning/cpu/cpu/image-to-text_fp32_config_encoder.json
@@ -1,0 +1,51 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          224,
+          224
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "encoder_hidden_states"
+      }
+    ],
+    "compatibility": {
+      "transformers_attention": "eager"
+    }
+  },
+  "optim": {
+    "gelu_fusion": true,
+    "layer_norm_fusion": true,
+    "matmul_add_fusion": true,
+    "remove_isnan_in_attention_mask": true,
+    "reshape_mergedreshape": true
+  },
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "image-feature-extraction",
+    "model_class": "VisionEncoderWrapper",
+    "model_type": "vision-encoder-decoder"
+  }
+}

--- a/src/winml/modelkit/eval/image_to_text_evaluator.py
+++ b/src/winml/modelkit/eval/image_to_text_evaluator.py
@@ -73,7 +73,12 @@ class WinMLImageToTextEvaluator(WinMLEvaluator):
                 continue
 
             try:
-                out = self.pipe(image, text="")
+                pipeline_kwargs = (
+                    {"max_new_tokens": 32, "generate_kwargs": {"num_beams": 1}}
+                    if isinstance(references, (list, tuple))
+                    else {}
+                )
+                out = self.pipe(image, text="", **pipeline_kwargs)
             except Exception as e:
                 logger.warning("Pipeline call failed (skipping): %s", e)
                 skipped += 1

--- a/src/winml/modelkit/inference/pipeline.py
+++ b/src/winml/modelkit/inference/pipeline.py
@@ -510,10 +510,94 @@ _COMPAT_PIPELINE_FACTORIES = {
 }
 
 
-def _pipeline_component_kwargs(task: str, model_id: str | None) -> dict[str, str]:
+class _ImageToTextProcessor:
+    """Compose separate image and text processors for encoder-decoder captioning."""
+
+    def __init__(
+        self,
+        image_processor: Any,
+        tokenizer: Any,
+        decoder_start_token_id: int,
+    ) -> None:
+        if not callable(image_processor):
+            raise TypeError("Image-to-text requires a callable image processor.")
+        if not callable(tokenizer) or not callable(getattr(tokenizer, "batch_decode", None)):
+            raise TypeError("Image-to-text requires a callable tokenizer with batch decoding.")
+        self.image_processor = image_processor
+        self.tokenizer = tokenizer
+        self.decoder_start_token_id = decoder_start_token_id
+
+    def __call__(
+        self,
+        images: Any = None,
+        text: Any = None,
+        **kwargs: Any,
+    ) -> Any:
+        if images is None:
+            return self.tokenizer(text, **kwargs)
+        import torch
+
+        inputs = self.image_processor(images, **kwargs)
+        if text:
+            inputs.update(self.tokenizer(text, **kwargs))
+        else:
+            inputs["input_ids"] = torch.tensor([[self.decoder_start_token_id]], dtype=torch.int64)
+        return inputs
+
+    def post_process_image_text_to_text(self, generated_outputs: Any, **kwargs: Any) -> Any:
+        return self.tokenizer.batch_decode(generated_outputs, **kwargs)
+
+
+def _load_image_to_text_processor(
+    model_id: str,
+    *,
+    model: Any,
+    trust_remote_code: bool = False,
+) -> Any:
+    """Load or compose the image and text capabilities required by image-to-text."""
+    from transformers import AutoImageProcessor, AutoProcessor, ProcessorMixin
+
+    load_kwargs = {"trust_remote_code": True} if trust_remote_code else {}
+    processor = AutoProcessor.from_pretrained(model_id, **load_kwargs)
+    if isinstance(processor, ProcessorMixin):
+        if not callable(getattr(processor, "image_processor", None)):
+            raise TypeError("Image-to-text processor is missing a callable image processor.")
+        if not callable(getattr(processor, "tokenizer", None)):
+            raise TypeError("Image-to-text processor is missing a callable tokenizer.")
+        if not callable(getattr(processor, "post_process_image_text_to_text", None)):
+            raise TypeError("Image-to-text processor is missing generation decoding support.")
+        return processor
+
+    decoder_start_token_id = getattr(
+        getattr(model, "config", None),
+        "decoder_start_token_id",
+        None,
+    )
+    if not isinstance(decoder_start_token_id, int):
+        raise TypeError("Image-to-text model config is missing decoder_start_token_id.")
+    image_processor = AutoImageProcessor.from_pretrained(model_id, **load_kwargs)
+    return _ImageToTextProcessor(image_processor, processor, decoder_start_token_id)
+
+
+def _pipeline_component_kwargs(
+    task: str,
+    model_id: str | None,
+    *,
+    model: Any = None,
+    trust_remote_code: bool = False,
+) -> dict[str, Any]:
     """Select model components from the resolved pipeline's capabilities."""
     if model_id is None:
         return {}
+
+    if task == "image-text-to-text":
+        return {
+            "processor": _load_image_to_text_processor(
+                model_id,
+                model=model,
+                trust_remote_code=trust_remote_code,
+            )
+        }
 
     from transformers.pipelines import check_task
 
@@ -566,7 +650,12 @@ def create_pipeline(
             # "device" is for HF pipeline tensor placement, not ORT EP.
             # WinMLSession handles device delegation internally.
             "device": device,
-            **_pipeline_component_kwargs(hf_task, model_id),
+            **_pipeline_component_kwargs(
+                hf_task,
+                model_id,
+                model=model,
+                trust_remote_code=trust_remote_code,
+            ),
         }
         if trust_remote_code:
             kwargs["trust_remote_code"] = True

--- a/src/winml/modelkit/loader/resolution.py
+++ b/src/winml/modelkit/loader/resolution.py
@@ -668,6 +668,11 @@ def resolve_task(
 
     # --- Stage 4: composite tag (detection path) --------------------------
     composite = _composite_components_for_task(model_type, opt_task) if model_type else None
+    if surfaced == "image-text-to-text" and model_type:
+        image_to_text_composite = _composite_components_for_task(model_type, "image-to-text")
+        if image_to_text_composite is not None:
+            surfaced = "image-to-text"
+            composite = image_to_text_composite
 
     if source is None:  # structural invariant: Stage 1d always sets a source
         raise RuntimeError("resolve_task: internal invariant violated — source was not set")

--- a/tests/unit/eval/test_image_to_text_evaluator.py
+++ b/tests/unit/eval/test_image_to_text_evaluator.py
@@ -15,8 +15,6 @@ from winml.modelkit.inference.pipeline import _HF_PIPELINE_TASK_MAP
 
 def make_evaluator(columns_mapping=None):
     """Instantiate evaluator with mocked dataset + pipeline."""
-    import transformers
-
     from winml.modelkit.eval import DatasetConfig, WinMLEvaluationConfig
 
     mapping = columns_mapping or {}
@@ -40,12 +38,12 @@ def make_evaluator(columns_mapping=None):
         dataset=DatasetConfig(path="Teklia/IAM-line", columns_mapping=mapping),
     )
 
-    # Resolve the lazy Transformers export before patching it.
-    assert hasattr(transformers, "pipeline")
     with (
         patch("datasets.load_dataset", return_value=mock_ds),
-        patch("transformers.pipelines.pipeline", return_value=mock_pipe),
-        patch.object(transformers, "pipeline", return_value=mock_pipe),
+        patch(
+            "winml.modelkit.inference.pipeline.create_pipeline",
+            return_value=mock_pipe,
+        ),
     ):
         return WinMLImageToTextEvaluator(config, model)
 
@@ -124,6 +122,28 @@ class TestCompute:
         result = ev.compute()
         assert result["cer"] == 0.0
         assert result["n_samples"] == 1
+
+    def test_caps_caption_generation_without_changing_ocr_calls(self):
+        ev = make_evaluator()
+        ev.data = [
+            {"image": "caption-image", "text": ["caption one", "caption two"]},
+            {"image": "ocr-image", "text": "OCR TEXT"},
+        ]
+        ev.pipe = MagicMock(
+            side_effect=[
+                [{"generated_text": "caption one"}],
+                [{"generated_text": "OCR TEXT"}],
+            ]
+        )
+
+        ev.compute()
+
+        assert ev.pipe.call_args_list[0].kwargs == {
+            "text": "",
+            "max_new_tokens": 32,
+            "generate_kwargs": {"num_beams": 1},
+        }
+        assert ev.pipe.call_args_list[1].kwargs == {"text": ""}
 
     def test_skips_samples_with_missing_data(self):
         """None image or None text → skipped, n_samples reflects actual count."""

--- a/tests/unit/inference/test_pipeline.py
+++ b/tests/unit/inference/test_pipeline.py
@@ -29,6 +29,8 @@ from winml.modelkit.inference.pipeline import (
     _adapt_tokenizer_padding,
     _detect_tokenizer_dict_param,
     _ExtractiveQuestionAnsweringPipeline,
+    _ImageToTextProcessor,
+    _load_image_to_text_processor,
     _pipeline_component_kwargs,
     create_pipeline,
 )
@@ -186,6 +188,133 @@ class TestPipelineComponentKwargs:
             result = _pipeline_component_kwargs("test-task", "model-id")
 
         assert result == {"processor": "model-id"}
+
+    def test_image_to_text_composes_separate_image_processor_and_tokenizer(self) -> None:
+        tokenizer = MagicMock()
+        image_processor = MagicMock()
+        model = MagicMock()
+        model.config.decoder_start_token_id = 42
+
+        with (
+            patch("transformers.AutoProcessor.from_pretrained", return_value=tokenizer),
+            patch(
+                "transformers.AutoImageProcessor.from_pretrained",
+                return_value=image_processor,
+            ),
+        ):
+            result = _pipeline_component_kwargs(
+                "image-text-to-text", "model-id", model=model
+            )
+
+        processor = result["processor"]
+        assert isinstance(processor, _ImageToTextProcessor)
+        assert processor.tokenizer is tokenizer
+        assert processor.image_processor is image_processor
+        assert processor.decoder_start_token_id == 42
+
+    def test_image_to_text_preserves_existing_combined_processor(self) -> None:
+        from transformers import ProcessorMixin, ViTImageProcessor
+
+        class CombinedProcessor(ProcessorMixin):
+            image_processor_class = "AutoImageProcessor"
+            tokenizer_class = "AutoTokenizer"
+
+        processor = CombinedProcessor(ViTImageProcessor(), _make_fast_qa_tokenizer())
+        with (
+            patch("transformers.AutoProcessor.from_pretrained", return_value=processor),
+            patch("transformers.AutoImageProcessor.from_pretrained") as load_image_processor,
+        ):
+            result = _load_image_to_text_processor("model-id", model=MagicMock())
+
+        assert result is processor
+        load_image_processor.assert_not_called()
+
+    @pytest.mark.parametrize("missing_component", ["image_processor", "tokenizer"])
+    def test_image_to_text_rejects_incomplete_combined_processor(
+        self, missing_component: str
+    ) -> None:
+        from transformers import ProcessorMixin, ViTImageProcessor
+
+        class CombinedProcessor(ProcessorMixin):
+            image_processor_class = "AutoImageProcessor"
+            tokenizer_class = "AutoTokenizer"
+
+        processor = CombinedProcessor(ViTImageProcessor(), _make_fast_qa_tokenizer())
+        setattr(processor, missing_component, None)
+
+        with (
+            patch("transformers.AutoProcessor.from_pretrained", return_value=processor),
+            pytest.raises(TypeError, match=f"callable {missing_component.replace('_', ' ')}"),
+        ):
+            _load_image_to_text_processor("model-id", model=MagicMock())
+
+    @pytest.mark.parametrize(
+        ("image_processor", "tokenizer", "message"),
+        [
+            (object(), MagicMock(), "callable image processor"),
+            (MagicMock(), object(), "callable tokenizer with batch decoding"),
+        ],
+    )
+    def test_image_to_text_rejects_missing_component_capability(
+        self,
+        image_processor: Any,
+        tokenizer: Any,
+        message: str,
+    ) -> None:
+        with pytest.raises(TypeError, match=message):
+            _ImageToTextProcessor(image_processor, tokenizer, 42)
+
+    def test_image_to_text_rejects_missing_decoder_start_token(self) -> None:
+        tokenizer = MagicMock()
+        image_processor = MagicMock()
+        model = MagicMock()
+        model.config.decoder_start_token_id = None
+
+        with (
+            patch("transformers.AutoProcessor.from_pretrained", return_value=tokenizer),
+            patch(
+                "transformers.AutoImageProcessor.from_pretrained",
+                return_value=image_processor,
+            ),
+            pytest.raises(TypeError, match="missing decoder_start_token_id"),
+        ):
+            _load_image_to_text_processor("model-id", model=model)
+
+    def test_composed_processor_preprocesses_images_and_decodes_generation(self) -> None:
+        tokenizer = MagicMock()
+        tokenizer.batch_decode.return_value = ["a caption"]
+        image_processor = MagicMock(return_value={"pixel_values": torch.ones(1, 3, 4, 4)})
+        processor = _ImageToTextProcessor(image_processor, tokenizer, 42)
+
+        result = processor(images="image", text="", return_tensors="pt")
+        decoded = processor.post_process_image_text_to_text(
+            torch.tensor([[1, 2]]), skip_special_tokens=True
+        )
+
+        image_processor.assert_called_once_with("image", return_tensors="pt")
+        assert set(result) == {"pixel_values", "input_ids"}
+        assert result["input_ids"].tolist() == [[42]]
+        tokenizer.batch_decode.assert_called_once()
+        assert decoded == ["a caption"]
+
+    def test_composed_processor_preserves_nonempty_text_prompt(self) -> None:
+        tokenizer = MagicMock(return_value={"input_ids": torch.tensor([[7, 8]])})
+        image_processor = MagicMock(return_value={"pixel_values": torch.ones(1, 3, 4, 4)})
+        processor = _ImageToTextProcessor(image_processor, tokenizer, 42)
+
+        result = processor(images="image", text="describe", return_tensors="pt")
+
+        tokenizer.assert_called_once_with("describe", return_tensors="pt")
+        assert result["input_ids"].tolist() == [[7, 8]]
+
+    def test_composed_processor_public_signatures_match_pipeline_calls(self) -> None:
+        call_parameters = inspect.signature(_ImageToTextProcessor.__call__).parameters
+        decode_parameters = inspect.signature(
+            _ImageToTextProcessor.post_process_image_text_to_text
+        ).parameters
+
+        assert {"images", "text", "kwargs"} <= set(call_parameters)
+        assert {"generated_outputs", "kwargs"} <= set(decode_parameters)
 
 
 class TestCreatePipeline:

--- a/tests/unit/loader/test_detect_task_and_class.py
+++ b/tests/unit/loader/test_detect_task_and_class.py
@@ -94,9 +94,57 @@ class TestTasksManagerFallback:
 
             r = resolve_task(config)
 
-        assert r.task == "image-text-to-text"
+        assert r.task == "image-to-text"
         # Should fallback to architecture class
         assert r.model_class == BlipForConditionalGeneration
+
+    def test_auto_detected_alias_uses_registered_image_to_text_composite(self):
+        import winml.modelkit.models.hf  # noqa: F401
+
+        config = MagicMock()
+        config.architectures = ["VisionEncoderDecoderModel"]
+        config.model_type = "vision-encoder-decoder"
+        config._name_or_path = ""
+
+        with patch(
+            "winml.modelkit.loader.resolution._infer_task_from_architecture",
+            return_value="image-text-to-text",
+        ):
+            r = resolve_task(config)
+
+        assert r.task == "image-to-text"
+        assert r.optimum_task == "image-to-text"
+        assert r.composite is not None
+
+    def test_auto_detected_alias_is_preserved_without_image_to_text_composite(self):
+        config = MagicMock()
+        config.architectures = ["BlipForConditionalGeneration"]
+        config.model_type = "unregistered-multimodal"
+        config._name_or_path = ""
+
+        with patch(
+            "winml.modelkit.loader.resolution._infer_task_from_architecture",
+            return_value="image-text-to-text",
+        ):
+            r = resolve_task(config)
+
+        assert r.task == "image-text-to-text"
+        assert r.optimum_task == "image-text-to-text"
+        assert r.composite is None
+
+    def test_explicit_image_to_text_is_unchanged(self):
+        import winml.modelkit.models.hf  # noqa: F401
+
+        config = MagicMock()
+        config.architectures = ["VisionEncoderDecoderModel"]
+        config.model_type = "vision-encoder-decoder"
+        config._name_or_path = ""
+
+        r = resolve_task(config, task="image-to-text")
+
+        assert r.task == "image-to-text"
+        assert r.optimum_task == "image-to-text"
+        assert r.composite is not None
 
 
 class TestModelTaskDefaultsOverride:


### PR DESCRIPTION
## Summary

Adds CPU support for `nlpconnect/vit-gpt2-image-captioning`, a ViT/GPT-2 image-captioning composite, with FP32 and materially realized FP16 encoder/decoder recipes. The L2 contribution generalizes task normalization, multimodal processor composition, and bounded caption evaluation. On final candidate `4679e5062425c4ecc131ee5481af427e15198080`, the committed Goal ceiling was reached at **L3 PASS** with full planned CPU coverage.

## Model metadata

### What the model does

An image-captioning encoder-decoder model that transforms one RGB image into an English natural-language caption: a ViT encoder produces visual patch states and a cross-attentive GPT-2 causal decoder generates caption tokens.

- Evidence: the pinned model card declares image-to-text/image-captioning and provides captioning examples; the pinned config declares `VisionEncoderDecoderModel` with nested ViT encoder and GPT-2 decoder at revision `dc68f91c06a1ba6f15268e5b9c13ae7a7c514084`; real-image PyTorch and split-ONNX generation both produced English captions.
- Confidence: `verified`.

### Primary user stories

- A user supplies a photograph to obtain a concise English description for image understanding, indexing, or accessibility workflows. Evidence: the pinned model-card widget and sample pipeline use photographs as input and `generated_text` captions as output. Confidence: `verified`.

### Supported tasks

- `image-to-text` across the checkpoint, Transformers, Optimum ONNX, and WinML surfaces. The checkpoint pipeline tag is `image-to-text`; Optimum registers `vision-encoder-decoder` for `image-to-text` and `image-to-text-with-past`; WinML explicitly registers the `image-to-text` composite and emits `image-feature-extraction` plus `text2text-generation` components. Confidence: `verified`.
- `image-text-to-text` at the Transformers surface. Current `TasksManager` auto-detection returns `image-text-to-text`, but the prior WinML ONNX export path rejected that alias. Confidence: `verified`.

### Model architecture

```text
VisionEncoderDecoderModel
|- ViT encoder (224x224 RGB, patch 16, 197 tokens, hidden 768)
|  |- Patch projection + CLS/position embeddings
|  |- Encoder block x 12: self-attention + MLP + residual/LayerNorm
|  `- encoder_hidden_states [1,197,768]
`- GPT-2 LM decoder (vocab 50,257, max positions 1,024)
   |- Token + position embeddings
   |- Decoder block x 12: causal self-attention + cross-attention + MLP
   |- Static KV cache (12 heads, head dim 64)
   `- LM head -> logits [1,1,50257] -> greedy generation
```

- Source/confidence: pinned nested ViT/GPT-2 config dimensions, Transformers `VisionEncoderDecoderModel` source, current WinML `VisionDecoderWrapper` source, and loaded encoder/decoder ONNX graph contracts and hierarchy tags (`verified`). Encoder and decoder widths are both 768, so this checkpoint needs no encoder-to-decoder projection module.

## Validation and support evidence

### Baseline

- Pinned current `main`: `24cccfb23d6e3c3b93ae9bb94399c326cee8ecea`. The reusable baseline evidence was originally measured at `e564a6375d6cd2b596fb3d21d918f07824b349e0`; the revision-4 impact gate classified the move to current `main` as `PARTIAL-RERUN`, with identity/domain, Optimum, dataset-schema, and task-resolution evidence reused and all candidate build/perf/parity/Eval/Analyze/quality stages rerun on the final SHA.
- WinML version: baseline package metadata `0.2.0`, source `pyproject` `0.3.0`; final testing used `0.3.0` source with the exact lockfile.
- Recipe-free inspect/build baseline: `REUSED-FAIL-CONTRACT` / `REUSED-FAIL`. Auto-detection selected `image-text-to-text`; WinML rejected that task for `vision-encoder-decoder`, and build exited 2 before export. Consequently, no baseline ONNX node count, component latency, parity, or task metric was produced.
- Starting auto-config: explicit `image-to-text` emitted exactly two components, encoder `image-feature-extraction` and decoder `text2text-generation`.
- Baseline Eval failed before sample processing because `AutoProcessor` resolved to a tokenizer-only object, so it produced no valid task metric.
- Optimum probe: vendor tasks were `image-to-text` and `image-to-text-with-past`; WinML additionally registered `feature-extraction` and `text2text-generation`. Verdict: `VENDOR+OVERRIDE`.

### Goal

- **Effort L2:** shared task/processor/evaluator support plus recipes and regression coverage.
- **Goal L3:** four CPU component/precision artifacts, concrete component perf, FP32/FP16 tensor parity, and exactly one bounded FP32 functional Eval.
- **Outcome L2:** ship the shared capability, four exact recipes, tests, and findings.
- Success definition: L0 validates all four exact artifacts; L1 retains latency, throughput, memory, and assembled generation; L2 compares encoder, logits, all present KV tensors, token sequence, EOS, and decoded caption for FP32 and FP16; L3 processes 1-2 pinned COCO rows with one crop/prompt/beam and `max_new_tokens <= 32`, emitting valid CIDEr/CER without a benchmark claim.
- The revision-4 charter preserved the L3 ceiling; no ceiling downgrade or re-issued narrower charter occurred.

### Outcome

- Shipped tier: **L2**. Highest Goal verdict: **L3 PASS**.
- Coverage: `full`; deferred tuples: none.
- Final candidate: `4679e5062425c4ecc131ee5481af427e15198080`, one commit over pinned `main` `24cccfb23d6e3c3b93ae9bb94399c326cee8ecea`.
- Shipped recipes: FP32 and FP16 encoder/decoder configurations under `examples/recipes/nlpconnect_vit-gpt2-image-captioning/cpu/cpu/`.
- Shipped shared code: `src/winml/modelkit/loader/resolution.py`, `src/winml/modelkit/inference/pipeline.py`, and `src/winml/modelkit/eval/image_to_text_evaluator.py`, with focused regression coverage in the corresponding loader, pipeline, and evaluator unit tests.
- Learner findings refreshed in Lane A: `vision-encoder-decoder-005` (composite config, processor/tokenizer, hierarchy, trace, and KV-cache contract), `-006` (precision-specific CPU realization and four component perf rows), `-007` (FP32/FP16 tensor/cache parity, token-8 divergence, and the separate single L3 smoke), and `-008` (component mapping and static provider-rule classifications with the runtime caveat).
- Methodology declaration: methodology friction was observed. `_meta-109` records a `CLI-surprise | silent-failure`: the monolithic `winml analyze --ep all --check-optim` entered OpenVINO provider installation/registration and repeated optimization probes, then was interrupted before emitting JSON, so `ANALYZE-PARTIAL-SUCCESS` could not recover evidence that did not exist. The bounded resolution used explicit rule-backed provider/device static Analyze scans without `--check-optim` or provider installation, aggregated only complete JSON, and did not infer runtime support from static classifications; final candidate `4679e5062425c4ecc131ee5481af427e15198080` confirmed the method with 24 complete scans in the verified 296-file seal. Environment bootstrap recovery and contract-expected L2/component/single-Eval scripts are not additional Step 4b findings.
- Lane A Draft PR: [gim-home/ModelKitArtifacts#217](https://github.com/gim-home/ModelKitArtifacts/pull/217) at commit `905210e433b2c59145023b91b06c97935a7e292e`. Its scope is model knowledge findings `vision-encoder-decoder-005` through `-008`, methodology finding `_meta-109`, and the paired tester/reviewer contract edits; it contains no model-PR source or recipe changes.

### Per-EP/device/precision results

#### Goal ladder

| Tier | Verdict | Exact evidence |
|---|---|---|
| L0 | PASS | Four exact CPU artifacts structurally and materially validated. |
| L1 | PASS | Four schema-v2 component perf rows plus FP32/FP16 assembled generation. |
| L2 | PASS | FP32/FP16 encoder, logits, and all 24 present KV outputs compared against PyTorch. |
| L3 | PASS | Exactly one final-SHA FP32 CPU functional smoke Eval processed two pinned COCO rows. |

#### L0 artifact results

| EP / Device | Precision | Component | Verdict | Build | Graph | Realized parameters | External data |
|---|---|---|---|---:|---|---|---:|
| CPUExecutionProvider / cpu | fp32 | encoder | PASS | 62.48397445678711 s | IR 8, opset 17, 366 nodes | FLOAT 200; INT64 6 | 343349860 bytes |
| CPUExecutionProvider / cpu | fp32 | decoder | PASS | 96.82916760444641 s | IR 8, opset 17, 777 nodes | FLOAT 254; INT64 43; BOOL 1 | 765632512 bytes |
| CPUExecutionProvider / cpu | fp16 | encoder | PASS | 73.1825680732727 s | IR 8, opset 17, 368 nodes | FLOAT16 200; INT64 6 | 171674930 bytes |
| CPUExecutionProvider / cpu | fp16 | decoder | PASS | 115.44248104095459 s | IR 8, opset 17, 827 nodes | FLOAT16 254; INT64 43; BOOL 1 | 382824448 bytes |

All four artifacts passed external-data colocation, realized-precision, named-I/O, and component-shape checks. Decoder artifacts expose 24 past-KV inputs, 24 present-KV outputs, logits `[1,1,50257]`, and encoder width 768.

#### L1 component perf

Each row is one component benchmark with 10 iterations plus 2 warmups; these values are not end-to-end caption latency.

| EP / Device | Precision | Component | Verdict | Mean | p50 | Throughput | RAM delta | VRAM local/shared delta |
|---|---|---|---|---:|---:|---:|---:|---:|
| CPUExecutionProvider / cpu | fp32 | encoder | PASS | 60.372 ms | 60.568 ms | 16.56 samples/s | 29.44 MB | 0.0 / 0.0 MB |
| CPUExecutionProvider / cpu | fp32 | decoder | PASS | 43.645 ms | 43.613 ms | 22.91 samples/s | 113.08 MB | 0.0 / 0.0 MB |
| CPUExecutionProvider / cpu | fp16 | encoder | PASS | 108.148 ms | 108.727 ms | 9.25 samples/s | 36.79 MB | 0.0 / 0.0 MB |
| CPUExecutionProvider / cpu | fp16 | decoder | PASS | 40.725 ms | 41.485 ms | 24.56 samples/s | 126.42 MB | 0.0 / 0.0 MB |

FP16 encoder is slower than FP32 encoder in this run; FP16 decoder is slightly faster than FP32 decoder. No whole-pipeline or cross-run speedup claim is made.

#### L2 numeric and generation results

| Precision | Tensor | Shape | Cosine | Max abs | Mean abs |
|---|---|---|---:|---:|---:|
| fp32 | encoder | `[1,197,768]` | 0.9999999999987006 | 2.913177013397217e-06 | 3.1191972154940844e-07 |
| fp32 | logits | `[1,1,50257]` | 0.9999999999999822 | 4.9591064453125e-05 | 2.044241135718656e-05 |
| fp16 | encoder | `[1,197,768]` | 0.9999996043261942 | 0.0011739134788513184 | 0.0001730068317604427 |
| fp16 | logits | `[1,1,50257]` | 0.9999999929462833 | 0.022426605224609375 | 0.004588346706947287 |

- FP32 present KV outputs: 24; minimum cosine `0.999999999999737`; maximum absolute error `0.00000476837158203125`.
- FP16 present KV outputs: 24; minimum cosine `0.9999997403654044`; maximum absolute error `0.006281375885009766`.
- Generation completed for both precisions, but token IDs are not identical to PyTorch. Both first diverge at token index 8: PyTorch selects token 5671, `monitor`, while WinML selects token 5118, `chair`. PyTorch decoded `a desk with a computer and a monitor `; WinML decoded `a desk with a computer and a chair `.
- At the FP32 divergence score, PyTorch ranks `monitor` first at `-32.856346130371094` and `chair` second at `-33.25397491455078`; WinML ranks `chair` first at `-23.347267150878906` and `monitor` third at `-25.002408981323242`. The selected-logit delta is `-7.853937149047852`.
- At the FP16 divergence score, PyTorch has the same top two logits; WinML ranks `chair` first at `-23.33856201171875` and `monitor` third at `-25.014751434326172`. The selected-logit delta is `-7.841594696044922`.

#### Functional smoke Eval

**PASS, operability evidence only; not representative accuracy or benchmark quality.** Exactly one Eval ran on final candidate `4679e5062425c4ecc131ee5481af427e15198080`: `CPUExecutionProvider` / `cpu` / FP32, using the deterministic first 2 streaming rows from `LIME-DATA/COCO-Caption2017` revision `b14474455722b8c56eb7cdeb3f6be76fca1bba7a`, split `train`. Requested samples: 2; processed samples: 2. The image input, list-of-five-caption labels, and one deterministic greedy English-caption prediction were schema- and semantics-verified.

Fan-out caps were candidate labels/prompts `1`, beams `1`, frames/crops `1`, sequence/generation length `32`, and references per image `5`. Raw metrics: **CIDEr 0.8427; CER 0.6316**. There was no FP16 Eval, accelerator Eval, or benchmark-scale accuracy run. The former blocker was tokenizer-only `AutoProcessor` resolution; the shipped capability composes image preprocessing with token decoding for the registered image-to-text path.

### Delta

#### Recipes

- FP32 encoder and decoder recipes are structurally identical to their explicit `image-to-text` auto-config outputs; their structured recipe delta is empty.
- For both FP16 components, JSON pointer `/quant` changes from `null` to `{mode:fp16,fp16_keep_io_types:true,nodes_to_exclude:null}`. No other structured recipe field differs from the corresponding starting config.
- All recipes remain reducible to the same registered composite behavior: encoder `image-feature-extraction` plus decoder `text2text-generation`. Recipe validation used no recipe-owned semantic CLI overrides.
- `examples/recipes/README.md` is untouched.

#### Bug fix explanation: registered task alias normalization

1. **Symptom and trigger:** recipe-free inspect/build of the pinned `VisionEncoderDecoderModel` auto-detected Transformers task `image-text-to-text`, which WinML rejected before export even though the registered composite capability is `image-to-text`.
2. **Root cause:** the Transformers-facing alias remained valid at that boundary, but loader task resolution did not normalize a registered vision-encoder-decoder alias to WinML's public composite task.
3. **Changed symbols and mechanism:** task-resolution symbols in `src/winml/modelkit/loader/resolution.py` now normalize the registered alias to `image-to-text` while preserving explicit tasks and aliases without a registered mapping.
4. **General rule:** the decision is derived from registered task/composite capability and model metadata, not from the checkpoint ID.
5. **Compatibility and blast radius:** explicit `image-to-text`, unrelated model families, and unregistered aliases retain their prior behavior; the intentional change is that registered vision-encoder-decoder auto detection now reaches the supported WinML composite.
6. **Regression evidence:** focused loader/pipeline/evaluator coverage passed `95 passed in 12.41s`; the broader models partition passed `1527 passed, 6 skipped, 2 xfailed`; recipe-free final-SHA inspect/config/build reached the supported two-component path; all nine GitHub checks succeeded.

#### Bug fix explanation: image-to-text processor composition

1. **Symptom and trigger:** image-to-text Eval failed before processing a sample when `AutoProcessor` resolved this checkpoint to a tokenizer-only object lacking image preprocessing.
2. **Root cause:** the pipeline accepted the incomplete processor object as final instead of checking whether the task required both image preprocessing and token decoding capabilities.
3. **Changed symbols and mechanism:** processor-loading symbols in `src/winml/modelkit/inference/pipeline.py` now preserve complete `ProcessorMixin` objects and compose `AutoImageProcessor` with `AutoTokenizer` only when the registered image-to-text capability requires the missing half.
4. **General rule:** composition is capability-driven and task-driven, not keyed to `nlpconnect/vit-gpt2-image-captioning`.
5. **Compatibility and blast radius:** complete processors remain unchanged; explicit tasks and unrelated model families retain current resolution; OCR scalar semantics remain unchanged.
6. **Regression evidence:** focused tests passed `95 passed in 12.41s`; the commands/eval partition passed `3606 passed, 9 skipped, 1 warning`; the final smoke processed both selected COCO rows and emitted CIDEr/CER.

#### Bug fix explanation: bounded caption evaluation

1. **Symptom and trigger:** the previous image-to-text evaluator path could not produce a semantically valid bounded caption smoke from this tokenizer-only processor path and list-valued COCO references.
2. **Root cause:** evaluator handling needed task-aware image preprocessing, deterministic bounded generation, and caption-reference semantics rather than treating caption lists or OCR-style scalar labels interchangeably.
3. **Changed symbols and mechanism:** image-to-text evaluation symbols in `src/winml/modelkit/eval/image_to_text_evaluator.py` accept the composed processor path, cap generation, and retain caption references for CIDEr/CER while producing one decoded prediction per image.
4. **General rule:** behavior follows task schema, processor capabilities, and label shape; it does not hardcode the checkpoint or dataset rows.
5. **Compatibility and blast radius:** empty/nonempty prompts retain intended behavior; list-valued caption references are bounded for caption evaluation, while OCR scalar evaluation remains unchanged.
6. **Regression evidence:** focused evaluator tests are included in `95 passed in 12.41s`; the commands/eval partition passed; exactly one final-SHA run processed 2/2 pinned rows with prompts `1`, beams `1`, crops `1`, generation length `32`, CIDEr `0.8427`, and CER `0.6316`.

Quality gates were all exit zero: Ruff passed; mypy reported no issues in 435 source files; analyze `1526 passed, 45 skipped`; models `1527 passed, 6 skipped, 2 xfailed`; optim `714 passed, 16 skipped, 1 xfailed`; commands `3606 passed, 9 skipped, 1 warning`; remaining `870 passed, 2 skipped, 1 deselected, 1 warning`.

### Analyze summary - component level and op level

Static rule analysis **PASS** completed for all four artifacts. This is static provider-rule compatibility analysis, not accelerator runtime execution; no accelerator runtime PASS/FAIL is inferred from these classifications.

#### Component-level summary

| Artifact | Architecture coverage | Mapping | Confidence |
|---|---|---|---|
| fp32-encoder | ViT patch / 12 encoder blocks | 246 mapped, 120 partial, 0 unmapped | mapped+partial |
| fp32-decoder | GPT-2 embeddings / 12 decoder blocks / self+cross attention / KV / LM head | 764 mapped, 13 partial, 0 unmapped | mapped+partial |
| fp16-encoder | ViT patch / 12 encoder blocks | 246 mapped, 122 partial, 0 unmapped | mapped+partial |
| fp16-decoder | GPT-2 embeddings / 12 decoder blocks / self+cross attention / KV / LM head | 764 mapped, 63 partial, 0 unmapped | mapped+partial |

The retained mapping gaps are graph-support nodes outside repeated module scopes as a partial semantic region and runtime generation as runtime-only, with no fabricated ONNX node mapping.

#### Op-level summary

| Artifact | Graph | Domains | Dominant ops | Static EP roll-up |
|---|---|---|---|---|
| fp32-encoder | 366 ops / 11 types | ai.onnx 354; com.microsoft 12 | Reshape 121; Gemm 72; Transpose 49; Add 37; LayerNormalization 25 | NvTensorRTRTX GPU, OpenVINO CPU/GPU/NPU, QNN GPU/NPU: no partial/unsupported/unknown types |
| fp32-decoder | 777 ops / 22 types | ai.onnx 777 | Reshape 219; Transpose 108; Add 86; Gemm 84; Mul 72 | Decoder findings below |
| fp16-encoder | 368 ops / 12 types | ai.onnx 356; com.microsoft 12 | Reshape 121; Gemm 72; Transpose 49; Add 37; LayerNormalization 25 | NvTensorRTRTX GPU, OpenVINO CPU/GPU/NPU, QNN GPU/NPU: no partial/unsupported/unknown types |
| fp16-decoder | 827 ops / 22 types | ai.onnx 827 | Reshape 219; Transpose 108; Add 86; Gemm 84; Mul 72 | Decoder findings below |

For both decoder artifacts, NvTensorRTRTX GPU has `Where` and `ScatterND` unknown; OpenVINO CPU/GPU/NPU additionally marks `Add` unsupported; QNN GPU marks `Concat` and `Gather` partial, `LessOrEqual` unsupported, and `Where`/`ScatterND` unknown; QNN NPU marks `Gather` partial and `Where`/`ScatterND` unknown. VitisAI NPU has `runtime_support=false` with empty classifications. Build-local DML rows also have `runtime_support=false` with empty classifications and are not used as EP support evidence.

### Reproduce commands

```powershell
$OUT='temp/vit-gpt2-image-captioning'
winml build -c examples/recipes/nlpconnect_vit-gpt2-image-captioning/cpu/cpu/image-to-text_fp32_config_encoder.json -m nlpconnect/vit-gpt2-image-captioning -o $OUT/fp32-encoder
winml build -c examples/recipes/nlpconnect_vit-gpt2-image-captioning/cpu/cpu/image-to-text_fp32_config_decoder.json -m nlpconnect/vit-gpt2-image-captioning -o $OUT/fp32-decoder
winml perf -m $OUT/fp32-encoder/model.onnx -c examples/recipes/nlpconnect_vit-gpt2-image-captioning/cpu/cpu/image-to-text_fp32_config_encoder.json --ep cpu --device cpu --skip-build --format json -o $OUT/perf-encoder.json
```