### PR TITLE
test(e2e): composite (t5-small) export/build/perf tests + perf composite auto-detect

### DIFF
--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -773,12 +773,20 @@ class PerfBenchmark:
             # file" error from AutoConfig.
             raise FileNotFoundError(f"ONNX file not found: {model_path}")
 
-        # Composite auto-detection (mirror build / export). A bare seq2seq model
-        # such as T5 auto-detects to a granular single-model task
-        # (text2text-generation) and would benchmark only the decoder. Resolve
-        # the composite via the shared registry bridge and load the whole
-        # pipeline so every sub-model is built and benchmarked. Explicit --task
-        # and ONNX inputs keep their resolved task untouched.
+        # Composite auto-detection. A bare seq2seq model such as T5 auto-detects
+        # to a granular single-model task (text2text-generation) and would
+        # benchmark only the decoder.
+        #
+        # Why this differs from build/export: those commands *fan out* into one
+        # independent build per sub-model, so they use resolve_composite_components
+        # -> a {name: sub_model_task} map (encoder=feature-extraction,
+        # decoder=text2text-generation) and never construct a composite object.
+        # perf instead loads ONE live WinMLCompositeModel and benchmarks its
+        # sub-models, which requires a registered composite *pipeline* task
+        # (translation/summarization) to route WinMLAutoModel.from_pretrained --
+        # a different namespace from the sub-model tasks. resolve_composite_load_task
+        # bridges detection to that loadable pipeline task. Explicit --task and
+        # ONNX inputs keep their resolved task untouched.
         resolved_task = self.config.task
         if not is_onnx and resolved_task is None:
             from ..loader.resolution import resolve_composite_load_task

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -773,6 +773,25 @@ class PerfBenchmark:
             # file" error from AutoConfig.
             raise FileNotFoundError(f"ONNX file not found: {model_path}")
 
+        # Composite auto-detection (mirror build / export). A bare seq2seq model
+        # such as T5 auto-detects to a granular single-model task
+        # (text2text-generation) and would benchmark only the decoder. Resolve
+        # the composite via the shared registry bridge and load the whole
+        # pipeline so every sub-model is built and benchmarked. Explicit --task
+        # and ONNX inputs keep their resolved task untouched.
+        resolved_task = self.config.task
+        if not is_onnx and resolved_task is None:
+            from ..loader.resolution import resolve_composite_load_task
+
+            try:
+                resolved_task = resolve_composite_load_task(model_id)
+            except OSError as e:
+                # Config not resolvable (e.g. invalid or unreachable model id).
+                # Fall back to single-model loading; from_pretrained re-attempts
+                # the config load and surfaces a clear error if the id is truly
+                # bad. Mirrors build's composite-detection guard.
+                logger.debug("Composite detection unavailable (config not resolvable): %s", e)
+
         # Only override config for explicitly requested build/export changes.
         override: WinMLBuildConfig | dict[str, Any] | None = None
         if self.config.export_overrides:
@@ -792,7 +811,7 @@ class PerfBenchmark:
         force_rebuild = self.config.rebuild or self.config.ignore_cache
 
         common_kwargs: dict[str, Any] = {
-            "task": self.config.task,
+            "task": resolved_task,
             "config": override,
             "device": self._resolved_device or self.config.device,
             "precision": self.config.precision,

--- a/src/winml/modelkit/loader/resolution.py
+++ b/src/winml/modelkit/loader/resolution.py
@@ -366,6 +366,38 @@ def composite_pipeline_tasks(model_type: str) -> list[str]:
     return sorted(task for (mt, task) in _composite_registry() if mt == model_type)
 
 
+def resolve_composite_load_task(
+    hf_model: str | None,
+    *,
+    trust_remote_code: bool = False,
+) -> str | None:
+    """Registered composite *pipeline* task for loading ``hf_model``, else ``None``.
+
+    :func:`resolve_composite_components` tells the fan-out commands (config /
+    export / build) *which* sub-models to build. The model loaders
+    (``WinMLAutoModel`` / ``WinMLCompositeModel``) instead need a concrete
+    registry task to instantiate the pipeline object. This bridges the two on the
+    auto-detection path: it applies the same seq2seq detection, then maps the
+    detected composite back to a loadable pipeline task so a bare ``winml perf``
+    / benchmark call builds the whole pipeline instead of a single sub-model.
+
+    When a model_type registers several pipeline tasks that share the same
+    sub-models (e.g. T5 ``summarization`` / ``translation``), detection has
+    already deduped them to one component set, so the sorted-first pipeline task
+    is a deterministic, sub-model-equivalent choice. Model types whose composite
+    tasks expose *different* sub-models make detection raise before reaching here.
+    """
+    from transformers import AutoConfig
+
+    if hf_model is None:
+        return None
+    config = AutoConfig.from_pretrained(hf_model, trust_remote_code=trust_remote_code)
+    if resolve_task(config).composite is None:
+        return None
+    tasks = composite_pipeline_tasks(config.model_type)
+    return tasks[0] if tasks else None
+
+
 # Optimum-canonical generation task that detect-path seq2seq models surface;
 # bridged to the model_type's composite. Universal taxonomy, not a model name.
 _SEQ2SEQ_GENERATION_TASK = "text2text-generation"

--- a/src/winml/modelkit/loader/resolution.py
+++ b/src/winml/modelkit/loader/resolution.py
@@ -394,7 +394,14 @@ def resolve_composite_load_task(
     config = AutoConfig.from_pretrained(hf_model, trust_remote_code=trust_remote_code)
     if resolve_task(config).composite is None:
         return None
-    tasks = composite_pipeline_tasks(config.model_type)
+    model_type = getattr(config, "model_type", None)
+    if model_type is None:
+        return None
+    # Normalize before the registry lookup -- registry keys are lower/hyphenated
+    # (e.g. "vision-encoder-decoder"), and this mirrors the other composite call
+    # sites (_get_custom_model_class / resolve_task), so a model_type carrying
+    # underscores or mixed case still maps to its pipeline tasks.
+    tasks = composite_pipeline_tasks(model_type.lower().replace("_", "-"))
     return tasks[0] if tasks else None
 
 

--- a/tests/e2e/test_build_e2e.py
+++ b/tests/e2e/test_build_e2e.py
@@ -358,3 +358,56 @@ class TestBuildDynamicAxes:
         dims = pixel_values.type.tensor_type.shape.dim
         assert dims[0].dim_param == "batch", f"expected a symbolic batch dim, got {list(dims)}"
         assert [d.dim_value for d in dims[1:]] == [3, 224, 224]
+
+
+# ===========================================================================
+# Composite model: encoder-decoder build fan-out.
+# ===========================================================================
+
+
+@pytest.mark.slow
+@pytest.mark.network
+class TestBuildT5Composite:
+    """A composite model builds one artifact per sub-component.
+
+    ``google-t5/t5-small`` resolves to two sub-models (encoder + decoder). With
+    no ``-c`` config the build auto-detects the composite (via the seq2seq
+    bridge) and fans out into one build per component, each producing its own
+    ``<component>_model.onnx`` under the output dir. Component names come from
+    the registry so the test stays architecture-agnostic.
+    """
+
+    def test_composite_fanout(self, tmp_path: Path):
+        from winml.modelkit.loader.resolution import resolve_composite_components
+
+        components = resolve_composite_components("google-t5/t5-small")
+        assert components, "google-t5/t5-small did not resolve to a composite model"
+
+        output_dir = tmp_path / "output"
+        result = CliRunner().invoke(
+            build,
+            [
+                "-m",
+                "google-t5/t5-small",
+                "-o",
+                str(output_dir),
+                "--no-quant",
+                "--no-compile",
+                "--no-analyze",
+            ],
+            obj={"debug": True},
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"build failed (exit {result.exit_code}):\n{result.output}"
+
+        onnx_names = [p.name for p in output_dir.rglob("*.onnx")]
+        assert onnx_names, (
+            f"No ONNX files found in {output_dir}. Contents: "
+            f"{[str(p) for p in output_dir.rglob('*')]}"
+        )
+        # Each sub-component contributes its own build artifacts; the final
+        # per-component model is named ``<component>_model.onnx``.
+        for name in components:
+            assert f"{name}_model.onnx" in onnx_names, (
+                f"missing built artifact for sub-model {name!r}; produced: {onnx_names}"
+            )

--- a/tests/e2e/test_export_e2e.py
+++ b/tests/e2e/test_export_e2e.py
@@ -43,6 +43,11 @@ pytestmark = [pytest.mark.e2e, pytest.mark.slow, pytest.mark.network, pytest.mar
 
 _MODEL = "microsoft/resnet-50"
 
+# Composite (encoder-decoder) model exercised by the fan-out tests. Its
+# sub-component names/tasks are resolved from the registry at runtime rather
+# than hardcoded, so the tests stay architecture-agnostic.
+_COMPOSITE_MODEL = "google-t5/t5-small"
+
 # Full WinMLBuildConfig used by ``-c PATH`` tests. Sets opset_version=18 so the
 # resulting ONNX model can be verified via its default-domain opset.
 _BUILD_CONFIG: dict = {
@@ -503,3 +508,71 @@ class TestExportDynamicAxes:
         onnx_path = tmp_path / "model.onnx"
         bad = _write_json(tmp_path / "axes.json", {"pixel_values": {"0": ""}})
         _assert_fails(_happy_args(onnx_path, "--dynamic-axes", str(bad)), onnx_path)
+
+
+# ===========================================================================
+# Composite model: encoder-decoder fan-out
+# ===========================================================================
+
+
+class TestExportT5Composite:
+    """Composite (encoder-decoder) export fans out into one ONNX per sub-model.
+
+    ``google-t5/t5-small`` resolves to two sub-components (encoder + decoder).
+    Exporting the whole model writes ``<stem>_<component>.onnx`` for every
+    component instead of the verbatim ``-o`` path, while ``--submodel`` narrows
+    the fan-out to a single component. Component names are read from the
+    registry so the assertions never hardcode architecture-specific labels.
+    """
+
+    def _components(self) -> dict[str, str]:
+        from winml.modelkit.loader.resolution import resolve_composite_components
+
+        components = resolve_composite_components(_COMPOSITE_MODEL)
+        assert components, f"{_COMPOSITE_MODEL} did not resolve to a composite model"
+        return components
+
+    def test_composite_fanout(self, tmp_path: Path):
+        components = self._components()
+        onnx_path = tmp_path / "model.onnx"
+
+        result = _invoke(["-m", _COMPOSITE_MODEL, "-o", str(onnx_path)])
+        assert result.exit_code == 0, f"export failed (exit {result.exit_code}):\n{result.output}"
+
+        # The verbatim -o path is never written for a multi-component fan-out;
+        # each sub-model lands at ``<stem>_<component>.onnx`` instead.
+        assert not onnx_path.exists(), "composite export unexpectedly wrote the verbatim -o path"
+        for name in components:
+            component_path = tmp_path / f"{onnx_path.stem}_{name}.onnx"
+            assert component_path.exists(), f"missing sub-model ONNX for {name!r}: {component_path}"
+            model = onnx.load(str(component_path))
+            assert list(model.graph.node), f"sub-model {name!r} has zero graph nodes"
+
+    def test_submodel_narrows_to_single(self, tmp_path: Path):
+        components = self._components()
+        selected = next(iter(components))
+        onnx_path = tmp_path / "model.onnx"
+
+        result = _invoke(["-m", _COMPOSITE_MODEL, "-o", str(onnx_path), "--submodel", selected])
+        assert result.exit_code == 0, f"export failed (exit {result.exit_code}):\n{result.output}"
+
+        # Only the selected component is written; the others are skipped.
+        assert (tmp_path / f"{onnx_path.stem}_{selected}.onnx").exists()
+        for name in components:
+            if name == selected:
+                continue
+            assert not (tmp_path / f"{onnx_path.stem}_{name}.onnx").exists(), (
+                f"--submodel {selected!r} should not export component {name!r}"
+            )
+
+    def test_unknown_submodel_fails(self, tmp_path: Path):
+        # An unknown sub-model name is rejected before any ONNX is produced.
+        onnx_path = tmp_path / "model.onnx"
+        result = _invoke(
+            ["-m", _COMPOSITE_MODEL, "-o", str(onnx_path), "--submodel", "not_a_submodel"],
+            catch=True,
+        )
+        assert result.exit_code != 0, f"expected failure, got exit=0:\n{result.output}"
+        assert not list(tmp_path.glob("*.onnx")), (
+            "no ONNX should be written on an invalid --submodel"
+        )

--- a/tests/e2e/test_perf_e2e.py
+++ b/tests/e2e/test_perf_e2e.py
@@ -825,7 +825,8 @@ class TestPerfT5Composite:
         from winml.modelkit.loader.resolution import resolve_composite_components
 
         components = resolve_composite_components("google-t5/t5-small")
-        assert components, "google-t5/t5-small did not resolve to a composite model"
+        # t5-small is an encoder-decoder pipeline: exactly two sub-models.
+        assert set(components) == {"encoder", "decoder"}
 
         output_file = tmp_path / "perf_t5_composite.json"
         result = CliRunner().invoke(
@@ -852,8 +853,8 @@ class TestPerfT5Composite:
 
         data = json.loads(output_file.read_text())
         assert data["model_id"] == "google-t5/t5-small"
-        assert data["component_count"] == len(components)
-        assert set(data["components"]) == set(components)
+        assert data["component_count"] == 2
+        assert set(data["components"]) == {"encoder", "decoder"}
 
         # Every sub-model was benchmarked individually: it carries its own task
         # and a positive mean latency.

--- a/tests/e2e/test_perf_e2e.py
+++ b/tests/e2e/test_perf_e2e.py
@@ -804,6 +804,66 @@ class TestPerfDynamicAxes:
 
 
 # ===========================================================================
+# Composite model: per-sub-model benchmarking.
+# ===========================================================================
+
+
+class TestPerfT5Composite:
+    """A composite pipeline benchmarks each sub-model and reports them together.
+
+    ``google-t5/t5-small`` is a composite (encoder + decoder). Like ``build`` and
+    ``export``, perf auto-detects the composite from a bare ``-m`` (no explicit
+    task) and builds the whole pipeline; it then benchmarks each sub-model
+    individually and writes a combined report keyed by component name. An
+    explicit pipeline task (``--task translation``) selects the same composite.
+    Component names/tasks are read from the registry to keep the assertions
+    architecture-agnostic.
+    """
+
+    @pytest.mark.parametrize("extra_args", [[], ["--task", "translation"]], ids=["auto", "task"])
+    def test_composite_report_cpu(self, extra_args: list[str], tmp_path: Path):
+        from winml.modelkit.loader.resolution import resolve_composite_components
+
+        components = resolve_composite_components("google-t5/t5-small")
+        assert components, "google-t5/t5-small did not resolve to a composite model"
+
+        output_file = tmp_path / "perf_t5_composite.json"
+        result = CliRunner().invoke(
+            perf,
+            [
+                "-m",
+                "google-t5/t5-small",
+                "--device",
+                "cpu",
+                "--iterations",
+                "3",
+                "--warmup",
+                "1",
+                "-o",
+                str(output_file),
+                "--no-memory",
+                *extra_args,
+            ],
+            obj={},
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"perf failed (exit {result.exit_code}):\n{result.output}"
+        assert output_file.exists()
+
+        data = json.loads(output_file.read_text())
+        assert data["model_id"] == "google-t5/t5-small"
+        assert data["component_count"] == len(components)
+        assert set(data["components"]) == set(components)
+
+        # Every sub-model was benchmarked individually: it carries its own task
+        # and a positive mean latency.
+        for name, component_task in components.items():
+            component = data["components"][name]
+            assert component["benchmark_info"]["task"] == component_task
+            assert component["latency_ms"]["mean"] > 0, f"sub-model {name!r} has no latency"
+
+
+# ===========================================================================
 # GenAI runtime (winml-genai): --device / --ep override
 # ===========================================================================
 

--- a/tests/e2e/test_perf_e2e.py
+++ b/tests/e2e/test_perf_e2e.py
@@ -808,6 +808,9 @@ class TestPerfDynamicAxes:
 # ===========================================================================
 
 
+@pytest.mark.slow
+@pytest.mark.network
+@pytest.mark.timeout(1800)
 class TestPerfT5Composite:
     """A composite pipeline benchmarks each sub-model and reports them together.
 

--- a/tests/unit/loader/test_composite_pipeline_tasks.py
+++ b/tests/unit/loader/test_composite_pipeline_tasks.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------
 """Unit tests for ``composite_pipeline_tasks`` — registry-driven, offline."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -77,3 +77,23 @@ class TestResolveCompositeLoadTask:
         config = make_mock_config("resnet", ["ResNetForImageClassification"])
         with patch("transformers.AutoConfig.from_pretrained", return_value=config):
             assert resolve_composite_load_task("some/resnet-checkpoint") is None
+
+    def test_model_type_is_normalized_before_registry_lookup(self, make_mock_config) -> None:
+        # Registry keys are lower/hyphenated; a raw model_type with underscores or
+        # mixed case must still map to its pipeline task. resolve_task is stubbed to
+        # report "composite" so this isolates the normalization step (without it,
+        # composite_pipeline_tasks("Vision_Encoder_Decoder") is [] -> None).
+        registered = "vision-encoder-decoder"
+        expected = composite_pipeline_tasks(registered)
+        assert expected, f"{registered!r} should be a registered composite"
+
+        config = make_mock_config("Vision_Encoder_Decoder", ["VisionEncoderDecoderModel"])
+        detected = MagicMock()
+        detected.composite = {"encoder": "feature-extraction", "decoder": "image-to-text"}
+        with (
+            patch("winml.modelkit.loader.resolution.resolve_task", return_value=detected),
+            patch("transformers.AutoConfig.from_pretrained", return_value=config),
+        ):
+            result = resolve_composite_load_task("some/vision-encoder-decoder-checkpoint")
+
+        assert result == expected[0]

--- a/tests/unit/loader/test_composite_pipeline_tasks.py
+++ b/tests/unit/loader/test_composite_pipeline_tasks.py
@@ -4,9 +4,12 @@
 # --------------------------------------------------------------------------
 """Unit tests for ``composite_pipeline_tasks`` — registry-driven, offline."""
 
+from unittest.mock import patch
+
 import pytest
 
 from winml.modelkit.loader import composite_pipeline_tasks
+from winml.modelkit.loader.resolution import resolve_composite_load_task
 
 
 def test_bart_serves_summarization_and_table_qa_sorted():
@@ -35,10 +38,42 @@ def test_registry_accessor_raises_loudly_when_empty(monkeypatch):
     # than let every reader silently return []/None (composites disabled unnoticed).
     import winml.modelkit.models.hf  # noqa: F401 — ensure real registrations land first
 
-    monkeypatch.setattr(
-        "winml.modelkit.models.winml.composite_model.COMPOSITE_MODEL_REGISTRY", {}
-    )
+    monkeypatch.setattr("winml.modelkit.models.winml.composite_model.COMPOSITE_MODEL_REGISTRY", {})
     from winml.modelkit.loader.resolution import _composite_registry
 
     with pytest.raises(RuntimeError, match="COMPOSITE_MODEL_REGISTRY is empty"):
         _composite_registry()
+
+
+class TestResolveCompositeLoadTask:
+    """``resolve_composite_load_task`` bridges detection to a loadable pipeline task.
+
+    The fan-out commands use ``resolve_composite_components`` (which sub-models),
+    but the model loaders need a concrete registry task to instantiate the
+    pipeline. This helper maps a detected composite back to its sorted-first
+    pipeline task so a bare ``winml perf -m <composite>`` builds the whole
+    pipeline. Config loading is mocked to keep the test offline.
+    """
+
+    def test_none_model_returns_none_without_loading_config(self) -> None:
+        # No model id -> nothing to resolve, and no config round-trip attempted.
+        with patch("transformers.AutoConfig.from_pretrained") as mock_cfg:
+            assert resolve_composite_load_task(None) is None
+        mock_cfg.assert_not_called()
+
+    def test_composite_model_maps_to_sorted_first_pipeline_task(self, make_mock_config) -> None:
+        # A seq2seq composite (T5) resolves to its deterministic sorted-first
+        # pipeline task -- sub-model-equivalent to the others it registers.
+        config = make_mock_config("t5", ["T5ForConditionalGeneration"])
+        with patch("transformers.AutoConfig.from_pretrained", return_value=config):
+            result = resolve_composite_load_task("some/t5-checkpoint")
+
+        tasks = composite_pipeline_tasks("t5")
+        assert tasks, "t5 should register composite pipeline tasks"
+        assert result == tasks[0]
+
+    def test_non_composite_model_returns_none(self, make_mock_config) -> None:
+        # A plain classifier is not a composite -> no pipeline task to load.
+        config = make_mock_config("resnet", ["ResNetForImageClassification"])
+        with patch("transformers.AutoConfig.from_pretrained", return_value=config):
+            assert resolve_composite_load_task("some/resnet-checkpoint") is None


### PR DESCRIPTION
## What

Adds end-to-end coverage for a composite (encoder-decoder) model,
`google-t5/t5-small`, across `export`, `build`, and `perf`, and fixes a gap
where a bare `winml perf -m <composite>` did **not** benchmark the whole
pipeline.

## Why / the perf fix

`export` and `build` already auto-detect composites from a bare `-m` (no
`--task`) and fan out per sub-model. `perf` did not: a bare seq2seq model such
as T5 auto-detected to a granular single-model task (`text2text-generation`)
and benchmarked **only the decoder**.

Root cause: `WinMLAutoModel.from_pretrained` only consults the composite
registry when `task is not None`, so the auto path never routed T5 to its
composite.

Fix (perf-scoped, mirrors how `build`/`export` detect composites in the command
layer):

- `loader/resolution.py`: new `resolve_composite_load_task(hf_model)` — loads
  `AutoConfig` once and, if the model is a registered composite, returns its
  deterministic sorted-first *pipeline* task (a loadable registry task); else
  `None`.
- `commands/perf.py` `_load_model`: on the HF auto path (not ONNX, `task=None`)
  resolve the composite and pass that task to `from_pretrained`, wrapped in an
  `OSError` guard that falls back to single-model loading (matches build's
  "config not resolvable" guard) so an invalid/unreachable id degrades cleanly.

### build/export vs perf

`build`/`export` *fan out* into one independent build per sub-model, so they use
`resolve_composite_components` → a `{name: sub_model_task}` map and never
construct a composite object. `perf` instead loads one live
`WinMLCompositeModel` and benchmarks its sub-models, which requires a registered
composite *pipeline* task (`translation`/`summarization`) to route
`from_pretrained` — a different namespace from the sub-model tasks. Hence the
separate `resolve_composite_load_task` bridge.

## Tests

- `TestExportT5Composite`, `TestBuildT5Composite`, `TestPerfT5Composite`
  (parametrized over auto + `--task translation`).
- Offline unit tests for `resolve_composite_load_task`
  (None / composite / non-composite).