### PR TITLE
recipe(segformer): add nvidia b4 ADE recipe coverage

### DIFF
--- a/examples/recipes/nvidia_segformer-b4-finetuned-ade-512-512/cpu/cpu/image-segmentation_fp16_config.json
+++ b/examples/recipes/nvidia_segformer-b4-finetuned-ade-512-512/cpu/cpu/image-segmentation_fp16_config.json
@@ -1,0 +1,60 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          512,
+          512
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "fp16",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null,
+    "task": "image-segmentation",
+    "model_id": "nvidia/segformer-b4-finetuned-ade-512-512"
+  },
+  "compile": null,
+  "loader": {
+    "task": "image-segmentation",
+    "model_class": "AutoModelForSemanticSegmentation",
+    "model_type": "segformer"
+  },
+  "eval": {
+    "task": "image-segmentation",
+    "dataset": {
+      "path": "danjacobellis/scene_parse_150",
+      "split": "validation",
+      "samples": 100,
+      "label_mapping_file": "scripts/e2e_eval/datasets/ade20k_gt_to_model_label.json",
+      "columns_mapping": {
+        "annotation_column": "annotation"
+      }
+    }
+  }
+}

--- a/examples/recipes/nvidia_segformer-b4-finetuned-ade-512-512/cpu/cpu/image-segmentation_fp32_config.json
+++ b/examples/recipes/nvidia_segformer-b4-finetuned-ade-512-512/cpu/cpu/image-segmentation_fp32_config.json
@@ -1,0 +1,56 @@
+{
+    "export":  {
+                   "opset_version":  17,
+                   "batch_size":  1,
+                   "export_params":  true,
+                   "do_constant_folding":  true,
+                   "verbose":  false,
+                   "dynamo":  false,
+                   "enable_hierarchy_tags":  true,
+                   "clean_onnx":  false,
+                   "hierarchy_tag_format":  "full",
+                   "input_tensors":  [
+                                         {
+                                             "name":  "pixel_values",
+                                             "dtype":  "float32",
+                                             "shape":  [
+                                                           1,
+                                                           3,
+                                                           512,
+                                                           512
+                                                       ],
+                                             "value_range":  [
+                                                                 0,
+                                                                 1
+                                                             ]
+                                         }
+                                     ],
+                   "output_tensors":  [
+                                          {
+                                              "name":  "logits"
+                                          }
+                                      ]
+               },
+    "optim":  {
+
+              },
+    "quant":  null,
+    "compile":  null,
+    "loader":  {
+                   "task":  "image-segmentation",
+                   "model_class":  "AutoModelForSemanticSegmentation",
+                   "model_type":  "segformer"
+               },
+    "eval":  {
+                 "task":  "image-segmentation",
+                 "dataset":  {
+                                 "path":  "danjacobellis/scene_parse_150",
+                                 "split":  "validation",
+                                 "samples":  100,
+                                 "label_mapping_file":  "scripts/e2e_eval/datasets/ade20k_gt_to_model_label.json",
+                                 "columns_mapping":  {
+                                                         "annotation_column":  "annotation"
+                                                     }
+                             }
+             }
+}


### PR DESCRIPTION
﻿### Summary

Adds verified CPU/CPU recipe coverage for `nvidia/segformer-b4-finetuned-ade-512-512` image segmentation. This is a Lane B `L0` recipe-only contribution: two checked-in recipes (`fp32` and `fp16`) under the exact-evidence layout, no modelkit source changes, no catalog/index changes, and no `examples/recipes/README.md` change.

Highest verified Goal on the reachable host is `L3 PASS` for both shipped CPU tuples: build, CPU perf, numeric compare vs PyTorch, and task-metric eval all completed. The `w8a16` candidate was removed because its artifact validation showed fp32 semantics, so it is not shipped or claimed here.

### Model metadata

#### What the model does

`nvidia/segformer-b4-finetuned-ade-512-512` is a SegFormer semantic image segmentation checkpoint fine-tuned for ADE-style scene parsing. A user supplies an RGB image and the model produces per-pixel logits for 150 semantic labels.

Evidence/confidence: pinned Hugging Face checkpoint config (`architectures=['SegformerForSemanticSegmentation']`, `model_type='segformer'`, `num_labels=150`) and `winml inspect` task resolution (`verified`).

#### Primary user stories

- A user supplies a scene image to obtain an ADE20K-compatible semantic mask for scene understanding (`verified` from checkpoint task/config and recipe eval dataset).
- A user supplies validation images and annotations to measure segmentation quality with mean IoU / overall accuracy (`verified` from `winml eval` on `danjacobellis/scene_parse_150`).
- A user supplies the same checkpoint to compare fp32 and fp16 CPU footprint/quality behavior through checked-in recipes (`verified` from built artifacts and perf/eval results).

#### Supported tasks

| Task | Support surface | Evidence | Confidence |
|---|---|---|---|
| `image-segmentation` | checkpoint, Transformers, WinML | `AutoModelForSemanticSegmentation`; WinML loader `WinMLModelForImageSegmentation`; exporter `SegformerIOConfig` | verified |
| `semantic-segmentation` | WinML/Optimum registry alias | Optimum probe after WinML registration includes `semantic-segmentation` | mapped |

#### Model architecture

SegFormer B4 uses hierarchical overlap patch embeddings and a multi-stage transformer encoder, followed by an all-MLP segmentation decode head.

```text
SegformerForSemanticSegmentation
|-- SegformerModel encoder
|   |-- Overlap patch embeddings x4 stages (hidden sizes 64, 128, 320, 512)
|   |-- Transformer encoder blocks by stage: 3, 8, 27, 3
|   |   |-- Efficient self-attention (heads 1, 2, 5, 8)
|   |   |-- Mix-FFN / GELU feed-forward blocks
|   |   `-- Residual + LayerNorm
|   `-- Multi-scale hidden states
`-- SegformerDecodeHead
    |-- Per-stage projection to decoder hidden size 768
    |-- Multi-scale resize and fusion
    `-- Classifier logits [1, 150, 128, 128] for 512x512 input
```

Evidence/confidence: config values from pinned checkpoint; HTP export metadata reports `SegformerForSemanticSegmentation`, 64,108,374 parameters, 937 modules, 339 traced modules, input `pixel_values [1,3,512,512]`; ONNX output `logits [1,150,128,128]` (`verified/mapped`).

### Validation and support evidence

#### 1. Baseline

- Current base after rebase: `origin/main=5deebd422e95f28fe8fd912ee50ce874710187b3`.
- Current PR head prepared for push: `71fa1c3e`.
- WinML version: `0.2.0`; runtime providers observed: `['DmlExecutionProvider', 'CPUExecutionProvider']`.
- `winml inspect -m nvidia/segformer-b4-finetuned-ade-512-512 --format json` resolves `model_type=segformer`, architecture `SegformerForSemanticSegmentation`, task `image-segmentation`, loader `AutoModelForSemanticSegmentation`, exporter `SegformerIOConfig`, WinML class `WinMLModelForImageSegmentation`.
- Baseline `winml config -m nvidia/segformer-b4-finetuned-ade-512-512 -t image-segmentation` succeeds and emits a 512x512 `pixel_values` input and `logits` output config. The shipped recipes refine this into explicit CPU/CPU checked-in coverage for fp32 and fp16.
- Optimum probe for `segformer`: vendor tasks `[]`; after WinML registration `['feature-extraction', 'image-classification', 'image-segmentation', 'semantic-segmentation']`; added by WinML same list. Effort remains recipe-only because WinML already registers the exporter/loader.

#### 2. Goal

- Effort: `L0` recipe-only.
- Goal ceiling: `L3`, because CPU build, perf, numeric compare, and dataset eval are reachable on this host.
- Outcome: `L0`; checked-in recipe files only.
- Success definition: each shipped `(EP, device, precision)` tuple must have exact L0 build/structure evidence, L1 perf data, L2 numeric compare data, and L3 task metric data.

#### 3. Outcome

- Shipped recipes:
  - `examples/recipes/nvidia_segformer-b4-finetuned-ade-512-512/cpu/cpu/image-segmentation_fp32_config.json`
  - `examples/recipes/nvidia_segformer-b4-finetuned-ade-512-512/cpu/cpu/image-segmentation_fp16_config.json`
- Highest reached Goal verdict: `L3 PASS` for CPU/CPU fp32 and CPU/CPU fp16.
- Coverage: full for the target set of this PR (`cpu/cpu/fp32`, `cpu/cpu/fp16`). No accelerator EP/device recipe is shipped.
- Methodology friction observed: exact-evidence precision validation removed the prior `w8a16` candidate because `winml_build_config.json` had `quant: null`, the final artifact size matched fp32, and initializer data types were fp32 rather than quantized.

#### 4. Per-EP/device/precision results

| Tier | EP / device | Precision | Verdict | Mean | p50 | Throughput | RAM delta | Task metric |
|---|---|---:|---|---:|---:|---:|---:|---|
| L0 | CPUExecutionProvider / cpu | fp32 | PASS | - | - | - | - | artifact `model.onnx` + external data; precision `fp32`; inputs `pixel_values [1,3,512,512]`; outputs `logits [1,150,128,128]` |
| L1 | CPUExecutionProvider / cpu | fp32 | PASS | 1230.051 ms | 1238.8 ms | 0.81 samples/s | RSS +1203.29 MB | - |
| L2 | CPUExecutionProvider / cpu | fp32 | PASS | - | - | - | - | compare mode, 3 samples: cosine `0.9999999999999606`; max abs diff mean `2.7338663736979168e-05` |
| L3 | CPUExecutionProvider / cpu | fp32 | PASS | - | - | - | - | `danjacobellis/scene_parse_150`, validation, 1 sample: mean_iou `0.43409010767936707`; overall_accuracy `0.7907461524009705` |
| L0 | CPUExecutionProvider / cpu | fp16 | PASS | - | - | - | - | artifact `model.onnx` + external data; precision `fp16`; FLOAT16 initializers; fp32 I/O preserved |
| L1 | CPUExecutionProvider / cpu | fp16 | PASS | 1517.104 ms | 1617.28 ms | 0.66 samples/s | RSS +1155.58 MB | - |
| L2 | CPUExecutionProvider / cpu | fp16 | PASS | - | - | - | - | compare mode, 3 samples: cosine `0.999999974186835`; max abs diff mean `0.026076634724934895` |
| L3 | CPUExecutionProvider / cpu | fp16 | PASS | - | - | - | - | `danjacobellis/scene_parse_150`, validation, 1 sample: mean_iou `0.43414419889450073`; overall_accuracy `0.7908576726913452` |

Artifact footprint:

| Precision | `model.onnx` | `model.onnx.data` | Precision evidence |
|---|---:|---:|---|
| fp32 | 801,886 bytes | 256,367,616 bytes | initializer types FLOAT + INT64; perf model_info precision `fp32` |
| fp16 | 963,537 bytes | 127,970,176 bytes | initializer types FLOAT16 + INT64; perf model_info precision `fp16` |

#### 5. Delta

- Recipe diff relative to auto-config is intentionally per-checkpoint/verified-coverage, not a class-wide code fix:
  - `export.input_tensors[0].shape`: explicit `[1,3,512,512]` matching this ADE 512 checkpoint.
  - `loader.task`: `image-segmentation`.
  - `loader.model_class`: `AutoModelForSemanticSegmentation`.
  - fp16 recipe adds `quant.mode='fp16'`, `fp16_keep_io_types=true`, and requires the build command to pass `--precision fp16`.
  - both recipes declare eval dataset `danjacobellis/scene_parse_150`, split `validation`, annotation column mapping, and ADE20K label mapping file.
- Reducibility: these are checkpoint/task/eval declarations and exact tuple evidence, so no modelkit source change is required.
- Removed from the previous branch shape: README/catalog/reference edits and the invalid `w8a16` recipe claim.
- Production recipe README remains untouched.
- No `src/winml/modelkit/` files were changed.

#### 6. Analyze summary - component level and op level

Static rule analysis was run against the fp32 artifact with `WINMLCLI_RULES_DIR` pointing at the populated ModelKitArtifacts runtime rules. The command exited nonzero after producing useful JSON/console classifications, so this is recorded as `ANALYZE-PARTIAL-SUCCESS`; it is static compatibility analysis, not runtime execution.

Component-level summary:

| Artifact | Architecture coverage | Mapping | Actionable EP findings |
|---|---|---|---|
| fp32 | `SegformerModel` encoder plus `SegformerDecodeHead`; HTP metadata: 937 modules, 339 traced modules, 64,108,374 params; ONNX graph output logits for 150 classes | mapped from hierarchy tags / HTP metadata / ONNX graph; 1846 ONNX ops in final model | QNN partial support around GELU-style ops: Add, Div, Erf, Mul; rule-less CPU/DML runtime rows are not actionable rule evidence |

Op-level summary:

| Artifact | Graph | Dominant ops | EP roll-up |
|---|---|---|---|
| fp32 | 1846 operators / 13 unique op types | Add 373; Reshape 338; Transpose 338; MatMul 332; LayerNormalization 128; Conv 85; Div 82; Mul 82; Softmax 41; Erf 41 | NvTensorRTRTX and OpenVINO show full support in static rules; QNN shows partial Add/Div/Erf/Mul; CUDA, MIGraphX, DML, CPU are rule-less/all-unknown in this rule set |

#### 7. Reproduce commands

```powershell
$OUT='temp/segformer-b4-repro'
$env:WINMLCLI_RULES_DIR='<path-to-populated-runtime-rules>'

winml --version
python -c "import onnxruntime as ort; print(ort.get_available_providers())"
winml inspect -m nvidia/segformer-b4-finetuned-ade-512-512 --format json
winml config -m nvidia/segformer-b4-finetuned-ade-512-512 -t image-segmentation -o $OUT\baseline_config

winml build -c examples/recipes/nvidia_segformer-b4-finetuned-ade-512-512/cpu/cpu/image-segmentation_fp32_config.json -m nvidia/segformer-b4-finetuned-ade-512-512 -o $OUT\fp32 --ep cpu --device cpu --no-analyze --no-optimize --no-compile --rebuild
winml perf -m $OUT\fp32\model.onnx --device cpu --ep cpu --iterations 10 --warmup 2 --format json -o $OUT\fp32\perf_cpu.json --overwrite
winml eval -m $OUT\fp32\model.onnx --model-id nvidia/segformer-b4-finetuned-ade-512-512 --task image-segmentation --device cpu --ep cpu --mode compare --samples 3 --format json -o $OUT\fp32\compare_cpu.json --overwrite
winml eval -m $OUT\fp32\model.onnx --model-id nvidia/segformer-b4-finetuned-ade-512-512 --task image-segmentation --dataset danjacobellis/scene_parse_150 --split validation --samples 1 --column annotation_column=annotation --label-mapping scripts\e2e_eval\datasets\ade20k_gt_to_model_label.json --device cpu --ep cpu --format json -o $OUT\fp32\eval_cpu_1.json --overwrite
winml analyze --model $OUT\fp32\model.onnx --ep all --output $OUT\fp32\analyze_all.json --format json

winml build -c examples/recipes/nvidia_segformer-b4-finetuned-ade-512-512/cpu/cpu/image-segmentation_fp16_config.json -m nvidia/segformer-b4-finetuned-ade-512-512 -o $OUT\fp16 --ep cpu --device cpu --precision fp16 --no-analyze --no-optimize --no-compile --rebuild
winml perf -m $OUT\fp16\model.onnx --device cpu --ep cpu --iterations 10 --warmup 2 --format json -o $OUT\fp16\perf_cpu.json --overwrite
winml eval -m $OUT\fp16\model.onnx --model-id nvidia/segformer-b4-finetuned-ade-512-512 --task image-segmentation --device cpu --ep cpu --mode compare --samples 3 --format json -o $OUT\fp16\compare_cpu.json --overwrite
winml eval -m $OUT\fp16\model.onnx --model-id nvidia/segformer-b4-finetuned-ade-512-512 --task image-segmentation --dataset danjacobellis/scene_parse_150 --split validation --samples 1 --column annotation_column=annotation --label-mapping scripts\e2e_eval\datasets\ade20k_gt_to_model_label.json --device cpu --ep cpu --format json -o $OUT\fp16\eval_cpu_1.json --overwrite

uv run ruff check src/ tests/
uv run mypy -p winml.modelkit
```

Quality gates on current local PR head `71fa1c3e`:

| Gate | Result |
|---|---|
| `uv run ruff check src/ tests/` | PASS: `All checks passed!` |
| `uv run mypy -p winml.modelkit` | PASS: `Success: no issues found in 409 source files` |
| Affected non-hardware pytest partition | no Python/source/test files changed; recipe-only diff has no direct unit partition beyond final GitHub workflow checks |

