### PR TITLE
test(e2e): add --submodel coverage for export, build, and perf

### DIFF
--- a/tests/e2e/test_build_e2e.py
+++ b/tests/e2e/test_build_e2e.py
@@ -411,3 +411,66 @@ class TestBuildT5Composite:
             assert f"{name}_model.onnx" in onnx_names, (
                 f"missing built artifact for sub-model {name!r}; produced: {onnx_names}"
             )
+
+    def test_submodel_narrows_to_single(self, tmp_path: Path):
+        from winml.modelkit.loader.resolution import resolve_composite_components
+
+        components = resolve_composite_components("google-t5/t5-small")
+        assert components, "google-t5/t5-small did not resolve to a composite model"
+        selected = next(iter(components))
+
+        output_dir = tmp_path / "output"
+        result = CliRunner().invoke(
+            build,
+            [
+                "-m",
+                "google-t5/t5-small",
+                "-o",
+                str(output_dir),
+                "--submodel",
+                selected,
+                "--no-quant",
+                "--no-compile",
+                "--no-analyze",
+            ],
+            obj={"debug": True},
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"build failed (exit {result.exit_code}):\n{result.output}"
+
+        onnx_names = [p.name for p in output_dir.rglob("*.onnx")]
+        # Only the selected sub-model is built; the others are skipped entirely.
+        assert f"{selected}_model.onnx" in onnx_names, (
+            f"missing built artifact for selected sub-model {selected!r}; produced: {onnx_names}"
+        )
+        for name in components:
+            if name == selected:
+                continue
+            assert f"{name}_model.onnx" not in onnx_names, (
+                f"--submodel {selected!r} should not build component {name!r}; "
+                f"produced: {onnx_names}"
+            )
+
+    def test_unknown_submodel_fails(self, tmp_path: Path):
+        # An unknown sub-model name is rejected before any build runs.
+        output_dir = tmp_path / "output"
+        result = CliRunner().invoke(
+            build,
+            [
+                "-m",
+                "google-t5/t5-small",
+                "-o",
+                str(output_dir),
+                "--submodel",
+                "not_a_submodel",
+                "--no-quant",
+                "--no-compile",
+                "--no-analyze",
+            ],
+            obj={"debug": True},
+            catch_exceptions=True,
+        )
+        assert result.exit_code != 0, f"expected failure, got exit=0:\n{result.output}"
+        assert not list(output_dir.rglob("*.onnx")), (
+            "no ONNX should be built on an invalid --submodel"
+        )

--- a/tests/e2e/test_export_e2e.py
+++ b/tests/e2e/test_export_e2e.py
@@ -576,3 +576,18 @@ class TestExportT5Composite:
         assert not list(tmp_path.glob("*.onnx")), (
             "no ONNX should be written on an invalid --submodel"
         )
+
+    def test_submodel_on_non_composite_fails(self, tmp_path: Path):
+        # --submodel only makes sense for a composite model; a plain single
+        # model (resnet-50) resolves to no sub-components, so the option is
+        # rejected up front and nothing is exported.
+        onnx_path = tmp_path / "model.onnx"
+        result = _invoke(
+            ["-m", _MODEL, "-o", str(onnx_path), "--submodel", "encoder"],
+            catch=True,
+        )
+        assert result.exit_code != 0, f"expected failure, got exit=0:\n{result.output}"
+        assert "not a composite model" in result.output
+        assert not list(tmp_path.glob("*.onnx")), (
+            "no ONNX should be written when --submodel targets a non-composite model"
+        )

--- a/tests/e2e/test_perf_e2e.py
+++ b/tests/e2e/test_perf_e2e.py
@@ -866,6 +866,71 @@ class TestPerfT5Composite:
             assert component["benchmark_info"]["task"] == component_task
             assert component["latency_ms"]["mean"] > 0, f"sub-model {name!r} has no latency"
 
+    def test_submodel_benchmarks_single(self, tmp_path: Path):
+        from winml.modelkit.loader.resolution import resolve_composite_components
+
+        components = resolve_composite_components("google-t5/t5-small")
+        assert set(components) == {"encoder", "decoder"}
+        selected = next(iter(components))
+
+        output_file = tmp_path / "perf_t5_submodel.json"
+        result = CliRunner().invoke(
+            perf,
+            [
+                "-m",
+                "google-t5/t5-small",
+                "--submodel",
+                selected,
+                "--device",
+                "cpu",
+                "--iterations",
+                "3",
+                "--warmup",
+                "1",
+                "-o",
+                str(output_file),
+                "--no-memory",
+            ],
+            obj={},
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"perf failed (exit {result.exit_code}):\n{result.output}"
+        assert output_file.exists()
+
+        data = json.loads(output_file.read_text())
+        # --submodel benchmarks a single sub-model through the standalone path, so
+        # the report is the single-model schema -- not the composite fan-out one.
+        assert "component_count" not in data
+        assert "components" not in data
+        assert data["benchmark_info"]["task"] == components[selected]
+        assert data["latency_ms"]["mean"] > 0
+
+    def test_unknown_submodel_fails(self, tmp_path: Path):
+        # An unknown sub-model name is rejected before any benchmark runs.
+        output_file = tmp_path / "perf_t5_bad_submodel.json"
+        result = CliRunner().invoke(
+            perf,
+            [
+                "-m",
+                "google-t5/t5-small",
+                "--submodel",
+                "not_a_submodel",
+                "--device",
+                "cpu",
+                "--iterations",
+                "3",
+                "--warmup",
+                "1",
+                "-o",
+                str(output_file),
+                "--no-memory",
+            ],
+            obj={},
+            catch_exceptions=True,
+        )
+        assert result.exit_code != 0, f"expected failure, got exit=0:\n{result.output}"
+        assert not output_file.exists(), "no report should be written on an invalid --submodel"
+
 
 # ===========================================================================
 # GenAI runtime (winml-genai): --device / --ep override


### PR DESCRIPTION
## Summary

Extends the composite (`google-t5/t5-small`) e2e suites with `--submodel` cases across all three commands that support the option. Component names and tasks are read from the registry so the assertions stay architecture-agnostic.

## Changes

**`winml export`** (`test_export_e2e.py`)
- `test_submodel_on_non_composite_fails`: `--submodel` on a non-composite model (`resnet-50`) is rejected up front and nothing is exported.
- (Fan-out, narrows-to-single, and unknown-name cases already existed.)

**`winml build`** (`test_build_e2e.py`)
- `test_submodel_narrows_to_single`: only the selected sub-model's `<name>_model.onnx` is built; the other components are skipped.
- `test_unknown_submodel_fails`: an unknown name is rejected before any build runs.

**`winml perf`** (`test_perf_e2e.py`)
- `test_submodel_benchmarks_single`: `--submodel` benchmarks a single sub-model via the standalone single-model report (not the composite fan-out schema), with the correct component task and a positive latency.
- `test_unknown_submodel_fails`: an unknown name is rejected before any benchmark runs.

## Verification

- ruff clean on all three files.
- All 7 new tests pass locally (`-m e2e`): 4 rejection tests (~45s) and 3 real build/benchmark tests (~47s).