### PR TITLE
feat(loader): support published ONNX SAM composites

### DIFF
--- a/examples/recipes/Xenova_slimsam-77-uniform/cpu/cpu/mask-generation_fp16_config_image-encoder.json
+++ b/examples/recipes/Xenova_slimsam-77-uniform/cpu/cpu/mask-generation_fp16_config_image-encoder.json
@@ -1,0 +1,13 @@
+{
+  "export": null,
+  "optim": {},
+  "quant": {
+    "mode": "fp16",
+    "fp16_keep_io_types": true
+  },
+  "compile": null,
+  "loader": {
+    "task": "image-feature-extraction",
+    "component_name": "image-encoder"
+  }
+}

--- a/examples/recipes/Xenova_slimsam-77-uniform/cpu/cpu/mask-generation_fp16_config_prompt-decoder.json
+++ b/examples/recipes/Xenova_slimsam-77-uniform/cpu/cpu/mask-generation_fp16_config_prompt-decoder.json
@@ -1,0 +1,13 @@
+{
+  "export": null,
+  "optim": {},
+  "quant": {
+    "mode": "fp16",
+    "fp16_keep_io_types": true
+  },
+  "compile": null,
+  "loader": {
+    "task": "mask-generation",
+    "component_name": "prompt-decoder"
+  }
+}

--- a/examples/recipes/Xenova_slimsam-77-uniform/cpu/cpu/mask-generation_fp32_config_image-encoder.json
+++ b/examples/recipes/Xenova_slimsam-77-uniform/cpu/cpu/mask-generation_fp32_config_image-encoder.json
@@ -1,0 +1,10 @@
+{
+  "export": null,
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "image-feature-extraction",
+    "component_name": "image-encoder"
+  }
+}

--- a/examples/recipes/Xenova_slimsam-77-uniform/cpu/cpu/mask-generation_fp32_config_prompt-decoder.json
+++ b/examples/recipes/Xenova_slimsam-77-uniform/cpu/cpu/mask-generation_fp32_config_prompt-decoder.json
@@ -1,0 +1,10 @@
+{
+  "export": null,
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "mask-generation",
+    "component_name": "prompt-decoder"
+  }
+}

--- a/src/winml/modelkit/commands/build.py
+++ b/src/winml/modelkit/commands/build.py
@@ -1322,6 +1322,8 @@ def build(
                 components = {submodel: components[submodel]}
 
             if components:
+                if model is None:
+                    raise RuntimeError("Composite components require a Hugging Face model ID.")
                 if use_cache:
                     raise click.UsageError(
                         "--use-cache is not supported for composite models. "

--- a/src/winml/modelkit/commands/build.py
+++ b/src/winml/modelkit/commands/build.py
@@ -1075,6 +1075,31 @@ def build(
         _configs_to_validate: list[WinMLBuildConfig] = (
             config_or_configs if isinstance(config_or_configs, list) else [config_or_configs]
         )
+
+        # A portable composite-component recipe keeps the Hub model ID in
+        # ``-m`` and identifies its graph role in loader.component_name. Resolve
+        # that role to the published ONNX graph before deciding the build path.
+        if (
+            model
+            and not isinstance(config_or_configs, list)
+            and isinstance(config_or_configs.loader.component_name, str)
+            and (model_input is None or model_input.kind is not ModelInputKind.ONNX_FILE)
+        ):
+            from ..loader.resolution import resolve_composite_onnx_sources
+
+            sources = resolve_composite_onnx_sources(
+                model,
+                component_name=config_or_configs.loader.component_name,
+                precision=precision,
+                trust_remote_code=trust_remote_code,
+            )
+            if sources is None:
+                raise click.UsageError(
+                    f"Model {model!r} does not publish ONNX sources for composite "
+                    f"component {config_or_configs.loader.component_name!r}."
+                )
+            model = next(iter(sources.values()))
+            model_input = classify_model_input(model)
         try:
             for _cfg in _configs_to_validate:
                 _cfg.validate()
@@ -1309,6 +1334,14 @@ def build(
 
                 completed: list[str] = []
                 try:
+                    from ..loader.resolution import resolve_composite_onnx_sources
+
+                    component_sources = resolve_composite_onnx_sources(
+                        model,
+                        task=task_hint,
+                        precision=precision,
+                        trust_remote_code=trust_remote_code,
+                    )
                     for name, component_task in components.items():
                         console.print(
                             f"\n[bold blue]Sub-model:[/bold blue] {name} (task={component_task})"
@@ -1316,16 +1349,31 @@ def build(
 
                         from ..config import generate_build_config as gen_cfg
 
-                        component_config = gen_cfg(
-                            model,
-                            task=component_task,
-                            trust_remote_code=trust_remote_code,
-                            device=device,
-                            precision=precision,
-                            ep=ep,
-                            shape_config=shape_overrides,
-                            override={"export": export_overrides} if export_overrides else None,
+                        component_source = (
+                            component_sources.get(name) if component_sources else None
                         )
+                        if component_source is not None:
+                            from ..config import generate_onnx_build_config
+
+                            component_config = generate_onnx_build_config(
+                                component_source,
+                                task=component_task,
+                                device=device,
+                                precision=precision,
+                                ep=ep,
+                            )
+                            component_config.loader.component_name = name
+                        else:
+                            component_config = gen_cfg(
+                                model,
+                                task=component_task,
+                                trust_remote_code=trust_remote_code,
+                                device=device,
+                                precision=precision,
+                                ep=ep,
+                                shape_config=shape_overrides,
+                                override={"export": export_overrides} if export_overrides else None,
+                            )
                         # Carry over quant/compile settings from the outer config
                         # (already patched by CLI overrides like --no-quant /
                         # --no-compile). Deep-copy to avoid sharing mutable state
@@ -1378,8 +1426,8 @@ def build(
                         _run_single_build(
                             config=component_config,
                             config_file=None,
-                            model_id=model,
-                            is_onnx=False,
+                            model_id=component_source or model,
+                            is_onnx=component_source is not None,
                             resolved_dir=resolved_dir,
                             rebuild=rebuild,
                             cache_key=name,

--- a/src/winml/modelkit/commands/config.py
+++ b/src/winml/modelkit/commands/config.py
@@ -363,13 +363,13 @@ def config(
                 hf_model, model_type, task, trust_remote_code=trust_remote_code
             )
             if pipeline_components:
-                # Export controls target a single export graph; a composite model
-                # has one export per sub-component with distinct inputs. Reject on
-                # raw flag presence — before loading/validating the JSON — so the
-                # composite-specific error wins (mirroring the ONNX path) instead
-                # of a downstream "Invalid export configuration". config never fans
-                # these overrides out across heterogeneous components.
-                if _export_flags_given:
+                from ..loader.resolution import (
+                    composite_requires_pretrained_onnx,
+                    resolve_composite_onnx_sources,
+                )
+
+                published_only = composite_requires_pretrained_onnx(pipeline_components)
+                if not published_only and _export_flags_given:
                     raise click.UsageError(
                         "--input-specs, --export-config, and --dynamic-axes are not "
                         "supported for composite (multi-component) models, whose "
@@ -377,26 +377,56 @@ def config(
                         "the per-component configs first, then edit their export "
                         "sections individually."
                     )
-                # composite model: generate one config per sub-component
-                _generate_pipeline_configs(
-                    pipeline_components,
-                    hf_model=hf_model,
-                    model_class=model_class,
-                    model_type=model_type,
-                    override=override,
-                    shape_config=shape_config,
-                    library_name=library_name,
-                    device=device,
-                    precision=precision,
-                    trust_remote_code=trust_remote_code,
-                    ep=ep,
-                    no_quant=not quant,
-                    no_compile=no_compile,
-                    output=output,
-                    overwrite=overwrite,
-                    console=console,
+                component_sources = (
+                    resolve_composite_onnx_sources(
+                        hf_model,
+                        task=task,
+                        precision=precision,
+                        trust_remote_code=trust_remote_code,
+                    )
+                    if hf_model
+                    else None
                 )
-                return
+                use_composite = component_sources is not None or not published_only
+
+                # Export controls target a single export graph; a composite model
+                # has one export per sub-component with distinct inputs. Reject on
+                # raw flag presence — before loading/validating the JSON — so the
+                # composite-specific error wins (mirroring the ONNX path) instead
+                # of a downstream "Invalid export configuration". config never fans
+                # these overrides out across heterogeneous components.
+                if use_composite and _export_flags_given:
+                    raise click.UsageError(
+                        "--input-specs, --export-config, and --dynamic-axes are not "
+                        "supported for composite (multi-component) models, whose "
+                        "sub-components each have their own export inputs. Generate "
+                        "the per-component configs first, then edit their export "
+                        "sections individually."
+                    )
+                # Composite model: generate one config per sub-component. An
+                # optional published-ONNX registration with no sources falls
+                # through to the pre-existing single PyTorch export path.
+                if use_composite:
+                    _generate_pipeline_configs(
+                        pipeline_components,
+                        component_sources=component_sources,
+                        hf_model=hf_model,
+                        model_class=model_class,
+                        model_type=model_type,
+                        override=override,
+                        shape_config=shape_config,
+                        library_name=library_name,
+                        device=device,
+                        precision=precision,
+                        trust_remote_code=trust_remote_code,
+                        ep=ep,
+                        no_quant=not quant,
+                        no_compile=no_compile,
+                        output=output,
+                        overwrite=overwrite,
+                        console=console,
+                    )
+                    return
 
             # Load export CLI overrides now that the multi-graph paths (ONNX,
             # --module, composite) have all been rejected — the single HF config
@@ -603,6 +633,7 @@ def _resolve_composite_model_components(
 def _generate_pipeline_configs(
     components: dict[str, str],
     *,
+    component_sources: dict[str, str] | None,
     hf_model: str | None,
     model_class: str | None,
     model_type: str | None,
@@ -620,7 +651,7 @@ def _generate_pipeline_configs(
     console: Any,
 ) -> None:
     """Generate and save one config file per pipeline sub-component."""
-    from ..config import generate_hf_build_config
+    from ..config import generate_hf_build_config, generate_onnx_build_config
 
     for component_name, component_task in components.items():
         console.print(
@@ -628,19 +659,32 @@ def _generate_pipeline_configs(
             f"(task={component_task})...[/dim]"
         )
 
-        cfg = generate_hf_build_config(
-            model_id=hf_model,
-            task=component_task,
-            model_class=model_class,
-            model_type=model_type,
-            override=override,
-            shape_config=shape_config,
-            library_name=library_name,
-            device=device,
-            precision=precision,
-            trust_remote_code=trust_remote_code,
-            ep=ep,
-        )
+        source = component_sources.get(component_name) if component_sources else None
+        if source is not None:
+            cfg = generate_onnx_build_config(
+                source,
+                task=component_task,
+                override=override,
+                device=device,
+                precision=precision,
+                ep=ep,
+            )
+            cfg.loader.component_name = component_name
+            cfg.loader.model_type = model_type
+        else:
+            cfg = generate_hf_build_config(
+                model_id=hf_model,
+                task=component_task,
+                model_class=model_class,
+                model_type=model_type,
+                override=override,
+                shape_config=shape_config,
+                library_name=library_name,
+                device=device,
+                precision=precision,
+                trust_remote_code=trust_remote_code,
+                ep=ep,
+            )
         _apply_stage_overrides(cfg, no_quant=no_quant, no_compile=no_compile)
 
         config_json = json.dumps(cfg.to_dict(), indent=2)

--- a/src/winml/modelkit/eval/evaluate.py
+++ b/src/winml/modelkit/eval/evaluate.py
@@ -330,6 +330,16 @@ def evaluate(config: WinMLEvaluationConfig) -> EvalResult:
     config = replace(
         config, mode=mode, task=_resolve_task(config), dataset=deepcopy(config.dataset)
     )
+    if config.task == "mask-generation" and config.model_path is None and config.model_id:
+        from ..loader.resolution import resolve_composite_onnx_sources
+
+        sources = resolve_composite_onnx_sources(
+            config.model_id,
+            task=config.task,
+            precision=config.precision,
+        )
+        if sources is not None:
+            config = replace(config, model_path=sources)
     if config.mode != "compare" and config.dataset.path is None:
         default = _DEFAULT_DATASETS.get(config.task) if config.task is not None else None
         if default is None:

--- a/src/winml/modelkit/eval/mask_generation_evaluator.py
+++ b/src/winml/modelkit/eval/mask_generation_evaluator.py
@@ -167,6 +167,13 @@ class WinMLMaskGenerationEvaluator(WinMLEvaluator):
                 "Use prompt_mode='bbox' or 'point'."
             )
         self._enc_sess, self._dec_sess = self._load_sessions()
+        self._decoder_input_names = _node_names(self._dec_sess.get_inputs())
+        if "input_boxes" not in self._decoder_input_names:
+            if "prompt_mode" in mapping and self._prompt_mode == "bbox":
+                raise ValueError(
+                    "The decoder does not accept box prompts; use prompt_mode='point'."
+                )
+            self._prompt_mode = "point"
         self._encoder_input_name = _resolve_encoder_input_name(self._enc_sess)
         self._encoder_output_names = _node_names(self._enc_sess.get_outputs())
         self._embedding_input_names = _resolve_embedding_input_names(
@@ -330,6 +337,7 @@ class WinMLMaskGenerationEvaluator(WinMLEvaluator):
             scale_y=scale_y,
             emb=emb,
             required_embed_names=self._embedding_input_names,
+            required_input_names=self._decoder_input_names,
         )
         dec_out = self._dec_sess.run(
             list(self._decoder_output_names),
@@ -427,7 +435,7 @@ def _resolve_embedding_input_names(
 ) -> tuple[str, ...]:
     """Match decoder embedding inputs to encoder output names."""
     decoder_inputs = _node_names(dec_sess.get_inputs())
-    required_prompt_inputs = ("input_points", "input_labels", "input_boxes")
+    required_prompt_inputs = ("input_points", "input_labels")
     missing_prompt = [name for name in required_prompt_inputs if name not in decoder_inputs]
     if missing_prompt:
         raise ValueError(
@@ -599,6 +607,11 @@ def _build_decoder_inputs(
         "image_embeddings.1",
         "image_embeddings.2",
     ),
+    required_input_names: tuple[str, ...] = (
+        "input_points",
+        "input_labels",
+        "input_boxes",
+    ),
 ) -> dict[str, np.ndarray]:
     """Assemble the decoder feed dict for bbox or point prompts.
 
@@ -648,11 +661,12 @@ def _build_decoder_inputs(
             f"Encoder output missing required keys {missing_embeds}. Got: {list(emb.keys())}"
         )
 
-    feed = {
+    prompt_feed = {
         "input_points": points,
         "input_labels": labels,
         "input_boxes": box,
     }
+    feed = {name: value for name, value in prompt_feed.items() if name in required_input_names}
     feed.update({name: emb[name] for name in required_embed_names})
     return feed
 

--- a/src/winml/modelkit/loader/config.py
+++ b/src/winml/modelkit/loader/config.py
@@ -71,6 +71,7 @@ class WinMLLoaderConfig:
     model_class: str | None = None
     model_type: str | None = None
     module_path: str | None = None
+    component_name: str | None = None
     user_script: str | None = None
     trust_remote_code: bool = False
 
@@ -89,6 +90,8 @@ class WinMLLoaderConfig:
             result["model_type"] = self.model_type
         if self.module_path is not None:
             result["module_path"] = self.module_path
+        if self.component_name is not None:
+            result["component_name"] = self.component_name
         if self.user_script is not None:
             result["user_script"] = self.user_script
         if self.trust_remote_code:
@@ -110,6 +113,7 @@ class WinMLLoaderConfig:
             model_class=data.get("model_class"),
             model_type=data.get("model_type"),
             module_path=data.get("module_path"),
+            component_name=data.get("component_name"),
             user_script=data.get("user_script"),
             trust_remote_code=data.get("trust_remote_code", False),
         )

--- a/src/winml/modelkit/loader/onnx_hub.py
+++ b/src/winml/modelkit/loader/onnx_hub.py
@@ -19,10 +19,135 @@ The function exposed here, :func:`resolve_hf_onnx_path`, is called by
 from __future__ import annotations
 
 import logging
+from collections import Counter
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _GraphContract:
+    path: Path
+    inputs: tuple[tuple[str, str, int], ...]
+    outputs: tuple[tuple[str, str, int], ...]
+    precision: str
+
+
+def _inspect_runnable_graph(path: Path) -> _GraphContract | None:
+    """Return a runnable graph's I/O contract, or ``None`` when ORT rejects it."""
+    import onnx
+    import onnxruntime as ort
+
+    try:
+        options = ort.SessionOptions()
+        options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_DISABLE_ALL
+        session = ort.InferenceSession(
+            str(path),
+            sess_options=options,
+            providers=["CPUExecutionProvider"],
+        )
+        model = onnx.load(path, load_external_data=False)
+    except Exception as error:
+        logger.warning("Ignoring unusable published ONNX graph %s: %s", path.name, error)
+        return None
+
+    type_counts = Counter(initializer.data_type for initializer in model.graph.initializer)
+    fp16 = type_counts[onnx.TensorProto.FLOAT16]
+    fp32 = type_counts[onnx.TensorProto.FLOAT]
+    precision = "fp16" if fp16 > fp32 else "fp32"
+
+    def contract(nodes: list[Any]) -> tuple[tuple[str, str, int], ...]:
+        return tuple((node.name, node.type, len(node.shape)) for node in nodes)
+
+    return _GraphContract(
+        path=path,
+        inputs=contract(session.get_inputs()),
+        outputs=contract(session.get_outputs()),
+        precision=precision,
+    )
+
+
+def resolve_hf_onnx_encoder_decoder(
+    model_id: str,
+    *,
+    revision: str | None = None,
+    precision: str = "fp32",
+    cache_dir: str | Path | None = None,
+    token: str | bool | None = None,
+) -> dict[str, Path]:
+    """Discover a runnable image-encoder/prompt-decoder pair in a Hub repo.
+
+    Selection is graph-contract driven rather than filename driven. The encoder
+    has one rank-4 tensor input; the decoder consumes one or more encoder outputs
+    plus a rank-3 integer prompt tensor. Invalid published variants are ignored
+    after an ORT CPU session probe. An fp16 build may safely fall back to fp32
+    source graphs because the normal build pipeline performs fp16 conversion.
+    """
+    from huggingface_hub import list_repo_files
+
+    files = sorted(
+        name
+        for name in list_repo_files(model_id, revision=revision, token=token)
+        if name.lower().endswith(".onnx")
+    )
+    if not files:
+        raise FileNotFoundError(f"No published ONNX graphs found in Hub repo {model_id!r}.")
+
+    graphs: list[_GraphContract] = []
+    for filename in files:
+        path = resolve_hf_onnx_path(
+            f"{model_id}/{filename}",
+            revision=revision,
+            cache_dir=cache_dir,
+            token=token,
+        )
+        graph = _inspect_runnable_graph(path)
+        if graph is not None:
+            graphs.append(graph)
+
+    preferred_precisions = ("fp16", "fp32") if precision == "fp16" else ("fp32",)
+    candidates: list[tuple[int, int, str, _GraphContract, _GraphContract]] = []
+    for encoder in graphs:
+        encoder_inputs = encoder.inputs
+        if len(encoder_inputs) != 1 or encoder_inputs[0][2] != 4:
+            continue
+        encoder_outputs = {name for name, _dtype, _rank in encoder.outputs}
+        for decoder in graphs:
+            if decoder.path == encoder.path or decoder.precision != encoder.precision:
+                continue
+            decoder_inputs = {name for name, _dtype, _rank in decoder.inputs}
+            shared = encoder_outputs & decoder_inputs
+            has_integer_prompt = any(
+                rank == 3 and "int" in dtype.lower() for _name, dtype, rank in decoder.inputs
+            )
+            if not shared or not has_integer_prompt:
+                continue
+            try:
+                precision_rank = preferred_precisions.index(encoder.precision)
+            except ValueError:
+                continue
+            candidates.append((precision_rank, -len(shared), str(encoder.path), encoder, decoder))
+
+    if not candidates:
+        contracts = [
+            {
+                "file": graph.path.name,
+                "precision": graph.precision,
+                "inputs": [name for name, _dtype, _rank in graph.inputs],
+                "outputs": [name for name, _dtype, _rank in graph.outputs],
+            }
+            for graph in graphs
+        ]
+        raise ValueError(
+            "Published ONNX graphs do not contain a runnable encoder/decoder pair "
+            f"for precision {precision!r}: {contracts}"
+        )
+
+    _rank, _shared, _path, encoder, decoder = min(candidates, key=lambda row: row[:3])
+    return {"image-encoder": encoder.path, "prompt-decoder": decoder.path}
 
 
 def resolve_hf_onnx_path(
@@ -79,9 +204,7 @@ def resolve_hf_onnx_path(
         # ``.onnx`` files so the user can pick the right one without leaving
         # the terminal. Re-raise as ``FileNotFoundError`` so callers that
         # already handle local-file-missing errors get a consistent type.
-        hint = _format_available_onnx_files(
-            repo_id, revision=revision, token=token
-        )
+        hint = _format_available_onnx_files(repo_id, revision=revision, token=token)
         raise FileNotFoundError(
             f"ONNX file '{filename}' not found in Hub repo '{repo_id}'.\n{hint}"
         ) from e
@@ -171,5 +294,6 @@ def _format_available_onnx_files(
 
 
 __all__ = [
+    "resolve_hf_onnx_encoder_decoder",
     "resolve_hf_onnx_path",
 ]

--- a/src/winml/modelkit/loader/onnx_hub.py
+++ b/src/winml/modelkit/loader/onnx_hub.py
@@ -34,6 +34,7 @@ class _GraphContract:
     inputs: tuple[tuple[str, str, int], ...]
     outputs: tuple[tuple[str, str, int], ...]
     precision: str
+    has_quantized_weights: bool = False
 
 
 def _inspect_runnable_graph(path: Path) -> _GraphContract | None:
@@ -58,6 +59,9 @@ def _inspect_runnable_graph(path: Path) -> _GraphContract | None:
     fp16 = type_counts[onnx.TensorProto.FLOAT16]
     fp32 = type_counts[onnx.TensorProto.FLOAT]
     precision = "fp16" if fp16 > fp32 else "fp32"
+    has_quantized_weights = bool(
+        type_counts[onnx.TensorProto.INT8] or type_counts[onnx.TensorProto.UINT8]
+    )
 
     def contract(nodes: list[Any]) -> tuple[tuple[str, str, int], ...]:
         return tuple((node.name, node.type, len(node.shape)) for node in nodes)
@@ -67,6 +71,7 @@ def _inspect_runnable_graph(path: Path) -> _GraphContract | None:
         inputs=contract(session.get_inputs()),
         outputs=contract(session.get_outputs()),
         precision=precision,
+        has_quantized_weights=has_quantized_weights,
     )
 
 
@@ -109,14 +114,18 @@ def resolve_hf_onnx_encoder_decoder(
             graphs.append(graph)
 
     preferred_precisions = ("fp16", "fp32") if precision == "fp16" else ("fp32",)
-    candidates: list[tuple[int, int, str, _GraphContract, _GraphContract]] = []
+    candidates: list[tuple[int, int, _GraphContract, _GraphContract, tuple[str, ...]]] = []
     for encoder in graphs:
         encoder_inputs = encoder.inputs
         if len(encoder_inputs) != 1 or encoder_inputs[0][2] != 4:
             continue
         encoder_outputs = {name for name, _dtype, _rank in encoder.outputs}
         for decoder in graphs:
-            if decoder.path == encoder.path or decoder.precision != encoder.precision:
+            if (
+                decoder.path == encoder.path
+                or decoder.precision != encoder.precision
+                or decoder.has_quantized_weights != encoder.has_quantized_weights
+            ):
                 continue
             decoder_inputs = {name for name, _dtype, _rank in decoder.inputs}
             shared = encoder_outputs & decoder_inputs
@@ -129,7 +138,10 @@ def resolve_hf_onnx_encoder_decoder(
                 precision_rank = preferred_precisions.index(encoder.precision)
             except ValueError:
                 continue
-            candidates.append((precision_rank, -len(shared), str(encoder.path), encoder, decoder))
+            quantization_rank = int(encoder.has_quantized_weights)
+            candidates.append(
+                (precision_rank, quantization_rank, encoder, decoder, tuple(sorted(shared)))
+            )
 
     if not candidates:
         contracts = [
@@ -146,7 +158,34 @@ def resolve_hf_onnx_encoder_decoder(
             f"for precision {precision!r}: {contracts}"
         )
 
-    _rank, _shared, _path, encoder, decoder = min(candidates, key=lambda row: row[:3])
+    best_source_rank = min(candidate[:2] for candidate in candidates)
+    preferred_candidates = sorted(
+        (candidate for candidate in candidates if candidate[:2] == best_source_rank),
+        key=lambda candidate: (str(candidate[2].path), str(candidate[3].path)),
+    )
+    if len(preferred_candidates) != 1:
+        pairs = [
+            {
+                "image-encoder": encoder.path.name,
+                "prompt-decoder": decoder.path.name,
+                "precision": encoder.precision,
+                "shared_outputs": list(shared),
+            }
+            for (
+                _precision_rank,
+                _quantization_rank,
+                encoder,
+                decoder,
+                shared,
+            ) in preferred_candidates
+        ]
+        raise ValueError(
+            "Published ONNX graphs contain multiple valid encoder/decoder pairs "
+            f"for precision {precision!r}; unable to select one unambiguously. "
+            f"Candidate pairs: {pairs}"
+        )
+
+    _precision_rank, _quantization_rank, encoder, decoder, _shared = preferred_candidates[0]
     return {"image-encoder": encoder.path, "prompt-decoder": decoder.path}
 
 

--- a/src/winml/modelkit/loader/resolution.py
+++ b/src/winml/modelkit/loader/resolution.py
@@ -350,6 +350,70 @@ def resolve_composite_components(
     return resolve_task(config).composite
 
 
+def resolve_composite_onnx_sources(
+    hf_model: str,
+    *,
+    task: str | None = None,
+    component_name: str | None = None,
+    precision: str = "fp32",
+    trust_remote_code: bool = False,
+) -> dict[str, str] | None:
+    """Resolve published ONNX sources for a registered composite model."""
+    from transformers import AutoConfig
+
+    config = AutoConfig.from_pretrained(hf_model, trust_remote_code=trust_remote_code)
+    model_type = config.model_type.lower().replace("_", "-")
+    registry = _composite_registry()
+
+    if task is not None and (model_type, task) in registry:
+        composite_cls = registry[(model_type, task)]
+    else:
+        resolution = resolve_task(config, task=task)
+        matching = [
+            cls
+            for (registered_type, _registered_task), cls in registry.items()
+            if registered_type == model_type
+            and resolution.composite == dict(cls._SUB_MODEL_CONFIG)
+            and (component_name is None or component_name in cls._SUB_MODEL_CONFIG)
+        ]
+        if not matching:
+            return None
+        if len(set(matching)) != 1:
+            raise ValueError(
+                f"{model_type!r} has multiple matching composite ONNX sources; pass --task."
+            )
+        composite_cls = matching[0]
+
+    sources = composite_cls.resolve_pretrained_onnx(
+        hf_model,
+        revision=getattr(config, "_commit_hash", None),
+        precision=precision,
+    )
+    if sources is None:
+        return None
+    resolved = {name: str(path) for name, path in sources.items()}
+    if component_name is not None:
+        if component_name not in resolved:
+            raise ValueError(
+                f"Published composite has no component {component_name!r}; "
+                f"available: {sorted(resolved)}"
+            )
+        return {component_name: resolved[component_name]}
+    return resolved
+
+
+def composite_requires_pretrained_onnx(components: CompositeComponents) -> bool:
+    """Whether a registered composite exists only for published ONNX sources.
+
+    Such registrations augment an architecture without replacing its existing
+    PyTorch export behavior when the checkpoint publishes no ONNX components.
+    """
+    matching = {
+        cls for cls in _composite_registry().values() if components == dict(cls._SUB_MODEL_CONFIG)
+    }
+    return len(matching) == 1 and next(iter(matching))._PRETRAINED_ONNX_ONLY
+
+
 def composite_pipeline_tasks(model_type: str) -> list[str]:
     """Pipeline (composite) tasks a model_type can serve, sorted; ``[]`` for non-composites.
 

--- a/src/winml/modelkit/loader/task.py
+++ b/src/winml/modelkit/loader/task.py
@@ -129,6 +129,7 @@ KNOWN_TASKS: frozenset[str] = frozenset(_TASK_REGISTRY)
 COMPOSITE_TASKS: frozenset[str] = frozenset(
     {
         "image-to-text",
+        "mask-generation",
         "summarization",
         "table-question-answering",
         "text-generation",

--- a/src/winml/modelkit/models/hf/sam.py
+++ b/src/winml/modelkit/models/hf/sam.py
@@ -34,7 +34,7 @@ Exports:
 from __future__ import annotations
 
 import types
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import torch
 import torch.nn.functional as F
@@ -48,6 +48,7 @@ from optimum.utils.input_generators import (
 from transformers import Sam2Model, SamModel
 
 from ...export import register_onnx_overwrite
+from ..winml.composite_model import WinMLCompositeModel, register_composite_model
 
 
 if TYPE_CHECKING:
@@ -402,6 +403,41 @@ MODEL_CLASS_MAPPING: dict[tuple[str, str | None], type] = {
 }
 
 
+@register_composite_model("sam", "mask-generation")
+class WinMLSAMModel(WinMLCompositeModel):
+    """SAM composite backed by published encoder and prompt-decoder ONNX graphs."""
+
+    _PRETRAINED_ONNX_ONLY: ClassVar[bool] = True
+    _SUB_MODEL_CONFIG: ClassVar[dict[str, str]] = {
+        "image-encoder": "image-feature-extraction",
+        "prompt-decoder": "mask-generation",
+    }
+
+    @classmethod
+    def resolve_pretrained_onnx(
+        cls,
+        model_id: str,
+        *,
+        revision: str | None = None,
+        precision: str = "fp32",
+    ) -> dict[str, str] | None:
+        """Discover the checkpoint's runnable published ONNX graph pair."""
+        from ...loader.onnx_hub import resolve_hf_onnx_encoder_decoder
+
+        try:
+            sources = resolve_hf_onnx_encoder_decoder(
+                model_id,
+                revision=revision,
+                precision=precision,
+            )
+        except FileNotFoundError:
+            # Published ONNX is an optional source for SAM. Ordinary PyTorch
+            # checkpoints must retain the existing export path. Malformed or
+            # ambiguous published graph sets still raise and fail closed.
+            return None
+        return {name: str(path) for name, path in sources.items()}
+
+
 # Note: No model-specific build config needed. The analyzer autoconf loop
 # discovers optimization flags automatically. See issue #232.
 
@@ -577,9 +613,7 @@ def _patched_sam2_prompt_encoder_forward(
 
     # _original_forward is added dynamically by Sam2ModelPatcher (not on the class),
     # so it's reached via nn.Module.__getattr__ (typed Tensor | Module); type it callable.
-    orig_forward = cast(
-        "Callable[..., tuple[torch.Tensor, torch.Tensor]]", self._original_forward
-    )
+    orig_forward = cast("Callable[..., tuple[torch.Tensor, torch.Tensor]]", self._original_forward)
 
     # If use_mask_input not provided, use original behavior
     if use_mask_input is None:
@@ -1084,6 +1118,7 @@ __all__ = [
     "Sam2ModelPatcher",
     "Sam2NormalizedVisionConfig",
     "SamMaskGenerationIOConfig",
+    "WinMLSAMModel",
     "_patched_sam2_multiscale_block_forward",
     "_patched_sam2_prompt_encoder_forward",
 ]

--- a/src/winml/modelkit/models/winml/composite_model.py
+++ b/src/winml/modelkit/models/winml/composite_model.py
@@ -105,6 +105,18 @@ class WinMLCompositeModel(PreTrainedModel):
     """
 
     _SUB_MODEL_CONFIG: ClassVar[dict[str, str]] = {}
+    _PRETRAINED_ONNX_ONLY: ClassVar[bool] = False
+
+    @classmethod
+    def resolve_pretrained_onnx(
+        cls,
+        model_id: str,
+        *,
+        revision: str | None = None,
+        precision: str = "fp32",
+    ) -> Mapping[str, str | Path] | None:
+        """Resolve published ONNX components when this composite supports them."""
+        return None
 
     def __init__(
         self,
@@ -182,6 +194,23 @@ class WinMLCompositeModel(PreTrainedModel):
                 force_rebuild=force_rebuild,
                 sub_model_kwargs=sub_model_kwargs,
                 trust_remote_code=trust_remote_code,
+                **kwargs,
+            )
+
+        published = cls.resolve_pretrained_onnx(
+            model_id,
+            revision=getattr(hf_config, "_commit_hash", None),
+            precision=cast("str", kwargs.get("precision", "fp32")),
+        )
+        if published is not None:
+            return cls.from_onnx(
+                published,
+                task=task,
+                hf_config=hf_config,
+                device=device,
+                precision=kwargs.pop("precision", "fp32"),
+                use_cache=use_cache,
+                force_rebuild=force_rebuild,
                 **kwargs,
             )
         from ..auto import WinMLAutoModel

--- a/src/winml/modelkit/pattern/base.py
+++ b/src/winml/modelkit/pattern/base.py
@@ -604,6 +604,13 @@ class Pattern(ABC):
                         cast("tuple[int, ...]", info.shape)
                     ).get_value(type_annotation)
 
+        # Pattern validation must fail closed when shape/value metadata is
+        # unavailable. Pattern implementations use these arrays to derive
+        # dtype-dependent constants; allowing a partial mapping through turns
+        # an incomplete shape-inference result into an analyzer-wide KeyError.
+        if any(name not in inputs for name in input_infos):
+            return None
+
         # Build is_constant_map from input_infos
         is_constant_map = {name: info.is_constant for name, info in input_infos.items()}
 

--- a/tests/unit/analyze/pattern/test_pattern_matcher_robustness.py
+++ b/tests/unit/analyze/pattern/test_pattern_matcher_robustness.py
@@ -13,6 +13,7 @@ from onnx.defs import get_schema
 
 from winml.modelkit.onnx import ONNXDomain
 from winml.modelkit.pattern import (
+    LayerNormalizationPowPattern,
     Pattern,
     PatternMatcher,
     PatternSchema,
@@ -185,3 +186,38 @@ class TestPatternMatcherLookupInvariants:
         results = matcher.match_skeleton()
         # The pattern can't match because the edge is missing
         assert len(results) == 0
+
+
+class TestPatternMatcherIncompleteInputMetadata:
+    """Incomplete shape inference must reject a match, not abort analysis."""
+
+    def test_layernorm_without_input_shape_skips_match(self) -> None:
+        x = helper.make_tensor_value_info("X", TensorProto.FLOAT, None)
+        y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, None)
+        scale = numpy_helper.from_array(np.ones([4], dtype=np.float32), name="Scale")
+        bias = numpy_helper.from_array(np.zeros([4], dtype=np.float32), name="B")
+        exponent = numpy_helper.from_array(np.array(2.0, dtype=np.float32), name="Exponent")
+        epsilon = numpy_helper.from_array(np.array(1e-5, dtype=np.float32), name="Epsilon")
+        nodes = [
+            helper.make_node("ReduceMean", ["X"], ["mean"], axes=[-1], name="mean"),
+            helper.make_node("Sub", ["X", "mean"], ["centered"], name="sub"),
+            helper.make_node("Pow", ["centered", "Exponent"], ["squared"], name="pow"),
+            helper.make_node("ReduceMean", ["squared"], ["variance"], axes=[-1], name="variance"),
+            helper.make_node("Add", ["variance", "Epsilon"], ["stabilized"], name="epsilon"),
+            helper.make_node("Sqrt", ["stabilized"], ["stddev"], name="sqrt"),
+            helper.make_node("Div", ["centered", "stddev"], ["normalized"], name="div"),
+            helper.make_node("Mul", ["normalized", "Scale"], ["scaled"], name="scale"),
+            helper.make_node("Add", ["scaled", "B"], ["Y"], name="bias"),
+        ]
+        graph = helper.make_graph(
+            nodes,
+            "incomplete_layernorm",
+            [x],
+            [y],
+            [scale, bias, exponent, epsilon],
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+        matcher = PatternMatcher(model)
+        matcher.register_pattern(LayerNormalizationPowPattern())
+
+        assert matcher.match() == []

--- a/tests/unit/commands/test_config_cli.py
+++ b/tests/unit/commands/test_config_cli.py
@@ -211,6 +211,107 @@ class TestConfigCliInterface:
         result = runner.invoke(config, ["-m", "test", "-o", str(output_file)])
         assert result.exit_code == 0, f"Output to file should succeed: {result.output}"
 
+
+class TestSamConfigSourceSelection:
+    """SAM config routing distinguishes PyTorch and published-ONNX checkpoints."""
+
+    @staticmethod
+    def _single_sam_config() -> MagicMock:
+        cfg = MagicMock()
+        cfg.loader.task = "mask-generation"
+        cfg.loader.model_class = "SAMMaskGeneration"
+        cfg.export = None
+        cfg.quant = None
+        cfg.to_dict.return_value = {
+            "loader": {
+                "task": "mask-generation",
+                "model_class": "SAMMaskGeneration",
+                "model_type": "sam",
+            },
+            "export": None,
+            "optim": {},
+            "quant": None,
+            "compile": None,
+        }
+        return cfg
+
+    def test_pytorch_sam_uses_existing_single_config_path(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        from transformers import SamConfig
+
+        from winml.modelkit.commands.config import config
+
+        output = tmp_path / "sam.json"
+        with (
+            patch("transformers.AutoConfig.from_pretrained", return_value=SamConfig()),
+            patch(
+                "winml.modelkit.models.hf.sam.WinMLSAMModel.resolve_pretrained_onnx",
+                return_value=None,
+            ),
+            patch(
+                "winml.modelkit.config.generate_hf_build_config",
+                return_value=self._single_sam_config(),
+            ) as generate_hf,
+            patch("winml.modelkit.commands.config._generate_pipeline_configs") as pipeline,
+        ):
+            result = runner.invoke(
+                config,
+                [
+                    "-m",
+                    "facebook/sam-vit-base",
+                    "--task",
+                    "mask-generation",
+                    "--no-compile",
+                    "-o",
+                    str(output),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(output.read_text())["loader"]["model_class"] == "SAMMaskGeneration"
+        generate_hf.assert_called_once()
+        pipeline.assert_not_called()
+
+    def test_published_onnx_sam_uses_composite_config_path(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        from transformers import SamConfig
+
+        from winml.modelkit.commands.config import config
+
+        sources = {
+            "image-encoder": "encoder.onnx",
+            "prompt-decoder": "decoder.onnx",
+        }
+        with (
+            patch("transformers.AutoConfig.from_pretrained", return_value=SamConfig()),
+            patch(
+                "winml.modelkit.models.hf.sam.WinMLSAMModel.resolve_pretrained_onnx",
+                return_value=sources,
+            ),
+            patch("winml.modelkit.commands.config._generate_pipeline_configs") as pipeline,
+        ):
+            result = runner.invoke(
+                config,
+                [
+                    "-m",
+                    "Xenova/slimsam-77-uniform",
+                    "--task",
+                    "mask-generation",
+                    "--no-compile",
+                    "-o",
+                    str(tmp_path / "slimsam.json"),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert pipeline.call_args.kwargs["component_sources"] == sources
+
+
+class TestConfigCliInterfaceContinued:
+    """Remaining config CLI interface and override tests."""
+
     def test_model_type_without_model(
         self,
         runner: CliRunner,

--- a/tests/unit/config/test_build_onnx.py
+++ b/tests/unit/config/test_build_onnx.py
@@ -38,6 +38,22 @@ from winml.modelkit.quant import WinMLQuantizationConfig
 from winml.modelkit.utils.config_utils import merge_config
 
 
+def test_loader_component_name_round_trips() -> None:
+    config = WinMLBuildConfig.from_dict(
+        {
+            "export": None,
+            "loader": {
+                "task": "mask-generation",
+                "model_type": "sam",
+                "component_name": "prompt-decoder",
+            },
+        }
+    )
+
+    assert config.loader.component_name == "prompt-decoder"
+    assert config.to_dict()["loader"]["component_name"] == "prompt-decoder"
+
+
 # =============================================================================
 # Fixtures
 # =============================================================================

--- a/tests/unit/eval/test_mask_generation_evaluator.py
+++ b/tests/unit/eval/test_mask_generation_evaluator.py
@@ -171,6 +171,33 @@ class TestBuildDecoderInputsPoint:
         # boxes empty
         assert feed["input_boxes"].shape == (1, 0, 4)
 
+    def test_point_only_decoder_omits_unsupported_box_tensor(self) -> None:
+        feed = _build_decoder_inputs(
+            prompt={"point": [15, 25], "label": 1},
+            prompt_mode="point",
+            scale_x=2.0,
+            scale_y=3.0,
+            emb={
+                "image_embeddings": np.zeros((1, 256, 64, 64), dtype=np.float32),
+                "image_positional_embeddings": np.zeros((1, 256, 64, 64), dtype=np.float32),
+            },
+            required_embed_names=("image_embeddings", "image_positional_embeddings"),
+            required_input_names=(
+                "input_points",
+                "input_labels",
+                "image_embeddings",
+                "image_positional_embeddings",
+            ),
+        )
+
+        assert "input_boxes" not in feed
+        assert set(feed) == {
+            "input_points",
+            "input_labels",
+            "image_embeddings",
+            "image_positional_embeddings",
+        }
+
 
 class TestBuildDecoderInputsInvalidMode:
     def test_text_mode_rejected_with_helpful_message(self) -> None:

--- a/tests/unit/loader/test_composite_tasks.py
+++ b/tests/unit/loader/test_composite_tasks.py
@@ -49,6 +49,14 @@ class TestCompositeTasksSync:
             "Update COMPOSITE_TASKS in src/winml/modelkit/loader/task.py."
         )
 
+    def test_sam_mask_generation_has_published_graph_roles(self) -> None:
+        from winml.modelkit.loader.resolution import resolve_composite
+
+        assert resolve_composite("sam", "mask-generation") == {
+            "image-encoder": "image-feature-extraction",
+            "prompt-decoder": "mask-generation",
+        }
+
 
 class TestCompositeTasksVsKnownTasks:
     def test_summarization_translation_excluded_from_known_tasks(self) -> None:

--- a/tests/unit/loader/test_onnx_composite_hub.py
+++ b/tests/unit/loader/test_onnx_composite_hub.py
@@ -1,0 +1,82 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Tests for graph-contract-driven composite ONNX discovery."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from winml.modelkit.loader import onnx_hub
+from winml.modelkit.models.hf.sam import WinMLSAMModel
+
+
+def _graph(
+    name: str,
+    *,
+    inputs: tuple[tuple[str, str, int], ...],
+    outputs: tuple[tuple[str, str, int], ...],
+    precision: str,
+) -> onnx_hub._GraphContract:
+    return onnx_hub._GraphContract(Path(name), inputs, outputs, precision)
+
+
+def test_resolver_selects_matching_graph_contract_and_falls_back_to_fp32(monkeypatch) -> None:
+    graphs = {
+        "encoder_fp16.onnx": None,
+        "decoder_fp16.onnx": None,
+        "encoder.onnx": _graph(
+            "encoder.onnx",
+            inputs=(("pixels", "tensor(float)", 4),),
+            outputs=(("embedding", "tensor(float)", 4), ("position", "tensor(float)", 4)),
+            precision="fp32",
+        ),
+        "decoder.onnx": _graph(
+            "decoder.onnx",
+            inputs=(
+                ("points", "tensor(float)", 4),
+                ("labels", "tensor(int64)", 3),
+                ("embedding", "tensor(float)", 4),
+                ("position", "tensor(float)", 4),
+            ),
+            outputs=(("scores", "tensor(float)", 3), ("masks", "tensor(float)", 5)),
+            precision="fp32",
+        ),
+    }
+    monkeypatch.setattr(
+        "huggingface_hub.list_repo_files",
+        lambda *args, **kwargs: list(graphs),
+    )
+    monkeypatch.setattr(
+        onnx_hub,
+        "resolve_hf_onnx_path",
+        lambda model_id, **kwargs: Path(model_id.rsplit("/", 1)[-1]),
+    )
+    monkeypatch.setattr(onnx_hub, "_inspect_runnable_graph", lambda path: graphs[path.name])
+
+    result = onnx_hub.resolve_hf_onnx_encoder_decoder("org/model", precision="fp16")
+
+    assert result == {
+        "image-encoder": Path("encoder.onnx"),
+        "prompt-decoder": Path("decoder.onnx"),
+    }
+
+
+def test_sam_published_onnx_absence_preserves_pytorch_fallback(monkeypatch) -> None:
+    monkeypatch.setattr("huggingface_hub.list_repo_files", lambda *args, **kwargs: [])
+
+    assert WinMLSAMModel.resolve_pretrained_onnx("facebook/sam-vit-base") is None
+
+
+def test_sam_malformed_published_onnx_still_fails_closed(monkeypatch) -> None:
+    monkeypatch.setattr(
+        onnx_hub,
+        "resolve_hf_onnx_encoder_decoder",
+        lambda *args, **kwargs: (_ for _ in ()).throw(ValueError("ambiguous pair")),
+    )
+
+    with pytest.raises(ValueError, match="ambiguous pair"):
+        WinMLSAMModel.resolve_pretrained_onnx("org/malformed-sam")

--- a/tests/unit/loader/test_onnx_composite_hub.py
+++ b/tests/unit/loader/test_onnx_composite_hub.py
@@ -20,8 +20,9 @@ def _graph(
     inputs: tuple[tuple[str, str, int], ...],
     outputs: tuple[tuple[str, str, int], ...],
     precision: str,
+    has_quantized_weights: bool = False,
 ) -> onnx_hub._GraphContract:
-    return onnx_hub._GraphContract(Path(name), inputs, outputs, precision)
+    return onnx_hub._GraphContract(Path(name), inputs, outputs, precision, has_quantized_weights)
 
 
 def test_resolver_selects_matching_graph_contract_and_falls_back_to_fp32(monkeypatch) -> None:
@@ -63,6 +64,112 @@ def test_resolver_selects_matching_graph_contract_and_falls_back_to_fp32(monkeyp
         "image-encoder": Path("encoder.onnx"),
         "prompt-decoder": Path("decoder.onnx"),
     }
+
+
+def test_resolver_prefers_unquantized_graph_family(monkeypatch) -> None:
+    graphs = {
+        "encoder.onnx": _graph(
+            "encoder.onnx",
+            inputs=(("pixels", "tensor(float)", 4),),
+            outputs=(("embedding", "tensor(float)", 4),),
+            precision="fp32",
+        ),
+        "decoder.onnx": _graph(
+            "decoder.onnx",
+            inputs=(
+                ("labels", "tensor(int64)", 3),
+                ("embedding", "tensor(float)", 4),
+            ),
+            outputs=(("masks", "tensor(float)", 5),),
+            precision="fp32",
+        ),
+        "encoder_quantized.onnx": _graph(
+            "encoder_quantized.onnx",
+            inputs=(("pixels", "tensor(float)", 4),),
+            outputs=(("embedding", "tensor(float)", 4),),
+            precision="fp32",
+            has_quantized_weights=True,
+        ),
+        "decoder_quantized.onnx": _graph(
+            "decoder_quantized.onnx",
+            inputs=(
+                ("labels", "tensor(int64)", 3),
+                ("embedding", "tensor(float)", 4),
+            ),
+            outputs=(("masks", "tensor(float)", 5),),
+            precision="fp32",
+            has_quantized_weights=True,
+        ),
+    }
+    monkeypatch.setattr("huggingface_hub.list_repo_files", lambda *args, **kwargs: list(graphs))
+    monkeypatch.setattr(
+        onnx_hub,
+        "resolve_hf_onnx_path",
+        lambda model_id, **kwargs: Path(model_id.rsplit("/", 1)[-1]),
+    )
+    monkeypatch.setattr(onnx_hub, "_inspect_runnable_graph", lambda path: graphs[path.name])
+
+    result = onnx_hub.resolve_hf_onnx_encoder_decoder("org/model")
+
+    assert result == {
+        "image-encoder": Path("encoder.onnx"),
+        "prompt-decoder": Path("decoder.onnx"),
+    }
+
+
+def test_resolver_rejects_multiple_valid_graph_pairs_as_ambiguous(monkeypatch) -> None:
+    graphs = {
+        "encoder_a.onnx": _graph(
+            "encoder_a.onnx",
+            inputs=(("pixels", "tensor(float)", 4),),
+            outputs=(("embedding_a", "tensor(float)", 4),),
+            precision="fp32",
+        ),
+        "decoder_a.onnx": _graph(
+            "decoder_a.onnx",
+            inputs=(
+                ("labels", "tensor(int64)", 3),
+                ("embedding_a", "tensor(float)", 4),
+            ),
+            outputs=(("masks", "tensor(float)", 5),),
+            precision="fp32",
+        ),
+        "encoder_b.onnx": _graph(
+            "encoder_b.onnx",
+            inputs=(("pixels", "tensor(float)", 4),),
+            outputs=(("embedding_b", "tensor(float)", 4),),
+            precision="fp32",
+        ),
+        "decoder_b.onnx": _graph(
+            "decoder_b.onnx",
+            inputs=(
+                ("labels", "tensor(int64)", 3),
+                ("embedding_b", "tensor(float)", 4),
+            ),
+            outputs=(("masks", "tensor(float)", 5),),
+            precision="fp32",
+        ),
+    }
+    monkeypatch.setattr(
+        "huggingface_hub.list_repo_files",
+        lambda *args, **kwargs: list(reversed(graphs)),
+    )
+    monkeypatch.setattr(
+        onnx_hub,
+        "resolve_hf_onnx_path",
+        lambda model_id, **kwargs: Path(model_id.rsplit("/", 1)[-1]),
+    )
+    monkeypatch.setattr(onnx_hub, "_inspect_runnable_graph", lambda path: graphs[path.name])
+
+    with pytest.raises(ValueError) as error:
+        onnx_hub.resolve_hf_onnx_encoder_decoder("org/ambiguous-model")
+
+    message = str(error.value)
+    assert "multiple valid encoder/decoder pairs" in message
+    assert "unable to select one unambiguously" in message
+    assert message.index("encoder_a.onnx") < message.index("encoder_b.onnx")
+    assert "decoder_a.onnx" in message
+    assert "decoder_b.onnx" in message
 
 
 def test_sam_published_onnx_absence_preserves_pytorch_fallback(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Adds generalized support for published ONNX-only SAM composites, exercised on `Xenova/slimsam-77-uniform` for CPU `mask-generation` in fp32 and fp16. The L2 effort ships reusable two-graph discovery/build/eval support plus four component recipes; Goal L3 passed on both precision tuples. Current head `487ff8a7ed976e28b9b2625acdd69a8346cb6c0e` also makes graph-pair selection fail closed when multiple equally preferred pairs are valid, adds genuine ambiguity/family-preference tests, and restores whole-package mypy.

## Model metadata

### What the model does

SlimSAM is a promptable image-segmentation model: a user supplies a 1024-pixel-normalized RGB image plus spatial prompts, and the composite image encoder and prompt/mask decoder return three candidate masks with predicted IoU scores. Confidence: **verified** from the [pinned model card](https://huggingface.co/Xenova/slimsam-77-uniform/blob/5850ab45f587c112167512ffef949107115e26a0/README.md) and [config](https://huggingface.co/Xenova/slimsam-77-uniform/blob/5850ab45f587c112167512ffef949107115e26a0/config.json).

### Primary user stories

- Interactive subject extraction from foreground/background point prompts — **verified** from the pinned model card.
- Compute image embeddings once and reuse them with new point prompts — **mapped** from the published graph split and SAM source structure.

### Supported tasks

- `mask-generation`: checkpoint, Transformers, and WinML — **verified**.
- `feature-extraction`: Optimum ONNX and WinML — **verified**.

### Model architecture

```text
SamModel (promptable segmentation; config-instantiated parameters: 9,723,528)
├── Image preprocessing (RGB; longest edge 1024; normalize; pad 1024x1024)
├── Vision encoder → vision_encoder.onnx
│   ├── 16x16 patch embedding (3 → 168; 64x64 grid)
│   ├── Vision transformer blocks x12 (12 heads; MLP 168 → 696 → 168)
│   │   ├── Window attention size 14 x8 blocks
│   │   └── Global attention at blocks 2, 5, 8, 11
│   └── Neck projection → image + positional embeddings [B,256,64,64]
├── Prompt encoder → prompt_encoder_mask_decoder.onnx
│   └── Point coordinates/labels → sparse prompt embeddings
├── Mask decoder → prompt_encoder_mask_decoder.onnx
│   ├── Two-way attention blocks x2 (width 256; 8 heads; MLP 2048)
│   ├── Mask hypernetworks → 3 low-resolution candidate masks
│   └── IoU prediction head → 3 candidate scores
└── Runtime post-processing (resize/crop to original image; choose candidate)
```

- Source/confidence: pinned checkpoint config and Transformers SAM source (**verified/mapped**); the repository publishes the encoder and decoder as two cooperating ONNX graphs at revision [`5850ab45f587c112167512ffef949107115e26a0`](https://huggingface.co/Xenova/slimsam-77-uniform/tree/5850ab45f587c112167512ffef949107115e26a0/onnx).

## Validation and support evidence

### 1. Baseline

Pinned baseline: winml-cli `e7509b1e908c74beff0a5655b8f8d7de69c5afae`, WinML CLI `0.2.0`.

- Exact checkpoint revision: [`5850ab45f587c112167512ffef949107115e26a0`](https://huggingface.co/Xenova/slimsam-77-uniform/tree/5850ab45f587c112167512ffef949107115e26a0). It is ONNX-only and has no PyTorch weights.
- Published fp32 source hashes: image encoder `9f8433273a6750b587779baa0cf5508111001bf7e7acfcf585d370139fd366d0`; prompt decoder `f4514391764fbd56e08e119060d874ecd7d52994bfb1968af159e12d4943b5bb`.
- Optimum probe: vendor tasks = `feature-extraction`; after WinML registration = `feature-extraction`, `mask-generation`; classification = `VENDOR+OVERRIDE`.
- `winml config --task mask-generation` exited 0, and inspect resolved `mask-generation` / `SAMMaskGeneration` / `SamMaskGenerationIOConfig`.
- Recipe-free baseline build exited 2 after `17.489 s`, emitted no ONNX artifact, and reported `Model class 'SAMMaskGeneration' not found for task 'feature-extraction'`. Build had fallen back to `feature-extraction` despite inspect/config resolving `mask-generation`.
- Baseline perf was unavailable because build emitted no artifact. Supplementary published-fp32 CPU perf passed: encoder mean/p50 `1063.618/1055.979 ms` (`0.94 samples/s`); one-point decoder mean/p50 `26.607/26.708 ms` (`37.58 samples/s`).
- Baseline artifact eval was unavailable. Supplementary fp32 composite eval loaded both sessions but the pre-change evaluator required absent `input_boxes`; published fp16 graphs failed ORT initialization with a float/float16 Cast mismatch.

### 2. Goal

| Axis | Commitment |
|---|---|
| Effort | **L2** — generalized class-of-models support for ONNX-only SAM composites |
| Goal ceiling | **L3** — task evaluation on every frozen CPU/cpu precision tuple |
| Outcome | **L2** — reusable task-family/code support plus recipes |
| Success definition | fp32 and fp16 encoder+decoder builds; composite perf; numeric comparison against the exact published fp32 pair; pinned-dataset mask-generation eval |

No charter downgrade was issued.

### 3. Outcome

- Current PR head: [`487ff8a7`](https://github.com/microsoft/winml-cli/commit/487ff8a7ed976e28b9b2625acdd69a8346cb6c0e).
- Highest Goal verdict: **L3 PASS**; full frozen coverage for CPU/cpu fp32 and fp16 composite tuples; no deferred tuples.
- Reviewer blockers 1–3 are addressed at current head: optional model-ID narrowing is explicit; multiple equally preferred valid graph pairs are rejected deterministically; tests cover genuine ambiguity, unquantized-family preference, fp32 fallback, native-PyTorch fallback, and malformed published ONNX.
- Producer validation: ambiguity/fallback focus `5 passed`; whole-package mypy `Success: no issues found in 403 source files`; broad relevant suite `1577 passed`; four recipe builds `4/4 PASS` with `Build complete`, `model.onnx`, and `winml_build_config.json`. All current GitHub checks pass, including lint, CodeQL, and all CI test partitions.
- Tester recheck `c836baf13860a5ac02124284a6a3c6a7e2f9f574229219ac5aa7bd0312ac35b6` at current head: terminal **PASS**; refreshed four builds plus bounded fp32 L1–L3 spot checks preserved artifact selection and execution contracts. Rebuilt bytes differ only by an unused `com.microsoft.dml` opset import; graph I/O, node contracts/attributes, initializer values, IR, and used domains are execution-equivalent.
- L0: 4/4 component builds passed. L1: composite CPU benchmark passed for both precisions. L2: exact-published-fp32-reference comparison passed; exact-revision PyTorch baseline is **BLOCKED_BY_CHECKPOINT_CONTENT**. L3: five-sample point-prompt evaluation passed for both precisions.
- Durable Lane A provenance: [PR 159](https://github.com/gim-home/ModelKitArtifacts/pull/159), foundational [commit `7da173de`](https://github.com/gim-home/ModelKitArtifacts/commit/7da173defff6ce561e455d5022fe514691bf2c27), and clarification [commit `fc7c1165`](https://github.com/gim-home/ModelKitArtifacts/commit/fc7c1165b9880e42c3064d3dd0874303d5b6225f). These record `sam-001`…`sam-006`, `_meta-082`, direct-ONNX evidence, and durable feature-gap `FILE:` references.

**Methodology friction observed: _meta-082 added.**

#### Direct-ONNX HTP evidence

All four resolved build configs retain `export=null`. Direct published-ONNX ingestion bypasses `HTPExporter`, so each artifact records `htp_metadata=NOT_PRODUCED_DIRECT_ONNX` and `metadata_exists=false`; HTP parameter/module/trace counts are not fabricated. Substitute evidence is the pinned configuration/source architecture, exact graph I/O, topology, and node-scope component mapping.

| Precision | Artifact | HTP status | Topology / component evidence |
|---|---|---|---|
| fp32 | image encoder | `NOT_PRODUCED_DIRECT_ONNX` | `1782` nodes; `vision_encoder`; `pixel_values` → image/positional embeddings |
| fp32 | prompt decoder | `NOT_PRODUCED_DIRECT_ONNX` | `810` nodes; `prompt_encoder`, `mask_decoder`; points/labels + embeddings → IoU/masks |
| fp16 | image encoder | `NOT_PRODUCED_DIRECT_ONNX` | `1785` nodes; same graph boundary after WinML fp16 conversion |
| fp16 | prompt decoder | `NOT_PRODUCED_DIRECT_ONNX` | `815` nodes; same graph boundary after WinML fp16 conversion |

Durable feature-gap references:

- `FILE: copilot-skills/dev_skill/adding-model-support/agents/learner.md` — direct-ONNX HTP evidence exception.
- `FILE: copilot-skills/dev_skill/adding-model-support/agents/reviewer.md` — direct-ONNX HTP review branch.
- `FILE: src/winml/modelkit/commands/perf.py` — expose graph-optimization/session options for converted SAM fp16 graphs requiring `ORT_DISABLE_ALL`.
- `FILE: copilot-skills/dev_skill/adding-model-support/agents/tester.md` — preserve the pinned published fp32 pair as the L2 reference when the exact revision has no PyTorch weights; collect capable-host runtime evidence before promoting static EP rows.

### 4. Per-EP/device/precision results — including perf and eval data

#### Goal ladder

| Tier | CPU/cpu fp32 | CPU/cpu fp16 | Evidence |
|---|---|---|---|
| L0 | PASS | PASS | Encoder + decoder fresh builds; 4/4 total |
| L1 | PASS | PASS_WITH_RUNTIME_CAVEAT | Composite benchmark, `ORT_DISABLE_ALL` |
| L2 | PASS | PASS | Exact published fp32 ONNX pair as reference |
| L3 | PASS | PASS | Pinned five-row point-prompt subset |

#### Composite perf (CPU, 3 warmups, 20 measured iterations)

| Precision | Mean | p50 | p90 | Throughput | Encoder mean | Decoder mean |
|---|---:|---:|---:|---:|---:|---:|
| fp32 | `1219.4138750011916 ms` | `1213.7237499991897 ms` | `1243.2789499987848 ms` | `0.8200661157796181 samples/s` | `1187.7435800022795 ms` | `31.67029499891214 ms` |
| fp16 | `1584.7703800012823 ms` | `1572.3618500051089 ms` | `1608.407509996323 ms` | `0.6310062407900322 samples/s` | `1545.1620049978374 ms` | `39.60837500344496 ms` |

#### L2 numeric comparison against the exact published fp32 pair

| Precision | Mask IoU | Mask Dice | Embeddings cosine | Predicted-masks cosine |
|---|---:|---:|---:|---:|
| fp32 | `1.0` | `1.0` | `0.9999999999999487` | `0.9999999995887173` |
| fp16 | `0.9930252396005821` | `0.9965004154183137` | `0.9999998499461553` | `0.9998631504023249` |

#### L3 task evaluation

Dataset: [`mattmdjaga/human_parsing_dataset`](https://huggingface.co/datasets/mattmdjaga/human_parsing_dataset/tree/db120bb5c18c146a8fbd2160f7575a288269fe7d), revision `db120bb5c18c146a8fbd2160f7575a288269fe7d`, split `train`, first five deterministic valid rows `sample_0000..sample_0004`, no shuffle, no streaming, seed `42`, `prompt_mode=point`.

| Precision | mIoU | Dice | Samples / skipped | Delta vs fp32 |
|---|---:|---:|---:|---|
| fp32 | `0.40013556173273895` | `0.5235086894209545` | `5 / 0` | — |
| fp16 | `0.39918580013126925` | `0.5229150662134483` | `5 / 0` | mIoU `-0.0009497616014697`; Dice `-0.0005936232075062` |

**fp16 ORT caveat:** default ORT session creation fails for both components; `ORT_DISABLE_ALL` passes for both. Standard `winml perf` exits 2 without JSON. Exact error: `Attempting to get index by a name which does not exist: InsertedPrecisionFreeCast_/vision_encoder/layers.3/layer_norm1/Constant_output_0 for node /vision_encoder/layers.0/layer_norm1/Mul/SimplifiedLayerNormFusion/`. Under the passing policy, fp16 is slower than fp32 on this CPU.

### 5. Delta

Four new CPU/cpu component recipes:

- fp32 image encoder and prompt decoder: direct published fp32 ONNX ingestion; no export, quantization, optimization, or compile.
- fp16 image encoder and prompt decoder: the same component roles plus `quant.mode=fp16` and `fp16_keep_io_types=true`; WinML converts the exact fp32 sources because the published fp16 variants are not runnable.

Generalized source delta:

- Discover and validate runnable published encoder/decoder graphs from I/O contracts; distinguish full-precision and quantized families; preserve the uniquely valid full-precision pair; reject malformed graphs and multiple equally preferred valid pairs.
- Generate portable component-role configs, resolve roles at build time, and route both graphs through direct ONNX ingestion while preserving native-PyTorch SAM fallback when no published pair exists.
- Resolve composite mask-generation model IDs for evaluation and infer point-only decoder capability without inventing unsupported box tensors.
- Reject pattern matches with incomplete required-input metadata instead of aborting analysis in dtype-dependent validation.
- Narrow the optional model ID with a runtime invariant before source resolution; no cast, ignore, or suppression.

Current scope: `21 files`, `899 insertions`, `55 deletions` — 4 recipes, 11 production Python files, and 6 unit-test files. The production recipe README is untouched.

### 6. Analyze summary — component level and op level

**ANALYZE-PARTIAL-SUCCESS:** all four processes exited 1 because unavailable host EP plugins could not register, but each emitted valid fail-closed JSON for all 11 requested EP/device targets. This is static rules analysis, not measured runtime support; every static row records `runtime_support=false`, and only CPU composite execution was measured.

#### Component-level summary

| Artifact | Architecture coverage | Mapping | Actionable static findings |
|---|---|---:|---|
| fp32 image encoder | patch embed; vision blocks x12; neck | `1775 mapped / 7 unmapped` | QNN partial: `Mod, Reshape, Transpose`; OpenVINO partial/unsupported arithmetic/casts |
| fp32 prompt decoder | prompt encoder; two-way decoder; mask/IoU heads | `809 mapped / 1 unmapped` | OpenVINO unsupported: `Mul, Div` |
| fp16 image encoder | patch embed; vision blocks x12; neck | `1775 mapped / 10 unmapped` | same grouped rule outcomes as fp32 encoder |
| fp16 prompt decoder | prompt encoder; two-way decoder; mask/IoU heads | `809 mapped / 6 unmapped` | same grouped rule outcomes as fp32 decoder |

#### Op-level summary

| Artifact | Graph | Dominant ops | EP roll-up |
|---|---|---|---|
| fp32 image encoder | `1782 ops / 26 types` | `Unsqueeze 245; Add 201; Mul 166` | TensorRT 12 supported + unknown remainder; QNN partial; OpenVINO unsupported set; five rule-less targets all unknown |
| fp32 prompt decoder | `810 ops / 32 types` | `Gather 137; Unsqueeze 124; Add 93` | TensorRT 8 supported + unknown remainder; QNN known set has no partial/unsupported; OpenVINO `Mul/Div` unsupported; five rule-less targets all unknown |
| fp16 image encoder | `1785 ops / 26 types` | `Unsqueeze 245; Add 201; Mul 166` | same grouped classifications as fp32 image encoder |
| fp16 prompt decoder | `815 ops / 32 types` | `Gather 137; Unsqueeze 124; Add 93` | same grouped classifications as fp32 prompt decoder |

Rules: [`v0.2.0`](https://github.com/microsoft/winml-cli/releases/tag/v0.2.0), archive SHA-256 `6dcabbe7f5493fbc2bd23de195ab6e35b3578d510f18c2e220bc5538a1f232cc`, `1746` parquet files.

### 7. Reproduce commands

```powershell
$MODEL='Xenova/slimsam-77-uniform'
$MODEL_REVISION='5850ab45f587c112167512ffef949107115e26a0'
$DATASET_REVISION='db120bb5c18c146a8fbd2160f7575a288269fe7d'
$OUT='slimsam-test-output'

winml config -m facebook/sam-vit-base --task mask-generation --ep cpu --device cpu --precision fp32 --no-compile -o "$OUT/facebook-sam.json" --overwrite --no-color
winml config -m $MODEL --task mask-generation --ep cpu --device cpu --precision fp32 --no-compile -o "$OUT/slimsam.json" --overwrite --no-color

foreach ($p in @('fp32','fp16')) {
  foreach ($role in @('image-encoder','prompt-decoder')) {
    winml build -c "examples/recipes/Xenova_slimsam-77-uniform/cpu/cpu/mask-generation_${p}_config_${role}.json" -m $MODEL -o "$OUT/build/${p}_${role}" --precision $p --no-compile --no-optimize --no-analyze --rebuild --no-color
  }
  winml eval -m "image-encoder=$OUT/build/${p}_image-encoder/model.onnx" -m "prompt-decoder=$OUT/build/${p}_prompt-decoder/model.onnx" --model-id $MODEL --task mask-generation --ep cpu --device cpu --precision $p --dataset mattmdjaga/human_parsing_dataset --dataset-revision $DATASET_REVISION --split train --samples 5 --no-shuffle --no-streaming --column prompt_mode=point --output "$OUT/eval_${p}.json" --overwrite --no-color
}

$RULES_ZIP="$OUT/rules-v0.2.0.zip"
Invoke-WebRequest 'https://github.com/microsoft/winml-cli/releases/download/v0.2.0/rules-v0.2.0.zip' -OutFile $RULES_ZIP
if ((Get-FileHash $RULES_ZIP -Algorithm SHA256).Hash.ToLowerInvariant() -ne '6dcabbe7f5493fbc2bd23de195ab6e35b3578d510f18c2e220bc5538a1f232cc') { throw 'rules hash mismatch' }
Expand-Archive $RULES_ZIP "$OUT/rules-v0.2.0" -Force
$env:WINMLCLI_RULES_DIR="$OUT/rules-v0.2.0"
foreach ($p in @('fp32','fp16')) {
  foreach ($role in @('image-encoder','prompt-decoder')) {
    winml analyze --model "$OUT/build/${p}_${role}/model.onnx" --ep all --device all --output "$OUT/analyze_${p}_${role}.json" --overwrite --format json --no-color
  }
}
Remove-Item Env:WINMLCLI_RULES_DIR
```
