### PR TITLE
recipe(vitpose): add SynthPose Base CPU recipes

### DIFF
--- a/examples/recipes/stanfordmimi_synthpose-vitpose-base-hf/cpu/cpu/keypoint-detection_fp16_config.json
+++ b/examples/recipes/stanfordmimi_synthpose-vitpose-base-hf/cpu/cpu/keypoint-detection_fp16_config.json
@@ -1,0 +1,64 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          256,
+          192
+        ],
+        "value_range": [
+          -2.1179039478302,
+          2.640000343322754
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "heatmaps"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "keypoint-detection",
+    "model_id": "stanfordmimi/synthpose-vitpose-base-hf",
+    "model_type": "vitpose",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "keypoint-detection",
+    "model_class": "VitPoseForPoseEstimation",
+    "model_type": "vitpose"
+  }
+}

--- a/examples/recipes/stanfordmimi_synthpose-vitpose-base-hf/cpu/cpu/keypoint-detection_fp32_config.json
+++ b/examples/recipes/stanfordmimi_synthpose-vitpose-base-hf/cpu/cpu/keypoint-detection_fp32_config.json
@@ -1,0 +1,42 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          256,
+          192
+        ],
+        "value_range": [
+          -2.1179039478302,
+          2.640000343322754
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "heatmaps"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "keypoint-detection",
+    "model_class": "VitPoseForPoseEstimation",
+    "model_type": "vitpose"
+  }
+}

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -262,6 +262,7 @@ def generate_random_inputs(
     symbolic_shapes = io_config.get("input_symbolic_shapes") or [
         [None] * len(s) for s in io_config["input_shapes"]
     ]
+    value_ranges = io_config.get("input_value_ranges") or {}
     overrides = shape_config or {}
 
     specs: dict[str, dict[str, Any]] = {}
@@ -290,6 +291,11 @@ def generate_random_inputs(
             "dtype": gen_dtype,
             "shape": list(resolved_shape),
         }
+        if name in value_ranges:
+            low, high = value_ranges[name]
+            # Persisted InputTensorSpec ranges are [low, high), while the
+            # legacy NumPy generator treats integer maxima as inclusive.
+            specs[name]["range"] = [int(low), int(high) - 1] if gen_dtype == "int" else [low, high]
 
     return generate_dummy_inputs_from_specs(specs)
 

--- a/tests/unit/commands/test_perf_cli.py
+++ b/tests/unit/commands/test_perf_cli.py
@@ -928,8 +928,7 @@ class TestGenerateRandomInputs:
     def test_persisted_build_config_range_reaches_perf_generation(self, tmp_path: Path) -> None:
         """WinMLSession must carry a co-located build range into perf inputs."""
         import numpy as np
-        import onnx
-        from onnx import TensorProto, helper
+        from onnx import TensorProto, helper, save
 
         from winml.modelkit.commands.perf import generate_random_inputs
         from winml.modelkit.session import WinMLSession
@@ -945,7 +944,7 @@ class TestGenerateRandomInputs:
         model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
         model.ir_version = 9
         model_path = tmp_path / "model.onnx"
-        onnx.save(model, model_path)
+        save(model, model_path)
         (tmp_path / "winml_build_config.json").write_text(
             json.dumps(
                 {"export": {"input_tensors": [{"name": "features", "value_range": [-9.0, -8.0]}]}}

--- a/tests/unit/commands/test_perf_cli.py
+++ b/tests/unit/commands/test_perf_cli.py
@@ -849,6 +849,118 @@ class TestResolveShape:
             )
 
 
+class TestGenerateRandomInputs:
+    def test_honors_negative_float_value_range(self) -> None:
+        """A configured range outside [0, 1) must replace the float fallback."""
+        import numpy as np
+
+        from winml.modelkit.commands.perf import generate_random_inputs
+
+        inputs = generate_random_inputs(
+            {
+                "input_names": ["features"],
+                "input_shapes": [[4, 32]],
+                "input_types": ["float32"],
+                "input_value_ranges": {"features": [-9.0, -8.0]},
+            }
+        )
+
+        assert np.all(inputs["features"] >= -9.0)
+        assert np.all(inputs["features"] < -8.0)
+
+    def test_honors_singleton_exclusive_integer_value_range(self) -> None:
+        """The canonical [7, 8) range must generate only the value seven."""
+        import numpy as np
+
+        from winml.modelkit.commands.perf import generate_random_inputs
+
+        inputs = generate_random_inputs(
+            {
+                "input_names": ["category_ids"],
+                "input_shapes": [[2, 512]],
+                "input_types": ["int64"],
+                "input_value_ranges": {"category_ids": [7, 8]},
+            }
+        )
+
+        assert inputs["category_ids"].dtype == np.int64
+        assert np.all(inputs["category_ids"] == 7)
+
+    def test_adapts_integer_high_exclusive_for_legacy_generator(self) -> None:
+        """The persisted exclusive high must not become a legal integer value."""
+        from winml.modelkit.commands.perf import generate_random_inputs
+
+        with patch(
+            "winml.modelkit.core.generate_dummy_inputs_from_specs",
+            return_value={"category_ids": MagicMock()},
+        ) as mock_generate:
+            generate_random_inputs(
+                {
+                    "input_names": ["category_ids"],
+                    "input_shapes": [[1, 8]],
+                    "input_types": ["int32"],
+                    "input_value_ranges": {"category_ids": [3, 7]},
+                }
+            )
+
+        assert mock_generate.call_args.args[0]["category_ids"]["range"] == [3, 6]
+
+    def test_unspecified_float_input_keeps_legacy_fallback(self) -> None:
+        """Ranges are per input; unspecified floats remain in [0, 1)."""
+        import numpy as np
+
+        from winml.modelkit.commands.perf import generate_random_inputs
+
+        inputs = generate_random_inputs(
+            {
+                "input_names": ["ranged", "default"],
+                "input_shapes": [[4, 32], [4, 32]],
+                "input_types": ["float32", "float32"],
+                "input_value_ranges": {"ranged": [-2.0, -1.0]},
+            }
+        )
+
+        assert np.all(inputs["ranged"] >= -2.0)
+        assert np.all(inputs["ranged"] < -1.0)
+        assert np.all(inputs["default"] >= 0.0)
+        assert np.all(inputs["default"] < 1.0)
+
+    def test_persisted_build_config_range_reaches_perf_generation(self, tmp_path: Path) -> None:
+        """WinMLSession must carry a co-located build range into perf inputs."""
+        import numpy as np
+        import onnx
+        from onnx import TensorProto, helper
+
+        from winml.modelkit.commands.perf import generate_random_inputs
+        from winml.modelkit.session import WinMLSession
+
+        input_info = helper.make_tensor_value_info("features", TensorProto.FLOAT, [1, 16])
+        output_info = helper.make_tensor_value_info("output", TensorProto.FLOAT, [1, 16])
+        graph = helper.make_graph(
+            [helper.make_node("Identity", ["features"], ["output"])],
+            "range_forwarding",
+            [input_info],
+            [output_info],
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+        model.ir_version = 9
+        model_path = tmp_path / "model.onnx"
+        onnx.save(model, model_path)
+        (tmp_path / "winml_build_config.json").write_text(
+            json.dumps(
+                {"export": {"input_tensors": [{"name": "features", "value_range": [-9.0, -8.0]}]}}
+            ),
+            encoding="utf-8",
+        )
+
+        session = WinMLSession(model_path, device="cpu")
+        assert session.io_config["input_value_ranges"] == {"features": [-9.0, -8.0]}
+
+        inputs = generate_random_inputs(session.io_config)
+        assert np.all(inputs["features"] >= -9.0)
+        assert np.all(inputs["features"] < -8.0)
+
+
 class TestEffectiveBatchSize:
     """Throughput must scale by the batch the session actually ran.
 


### PR DESCRIPTION
## Summary

Adds CPU `fp32` and genuine `fp16` support for [`stanfordmimi/synthpose-vitpose-base-hf`](https://huggingface.co/stanfordmimi/synthpose-vitpose-base-hf/tree/e1f00dc65c23aedd629089ba44b46154e84a7778), a top-down 52-keypoint human-pose model. Revised scope is **Effort L2 / Goal L2 / Outcome L2**: two recipes correct the processor-derived graph-input range, and a model-agnostic perf fix forwards persisted ranges into dummy-input generation. Both CPU tuples reached **L2 PASS** against pinned PyTorch eager; task evaluation remains `CLI-BLOCKED` because the available default is COCO-17, not this checkpoint's 52-keypoint layout.

## Model metadata

### What the model does

SynthPose ViTPose Base consumes an RGB person crop derived from an externally supplied person bounding box and emits 52 heatmaps: 17 COCO keypoints plus 35 motion-capture/anatomical markers for denser kinematic analysis. **Confidence: verified** from the [pinned model card and checkpoint](https://huggingface.co/stanfordmimi/synthpose-vitpose-base-hf/tree/e1f00dc65c23aedd629089ba44b46154e84a7778), configuration, and exported I/O contract.

### Primary user stories

- Supply an image and detected person boxes to obtain 52 image-space keypoint coordinates and confidence scores for markerless motion capture and kinematic analysis.
- Supply person crops to obtain the standard 17 COCO joints plus 35 denser anatomical markers for visualization or downstream biomechanical analysis.

Both are **verified** from the [pinned model card](https://huggingface.co/stanfordmimi/synthpose-vitpose-base-hf/blob/e1f00dc65c23aedd629089ba44b46154e84a7778/README.md).

### Supported tasks

- `keypoint-detection` ??? **verified** across the checkpoint pipeline tag, Transformers `VitPoseForPoseEstimation` / `VitPoseImageProcessor`, Optimum's `VitPoseOnnxConfig`, and WinML's existing [VitPose mapping](https://github.com/microsoft/winml-cli/blob/e7509b1e908c74beff0a5655b8f8d7de69c5afae/src/winml/modelkit/models/hf/vitpose.py).

### Model architecture

```text
VitPoseForPoseEstimation (90,003,508 parameters)
????????? ViTPose backbone
???   ????????? Patch projection: RGB 256x192 -> 192 tokens x 768 (16x16 patches)
???   ????????? Learned positional embeddings
???   ????????? Encoder block x 12
???   ???   ????????? LayerNorm -> self-attention (12 heads, head width 64) -> residual
???   ???   ????????? LayerNorm -> MLP (768 -> 3072 -> 768, GELU) -> residual
???   ????????? Final LayerNorm -> feature map [B,768,16,12]
????????? Classic pose decoder
???   ????????? ConvTranspose 768 -> 256, upsample to 32x24 + BatchNorm + ReLU
???   ????????? ConvTranspose 256 -> 256, upsample to 64x48 + BatchNorm + ReLU
???   ????????? 1x1 Conv 256 -> 52 heatmaps [B,52,64,48]
????????? Runtime-only VitPoseImageProcessor post-processing:
    heatmaps + person boxes -> 52 (x,y,score) keypoints
```

- Source/confidence: pinned checkpoint configuration and Transformers 4.57.6 `VitPoseForPoseEstimation` source (**verified**).

## Validation and support evidence

### Baseline

The frozen recipe-free baseline is clean `origin/main` commit [`e7509b1e908c74beff0a5655b8f8d7de69c5afae`](https://github.com/microsoft/winml-cli/commit/e7509b1e908c74beff0a5655b8f8d7de69c5afae), WinML `0.2.0`. Exact provenance outputs were:

```text
git rev-parse HEAD
> e7509b1e908c74beff0a5655b8f8d7de69c5afae

winml --version
> winml, version 0.2.0
```

Recipe-free build exited `0`, passed ONNX checking, and produced `pixel_values float32[1,3,256,192] -> heatmaps float32[1,52,64,48]`, 423 nodes, opset 17. The frozen baseline perf run used 10 warmups and 100 measured iterations: mean `90.12 ms`, p50 `88.63 ms`, throughput `11.1 samples/s`, model-load RSS delta `354.13 MB`, total RSS delta `379.67 MB`. A fresh detached recheck at the same immutable SHA again exited `0` (`Build complete in 40.3s`) and measured mean/p50 `96.643/96.707 ms`, `10.35 samples/s`, and `379.84 MB` total RSS delta.

Auto-config exited `0` and resolved `VitPoseForPoseEstimation`, `keypoint-detection`, input `pixel_values [1,3,256,192] float32`, output `heatmaps`, CPU/`CPUExecutionProvider`; it emitted `value_range: [0,1]`. The `fp16` config also exited `0` and emitted the generated fp16 conversion declaration. `[0,1)` was the unrefined dummy range: pinned `VitPoseImageProcessor` metadata derives valid float32 values from `-2.1179039478302` through `2.640000104904175`, and the semantic crop observed `-2.1179039478302` through `2.5702831745147705`.

Optimum probe: `keypoint-detection` is vendor-supported before and after WinML (`VENDOR+OVERRIDE`; WinML adds no task). Baseline/L3 eval is `CLI-BLOCKED`: the absent default dataset is COCO-17, while this checkpoint emits 52 heatmaps and has no supplied pinned 52-keypoint dataset or defensible 52-value OKS sigma vector.

### Goal

The reviewer-discovered range contradiction caused an explicit charter re-issue from L0/L2/L0 to **Effort L2 / Goal L2 / Outcome L2**. Success requires both CPU `fp32` and `fp16` tuples to pass L0 structure and persisted-range checks, L1 default plus processor-semantic perf, and L2 PyTorch heatmap plus 52-keypoint parity. Coverage is **full** for the committed CPU precision plan; there are no deferred tuples.

### Outcome

**Shipped tier: L2. Highest reached: L2 PASS. Coverage: full.** Producer shipment commit: [`ee6f4072b3d280f7e1e607bf48fb6838f11a06aa`](https://github.com/microsoft/winml-cli/commit/ee6f4072b3d280f7e1e607bf48fb6838f11a06aa). The exact four-file generalized fix is:

- `examples/recipes/stanfordmimi_synthpose-vitpose-base-hf/cpu/cpu/keypoint-detection_fp32_config.json`
- `examples/recipes/stanfordmimi_synthpose-vitpose-base-hf/cpu/cpu/keypoint-detection_fp16_config.json`
- `src/winml/modelkit/commands/perf.py`
- `tests/unit/commands/test_perf_cli.py`

No models 5???8, README, skill, scratch, or unrelated files are changed. Model knowledge is durable in Lane A commits [`ef623cc54ee8f75217e0abaaa85947b4aba1c1ee`](https://github.com/gim-home/ModelKitArtifacts/commit/ef623cc54ee8f75217e0abaaa85947b4aba1c1ee) and refreshed [`19db1325e38a0c60cb4739b866a753ef93e4e007`](https://github.com/gim-home/ModelKitArtifacts/commit/19db1325e38a0c60cb4739b866a753ef93e4e007), both on `origin/shzhen/model-breakdown-skill` and limited to VitPose knowledge.

**No methodology friction observed.** The generalized defect is already covered by `_meta-017`; no new methodology finding or skill edit was needed.

### Per-EP/device/precision results ??? including perf and eval data

| Tier | EP / device | Precision | Verdict | Evidence |
|---|---|---:|---|---|
| L0 | CPUExecutionProvider / cpu | fp32 | PASS | Fresh build; ONNX checker PASS; 423 nodes; persisted range exact |
| L0 | CPUExecutionProvider / cpu | fp16 | PASS | Fresh build; ONNX checker PASS; 425 nodes; 90,004,536 FLOAT16 and 0 FLOAT initializer elements; persisted range exact |
| L1 | CPUExecutionProvider / cpu | fp32 | PASS | Default and processor-semantic perf completed; generated values used both negative and positive configured values |
| L1 | CPUExecutionProvider / cpu | fp16 | PASS | Default and processor-semantic perf completed; generated values used both negative and positive configured values |
| L2 | CPUExecutionProvider / cpu | fp32 | PASS | Pinned PyTorch eager parity; 52/52 heatmap peaks match |
| L2 | CPUExecutionProvider / cpu | fp16 | PASS | Pinned PyTorch eager parity; 52/52 heatmap peaks match |

#### Perf

All rows use 10 warmups and 100 measured iterations; VRAM deltas are `0 MB` on CPU.

| Input | Precision | Mean | p50 | Throughput | RSS total delta |
|---|---:|---:|---:|---:|---:|
| Generic persisted-range | fp32 | 90.082 ms | 88.513 ms | 11.10 samples/s | 380.80 MB |
| Generic persisted-range | fp16 | 120.723 ms | 118.815 ms | 8.28 samples/s | 390.76 MB |
| Processor-semantic crop | fp32 | 91.666 ms | 89.780 ms | 10.91 samples/s | 381.02 MB |
| Processor-semantic crop | fp16 | 119.135 ms | 117.704 ms | 8.39 samples/s | 392.17 MB |

Generic `fp32` generated range: min `-2.117901563644409`, max `2.639974355697632`; generic `fp16`: min `-2.1178860664367676`, max `2.6399428844451904`. Both remain inside `[-2.1179039478302, 2.640000343322754)` and contain negative and positive values.

#### Numeric parity

Reference: `transformers.VitPoseForPoseEstimation` PyTorch eager at revision `e1f00dc65c23aedd629089ba44b46154e84a7778`, using the identical processor crop and person box `[70,115,280,250]`.

| Precision | Heatmap cosine | Heatmap max abs | Peak-grid matches | Keypoint max Euclidean error |
|---:|---:|---:|---:|---:|
| fp32 | 0.9999999999998754 | 8.940696716308594e-07 | 52/52 | 3.411968959808029e-05 px |
| fp16 | 0.9999999266198872 | 0.0007346272468566895 | 52/52 | 0.012464815032744195 px |

#### Eval

| EP / device | Precision | Verdict | Dataset / revision / metric | Exact blocker |
|---|---:|---|---|---|
| CPUExecutionProvider / cpu | fp32 | CLI-BLOCKED | none / none / none | Default local COCO dataset absent and structurally COCO-17; model emits 52 heatmaps; no compatible pinned dataset or defensible 52-value OKS sigma vector supplied |
| CPUExecutionProvider / cpu | fp16 | CLI-BLOCKED | none / none / none | Same blocker; exact eval attempt exited 1 and produced no result JSON |

### Delta

Both recipes change `/export/input_tensors/0/value_range` from auto-config `[0,1]` to processor-derived high-exclusive `[-2.1179039478302,2.640000343322754]`. The fp16 recipe additionally changes `/quant` from `null` to the generated fp16 declaration; fp32 otherwise retains the generated config.

`generate_random_inputs()` now forwards every persisted `io_config.input_value_ranges` entry without model-ID/model-type branches. Float bounds remain `[low, high)`; integer high-exclusive bounds are adapted to the legacy inclusive NumPy generator without admitting `high`; unspecified floats retain `[0,1)`. Regressions cover a negative `[-9,-8)` float sentinel, singleton/exclusive integer bounds, unspecified-float fallback, and a real `WinMLSession` loading a co-located build config. The focused no-recipe gate passed `80` tests; the final relevant gate passed `363`, skipped `6`, and xfailed `1`; changed-file Ruff, pre-commit, and diff checks passed. At final head `ee6f4072b3d280f7e1e607bf48fb6838f11a06aa`, the test-local ONNX imports are consolidated to `from onnx import TensorProto, helper, save` and `onnx.save(...)` is replaced by `save(...)` with no semantic change; the remediation-focused `80` tests, file Ruff, file pre-commit, diff check, and GitHub CodeQL/check rollup passed. The production recipe README remains untouched.

### Analyze summary ??? component level and op level

`ANALYZE-PARTIAL-SUCCESS`: public rules v0.2.0 produced complete 11/11 result payloads for each artifact, while command exit `1` reflects partial/unknown classifications. This is static rule analysis, not runtime execution; every row reported runtime support `false`.

#### Component-level summary

| Artifact | Architecture coverage | Mapping | Actionable EP findings |
|---|---|---|---|
| fp32 | embeddings; 12x encoder attention/MLP; final LayerNorm; token-to-map reshape; 2x deconvolution + 52-heatmap head | 423 mapped, 0 partial, 0 unmapped | QNN NPU/GPU partial: Div, Erf, Add, Mul; none unsupported |
| fp16 | same regions plus I/O Casts | 425 mapped, 0 partial, 0 unmapped | QNN NPU/GPU partial: Div, Erf, Add, Mul; none unsupported |

#### Op-level summary

| Artifact | Graph | Dominant ops | EP roll-up |
|---|---|---|---|
| fp32 | 423 ops / 13 types | Add 110; MatMul 96; Reshape 50; Transpose 50; Mul 48; LayerNormalization 25 | QNN NPU/GPU partial as above; TensorRT RTX and OpenVINO CPU/GPU/NPU unknown for ConvTranspose |
| fp16 | 425 ops / 14 types | Add 110; MatMul 96; Reshape 50; Transpose 50; Mul 48; LayerNormalization 25; Cast 2 | Same actionable/unknown findings |

CPU, CUDA, MIGraphX, DML, and VitisAI are all-unknown under this rules bundle. There are no component-mapping gaps.

### Reproduce commands

Portable public commands for the exact baseline/config gates and shipped artifacts:

```powershell
$MODEL='stanfordmimi/synthpose-vitpose-base-hf'
$OUT='temp/synthpose-vitpose-repro'
New-Item -ItemType Directory -Force -Path $OUT | Out-Null

git rev-parse HEAD
winml --version

# Recipe-free baseline and starting auto-config.
winml config -m $MODEL --task keypoint-detection --ep cpu --device cpu --no-compile -o $OUT/baseline_config.json --overwrite --no-color
winml build -m $MODEL -o $OUT/baseline --ep cpu --device cpu --no-analyze --no-optimize --no-quant --no-compile --rebuild --no-color
winml perf -m $OUT/baseline/model.onnx --ep cpu --device cpu --iterations 100 --warmup 10 --memory --output $OUT/baseline_perf.json --overwrite --format json --no-color

# Both exact config-vs-recipe gates.
winml config -m $MODEL --task keypoint-detection --ep cpu --device cpu --precision fp32 --no-compile -o $OUT/generated_fp32.json --overwrite --no-color
winml config -m $MODEL --task keypoint-detection --ep cpu --device cpu --precision fp16 --no-compile -o $OUT/generated_fp16.json --overwrite --no-color

winml build -c examples/recipes/stanfordmimi_synthpose-vitpose-base-hf/cpu/cpu/keypoint-detection_fp32_config.json -m $MODEL -o $OUT/fp32 --ep cpu --device cpu --precision fp32 --no-analyze --no-compile --rebuild --no-color
winml perf -m $OUT/fp32/model.onnx --ep cpu --device cpu --precision fp32 --iterations 100 --warmup 10 --memory --output $OUT/perf_fp32.json --overwrite --format json --no-color
winml eval -m $OUT/fp32/model.onnx --model-id $MODEL --task keypoint-detection --ep cpu --device cpu --precision fp32 --output $OUT/eval_fp32.json --overwrite --no-color
winml analyze --model $OUT/fp32/model.onnx --ep all --device all --htp-metadata $OUT/fp32/export_htp_metadata.json --output $OUT/analyze_fp32.json --overwrite --format json --no-color

winml build -c examples/recipes/stanfordmimi_synthpose-vitpose-base-hf/cpu/cpu/keypoint-detection_fp16_config.json -m $MODEL -o $OUT/fp16 --ep cpu --device cpu --precision fp16 --no-analyze --no-compile --rebuild --no-color
winml perf -m $OUT/fp16/model.onnx --ep cpu --device cpu --precision fp16 --iterations 100 --warmup 10 --memory --output $OUT/perf_fp16.json --overwrite --format json --no-color
winml eval -m $OUT/fp16/model.onnx --model-id $MODEL --task keypoint-detection --ep cpu --device cpu --precision fp16 --output $OUT/eval_fp16.json --overwrite --no-color
winml analyze --model $OUT/fp16/model.onnx --ep all --device all --htp-metadata $OUT/fp16/export_htp_metadata.json --output $OUT/analyze_fp16.json --overwrite --format json --no-color

uv run pytest tests/unit/commands/test_perf_cli.py -q
```
