### PR TITLE
recipe(bert-base-cased): add CPU fill-mask recipes

### DIFF
--- a/examples/recipes/google-bert_bert-base-cased/cpu/cpu/fill-mask_fp16_config.json
+++ b/examples/recipes/google-bert_bert-base-cased/cpu/cpu/fill-mask_fp16_config.json
@@ -1,0 +1,88 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          28996
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      },
+      {
+        "name": "token_type_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "fill-mask",
+    "model_id": "google-bert/bert-base-cased",
+    "model_type": "bert",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "fill-mask",
+    "model_class": "AutoModelForMaskedLM",
+    "model_type": "bert"
+  }
+}

--- a/examples/recipes/google-bert_bert-base-cased/cpu/cpu/fill-mask_fp32_config.json
+++ b/examples/recipes/google-bert_bert-base-cased/cpu/cpu/fill-mask_fp32_config.json
@@ -1,0 +1,66 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          28996
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      },
+      {
+        "name": "token_type_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "fill-mask",
+    "model_class": "AutoModelForMaskedLM",
+    "model_type": "bert"
+  }
+}


### PR DESCRIPTION
### Summary

Adds verified CPU fp32 and fp16 `fill-mask` recipes for `google-bert/bert-base-cased`. Current `main` already resolves, exports, runs, and evaluates this checkpoint, so this is an **Effort L0 / Outcome L0** exact-coverage contribution with no source change. Both required tuples reached **Goal L3 PASS**; the L3 pseudo-perplexity values are bounded three-sample smoke evidence, not broad accuracy estimates.

### Model metadata

#### What the model does

A cased English bidirectional BERT encoder with a masked-language-model head. It accepts token IDs, attention masks, and segment IDs and returns per-token logits over a 28,996-token vocabulary so masked tokens can be predicted from both left and right context. **Confidence: verified.**

Durable sources: [pinned model card](https://huggingface.co/google-bert/bert-base-cased/blob/cd5ef92a9fb2f889e972770a36d4ed042daf221e/README.md), [pinned checkpoint config](https://huggingface.co/google-bert/bert-base-cased/blob/cd5ef92a9fb2f889e972770a36d4ed042daf221e/config.json), and [`BertForMaskedLM` in Transformers 4.57.6](https://github.com/huggingface/transformers/blob/v4.57.6/src/transformers/models/bert/modeling_bert.py).

#### Primary user stories

- Supply cased English text containing a `[MASK]` token and obtain ranked vocabulary predictions for that position. **Confidence: verified.**
- Use the pretrained encoder representations as the starting point for fine-tuning a cased English downstream language-understanding model. **Confidence: verified.**

Source: [pinned model card](https://huggingface.co/google-bert/bert-base-cased/blob/cd5ef92a9fb2f889e972770a36d4ed042daf221e/README.md).

#### Supported tasks

- `fill-mask` through the checkpoint, Transformers, Optimum ONNX, and WinML surfaces. The checkpoint declares `BertForMaskedLM`; WinML resolves `AutoModelForMaskedLM`, `BertIOConfig`, and `WinMLModelForMaskedLM`. **Confidence: verified.**

Sources: [pinned checkpoint config](https://huggingface.co/google-bert/bert-base-cased/blob/cd5ef92a9fb2f889e972770a36d4ed042daf221e/config.json) and [Transformers implementation](https://github.com/huggingface/transformers/blob/v4.57.6/src/transformers/models/bert/modeling_bert.py).

#### Model architecture

```text
BertForMaskedLM
├── BertModel (add_pooling_layer=False)
│   ├── Embeddings (token 28996 x 768 + position 512 x 768 + segment 2 x 768)
│   └── Encoder stack x 12
│       ├── Bidirectional self-attention (12 heads, hidden 768)
│       ├── Feed-forward (768 -> 3072 -> 768, GELU)
│       └── Residual + LayerNorm
└── Masked-LM head
    ├── Dense 768 -> 768 + GELU + LayerNorm
    └── Tied vocabulary decoder 768 -> 28996 (logits per token)
```

- Source/confidence: [pinned checkpoint config](https://huggingface.co/google-bert/bert-base-cased/blob/cd5ef92a9fb2f889e972770a36d4ed042daf221e/config.json) and [`BertForMaskedLM`](https://github.com/huggingface/transformers/blob/v4.57.6/src/transformers/models/bert/modeling_bert.py) (`verified`).

### Validation and support evidence

#### Baseline

- Baseline: [`microsoft/winml-cli@e7509b1`](https://github.com/microsoft/winml-cli/commit/e7509b1e908c74beff0a5655b8f8d7de69c5afae), WinML `0.2.0`.
- Exact baseline provenance transcript:

```text
> winml --version
0.2.0
> git rev-parse HEAD
e7509b1e908c74beff0a5655b8f8d7de69c5afae
```
- Default support: recipe-free CPU build passed for `BertForMaskedLM`; the artifact accepts three `[1,512]` INT32 inputs and emits FLOAT logits shaped `[1,512,28996]`. Canonical and short-alias inspect/config results were semantically equivalent.
- Starting auto-config: fp32 is semantically identical to the shipped fp32 recipe. The fp16 config differs only by its generated `/quant` precision block.
- Baseline perf: mean `261.09 ms`, p50 `254.15 ms`, `3.83 samples/s`, total RSS delta `599.49 MB` (20 iterations, 5 warmups).
- Baseline eval: pinned `Salesforce/wikitext` `wikitext-2-raw-v1` test data, one shuffled sample with seed 42, pseudo-perplexity `5.2746`, NLL `1.6629`. The default 100-sample attempt was stopped as impractical because fill-mask PPPL performs one inference per token.
- Optimum probe: vendor and WinML both expose `feature-extraction`, `fill-mask`, `multiple-choice`, `question-answering`, `text-classification`, and `token-classification`; WinML adds no task for this model type.

#### Goal

- **Effort:** L0 — exact CPU precision recipes only.
- **Goal ceiling:** L3.
- **Outcome:** L0 — recipes plus report; no source change.
- **Success definition:** both required `CPUExecutionProvider / cpu` fp32 and fp16 tuples pass build, perf, named-output PyTorch parity, and bounded task evaluation.
- No charter re-issue occurred.

#### Outcome

- **Shipped tier:** L0.
- **Highest Goal verdict:** L3 PASS.
- **Coverage:** full; no deferred tuples and no final `FAIL`, `CLI-BLOCKED`, or `HOST-BLOCKED` verdicts.
- Shipped recipes: [fp32](https://github.com/microsoft/winml-cli/blob/7b6262f90e2088517ea8948c3cd0e05a967bc93b/examples/recipes/google-bert_bert-base-cased/cpu/cpu/fill-mask_fp32_config.json) and [fp16](https://github.com/microsoft/winml-cli/blob/7b6262f90e2088517ea8948c3cd0e05a967bc93b/examples/recipes/google-bert_bert-base-cased/cpu/cpu/fill-mask_fp16_config.json).
- Durable findings: [`bert-001` through `bert-007`](https://github.com/gim-home/ModelKitArtifacts/blob/46d9eb9784958e4946d9314e583a86a63a5ee9bf/copilot-skills/dev_skill/adding-model-support/model_knowledge/bert.json) shipped in [Lane A commit `46d9eb9784958e4946d9314e583a86a63a5ee9bf`](https://github.com/gim-home/ModelKitArtifacts/commit/46d9eb9784958e4946d9314e583a86a63a5ee9bf); [`bert-008`](https://github.com/gim-home/ModelKitArtifacts/blob/b2c851a40708a29b33e448598bb896d9c88345ce/copilot-skills/dev_skill/adding-model-support/model_knowledge/bert.json#L202-L228) shipped in remediation commit [`b2c851a40708a29b33e448598bb896d9c88345ce`](https://github.com/gim-home/ModelKitArtifacts/commit/b2c851a40708a29b33e448598bb896d9c88345ce). Both commits are on [ModelKitArtifacts PR #159](https://github.com/gim-home/ModelKitArtifacts/pull/159); `bert-008` records `108,340,804` parameters, `92 / 233` traced modules, and the `BertForMaskedLM` → `BertModel` / `BertOnlyMLMHead` hierarchy through `BertEmbeddings`, `BertEncoder`, and `BertLayer.0`–`BertLayer.11`.
- No methodology finding was required. No methodology friction observed.

#### Per-EP/device/precision results — including perf and eval data

##### Goal ladder

| Tier | CPU fp32 | CPU fp16 | Evidence |
|---|---|---|---|
| L0 | PASS | PASS | Recipe build completed; ONNX checker passed; generated config matched each recipe. |
| L1 | PASS | PASS | 100 measured iterations after 10 warmups with the same semantic `[1,512]` input. |
| L2 | PASS | PASS | Named `logits` compared with pinned PyTorch on three masked-token prompts. |
| L3 | PASS | PASS | Pinned, shuffled, streaming three-sample WikiText-2 subset. |

##### Perf

| EP / device | Precision | Verdict | Mean | p50 | Throughput | Total RSS Δ | VRAM Δ |
|---|---|---|---:|---:|---:|---:|---:|
| CPUExecutionProvider / cpu | fp32 | PASS | 249.537 ms | 245.162 ms | 4.01 samples/s | 599.87 MB | 0.00 MB |
| CPUExecutionProvider / cpu | fp16 | PASS | 295.078 ms | 290.010 ms | 3.39 samples/s | 648.20 MB | 0.00 MB |

##### L2 numeric parity

| EP / device | Precision | Verdict | Full-logit cosine | Max absolute error | Masked top-1 | Minimum top-5 overlap |
|---|---|---|---:|---:|---|---:|
| CPUExecutionProvider / cpu | fp32 | PASS | 0.9999999999953111 | 0.00009703636169433594 | 3/3 matched | 5/5 |
| CPUExecutionProvider / cpu | fp16 | PASS | 0.9999996630878892 | 0.0882720947265625 | 3/3 matched | 5/5 |

##### Eval

Dataset for both rows: [`Salesforce/wikitext`](https://huggingface.co/datasets/Salesforce/wikitext/tree/b08601e04326c79dfdd32d625aee71d232d685c3), configuration `wikitext-2-raw-v1`, revision `b08601e04326c79dfdd32d625aee71d232d685c3`, test split, 3 shuffled streaming samples, seed 42.

| EP / device | Precision | Verdict | Pseudo-perplexity | NLL | Elapsed |
|---|---|---|---:|---:|---:|
| CPUExecutionProvider / cpu | fp32 | PASS | 5.2357 | 1.6555 | 131.536 s |
| CPUExecutionProvider / cpu | fp16 | PASS | 5.2356 | 1.6555 | 151.398 s |

These PPPL/NLL values are deliberately bounded **three-sample smoke evidence**, not a broad WikiText-2 accuracy or corpus estimate.

#### Delta

- [fp32 recipe](https://github.com/microsoft/winml-cli/blob/7b6262f90e2088517ea8948c3cd0e05a967bc93b/examples/recipes/google-bert_bert-base-cased/cpu/cpu/fill-mask_fp32_config.json): semantically identical to default auto-config; no changed JSON pointers.
- [fp16 recipe](https://github.com/microsoft/winml-cli/blob/7b6262f90e2088517ea8948c3cd0e05a967bc93b/examples/recipes/google-bert_bert-base-cased/cpu/cpu/fill-mask_fp16_config.json): only `/quant` changes from absent to the generated fp16 precision declaration (`mode: fp16`, `fp16_keep_io_types: true`, task/model identity retained). This converts floating initializers to fp16 while retaining FLOAT logits; it is not a source-support repair.
- Reducibility is consistent with L0: current `main` already resolves and builds this checkpoint, and no metadata-, config-, or architecture-derived source gap was found.
- No code changed, recipe-free acceptance was not required, and the production recipe README remains untouched.

#### Analyze summary — component level and op level

`ANALYZE-PARTIAL-SUCCESS`: both static scans produced complete records; exit 1 reflects partial rule classifications, not a failed scan. Static rule analysis is compatibility evidence, not runtime execution.

##### Component-level summary

| Artifact | Architecture coverage | Mapping | Actionable EP findings |
|---|---|---|---|
| fp32 | embeddings; 12x encoder attention/feed-forward; masked-LM head | 442 mapped, 0 unmapped | QNN NPU/GPU partial: Div, Erf, Add, Mul; unsupported: none |
| fp16 | embeddings; 12x encoder attention/feed-forward; masked-LM head | 443 mapped, 0 unmapped | QNN NPU/GPU partial: Div, Erf, Add, Mul; unsupported: none |

##### Op-level summary

| Artifact | Graph | Dominant ops | EP roll-up |
|---|---|---|---|
| fp32 | 442 ops / 15 types | Add 125; MatMul 98; Mul 50; Reshape 48; Transpose 48; LayerNormalization 26; Div 13; Erf 13 | TensorRT GPU and OpenVINO NPU/GPU/CPU fully supported; QNN NPU/GPU partial as above |
| fp16 | 443 ops / 15 types | Add 125; MatMul 98; Mul 50; Reshape 48; Transpose 48; LayerNormalization 26; Div 13; Erf 13 | TensorRT GPU and OpenVINO NPU/GPU/CPU fully supported; QNN NPU/GPU partial as above |

Rule-less/all-unknown groups for both artifacts: CUDA GPU, MIGraphX GPU, DirectML GPU, CPU, and VitisAI NPU.

#### Reproduce commands

The portable PowerShell sequence below embeds the tester-supplied semantic-input and L2 helpers, pins the model and dataset revisions, and verifies the versioned public rules archive before analysis.

<details>
<summary>Portable commands and embedded helpers</summary>

```powershell
# From the pinned baseline checkout, these commands produced 0.2.0 and
# e7509b1e908c74beff0a5655b8f8d7de69c5afae respectively:
winml --version
git rev-parse HEAD

$OUT = 'model-support-repro/google-bert_bert-base-cased'
New-Item -ItemType Directory -Force -Path $OUT | Out-Null

$SEMANTIC_INPUT_HELPER = Join-Path $OUT 'make_semantic_inputs.py'
@'
#!/usr/bin/env python3
"""Create semantically valid fixed-shape BERT fill-mask inputs for winml perf."""
from __future__ import annotations
import argparse
import json
from pathlib import Path
import numpy as np
from transformers import AutoTokenizer
REVISION = "cd5ef92a9fb2f889e972770a36d4ed042daf221e"
PROMPT = "The capital of France is [MASK]."
def main() -> None:
    parser = argparse.ArgumentParser()
    parser.add_argument("--output", type=Path, required=True)
    parser.add_argument("--metadata", type=Path, required=True)
    parser.add_argument("--model-id", default="google-bert/bert-base-cased")
    parser.add_argument("--revision", default=REVISION)
    args = parser.parse_args()
    tokenizer = AutoTokenizer.from_pretrained(args.model_id, revision=args.revision)
    encoded = tokenizer(PROMPT, return_tensors="np", padding="max_length", truncation=True, max_length=512)
    inputs = {
        "input_ids": encoded["input_ids"].astype(np.int32),
        "attention_mask": encoded["attention_mask"].astype(np.int32),
        "token_type_ids": encoded["token_type_ids"].astype(np.int32),
    }
    mask_positions = np.argwhere(inputs["input_ids"] == tokenizer.mask_token_id).tolist()
    if len(mask_positions) != 1:
        raise RuntimeError(f"expected one [MASK], got {mask_positions}")
    args.output.parent.mkdir(parents=True, exist_ok=True)
    np.savez(args.output, **inputs)
    metadata = {
        "model_id": args.model_id, "revision": args.revision, "prompt": PROMPT,
        "mask_token": tokenizer.mask_token, "mask_token_id": tokenizer.mask_token_id,
        "mask_positions": mask_positions,
        "inputs": {key: {"shape": list(value.shape), "dtype": str(value.dtype), "min": int(value.min()), "max": int(value.max())} for key, value in inputs.items()},
    }
    args.metadata.write_text(json.dumps(metadata, indent=2), encoding="utf-8")
    print(json.dumps(metadata, indent=2))
if __name__ == "__main__":
    main()
'@ | Set-Content -Encoding utf8 $SEMANTIC_INPUT_HELPER

$L2_HARNESS = Join-Path $OUT 'l2_compare.py'
@'
#!/usr/bin/env python3
"""Portable named-output ONNX-vs-PyTorch parity check for BERT fill-mask."""
from __future__ import annotations
import argparse
import json
from pathlib import Path
import numpy as np
import onnxruntime as ort
import torch
from transformers import AutoModelForMaskedLM, AutoTokenizer
MODEL_REVISION = "cd5ef92a9fb2f889e972770a36d4ed042daf221e"
PROMPTS = [
    "The capital of France is [MASK].",
    "A robin is a kind of [MASK].",
    "The programmer fixed the [MASK] before running the tests.",
]
def cosine(a: np.ndarray, b: np.ndarray) -> float:
    x = a.astype(np.float64, copy=False).reshape(-1)
    y = b.astype(np.float64, copy=False).reshape(-1)
    return float(np.dot(x, y) / (np.linalg.norm(x) * np.linalg.norm(y)))
def top_ids(values: np.ndarray, k: int) -> list[int]:
    return np.argsort(values)[-k:][::-1].astype(int).tolist()
def main() -> None:
    parser = argparse.ArgumentParser()
    parser.add_argument("--fp32", type=Path, required=True)
    parser.add_argument("--fp16", type=Path, required=True)
    parser.add_argument("--output", type=Path, required=True)
    parser.add_argument("--model-id", default="google-bert/bert-base-cased")
    parser.add_argument("--revision", default=MODEL_REVISION)
    args = parser.parse_args()
    tokenizer = AutoTokenizer.from_pretrained(args.model_id, revision=args.revision)
    model = AutoModelForMaskedLM.from_pretrained(args.model_id, revision=args.revision)
    model.eval()
    cases = []
    for prompt in PROMPTS:
        encoded = tokenizer(prompt, return_tensors="pt", padding="max_length", truncation=True, max_length=512)
        positions = (encoded["input_ids"] == tokenizer.mask_token_id).nonzero(as_tuple=False)
        if positions.shape[0] != 1:
            raise RuntimeError(f"expected one mask in {prompt!r}, got {positions.tolist()}")
        with torch.no_grad():
            pt_logits = model(**encoded).logits.cpu().numpy()
        named_inputs = {
            "input_ids": encoded["input_ids"].cpu().numpy().astype(np.int32),
            "attention_mask": encoded["attention_mask"].cpu().numpy().astype(np.int32),
            "token_type_ids": encoded["token_type_ids"].cpu().numpy().astype(np.int32),
        }
        cases.append({"prompt": prompt, "token_index": int(positions[0, 1]), "pt_logits": pt_logits, "named_inputs": named_inputs})
    results: dict[str, object] = {
        "model_id": args.model_id, "revision": args.revision, "prompts": PROMPTS,
        "mask_token": tokenizer.mask_token, "mask_token_id": tokenizer.mask_token_id,
        "input_semantics": [{"prompt": case["prompt"], "named_inputs": {name: {"shape": list(value.shape), "dtype": str(value.dtype)} for name, value in case["named_inputs"].items()}} for case in cases],
        "pytorch_output_name": "logits", "artifacts": [],
    }
    for precision, model_path in (("fp32", args.fp32), ("fp16", args.fp16)):
        session = ort.InferenceSession(str(model_path), providers=["CPUExecutionProvider"])
        input_specs = {item.name: {"shape": item.shape, "type": item.type} for item in session.get_inputs()}
        output_names = [item.name for item in session.get_outputs()]
        if "logits" not in output_names:
            raise RuntimeError(f"named output logits missing from {output_names}")
        masked_rows = []
        full_dot = full_ref_sq = full_actual_sq = full_max_abs = 0.0
        output_shape = output_dtype = None
        for prompt_index, case in enumerate(cases):
            ort_logits = session.run(["logits"], case["named_inputs"])[0]
            pt_logits = case["pt_logits"]
            token_index = case["token_index"]
            output_shape, output_dtype = list(ort_logits.shape), str(ort_logits.dtype)
            ref_flat = pt_logits.astype(np.float64, copy=False).reshape(-1)
            actual_flat = ort_logits.astype(np.float64, copy=False).reshape(-1)
            full_dot += float(np.dot(ref_flat, actual_flat))
            full_ref_sq += float(np.dot(ref_flat, ref_flat))
            full_actual_sq += float(np.dot(actual_flat, actual_flat))
            full_max_abs = max(full_max_abs, float(np.max(np.abs(ref_flat - actual_flat))))
            ref, actual = pt_logits[0, token_index], ort_logits[0, token_index]
            ref_top5, actual_top5 = top_ids(ref, 5), top_ids(actual, 5)
            masked_rows.append({
                "prompt_index": prompt_index, "token_index": token_index,
                "pytorch_top5_ids": ref_top5, "onnx_top5_ids": actual_top5,
                "pytorch_top5_tokens": tokenizer.convert_ids_to_tokens(ref_top5),
                "onnx_top5_tokens": tokenizer.convert_ids_to_tokens(actual_top5),
                "top1_match": ref_top5[0] == actual_top5[0],
                "top5_set_overlap": len(set(ref_top5) & set(actual_top5)),
                "cosine": cosine(ref, actual),
                "max_abs": float(np.max(np.abs(ref.astype(np.float64) - actual.astype(np.float64)))),
                "mean_abs": float(np.mean(np.abs(ref.astype(np.float64) - actual.astype(np.float64)))),
            })
        results["artifacts"].append({
            "precision": precision, "model_path": str(model_path), "providers": session.get_providers(),
            "input_specs": input_specs, "output_names": output_names, "output_shape": output_shape,
            "output_dtype": output_dtype, "full_logits_cosine": full_dot / np.sqrt(full_ref_sq * full_actual_sq),
            "full_logits_max_abs": full_max_abs, "masked_token_results": masked_rows,
            "all_masked_top1_match": all(row["top1_match"] for row in masked_rows),
            "minimum_masked_top5_overlap": min(row["top5_set_overlap"] for row in masked_rows),
        })
    args.output.parent.mkdir(parents=True, exist_ok=True)
    args.output.write_text(json.dumps(results, indent=2), encoding="utf-8")
    print(json.dumps(results, indent=2))
if __name__ == "__main__":
    main()
'@ | Set-Content -Encoding utf8 $L2_HARNESS

winml config -m google-bert/bert-base-cased --task fill-mask --ep cpu --device cpu --precision fp32 --no-compile -o "$OUT/config_fp32.json" --overwrite --no-color
winml config -m google-bert/bert-base-cased --task fill-mask --ep cpu --device cpu --precision fp16 --no-compile -o "$OUT/config_fp16.json" --overwrite --no-color
winml build -m google-bert/bert-base-cased -o "$OUT/baseline" --ep cpu --device cpu --no-analyze --no-optimize --no-quant --no-compile --rebuild --no-color
winml build -c examples/recipes/google-bert_bert-base-cased/cpu/cpu/fill-mask_fp32_config.json -m google-bert/bert-base-cased -o "$OUT/fp32" --ep cpu --device cpu --precision fp32 --no-analyze --no-compile --rebuild --no-color
winml build -c examples/recipes/google-bert_bert-base-cased/cpu/cpu/fill-mask_fp16_config.json -m google-bert/bert-base-cased -o "$OUT/fp16" --ep cpu --device cpu --precision fp16 --no-analyze --no-compile --rebuild --no-color
python $SEMANTIC_INPUT_HELPER --output "$OUT/semantic_inputs.npz" --metadata "$OUT/semantic_inputs.json"
winml perf -m "$OUT/fp32/model.onnx" --ep cpu --device cpu --precision fp32 --input-data "$OUT/semantic_inputs.npz" --iterations 100 --warmup 10 --memory --output "$OUT/perf_fp32.json" --overwrite --format json --no-color
winml perf -m "$OUT/fp16/model.onnx" --ep cpu --device cpu --precision fp16 --input-data "$OUT/semantic_inputs.npz" --iterations 100 --warmup 10 --memory --output "$OUT/perf_fp16.json" --overwrite --format json --no-color
python $L2_HARNESS --fp32 "$OUT/fp32/model.onnx" --fp16 "$OUT/fp16/model.onnx" --output "$OUT/l2.json"
winml eval -m "$OUT/fp32/model.onnx" --model-id google-bert/bert-base-cased --task fill-mask --ep cpu --device cpu --precision fp32 --dataset Salesforce/wikitext --dataset-name wikitext-2-raw-v1 --dataset-revision b08601e04326c79dfdd32d625aee71d232d685c3 --split test --samples 3 --shuffle --streaming --column input_column=text --output "$OUT/eval_fp32.json" --overwrite --no-color
winml eval -m "$OUT/fp16/model.onnx" --model-id google-bert/bert-base-cased --task fill-mask --ep cpu --device cpu --precision fp16 --dataset Salesforce/wikitext --dataset-name wikitext-2-raw-v1 --dataset-revision b08601e04326c79dfdd32d625aee71d232d685c3 --split test --samples 3 --shuffle --streaming --column input_column=text --output "$OUT/eval_fp16.json" --overwrite --no-color

$RULES_ZIP = "$OUT/rules-v0.2.0.zip"
$RULES = "$OUT/rules-v0.2.0"
Invoke-WebRequest 'https://github.com/microsoft/winml-cli/releases/download/v0.2.0/rules-v0.2.0.zip' -OutFile $RULES_ZIP
if ((Get-FileHash $RULES_ZIP -Algorithm SHA256).Hash.ToLowerInvariant() -ne '6dcabbe7f5493fbc2bd23de195ab6e35b3578d510f18c2e220bc5538a1f232cc') { throw 'rules archive checksum mismatch' }
Expand-Archive $RULES_ZIP $RULES -Force
$env:WINMLCLI_RULES_DIR = (Resolve-Path $RULES).Path
winml analyze --model "$OUT/fp32/model.onnx" --ep all --device all --htp-metadata "$OUT/fp32/export_htp_metadata.json" --output "$OUT/analyze_fp32.json" --overwrite --format json --no-color
winml analyze --model "$OUT/fp16/model.onnx" --ep all --device all --htp-metadata "$OUT/fp16/export_htp_metadata.json" --output "$OUT/analyze_fp16.json" --overwrite --format json --no-color
Remove-Item Env:WINMLCLI_RULES_DIR
```

</details>
