### PR TITLE
feat(layoutlm): add document question answering support

### DIFF
--- a/examples/recipes/DmitrySpartak_layoutlm-invoices/cpu/cpu/document-question-answering_fp16_config.json
+++ b/examples/recipes/DmitrySpartak_layoutlm-invoices/cpu/cpu/document-question-answering_fp16_config.json
@@ -1,0 +1,102 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          50265
+        ]
+      },
+      {
+        "name": "bbox",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512,
+          4
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      },
+      {
+        "name": "token_type_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "start_logits"
+      },
+      {
+        "name": "end_logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "document-question-answering",
+    "model_id": "DmitrySpartak/layoutlm-invoices",
+    "model_type": "layoutlm",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "document-question-answering",
+    "model_class": "AutoModelForDocumentQuestionAnswering",
+    "model_type": "layoutlm"
+  }
+}

--- a/examples/recipes/DmitrySpartak_layoutlm-invoices/cpu/cpu/document-question-answering_fp32_config.json
+++ b/examples/recipes/DmitrySpartak_layoutlm-invoices/cpu/cpu/document-question-answering_fp32_config.json
@@ -1,0 +1,80 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          50265
+        ]
+      },
+      {
+        "name": "bbox",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512,
+          4
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      },
+      {
+        "name": "token_type_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "start_logits"
+      },
+      {
+        "name": "end_logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "document-question-answering",
+    "model_class": "AutoModelForDocumentQuestionAnswering",
+    "model_type": "layoutlm"
+  }
+}

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -457,6 +457,7 @@ def generate_random_inputs(
     symbolic_shapes = io_config.get("input_symbolic_shapes") or [
         [None] * len(s) for s in io_config["input_shapes"]
     ]
+    value_ranges = io_config.get("input_value_ranges") or {}
     overrides = shape_config or {}
 
     specs: dict[str, dict[str, Any]] = {}
@@ -485,6 +486,11 @@ def generate_random_inputs(
             "dtype": gen_dtype,
             "shape": list(resolved_shape),
         }
+        if name in value_ranges:
+            low, high = value_ranges[name]
+            # InputTensorSpec/config ranges are [low, high), while the legacy
+            # manual NumPy generator treats an integer spec's maximum as inclusive.
+            specs[name]["range"] = [int(low), int(high) - 1] if gen_dtype == "int" else [low, high]
 
     return generate_dummy_inputs_from_specs(specs)
 

--- a/src/winml/modelkit/loader/resolution.py
+++ b/src/winml/modelkit/loader/resolution.py
@@ -251,6 +251,7 @@ class TaskSource(str, Enum):
     USER_CLASS = "user-class"  # user passed --model-class; task inferred
     MODEL_ID_DEFAULT = "model-id-default"  # MODEL_TASK_MAPPING model-id default
     SENTINEL_DEFAULT = "sentinel-default"  # (model_type, None) sentinel
+    ARCHITECTURE_MAPPING = "architecture-mapping"  # models/hf metadata override
     TASKS_MANAGER = "tasks-manager"  # Optimum inference (incl. fill-mask upgrade)
     WRAPPED_LIBRARY = "wrapped-library"  # no architectures -> first supported task
     PIPELINE_TAG = "pipeline-tag"  # Hub pipeline_tag fallback
@@ -425,6 +426,25 @@ def _infer_task_from_architecture(config: PretrainedConfig) -> str:
     )
 
 
+def _get_architecture_task_override(config: PretrainedConfig) -> str | None:
+    """Return a registered task derived from model type + architecture head.
+
+    This is the data-driven escape hatch for concrete HuggingFace heads that
+    Optimum cannot infer (or infers incorrectly). Registrations live beside the
+    architecture's ONNX config under ``models/hf/``; no checkpoint IDs or
+    architecture branches belong in this shared resolver.
+    """
+    architectures = getattr(config, "architectures", None)
+    model_type = getattr(config, "model_type", None)
+    if not architectures or not model_type:
+        return None
+
+    from ..models.hf import ARCHITECTURE_TASK_MAPPING
+
+    model_type_norm = model_type.lower().replace("_", "-")
+    return ARCHITECTURE_TASK_MAPPING.get((model_type_norm, architectures[0]))
+
+
 def _composite_components_for_task(model_type: str, task: str) -> CompositeComponents | None:
     """Composite components serving a *detected* task, else None.
 
@@ -524,7 +544,9 @@ def resolve_task(
             # Task inferred from the architecture: surface it modality-aware, consistent
             # with the detection path (Stage 3), so e.g. a ViT backbone is
             # image-feature-extraction rather than the modality-blind feature-extraction.
-            opt_task = _infer_task_from_architecture(config)
+            opt_task = _get_architecture_task_override(config) or _infer_task_from_architecture(
+                config
+            )
             surfaced = _resolve_task_modality(config, opt_task)
         # A WinML build variant (model_type_override) may name a custom wrapper
         # registered in MODEL_CLASS_MAPPING rather than a transformers class —
@@ -617,13 +639,18 @@ def resolve_task(
             # lookup failure here — e.g. a wrapped library whose classes aren't registered
             # under framework="pt" — can't escape as a raw KeyError.
 
-    # 1c. TasksManager (reads config.architectures)
+    # 1c. Architecture metadata override, then TasksManager (both read
+    #     config.architectures). The override handles heads Optimum does not map.
     if opt_task is None:
-        try:
-            opt_task = _infer_task_from_architecture(config)
-            source = TaskSource.TASKS_MANAGER
-        except ValueError:
-            opt_task = None
+        opt_task = _get_architecture_task_override(config)
+        if opt_task is not None:
+            source = TaskSource.ARCHITECTURE_MAPPING
+        else:
+            try:
+                opt_task = _infer_task_from_architecture(config)
+                source = TaskSource.TASKS_MANAGER
+            except ValueError:
+                opt_task = None
 
     # 1d. Hub pipeline_tag fallback
     if opt_task is None and model_id and model_type:

--- a/src/winml/modelkit/models/hf/__init__.py
+++ b/src/winml/modelkit/models/hf/__init__.py
@@ -48,7 +48,12 @@ from .convnext import ConvNextIOConfig as _ConvNextIOConfig  # triggers registra
 from .depth_anything import DepthAnythingIOConfig as _DepthAnythingIOConfig  # triggers registration
 from .depth_pro import DepthProIOConfig as _DepthProIOConfig  # triggers registration
 from .detr import DETR_CONFIG
-from .layoutlm import LayoutLMQAIOConfig as _LayoutLMQAIOConfig  # triggers registration
+from .layoutlm import ARCHITECTURE_TASK_MAPPING as _LAYOUTLM_ARCHITECTURE_TASK_MAPPING
+from .layoutlm import MODEL_CLASS_MAPPING as _LAYOUTLM_CLASS_MAPPING
+from .layoutlm import (
+    LayoutLMDocumentQAOnnxConfig as _LayoutLMDocumentQAOnnxConfig,  # triggers registration
+)
+from .layoutlm import LayoutLMQAOnnxConfig as _LayoutLMQAOnnxConfig  # triggers registration
 from .layoutlmv3 import LAYOUTLMV3_CONFIG
 from .layoutlmv3 import LayoutLMv3IOConfig as _LayoutLMv3IOConfig  # triggers registration
 from .marian import MARIAN_CONFIG
@@ -123,6 +128,7 @@ MODEL_CLASS_MAPPING: dict[tuple[str, str | None], type] = {
         _BART_CLASS_MAPPING,
         _BLIP_CLASS_MAPPING,
         _CLIP_CLASS_MAPPING,
+        _LAYOUTLM_CLASS_MAPPING,
         _MARIAN_CLASS_MAPPING,
         _MU2_CLASS_MAPPING,
         _QWEN_CLASS_MAPPING,
@@ -137,6 +143,13 @@ MODEL_CLASS_MAPPING: dict[tuple[str, str | None], type] = {
         _VITPOSE_CLASS_MAPPING,
     )
     for _key, _model_cls in _sub_mapping.items()
+}
+
+# Registry for architecture heads that Optimum cannot map to their pipeline
+# task. Keys include model_type so identically named custom classes cannot
+# collide across model families.
+ARCHITECTURE_TASK_MAPPING: dict[tuple[str, str], str] = {
+    **_LAYOUTLM_ARCHITECTURE_TASK_MAPPING,
 }
 
 # Registry: model_type -> WinMLBuildConfig
@@ -168,6 +181,7 @@ MODEL_BUILD_CONFIGS = {
 }
 
 __all__ = [
+    "ARCHITECTURE_TASK_MAPPING",
     "MODEL_BUILD_CONFIGS",
     "MODEL_CLASS_MAPPING",
 ]

--- a/src/winml/modelkit/models/hf/layoutlm.py
+++ b/src/winml/modelkit/models/hf/layoutlm.py
@@ -21,11 +21,10 @@ import logging
 from typing import Any
 
 from optimum.exporters.onnx.model_configs import LayoutLMOnnxConfig
-from optimum.utils import NormalizedTextConfig
-from optimum.utils.input_generators import DummyBboxInputGenerator, DummyVisionInputGenerator
+from optimum.utils.input_generators import DummyTextInputGenerator
 from transformers import AutoModelForDocumentQuestionAnswering
 
-from ...export import MaxLengthTextInputGenerator, register_onnx_overwrite
+from ...export import register_onnx_overwrite
 
 
 logger = logging.getLogger(__name__)
@@ -85,7 +84,7 @@ def _adjust_roberta_position_embeddings(config: Any) -> None:
     )
 
 
-class LayoutLMTextInputGenerator(MaxLengthTextInputGenerator):
+class LayoutLMTextInputGenerator(DummyTextInputGenerator):  # type: ignore[misc]
     """Generate LayoutLM dummy text inputs with safe token-type IDs.
 
     LayoutLM checkpoints commonly set ``type_vocab_size=1``, so token-type
@@ -100,17 +99,18 @@ class LayoutLMTextInputGenerator(MaxLengthTextInputGenerator):
         float_dtype: str = "fp32",
     ) -> Any:
         """Generate a safe tensor for ``input_name``."""
-        tensor = super().generate(
-            input_name,
-            framework=framework,
-            int_dtype=int_dtype,
-            float_dtype=float_dtype,
-        )
         if input_name != "token_type_ids":
-            return tensor
-        # Most LayoutLM v1 checkpoints use type_vocab_size=1, so token types
-        # must stay zero to avoid embedding gather OOB during perf/build probes.
-        return tensor.new_zeros(tensor.shape)
+            return super().generate(input_name, framework, int_dtype, float_dtype)
+
+        type_vocab_size = max(1, int(self.normalized_config.type_vocab_size))
+        shape = [self.batch_size, self.sequence_length]
+        return self.random_int_tensor(
+            shape,
+            max_value=type_vocab_size,
+            min_value=0,
+            framework=framework,
+            dtype=int_dtype,
+        )
 
 
 @register_onnx_overwrite("layoutlm", "document-question-answering", library_name="transformers")
@@ -122,17 +122,9 @@ class LayoutLMDocumentQAOnnxConfig(LayoutLMOnnxConfig):  # type: ignore[misc]
     tensors returned by ``LayoutLMForQuestionAnswering``.
     """
 
-    # Bind sequence length to config.max_position_embeddings so max-length
-    # dummy generation is valid for full-size parity/perf probes.
-    NORMALIZED_CONFIG_CLASS = NormalizedTextConfig.with_args(
-        sequence_length="max_position_embeddings",
-        allow_new=True,
-    )
-
-    DUMMY_INPUT_GENERATOR_CLASSES: tuple[type[Any], ...] = (
+    DUMMY_INPUT_GENERATOR_CLASSES = (
         LayoutLMTextInputGenerator,
-        DummyVisionInputGenerator,
-        DummyBboxInputGenerator,
+        *LayoutLMOnnxConfig.DUMMY_INPUT_GENERATOR_CLASSES[1:],
     )
 
     def __init__(self, config: Any, task: str, **kwargs: Any) -> None:

--- a/src/winml/modelkit/models/hf/layoutlm.py
+++ b/src/winml/modelkit/models/hf/layoutlm.py
@@ -86,14 +86,11 @@ def _adjust_roberta_position_embeddings(config: Any) -> None:
 
 
 class LayoutLMTextInputGenerator(MaxLengthTextInputGenerator):
-    """Generate token types within the checkpoint's configured vocabulary.
+    """Generate LayoutLM dummy text inputs with safe token-type IDs.
 
-    Optimum's generic text generator samples token-type IDs from ``[0, 2)``.
-    LayoutLM checkpoints commonly set ``type_vocab_size=1``, where sampling 1
-    causes an embedding Gather out of bounds. Derive the exclusive upper bound
-    from config metadata instead.
+    LayoutLM checkpoints commonly set ``type_vocab_size=1``, so token-type
+    values must remain zero to avoid embedding gather out-of-bounds.
     """
->>>>>>> e65450dc (feat(layoutlm): add document question answering support)
 
     def generate(
         self,

--- a/src/winml/modelkit/models/hf/layoutlm.py
+++ b/src/winml/modelkit/models/hf/layoutlm.py
@@ -2,25 +2,98 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-"""LayoutLM HuggingFace Model Configuration."""
+"""LayoutLM v1 document-question-answering support.
+
+LayoutLM v1 uses an extractive question-answering head for document QA: the
+model consumes token IDs plus OCR-derived bounding boxes and emits start/end
+logits. Optimum does not register this model-type/task pair, and it cannot
+infer the task from ``LayoutLMForQuestionAnswering``.
+
+This module supplies the missing task metadata, model-class mapping, and ONNX
+configuration for the whole LayoutLM v1 family. It does not implement OCR,
+word/box alignment, or answer decoding; those remain external preprocessing
+and postprocessing steps.
+"""
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+import logging
+from typing import Any
 
 from optimum.exporters.onnx.model_configs import LayoutLMOnnxConfig
 from optimum.utils import NormalizedTextConfig
 from optimum.utils.input_generators import DummyBboxInputGenerator, DummyVisionInputGenerator
+from transformers import AutoModelForDocumentQuestionAnswering
 
 from ...export import MaxLengthTextInputGenerator, register_onnx_overwrite
 
 
-if TYPE_CHECKING:
-    import torch
+logger = logging.getLogger(__name__)
 
 
-class ZeroTokenTypeLayoutLMTextInputGenerator(MaxLengthTextInputGenerator):
-    """LayoutLM text dummy generator that keeps token_type_ids within type_vocab_size=1."""
+# The task is derived from checkpoint architecture metadata instead of a model
+# ID. The resolver consults this registry before Optimum task inference.
+ARCHITECTURE_TASK_MAPPING: dict[tuple[str, str], str] = {
+    ("layoutlm", "LayoutLMForQuestionAnswering"): "document-question-answering",
+}
+
+
+# Optimum has no model-class entry for document-question-answering. Transformers
+# does: its document-QA auto class maps LayoutLMConfig to
+# LayoutLMForQuestionAnswering.
+MODEL_CLASS_MAPPING: dict[tuple[str, str], type] = {
+    ("layoutlm", "document-question-answering"): AutoModelForDocumentQuestionAnswering,
+}
+
+
+def _adjust_roberta_position_embeddings(config: Any) -> None:
+    """Use the non-padding sequence length for RoBERTa-tokenized checkpoints.
+
+    RoBERTa tokenizers reserve ``pad_token_id + 1`` position slots, so their
+    configs commonly encode ``max_position_embeddings`` as usable length plus
+    that offset (for example, 514 for a usable length of 512). Only configs
+    that explicitly declare a RoBERTa tokenizer are adjusted; a LayoutLM model
+    with a positive padding ID but another position convention is untouched.
+    """
+    if getattr(config, "_position_offset_applied", False):
+        return
+
+    tokenizer_class = getattr(config, "tokenizer_class", "") or ""
+    if "roberta" not in tokenizer_class.lower():
+        return
+
+    max_positions = getattr(config, "max_position_embeddings", None)
+    pad_token_id = getattr(config, "pad_token_id", 0) or 0
+    if max_positions is None or pad_token_id <= 0:
+        return
+
+    adjusted = max_positions - pad_token_id - 1
+    if adjusted <= 0:
+        raise ValueError(
+            "Position offset adjustment would produce non-positive "
+            f"max_position_embeddings={adjusted} "
+            f"(original={max_positions}, pad_token_id={pad_token_id})"
+        )
+
+    config.max_position_embeddings = adjusted
+    config._position_offset_applied = True
+    logger.debug(
+        "Adjusted LayoutLM max_position_embeddings: %d -> %d (pad_token_id=%d)",
+        max_positions,
+        adjusted,
+        pad_token_id,
+    )
+
+
+class LayoutLMTextInputGenerator(MaxLengthTextInputGenerator):
+    """Generate token types within the checkpoint's configured vocabulary.
+
+    Optimum's generic text generator samples token-type IDs from ``[0, 2)``.
+    LayoutLM checkpoints commonly set ``type_vocab_size=1``, where sampling 1
+    causes an embedding Gather out of bounds. Derive the exclusive upper bound
+    from config metadata instead.
+    """
+>>>>>>> e65450dc (feat(layoutlm): add document question answering support)
 
     def generate(
         self,
@@ -28,41 +101,65 @@ class ZeroTokenTypeLayoutLMTextInputGenerator(MaxLengthTextInputGenerator):
         framework: str = "pt",
         int_dtype: str = "int64",
         float_dtype: str = "fp32",
-    ) -> torch.Tensor:
-        """Generate LayoutLM text inputs, replacing token_type_ids with zeros."""
-        tensor = cast(
-            "torch.Tensor",
-            super().generate(
-                input_name,
-                framework=framework,
-                int_dtype=int_dtype,
-                float_dtype=float_dtype,
-            ),
+    ) -> Any:
+        """Generate a safe tensor for ``input_name``."""
+        tensor = super().generate(
+            input_name,
+            framework=framework,
+            int_dtype=int_dtype,
+            float_dtype=float_dtype,
         )
-        if input_name == "token_type_ids":
-            return tensor.new_zeros(tensor.shape)
-        return tensor
+        if input_name != "token_type_ids":
+            return tensor
+        # Most LayoutLM v1 checkpoints use type_vocab_size=1, so token types
+        # must stay zero to avoid embedding gather OOB during perf/build probes.
+        return tensor.new_zeros(tensor.shape)
 
 
-@register_onnx_overwrite("layoutlm", "question-answering", library_name="transformers")
-class LayoutLMQAIOConfig(LayoutLMOnnxConfig):  # type: ignore[misc]  # optimum base is untyped
-    """LayoutLM question-answering OnnxConfig with bbox and safe token type IDs."""
+@register_onnx_overwrite("layoutlm", "document-question-answering", library_name="transformers")
+class LayoutLMDocumentQAOnnxConfig(LayoutLMOnnxConfig):  # type: ignore[misc]
+    """ONNX config for the LayoutLM v1 extractive document-QA head.
 
-    # sequence_length is bound to the model's max_position_embeddings so
-    # MaxLengthTextInputGenerator emits full-length text inputs instead of
-    # Optimum's default of 16 (allow_new=True permits adding this mapping).
-    # We deliberately do NOT map max_2d_position_embeddings here: Optimum's
-    # DummyBboxInputGenerator hardcodes its coordinate range (its
-    # normalized_config.max_2d_position_embeddings read is commented out
-    # upstream), so such a mapping is inert and never becomes a sequence
-    # length. bbox coordinate bounds for the shipped recipe come from the
-    # recipe's `value_range` instead.
+    Inputs remain ``input_ids``, ``bbox``, ``attention_mask`` and
+    ``token_type_ids`` from Optimum's LayoutLM config. Outputs are the two span
+    tensors returned by ``LayoutLMForQuestionAnswering``.
+    """
+
+    # Bind sequence length to config.max_position_embeddings so max-length
+    # dummy generation is valid for full-size parity/perf probes.
     NORMALIZED_CONFIG_CLASS = NormalizedTextConfig.with_args(
         sequence_length="max_position_embeddings",
         allow_new=True,
     )
+
     DUMMY_INPUT_GENERATOR_CLASSES: tuple[type[Any], ...] = (
-        ZeroTokenTypeLayoutLMTextInputGenerator,
+        LayoutLMTextInputGenerator,
         DummyVisionInputGenerator,
         DummyBboxInputGenerator,
     )
+
+    def __init__(self, config: Any, task: str, **kwargs: Any) -> None:
+        _adjust_roberta_position_embeddings(config)
+        super().__init__(config, task, **kwargs)
+
+    @property
+    def outputs(self) -> dict[str, dict[int, str]]:
+        """Return the extractive span-head output names and dynamic axes."""
+        return {
+            "start_logits": {0: "batch_size", 1: "sequence_length"},
+            "end_logits": {0: "batch_size", 1: "sequence_length"},
+        }
+
+
+@register_onnx_overwrite("layoutlm", "question-answering", library_name="transformers")
+class LayoutLMQAOnnxConfig(LayoutLMDocumentQAOnnxConfig):
+    """Back-compat alias for question-answering task wiring."""
+
+
+__all__ = [
+    "ARCHITECTURE_TASK_MAPPING",
+    "MODEL_CLASS_MAPPING",
+    "LayoutLMDocumentQAOnnxConfig",
+    "LayoutLMQAOnnxConfig",
+    "LayoutLMTextInputGenerator",
+]

--- a/tests/unit/commands/test_perf_cli.py
+++ b/tests/unit/commands/test_perf_cli.py
@@ -935,6 +935,55 @@ class TestResolveShape:
             )
 
 
+class TestGenerateRandomInputs:
+    @pytest.mark.parametrize("input_name", ["token_type_ids", "arbitrary_integer_input"])
+    def test_honors_exclusive_integer_value_range(self, input_name: str) -> None:
+        """Configured [0, 1) ranges produce only legal zero-valued indices."""
+        import numpy as np
+
+        from winml.modelkit.commands.perf import generate_random_inputs
+
+        inputs = generate_random_inputs(
+            {
+                "input_names": [input_name],
+                "input_shapes": [[1, 512]],
+                "input_types": ["int32"],
+                "input_value_ranges": {input_name: [0, 1]},
+            }
+        )
+
+        assert inputs[input_name].shape == (1, 512)
+        assert inputs[input_name].dtype == np.int64
+        assert np.all(inputs[input_name] == 0)
+
+    def test_ranges_and_unspecified_defaults_preserve_existing_generation(self) -> None:
+        """Ranges are per input; unspecified inputs retain legacy defaults."""
+        import numpy as np
+
+        from winml.modelkit.commands.perf import generate_random_inputs
+
+        inputs = generate_random_inputs(
+            {
+                "input_names": ["category_ids", "ranged_values", "default_values"],
+                "input_shapes": [[2, 3], [2, 3], [2, 3]],
+                "input_types": ["int64", "float16", "float32"],
+                "input_value_ranges": {
+                    "category_ids": [7, 8],
+                    "ranged_values": [-2.0, -1.0],
+                },
+            }
+        )
+
+        assert inputs["category_ids"].shape == (2, 3)
+        assert np.all(inputs["category_ids"] == 7)
+        assert inputs["ranged_values"].dtype == np.float32
+        assert np.all(inputs["ranged_values"] >= -2.0)
+        assert np.all(inputs["ranged_values"] < -1.0)
+        assert inputs["default_values"].dtype == np.float32
+        assert np.all(inputs["default_values"] >= 0.0)
+        assert np.all(inputs["default_values"] < 1.0)
+
+
 class TestEffectiveBatchSize:
     """Throughput must scale by the batch the session actually ran.
 

--- a/tests/unit/export/test_layoutlm_onnx_config.py
+++ b/tests/unit/export/test_layoutlm_onnx_config.py
@@ -1,0 +1,91 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Tests for LayoutLM v1 document-question-answering export support."""
+
+from __future__ import annotations
+
+import pytest
+from optimum.exporters.tasks import TasksManager
+from transformers import LayoutLMConfig
+
+from winml.modelkit.export import generate_dummy_inputs, resolve_io_specs
+from winml.modelkit.models.hf.layoutlm import (
+    LayoutLMDocumentQAOnnxConfig,
+    _adjust_roberta_position_embeddings,
+)
+
+
+@pytest.fixture
+def layoutlm_config() -> LayoutLMConfig:
+    config = LayoutLMConfig(
+        vocab_size=100,
+        hidden_size=32,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        intermediate_size=64,
+        max_position_embeddings=514,
+        pad_token_id=1,
+        type_vocab_size=1,
+    )
+    config.tokenizer_class = "RobertaTokenizer"
+    config.architectures = ["LayoutLMForQuestionAnswering"]
+    return config
+
+
+def test_document_qa_config_registered() -> None:
+    constructor = TasksManager.get_exporter_config_constructor(
+        exporter="onnx",
+        model_type="layoutlm",
+        task="document-question-answering",
+        library_name="transformers",
+    )
+    assert constructor.func is LayoutLMDocumentQAOnnxConfig
+
+
+def test_document_qa_io_specs(layoutlm_config: LayoutLMConfig) -> None:
+    specs = resolve_io_specs("layoutlm", "document-question-answering", layoutlm_config)
+    assert specs["input_names"] == [
+        "input_ids",
+        "bbox",
+        "attention_mask",
+        "token_type_ids",
+    ]
+    assert specs["output_names"] == ["start_logits", "end_logits"]
+
+
+def test_dummy_token_types_respect_type_vocab_size(layoutlm_config: LayoutLMConfig) -> None:
+    inputs = generate_dummy_inputs(
+        "layoutlm",
+        "document-question-answering",
+        layoutlm_config,
+        sequence_length=8,
+    )
+    assert inputs["token_type_ids"].shape == (1, 8)
+    assert inputs["token_type_ids"].unique().tolist() == [0]
+
+
+def test_roberta_position_offset_is_adjusted_once(layoutlm_config: LayoutLMConfig) -> None:
+    _adjust_roberta_position_embeddings(layoutlm_config)
+    assert layoutlm_config.max_position_embeddings == 512
+
+    _adjust_roberta_position_embeddings(layoutlm_config)
+    assert layoutlm_config.max_position_embeddings == 512
+
+
+def test_non_roberta_position_convention_is_untouched() -> None:
+    config = LayoutLMConfig(max_position_embeddings=512, pad_token_id=1)
+    config.tokenizer_class = "BertTokenizer"
+
+    _adjust_roberta_position_embeddings(config)
+
+    assert config.max_position_embeddings == 512
+
+
+def test_roberta_position_offset_rejects_non_positive_length(
+    layoutlm_config: LayoutLMConfig,
+) -> None:
+    layoutlm_config.max_position_embeddings = 2
+    with pytest.raises(ValueError, match="non-positive"):
+        _adjust_roberta_position_embeddings(layoutlm_config)

--- a/tests/unit/loader/test_layoutlm_resolution.py
+++ b/tests/unit/loader/test_layoutlm_resolution.py
@@ -1,0 +1,47 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Task and model-class resolution for LayoutLM v1 document QA."""
+
+from __future__ import annotations
+
+from transformers import LayoutLMConfig
+
+from winml.modelkit.loader.resolution import TaskSource, resolve_task
+
+
+def _document_qa_config() -> LayoutLMConfig:
+    config = LayoutLMConfig()
+    config.architectures = ["LayoutLMForQuestionAnswering"]
+    return config
+
+
+def test_layoutlm_document_qa_resolves_from_architecture() -> None:
+    resolution = resolve_task(_document_qa_config())
+
+    assert resolution.task == "document-question-answering"
+    assert resolution.optimum_task == "document-question-answering"
+    assert resolution.model_class.__name__ == "AutoModelForDocumentQuestionAnswering"
+    assert resolution.source == TaskSource.ARCHITECTURE_MAPPING
+
+
+def test_layoutlm_document_qa_explicit_task_uses_document_auto_class() -> None:
+    resolution = resolve_task(
+        _document_qa_config(),
+        task="document-question-answering",
+    )
+
+    assert resolution.task == "document-question-answering"
+    assert resolution.model_class.__name__ == "AutoModelForDocumentQuestionAnswering"
+    assert resolution.source == TaskSource.USER_TASK
+
+
+def test_layoutlm_other_head_is_not_forced_to_document_qa() -> None:
+    config = LayoutLMConfig()
+    config.architectures = ["LayoutLMForTokenClassification"]
+
+    resolution = resolve_task(config)
+
+    assert resolution.task == "token-classification"
+    assert resolution.source == TaskSource.TASKS_MANAGER


### PR DESCRIPTION
### Summary

Adds class-wide LayoutLM v1 `document-question-answering` export support and verified CPU fp32/fp16 recipes for `DmitrySpartak/layoutlm-invoices`. This matters because current `main` misresolves this checkpoint to next-sentence prediction and cannot build it. The shipped contribution is **Effort L1 / Outcome L1** and independently reaches **Goal L2 PASS** for both required tuples; end-to-end task evaluation remains CLI-blocked and is tracked by [#1132](https://github.com/microsoft/winml-cli/issues/1132).

### Model metadata

#### What the model does

This pinned LayoutLM v1 checkpoint is an extractive document-question-answering model for invoices and other documents. Its model forward consumes token IDs, normalized token bounding boxes, an attention mask, and token-type IDs, then emits per-token start and end logits. It does not consume a PDF or image directly: OCR, word/box construction, token alignment, and answer decoding are external pipeline stages. The resolved stock Transformers class ignores the checkpoint's extra `token_classifier_head` weights, so the model card's advertised non-consecutive-token behavior is not verified on this concrete runtime path. **Confidence: verified.**

Durable sources: [pinned model card](https://huggingface.co/DmitrySpartak/layoutlm-invoices/blob/ce2422049c250384731eccef90bf6d92e846b09c/README.md), [pinned checkpoint config](https://huggingface.co/DmitrySpartak/layoutlm-invoices/blob/ce2422049c250384731eccef90bf6d92e846b09c/config.json), and [`LayoutLMForQuestionAnswering` in Transformers 4.57.6](https://github.com/huggingface/transformers/blob/v4.57.6/src/transformers/models/layoutlm/modeling_layoutlm.py).

#### Primary user stories

- A user supplies an invoice document and a question such as “What is the invoice number?” to obtain an answer span for document review or extraction; an external OCR/layout pipeline must first turn the document into words and normalized boxes. **Confidence: verified.**
- A user supplies OCR-derived words, token bounding boxes, and a natural-language question to obtain start/end token scores for extracting an answer from an invoice. **Confidence: verified.**

Sources: the [pinned model card](https://huggingface.co/DmitrySpartak/layoutlm-invoices/blob/ce2422049c250384731eccef90bf6d92e846b09c/README.md), [pinned checkpoint config](https://huggingface.co/DmitrySpartak/layoutlm-invoices/blob/ce2422049c250384731eccef90bf6d92e846b09c/config.json), and [Transformers 4.57.6 implementation](https://github.com/huggingface/transformers/blob/v4.57.6/src/transformers/models/layoutlm/modeling_layoutlm.py).

#### Supported tasks

- `document-question-answering` — supported by the checkpoint and Transformers model head. **Confidence: verified.** WinML export/config support is added by this PR; WinML end-to-end evaluation is not yet supported and is tracked by [#1132](https://github.com/microsoft/winml-cli/issues/1132). Plain `question-answering` was deliberately not substituted because it would erase the document-layout contract.

#### Model architecture

```text
LayoutLMForQuestionAnswering
├── LayoutLMModel
│   ├── Embeddings (word + 1D position + x/y/h/w 2D layout + token type; hidden 768)
│   └── Encoder stack × 12
│       ├── Multi-head self-attention (12 heads)
│       ├── Feed-forward (768 → 3072 → 768, GELU)
│       └── Residual + LayerNorm
└── QA span head (Linear 768 → 2)
    ├── start_logits [batch, sequence]
    └── end_logits [batch, sequence]
```

- Source/confidence: [pinned checkpoint config](https://huggingface.co/DmitrySpartak/layoutlm-invoices/blob/ce2422049c250384731eccef90bf6d92e846b09c/config.json) and [`LayoutLMForQuestionAnswering` source in Transformers 4.57.6](https://github.com/huggingface/transformers/blob/v4.57.6/src/transformers/models/layoutlm/modeling_layoutlm.py) (`verified`).

### Validation and support evidence

#### Baseline

- Baseline: [`e7509b1e908c74beff0a5655b8f8d7de69c5afae`](https://github.com/microsoft/winml-cli/commit/e7509b1e908c74beff0a5655b8f8d7de69c5afae), WinML `0.2.0`.
- Exact-task config: **FAIL, exit 2** — `Task 'document-question-answering' not supported by TasksManager; no requested-task config artifact produced.`
- Automatic config behavior: it succeeds only by misresolving the checkpoint to `next-sentence-prediction` / `AutoModelForNextSentencePrediction`; this diagnostic output is not a valid starting recipe.
- Recipe-free build: **FAIL, exit 2** — `Unrecognized LayoutLMConfig for AutoModelForNextSentencePrediction; no model.onnx produced.`
- Perf floor: **FAIL, exit 2** — `ONNX file not found because baseline build failed.`
- Eval floor: **FAIL, exit 2** — `ONNX file not found; independent schema probe also rejects exact task document-question-answering as unsupported. Plain question-answering schema exists but was not substituted.`
- Optimum probe for `layoutlm`: vendor tasks and post-WinML tasks are both `feature-extraction`, `fill-mask`, `text-classification`, and `token-classification`; WinML adds no task. Verdict for `document-question-answering`: **UNREGISTERED**.

#### Goal

- **Committed Effort:** L1
- **Committed Goal ceiling:** L2
- **Committed Outcome:** L1
- **Success definition:** Both CPU/cpu fp32 and fp16 build structurally, execute 100-iteration perf with valid named LayoutLM inputs, and compare start/end logits to pinned PyTorch on identical OCR-derived boxes.
- No ceiling change was issued.

#### Outcome

- **Shipped tier:** L1
- **Highest Goal verdict:** L2 PASS
- **Coverage:** full
- **Deferred tuples:** none
- **Handoff:** PASS — learner-owned findings are durably shipped in ModelKitArtifacts Lane A commit [`7e939ae638193e0f83f717d7bee4f9b5b4311bf1`](https://github.com/gim-home/ModelKitArtifacts/commit/7e939ae638193e0f83f717d7bee4f9b5b4311bf1), tracked by [ModelKitArtifacts PR #159](https://github.com/gim-home/ModelKitArtifacts/pull/159).
- Shipped recipes:
  - [`document-question-answering_fp32_config.json`](https://github.com/microsoft/winml-cli/blob/e65450dcdbb57774f373ad93d806905a79fce33b/examples/recipes/DmitrySpartak_layoutlm-invoices/cpu/cpu/document-question-answering_fp32_config.json)
  - [`document-question-answering_fp16_config.json`](https://github.com/microsoft/winml-cli/blob/e65450dcdbb57774f373ad93d806905a79fce33b/examples/recipes/DmitrySpartak_layoutlm-invoices/cpu/cpu/document-question-answering_fp16_config.json)
- Shipped generalized code and focused tests are enumerated under **Delta**.
- Model findings captured and pushed in [ModelKitArtifacts Lane A commit `7e939ae638193e0f83f717d7bee4f9b5b4311bf1`](https://github.com/gim-home/ModelKitArtifacts/commit/7e939ae638193e0f83f717d7bee4f9b5b4311bf1) on [ModelKitArtifacts PR #159](https://github.com/gim-home/ModelKitArtifacts/pull/159): `layoutlm-002` architecture-driven exact-task resolution; `layoutlm-003` input bounds and generic high-exclusive range propagation; `layoutlm-004` fp32/fp16 build, perf, parity, and analysis; `layoutlm-005` exact eval blocker and issue #1132.
- Methodology: the producer/tester repair loop encountered the already-known generic `winml perf` value-range friction documented by `_meta-017`. No new methodology finding or verdict shape was required; no skill edit is part of this model PR.

#### Per-EP/device/precision results — including perf and eval data

##### Goal ladder

| Tier | Verdict | Evidence |
|---|---|---|
| L0 | PASS | Both required CPU/cpu precisions independently configured, built, and structurally validated. |
| L1 | PASS | Both tuples completed 10 warmups + 100 timed CLI iterations using named semantic NPZ input; exact numbers below. |
| L2 | PASS | Pinned PyTorch `LayoutLMForQuestionAnswering` comparison on identical named 512-token inputs with 33 nonzero boxed document tokens; start/end argmaxes preserved. |

##### Build and structural coverage

| EP / Device | Precision | Verdict | Structural evidence |
|---|---|---|---|
| CPUExecutionProvider / cpu | fp32 | PASS | config exit 0; build exit 0; Build complete; `onnx.checker` PASS; IR=8; opset=17; nodes=442; inputs=`input_ids`, `bbox`, `attention_mask`, `token_type_ids`; outputs=`start_logits`, `end_logits`; initializers: FLOAT 208, INT64 12; final artifact 508,972,442 bytes with external data. |
| CPUExecutionProvider / cpu | fp16 | PASS | config exit 0; build exit 0; Build complete; `onnx.checker` PASS; IR=8; opset=17; nodes=444; inputs=`input_ids`, `bbox`, `attention_mask`, `token_type_ids`; outputs=`start_logits`, `end_logits`; initializers: FLOAT16 208, INT64 12; final artifact 254,570,982 bytes with external data. |

##### Perf — named semantic document inputs

Each row used normalized OCR boxes, all-zero `token_type_ids`, 10 warmups, and 100 timed iterations on `CPUExecutionProvider`.

| EP / Device | Precision | Verdict | Mean | p50 | p90 | p95 | Throughput | RAM load Δ | RAM inference Δ | RAM total Δ | Local VRAM Δ |
|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| CPUExecutionProvider / cpu | fp32 | PASS | 208.185 ms | 201.974 ms | 236.443 ms | 245.382 ms | 4.8 samples/s | 334.71 MB | 103.98 MB | 438.69 MB | 0.0 MB |
| CPUExecutionProvider / cpu | fp16 | PASS | 256.448 ms | 251.709 ms | 289.198 ms | 297.091 ms | 3.9 samples/s | 347.75 MB | 117.7 MB | 465.46 MB | 0.0 MB |

##### Perf — default generated inputs after the generic range repair

These rows used no `--input-data`; each completed 10 warmups and 100 timed iterations.

| EP / Device | Precision | Verdict | Mean | p50 | Throughput | RAM total Δ |
|---|---|---|---:|---:|---:|---:|
| CPUExecutionProvider / cpu | fp32 | PASS | 213.624 ms | 206.071 ms | 4.68 samples/s | 441.04 MB |
| CPUExecutionProvider / cpu | fp16 | PASS | 252.585 ms | 245.067 ms | 3.96 samples/s | 467.14 MB |

Default `winml perf` now honors config-derived ranges for both repaired artifacts; generic integer, float, singleton, and unspecified-range behavior passes independently.

##### L2 numeric parity

The identical semantic input contains 33 nonzero document-box tokens, `bbox` range 0–755, monotonic boxes, and only token type 0. Reference/ONNX argmaxes are preserved at 16 for `start_logits` and 22 for `end_logits`.

| EP / Device | Precision | Output | Verdict | Shape | Cosine | Max abs | Mean abs | Ref argmax | ONNX argmax |
|---|---|---|---|---|---:|---:|---:|---:|---:|
| CPUExecutionProvider / cpu | fp32 | start_logits | PASS | [1, 512] | 0.9999999999999564 | 1.9073486328125e-05 | 3.6600977182388306e-06 | 16 | 16 |
| CPUExecutionProvider / cpu | fp32 | end_logits | PASS | [1, 512] | 0.9999999999999577 | 1.9073486328125e-05 | 3.725290298461914e-06 | 22 | 22 |
| CPUExecutionProvider / cpu | fp16 | start_logits | PASS | [1, 512] | 0.9999999880818508 | 0.009905815124511719 | 0.002066316083073616 | 16 | 16 |
| CPUExecutionProvider / cpu | fp16 | end_logits | PASS | [1, 512] | 0.999999960350131 | 0.010828971862792969 | 0.003938476555049419 | 22 | 22 |

##### Eval

Schema command verdict: **CLI-BLOCKED**, exit 2.

> Error: Task 'document-question-answering' is not supported by `winml eval`. Supported tasks: depth-estimation, feature-extraction, fill-mask, image-classification, image-feature-extraction, image-segmentation, image-to-text, keypoint-detection, mask-generation, next-sentence-prediction, object-detection, question-answering, sentence-similarity, sequence-classification, text-classification, token-classification, zero-shot-classification, zero-shot-image-classification.

| EP / Device | Precision | Verdict | Exit | Dataset / revision / subset | Metric | Exact error |
|---|---|---|---:|---|---|---|
| CPUExecutionProvider / cpu | fp32 | CLI-BLOCKED | 1 | — / — / — | — | `Error: Evaluation failed: Task 'document-question-answering' is not supported. Supported tasks: compare-tensor, depth-estimation, feature-extraction, fill-mask, image-classification, image-feature-extraction, image-segmentation, image-to-text, keypoint-detection, mask-generation, next-sentence-prediction, object-detection, question-answering, sentence-similarity, sequence-classification, text-classification, token-classification, zero-shot-classification, zero-shot-image-classification.` |
| CPUExecutionProvider / cpu | fp16 | CLI-BLOCKED | 1 | — / — / — | — | `Error: Evaluation failed: Task 'document-question-answering' is not supported. Supported tasks: compare-tensor, depth-estimation, feature-extraction, fill-mask, image-classification, image-feature-extraction, image-segmentation, image-to-text, keypoint-detection, mask-generation, next-sentence-prediction, object-detection, question-answering, sentence-similarity, sequence-classification, text-classification, token-classification, zero-shot-classification, zero-shot-image-classification.` |

No dataset or metric was produced. This is an eval task-family blocker, not an export, precision, or model-quality failure. The checkpoint forward graph is only the neural span scorer; OCR, PDF/image decoding, word/box normalization and alignment, and answer decoding remain external. The exact generalized gap is [#1132 — Add end-to-end document-question-answering inference and eval contract](https://github.com/microsoft/winml-cli/issues/1132) (open).

#### Delta

##### Recipes

- Baseline recipe: **none**. Comparison is **NOT-COMPARABLE** because exact-task config exited 2 before producing a config artifact; automatic config's next-sentence-prediction misresolution was diagnostic evidence, not a recipe baseline.
- After the fix, explicit and automatic generated configs resolve the requested task/class/I/O contract and are byte-semantically identical to the checked-in fp32/fp16 recipes.
- fp32 resolved build config: `optim={}`, `quant=null`, `compile=null`.
- fp16 resolved build config: `optim={}`, `quant.mode=fp16`, `compile=null`.
- No manual recipe-only override or JSON-pointer old/new delta exists.
- Recipe-free fp32 and fp16 acceptance is required and passed with the exact four-input/two-output contract.
- The production recipe README remains untouched.

##### Generalized code and tests

| Path | Symbols / behavior change |
|---|---|
| [`src/winml/modelkit/loader/resolution.py`](https://github.com/microsoft/winml-cli/blob/e65450dcdbb57774f373ad93d806905a79fce33b/src/winml/modelkit/loader/resolution.py) | Adds generic `model_type + architectures[0]` registry lookup before Optimum inference with explicit `TaskSource.ARCHITECTURE_MAPPING` provenance. There is no model-ID or LayoutLM branch in shared resolution code. |
| [`src/winml/modelkit/models/hf/layoutlm.py`](https://github.com/microsoft/winml-cli/blob/e65450dcdbb57774f373ad93d806905a79fce33b/src/winml/modelkit/models/hf/layoutlm.py) | Adds class-wide `LayoutLMForQuestionAnswering → document-question-answering`, `AutoModelForDocumentQuestionAnswering`, bbox-preserving four-input export, `start_logits`/`end_logits`, type-vocabulary-derived token types, and conditional RoBERTa position-offset handling. |
| [`src/winml/modelkit/models/hf/__init__.py`](https://github.com/microsoft/winml-cli/blob/e65450dcdbb57774f373ad93d806905a79fce33b/src/winml/modelkit/models/hf/__init__.py) | Imports LayoutLM registration and aggregates its class and architecture-task metadata. |
| [`src/winml/modelkit/commands/perf.py`](https://github.com/microsoft/winml-cli/blob/e65450dcdbb57774f373ad93d806905a79fce33b/src/winml/modelkit/commands/perf.py) | Generic `generate_random_inputs` now reads `io_config.input_value_ranges` per input and forwards valid metadata ranges. Canonical ranges stay high-exclusive; integer maxima are reduced by one only at the legacy generator's inclusive-max adapter boundary. Float ranges, shapes, tensor classification, and unspecified ranges retain prior behavior. |
| [`tests/unit/loader/test_layoutlm_resolution.py`](https://github.com/microsoft/winml-cli/blob/e65450dcdbb57774f373ad93d806905a79fce33b/tests/unit/loader/test_layoutlm_resolution.py) | Covers architecture-derived exact-task resolution, exact document auto class, and non-QA head preservation. |
| [`tests/unit/export/test_layoutlm_onnx_config.py`](https://github.com/microsoft/winml-cli/blob/e65450dcdbb57774f373ad93d806905a79fce33b/tests/unit/export/test_layoutlm_onnx_config.py) | Covers registration, exact I/O, token-type bounds, one-time conditional position adjustment, untouched non-RoBERTa convention, and invalid usable length. |
| [`tests/unit/commands/test_perf_cli.py`](https://github.com/microsoft/winml-cli/blob/e65450dcdbb57774f373ad93d806905a79fce33b/tests/unit/commands/test_perf_cli.py) | Adds model-agnostic regressions for high-exclusive integer ranges, arbitrary input names, singleton nonzero integer and float ranges, and unchanged defaults when no range is declared. |

The fix remains reducible and consistent with the frozen charter: it is class-of-models L1 code, metadata-driven, recipe-free accepted, and contains no checkpoint-only branching. Other LayoutLM heads remain on existing Optimum task paths.

#### Analyze summary — component level and op level

**ANALYZE-PARTIAL-SUCCESS** (exit 1): OpenVINO plugin registration failed because `onnxruntime_providers_shared.dll` was missing (Error 126); emitted JSON remained complete for all 11 EP/device rows. This is static rule analysis, not runtime execution on those accelerator EPs.

##### Component-level summary

| Artifact | Architecture coverage | Mapping | Confidence | Actionable EP findings |
|---|---|---|---|---|
| fp32 | embeddings; 12x encoder attention/FFN; QA span head | 442 mapped, 0 unmapped | mapped | QNNExecutionProvider/NPU and QNNExecutionProvider/GPU: partial=`Div,Erf,Add,Mul`; unsupported=none |
| fp16 | embeddings; 12x encoder attention/FFN; QA span head | 444 mapped, 0 unmapped | mapped | QNNExecutionProvider/NPU and QNNExecutionProvider/GPU: partial=`Div,Erf,Add,Mul`; unsupported=none |

Built-artifact ONNX mapping was absent from the frozen planner report; the tester derived it from emitted full hierarchy tags.

##### Op-level summary

| Artifact | Graph | Dominant operators | Grouped EP outcomes |
|---|---|---|---|
| fp32 | 442 operators / 16 unique types | Add 129; MatMul 97; Reshape 48; Transpose 48; Mul 37; LayerNormalization 25 | Fully supported by NvTensorRTRTX/GPU and OpenVINO NPU/GPU/CPU; QNN NPU/GPU partial on `Div,Erf,Add,Mul`, unsupported=none; all types unknown for CUDA/GPU, MIGraphX/GPU, Dml/GPU, CPU/CPU, VitisAI/NPU. |
| fp16 | 444 operators / 16 unique types | Add 129; MatMul 97; Reshape 48; Transpose 48; Mul 37; LayerNormalization 25 | Fully supported by NvTensorRTRTX/GPU and OpenVINO NPU/GPU/CPU; QNN NPU/GPU partial on `Div,Erf,Add,Mul`, unsupported=none; all types unknown for CUDA/GPU, MIGraphX/GPU, Dml/GPU, CPU/CPU, VitisAI/NPU. |

The host exposed `DmlExecutionProvider` and `CPUExecutionProvider`; only CPU runtime measurements are claimed. Static rows for NvTensorRTRTX, CUDA, MIGraphX, QNN, OpenVINO, DML, CPU, and VitisAI do not imply runtime validation.

#### Reproduce commands

The sequence below is portable PowerShell. It embeds the tester-supplied L2 harness verbatim and uses the versioned public `rules-v0.2.0.zip` archive with SHA-256 verification.

```powershell
$MODEL='DmitrySpartak/layoutlm-invoices'
$REVISION='ce2422049c250384731eccef90bf6d92e846b09c'
$BASELINE_COMMIT='e7509b1e908c74beff0a5655b8f8d7de69c5afae'
$OUT='temp/layoutlm-invoices-repro'
New-Item -ItemType Directory -Force -Path $OUT | Out-Null
$OUT=(Resolve-Path $OUT).Path
winml --version
git rev-parse HEAD

winml config -m $MODEL --task document-question-answering --ep cpu --device cpu --precision fp32 --no-compile -o (Join-Path $OUT 'generated_fp32.json') --overwrite --no-color
winml config -m $MODEL --task document-question-answering --ep cpu --device cpu --precision fp16 --no-compile -o (Join-Path $OUT 'generated_fp16.json') --overwrite --no-color
winml build -c examples/recipes/DmitrySpartak_layoutlm-invoices/cpu/cpu/document-question-answering_fp32_config.json -m $MODEL -o (Join-Path $OUT 'fp32') --ep cpu --device cpu --precision fp32 --no-analyze --rebuild --no-color
winml build -c examples/recipes/DmitrySpartak_layoutlm-invoices/cpu/cpu/document-question-answering_fp16_config.json -m $MODEL -o (Join-Path $OUT 'fp16') --ep cpu --device cpu --precision fp16 --no-analyze --rebuild --no-color

$HARNESS=Join-Path $OUT 'l2_layoutlm_parity.py'
@'
"""Portable LayoutLM ONNX-vs-PyTorch parity harness with semantic document boxes."""

from __future__ import annotations

import argparse
import hashlib
import json
from pathlib import Path

import numpy as np
import onnxruntime as ort
import torch
from transformers import AutoModelForDocumentQuestionAnswering, AutoTokenizer

MODEL_ID = "DmitrySpartak/layoutlm-invoices"
REVISION = "ce2422049c250384731eccef90bf6d92e846b09c"
OUTPUT_NAMES = ("start_logits", "end_logits")


def cosine(a: np.ndarray, b: np.ndarray) -> float:
    x = a.astype(np.float64).ravel()
    y = b.astype(np.float64).ravel()
    denom = np.linalg.norm(x) * np.linalg.norm(y)
    return float(np.dot(x, y) / denom) if denom else float(x.shape == y.shape and np.array_equal(x, y))


def make_inputs() -> tuple[dict[str, np.ndarray], dict[str, object]]:
    question_words = "what is the invoice number".split()
    document_words = [
        "ACME", "SUPPLIES", "Invoice", "Number", "INV-2026-0719", "Invoice", "Date",
        "July", "19", "2026", "Bill", "To", "Contoso", "Total", "$1,245.00",
    ]
    # Normalized OCR boxes in reading order, each satisfying 0 <= x0 <= x1 <= 1000
    # and 0 <= y0 <= y1 <= 1000. The invoice-number answer occupies one real box.
    document_boxes = [
        [70, 55, 245, 95], [255, 55, 430, 95], [70, 145, 165, 180],
        [175, 145, 285, 180], [300, 145, 520, 180], [70, 205, 165, 240],
        [175, 205, 255, 240], [270, 205, 335, 240], [345, 205, 375, 240],
        [385, 205, 445, 240], [70, 300, 125, 335], [135, 300, 170, 335],
        [185, 300, 300, 335], [70, 720, 140, 755], [155, 720, 290, 755],
    ]
    tokenizer = AutoTokenizer.from_pretrained(MODEL_ID, revision=REVISION, use_fast=True)
    encoded = tokenizer(
        question_words,
        document_words,
        is_split_into_words=True,
        truncation=True,
        max_length=512,
        padding="max_length",
        return_attention_mask=True,
        return_token_type_ids=True,
        return_tensors="np",
    )
    word_ids = encoded.word_ids(batch_index=0)
    sequence_ids = encoded.sequence_ids(batch_index=0)
    boxes = []
    for word_id, sequence_id in zip(word_ids, sequence_ids, strict=True):
        boxes.append(document_boxes[word_id] if sequence_id == 1 and word_id is not None else [0, 0, 0, 0])
    inputs = {
        "input_ids": encoded["input_ids"].astype(np.int32),
        "bbox": np.asarray([boxes], dtype=np.int32),
        "attention_mask": encoded["attention_mask"].astype(np.int32),
        "token_type_ids": np.zeros_like(encoded["input_ids"], dtype=np.int32),
    }
    answer_token_indices = [
        i for i, (wid, sid) in enumerate(zip(word_ids, sequence_ids, strict=True))
        if sid == 1 and wid == 4
    ]
    semantics = {
        "question": " ".join(question_words),
        "document_words": document_words,
        "document_boxes": document_boxes,
        "answer_text": "INV-2026-0719",
        "answer_token_indices": answer_token_indices,
        "nonzero_document_box_tokens": int(np.count_nonzero(np.asarray(boxes).sum(axis=1))),
        "bbox_min": int(inputs["bbox"].min()),
        "bbox_max": int(inputs["bbox"].max()),
        "bbox_monotonic": bool(np.all(inputs["bbox"][..., 0] <= inputs["bbox"][..., 2]) and np.all(inputs["bbox"][..., 1] <= inputs["bbox"][..., 3])),
        "token_type_unique": np.unique(inputs["token_type_ids"]).tolist(),
    }
    return inputs, semantics


def main() -> None:
    parser = argparse.ArgumentParser()
    parser.add_argument("--fp32", type=Path, required=True)
    parser.add_argument("--fp16", type=Path, required=True)
    parser.add_argument("--output", type=Path, required=True)
    args = parser.parse_args()
    inputs, semantics = make_inputs()

    model = AutoModelForDocumentQuestionAnswering.from_pretrained(MODEL_ID, revision=REVISION)
    model.eval()
    pt_inputs = {name: torch.from_numpy(value.astype(np.int64)) for name, value in inputs.items()}
    with torch.inference_mode():
        pt = model(**pt_inputs)
    reference = {"start_logits": pt.start_logits.cpu().numpy(), "end_logits": pt.end_logits.cpu().numpy()}

    artifacts = []
    for precision, path in (("fp32", args.fp32), ("fp16", args.fp16)):
        session = ort.InferenceSession(str(path), providers=["CPUExecutionProvider"])
        actual_names = [item.name for item in session.get_inputs()]
        if actual_names != list(inputs):
            raise RuntimeError(f"named input mismatch: {actual_names} != {list(inputs)}")
        onnx_outputs = dict(zip(OUTPUT_NAMES, session.run(list(OUTPUT_NAMES), inputs), strict=True))
        output_rows = []
        for name in OUTPUT_NAMES:
            ref = reference[name]
            got = onnx_outputs[name]
            output_rows.append({
                "name": name,
                "shape": list(got.shape),
                "cosine": cosine(ref, got),
                "max_abs": float(np.max(np.abs(ref.astype(np.float64) - got.astype(np.float64)))),
                "mean_abs": float(np.mean(np.abs(ref.astype(np.float64) - got.astype(np.float64)))),
                "reference_argmax": int(np.argmax(ref)),
                "onnx_argmax": int(np.argmax(got)),
            })
        artifacts.append({
            "precision": precision,
            "path": str(path),
            "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
            "providers": session.get_providers(),
            "input_specs": [{"name": x.name, "shape": x.shape, "type": x.type} for x in session.get_inputs()],
            "output_specs": [{"name": x.name, "shape": x.shape, "type": x.type} for x in session.get_outputs()],
            "outputs": output_rows,
        })

    result = {
        "model_id": MODEL_ID,
        "revision": REVISION,
        "reference_class": model.__class__.__name__,
        "seedless_deterministic_input": True,
        "semantics": semantics,
        "named_inputs": {name: {"shape": list(value.shape), "dtype": str(value.dtype)} for name, value in inputs.items()},
        "named_outputs": list(OUTPUT_NAMES),
        "artifacts": artifacts,
    }
    args.output.parent.mkdir(parents=True, exist_ok=True)
    args.output.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
    print(json.dumps(result, indent=2))


if __name__ == "__main__":
    main()
'@ | Set-Content -Path $HARNESS -Encoding utf8

python $HARNESS --fp32 (Join-Path $OUT 'fp32/model.onnx') --fp16 (Join-Path $OUT 'fp16/model.onnx') --output (Join-Path $OUT 'l2.json')

$INPUTS=Join-Path $OUT 'semantic_layoutlm_inputs.npz'
python -c "import importlib.util,numpy as np; s=importlib.util.spec_from_file_location('h',r'$HARNESS'); m=importlib.util.module_from_spec(s); s.loader.exec_module(m); x,_=m.make_inputs(); np.savez(r'$INPUTS',**x)"
winml perf -m (Join-Path $OUT 'fp32/model.onnx') --ep cpu --device cpu --precision fp32 --input-data $INPUTS --iterations 100 --warmup 10 --memory --output (Join-Path $OUT 'perf_fp32.json') --overwrite --format json --no-color
winml perf -m (Join-Path $OUT 'fp16/model.onnx') --ep cpu --device cpu --precision fp16 --input-data $INPUTS --iterations 100 --warmup 10 --memory --output (Join-Path $OUT 'perf_fp16.json') --overwrite --format json --no-color
winml perf -m (Join-Path $OUT 'fp32/model.onnx') --ep cpu --device cpu --precision fp32 --iterations 100 --warmup 10 --memory --output (Join-Path $OUT 'perf_default_fp32.json') --overwrite --format json --no-color
winml perf -m (Join-Path $OUT 'fp16/model.onnx') --ep cpu --device cpu --precision fp16 --iterations 100 --warmup 10 --memory --output (Join-Path $OUT 'perf_default_fp16.json') --overwrite --format json --no-color

python -m pytest tests/unit/commands/test_perf_cli.py -k 'honors_exclusive_integer_value_range or ranges_and_unspecified_defaults_preserve_existing_generation' -q
python -m pytest tests/unit/loader tests/unit/export/test_layoutlm_onnx_config.py tests/unit/commands/test_perf_cli.py -q

$RULES_ZIP=Join-Path $OUT 'rules-v0.2.0.zip'
Invoke-WebRequest 'https://github.com/microsoft/winml-cli/releases/download/v0.2.0/rules-v0.2.0.zip' -OutFile $RULES_ZIP
if((Get-FileHash $RULES_ZIP -Algorithm SHA256).Hash.ToLowerInvariant() -ne '6dcabbe7f5493fbc2bd23de195ab6e35b3578d510f18c2e220bc5538a1f232cc'){throw 'rules checksum mismatch'}
$RULES=Join-Path $OUT 'rules-v0.2.0'; Expand-Archive $RULES_ZIP $RULES -Force; $env:WINMLCLI_RULES_DIR=$RULES
winml analyze --model (Join-Path $OUT 'fp32/model.onnx') --ep all --device all --htp-metadata (Join-Path $OUT 'fp32/export_htp_metadata.json') --output (Join-Path $OUT 'analyze_fp32.json') --overwrite --format json --no-color
winml analyze --model (Join-Path $OUT 'fp16/model.onnx') --ep all --device all --htp-metadata (Join-Path $OUT 'fp16/export_htp_metadata.json') --output (Join-Path $OUT 'analyze_fp16.json') --overwrite --format json --no-color
Remove-Item Env:WINMLCLI_RULES_DIR

winml eval --schema --task document-question-answering --no-color
winml eval -m (Join-Path $OUT 'fp32/model.onnx') --model-id $MODEL --task document-question-answering --ep cpu --device cpu --precision fp32 --output (Join-Path $OUT 'eval_fp32.json') --overwrite --no-color
winml eval -m (Join-Path $OUT 'fp16/model.onnx') --model-id $MODEL --task document-question-answering --ep cpu --device cpu --precision fp16 --output (Join-Path $OUT 'eval_fp16.json') --overwrite --no-color

$BASELINE=Join-Path (Split-Path (Get-Location) -Parent) 'winml-cli-layoutlm-baseline'
git worktree add --detach $BASELINE $BASELINE_COMMIT
Push-Location $BASELINE
uv run winml config -m $MODEL --task document-question-answering --ep cpu --device cpu --precision fp32 --no-compile -o (Join-Path $OUT 'baseline_config_fp32.json') --overwrite --no-color
uv run winml build -m $MODEL -o (Join-Path $OUT 'baseline_build') --ep cpu --device cpu --no-analyze --no-optimize --no-quant --no-compile --rebuild --no-color
Pop-Location
```
