### PR TITLE
Fix large-model FP16 conversion and add XLM-RoBERTa NER recipes

### DIFF
--- a/examples/recipes/Davlan_xlm-roberta-large-ner-hrl/cpu/cpu/token-classification_fp16_config.json
+++ b/examples/recipes/Davlan_xlm-roberta-large-ner-hrl/cpu/cpu/token-classification_fp16_config.json
@@ -1,0 +1,64 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [1, 512],
+        "value_range": [0, 250002]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [1, 512],
+        "value_range": [0, 2]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "token-classification",
+    "model_id": "Davlan/xlm-roberta-large-ner-hrl",
+    "model_type": "xlm-roberta",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "token-classification",
+    "model_class": "XLMRobertaForTokenClassification",
+    "model_type": "xlm-roberta"
+  }
+}

--- a/examples/recipes/Davlan_xlm-roberta-large-ner-hrl/cpu/cpu/token-classification_fp32_config.json
+++ b/examples/recipes/Davlan_xlm-roberta-large-ner-hrl/cpu/cpu/token-classification_fp32_config.json
@@ -1,0 +1,42 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [1, 512],
+        "value_range": [0, 250002]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [1, 512],
+        "value_range": [0, 2]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "token-classification",
+    "model_class": "XLMRobertaForTokenClassification",
+    "model_type": "xlm-roberta"
+  }
+}

--- a/src/winml/modelkit/quant/fp16.py
+++ b/src/winml/modelkit/quant/fp16.py
@@ -13,13 +13,11 @@ from __future__ import annotations
 import logging
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import cast
 
+import onnx
 from google.protobuf.message import EncodeError
 
-
-if TYPE_CHECKING:
-    import onnx
 
 logger = logging.getLogger(__name__)
 
@@ -49,8 +47,6 @@ def convert_to_fp16(
     Returns:
         The converted model (same object as input due to ORT in-place mutation).
     """
-    import onnx
-    from onnx import TensorProto
     from onnxruntime.transformers.float16 import convert_float_to_float16
 
     model_path = Path(model) if isinstance(model, str | Path) else None
@@ -60,11 +56,13 @@ def convert_to_fp16(
         inspection_model = cast("onnx.ModelProto", model)
 
     # Skip if model is already FP16 (check floating-point initializer dtypes)
-    fp32_types = {TensorProto.FLOAT, TensorProto.DOUBLE, TensorProto.BFLOAT16}
+    fp32_types = {onnx.TensorProto.FLOAT, onnx.TensorProto.DOUBLE, onnx.TensorProto.BFLOAT16}
     initializers = inspection_model.graph.initializer
     if initializers:
-        float_inits = [t for t in initializers if t.data_type in fp32_types | {TensorProto.FLOAT16}]
-        if float_inits and all(t.data_type == TensorProto.FLOAT16 for t in float_inits):
+        float_inits = [
+            t for t in initializers if t.data_type in fp32_types | {onnx.TensorProto.FLOAT16}
+        ]
+        if float_inits and all(t.data_type == onnx.TensorProto.FLOAT16 for t in float_inits):
             logger.info("Model is already FP16 — skipping conversion.")
             if model_path is not None:
                 onnx.load_external_data_for_model(inspection_model, str(model_path.parent))

--- a/src/winml/modelkit/quant/fp16.py
+++ b/src/winml/modelkit/quant/fp16.py
@@ -11,23 +11,25 @@ the quantizer's ``mode="fp16"`` path.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
 
 from google.protobuf.message import EncodeError
 
 
 if TYPE_CHECKING:
-    from onnx import ModelProto
+    import onnx
 
 logger = logging.getLogger(__name__)
 
 
 def convert_to_fp16(
-    model: ModelProto,
+    model: onnx.ModelProto | str | Path,
     *,
     keep_io_types: bool = True,
     op_block_list: list[str] | None = None,
-) -> ModelProto:
+) -> onnx.ModelProto:
     """Convert an ONNX model from FP32 to FP16 precision.
 
     Uses onnxruntime.transformers.float16.convert_float_to_float16 internally.
@@ -36,7 +38,8 @@ def convert_to_fp16(
     Note: ORT's converter mutates the model in-place and returns the same object.
 
     Args:
-        model: Input ONNX ModelProto (will be mutated in-place by ORT).
+        model: Input ONNX ModelProto or path. ModelProto inputs are mutated
+            in-place by ORT. Path inputs support large external-data models.
         keep_io_types: If True, preserve FP32 model inputs/outputs by inserting
             Cast nodes at boundaries. Recommended for CPU-safe inference.
         op_block_list: Op types to keep in FP32 (e.g., ["LayerNorm", "Softmax"]).
@@ -46,19 +49,28 @@ def convert_to_fp16(
     Returns:
         The converted model (same object as input due to ORT in-place mutation).
     """
+    import onnx
     from onnx import TensorProto
     from onnxruntime.transformers.float16 import convert_float_to_float16
 
+    model_path = Path(model) if isinstance(model, str | Path) else None
+    if model_path is not None:
+        inspection_model = onnx.load(str(model_path), load_external_data=False)
+    else:
+        inspection_model = cast("onnx.ModelProto", model)
+
     # Skip if model is already FP16 (check floating-point initializer dtypes)
     fp32_types = {TensorProto.FLOAT, TensorProto.DOUBLE, TensorProto.BFLOAT16}
-    initializers = model.graph.initializer
+    initializers = inspection_model.graph.initializer
     if initializers:
         float_inits = [t for t in initializers if t.data_type in fp32_types | {TensorProto.FLOAT16}]
         if float_inits and all(t.data_type == TensorProto.FLOAT16 for t in float_inits):
             logger.info("Model is already FP16 — skipping conversion.")
-            return model
+            if model_path is not None:
+                onnx.load_external_data_for_model(inspection_model, str(model_path.parent))
+            return inspection_model
 
-    original_nodes = len(model.graph.node)
+    original_nodes = len(inspection_model.graph.node)
 
     logger.info("Converting model to FP16...")
     if keep_io_types:
@@ -66,24 +78,50 @@ def convert_to_fp16(
     if op_block_list:
         logger.info("  Keeping ops in FP32: %s", op_block_list)
 
-    try:
-        converted: ModelProto = convert_float_to_float16(
-            model,
-            keep_io_types=keep_io_types,
-            op_block_list=op_block_list,
+    if model_path is not None:
+        with tempfile.NamedTemporaryFile(
+            dir=model_path.parent, suffix=".shape_inferred.onnx", delete=False
+        ) as temporary:
+            inferred_path = Path(temporary.name)
+        try:
+            onnx.shape_inference.infer_shapes_path(str(model_path), str(inferred_path))
+            inferred_model = onnx.load(str(inferred_path))
+        finally:
+            inferred_path.unlink(missing_ok=True)
+        converted = cast(
+            "onnx.ModelProto",
+            convert_float_to_float16(
+                inferred_model,
+                keep_io_types=keep_io_types,
+                disable_shape_infer=True,
+                op_block_list=op_block_list,
+            ),
         )
-    except EncodeError:
-        logger.warning(
-            "FP16 conversion shape inference could not serialize the model; "
-            "retrying with shape inference disabled. This can happen for "
-            "large ONNX models that use external data."
-        )
-        converted = convert_float_to_float16(
-            model,
-            keep_io_types=keep_io_types,
-            disable_shape_infer=True,
-            op_block_list=op_block_list,
-        )
+    else:
+        try:
+            converted = cast(
+                "onnx.ModelProto",
+                convert_float_to_float16(
+                    model,
+                    keep_io_types=keep_io_types,
+                    op_block_list=op_block_list,
+                ),
+            )
+        except EncodeError:
+            logger.warning(
+                "FP16 conversion shape inference could not serialize the model; "
+                "retrying with shape inference disabled. This can happen for "
+                "large ONNX models that use external data."
+            )
+            converted = cast(
+                "onnx.ModelProto",
+                convert_float_to_float16(
+                    model,
+                    keep_io_types=keep_io_types,
+                    disable_shape_infer=True,
+                    op_block_list=op_block_list,
+                ),
+            )
 
     # ORT's converter appends Cast nodes at the end of the node list (for
     # keep_io_types), which breaks topological ordering. Re-sort the graph

--- a/src/winml/modelkit/quant/passes/fp16.py
+++ b/src/winml/modelkit/quant/passes/fp16.py
@@ -44,7 +44,7 @@ class FP16Pass(BaseQuantPass):
         use_external_data: bool = True,
     ) -> QuantizeResult:
         """Convert *model_path* to FP16 and write the result to *output_path*."""
-        from ...onnx import load_onnx, save_onnx
+        from ...onnx import save_onnx
         from ..config import QuantizeResult
         from ..fp16 import convert_to_fp16
 
@@ -59,9 +59,8 @@ class FP16Pass(BaseQuantPass):
         warnings: list[str] = []
 
         logger.info("Running FP16-only conversion (no quantization)...")
-        model = load_onnx(model_path, validate=False)
         model = convert_to_fp16(
-            model,
+            model_path,
             keep_io_types=self._config.fp16_keep_io_types,
             op_block_list=self._config.fp16_op_block_list,
         )

--- a/src/winml/modelkit/session/ep_registry.py
+++ b/src/winml/modelkit/session/ep_registry.py
@@ -40,6 +40,29 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def resolve_builtin_cpu() -> WinMLEPDevice:
+    """Resolve ORT's built-in CPU device without optional EP discovery."""
+    entry = EPEntry(
+        ep_name="CPUExecutionProvider",
+        dll_path=Path(),
+        source=BuiltinSource(eps=("CPUExecutionProvider",)),
+    )
+    handles = _dedup_ort_devices(
+        [
+            device
+            for device in _ort_get_ep_devices_or_fail(entry)
+            if device.ep_name == entry.ep_name
+        ]
+    )
+    if not handles:
+        raise WinMLEPRegistrationFailed(
+            "Built-in EP 'CPUExecutionProvider' exposed no devices via ort.get_ep_devices()."
+        )
+    devices = tuple(WinMLDevice(handle) for handle in handles)
+    winml_ep = WinMLEP(source=entry, devices=devices, arg0=entry.ep_name)
+    return winml_ep.ep_devices()[0]
+
+
 @contextlib.contextmanager
 def _suppress_dll_load_dialogs() -> Iterator[None]:
     """Suppress Windows Error Reporting popups triggered by failed DLL loads.

--- a/src/winml/modelkit/session/session.py
+++ b/src/winml/modelkit/session/session.py
@@ -432,7 +432,12 @@ class WinMLSession:
             target = resolve_device(
                 EPDeviceTarget(ep=ep or "auto", device=(device or "auto").lower())
             )
-            ep_device = WinMLEPRegistry.instance().auto_device(target)
+            if target.ep == "CPUExecutionProvider" and target.device == "cpu":
+                from .ep_registry import resolve_builtin_cpu
+
+                ep_device = resolve_builtin_cpu()
+            else:
+                ep_device = WinMLEPRegistry.instance().auto_device(target)
             _ergonomic_lazy = True
 
         if provider_options is not None:

--- a/tests/unit/optim/test_fp16.py
+++ b/tests/unit/optim/test_fp16.py
@@ -19,7 +19,6 @@ import shutil
 
 import numpy as np
 import onnx
-from onnx import ModelProto, TensorProto, helper, numpy_helper
 
 import winml.modelkit.onnx
 from winml.modelkit.quant.fp16 import convert_to_fp16
@@ -30,25 +29,29 @@ from winml.modelkit.quant.fp16 import convert_to_fp16
 # =============================================================================
 
 
-def _build_simple_fp32_model() -> ModelProto:
+def _build_simple_fp32_model() -> onnx.ModelProto:
     """Build a simple FP32 model: out = x + weight."""
-    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 4])
-    out = helper.make_tensor_value_info("out", TensorProto.FLOAT, [1, 4])
-    weight = numpy_helper.from_array(np.array([[1.0, 2.0, 3.0, 4.0]], dtype=np.float32), "weight")
-    add = helper.make_node("Add", ["x", "weight"], ["out"], name="add")
-    graph = helper.make_graph([add], "simple", [x], [out], [weight])
-    return helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+    x = onnx.helper.make_tensor_value_info("x", onnx.TensorProto.FLOAT, [1, 4])
+    out = onnx.helper.make_tensor_value_info("out", onnx.TensorProto.FLOAT, [1, 4])
+    weight = onnx.numpy_helper.from_array(
+        np.array([[1.0, 2.0, 3.0, 4.0]], dtype=np.float32), "weight"
+    )
+    add = onnx.helper.make_node("Add", ["x", "weight"], ["out"], name="add")
+    graph = onnx.helper.make_graph([add], "simple", [x], [out], [weight])
+    return onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 17)])
 
 
-def _build_multi_op_fp32_model() -> ModelProto:
+def _build_multi_op_fp32_model() -> onnx.ModelProto:
     """Build a model with multiple ops: out = Relu(x + weight)."""
-    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 4])
-    out = helper.make_tensor_value_info("out", TensorProto.FLOAT, [1, 4])
-    weight = numpy_helper.from_array(np.array([[1.0, 2.0, 3.0, 4.0]], dtype=np.float32), "weight")
-    add = helper.make_node("Add", ["x", "weight"], ["add_out"], name="add")
-    relu = helper.make_node("Relu", ["add_out"], ["out"], name="relu")
-    graph = helper.make_graph([add, relu], "multi_op", [x], [out], [weight])
-    return helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+    x = onnx.helper.make_tensor_value_info("x", onnx.TensorProto.FLOAT, [1, 4])
+    out = onnx.helper.make_tensor_value_info("out", onnx.TensorProto.FLOAT, [1, 4])
+    weight = onnx.numpy_helper.from_array(
+        np.array([[1.0, 2.0, 3.0, 4.0]], dtype=np.float32), "weight"
+    )
+    add = onnx.helper.make_node("Add", ["x", "weight"], ["add_out"], name="add")
+    relu = onnx.helper.make_node("Relu", ["add_out"], ["out"], name="relu")
+    graph = onnx.helper.make_graph([add, relu], "multi_op", [x], [out], [weight])
+    return onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 17)])
 
 
 # =============================================================================
@@ -64,7 +67,9 @@ class TestConvertToFP16:
         model = _build_simple_fp32_model()
         result = convert_to_fp16(model)
 
-        has_fp16 = any(init.data_type == TensorProto.FLOAT16 for init in result.graph.initializer)
+        has_fp16 = any(
+            init.data_type == onnx.TensorProto.FLOAT16 for init in result.graph.initializer
+        )
         assert has_fp16, "Expected at least one FP16 initializer after conversion"
 
     def test_path_conversion_uses_external_data_safe_shape_inference(self, tmp_path) -> None:
@@ -80,25 +85,27 @@ class TestConvertToFP16:
 
         result = convert_to_fp16(model_path)
 
-        assert any(init.data_type == TensorProto.FLOAT16 for init in result.graph.initializer)
+        assert any(
+            init.data_type == onnx.TensorProto.FLOAT16 for init in result.graph.initializer
+        )
 
     def test_already_fp16_external_data_path_is_relocatable(self, tmp_path) -> None:
         source_dir = tmp_path / "source"
         source_dir.mkdir()
         source_path = source_dir / "source.onnx"
         expected_weight = np.arange(1024, dtype=np.float16).reshape(1, 1024)
-        x = helper.make_tensor_value_info("x", TensorProto.FLOAT16, [1, 1024])
-        out = helper.make_tensor_value_info("out", TensorProto.FLOAT16, [1, 1024])
-        weight = numpy_helper.from_array(expected_weight, "weight")
-        graph = helper.make_graph(
-            [helper.make_node("Add", ["x", "weight"], ["out"])],
+        x = onnx.helper.make_tensor_value_info("x", onnx.TensorProto.FLOAT16, [1, 1024])
+        out = onnx.helper.make_tensor_value_info("out", onnx.TensorProto.FLOAT16, [1, 1024])
+        weight = onnx.numpy_helper.from_array(expected_weight, "weight")
+        graph = onnx.helper.make_graph(
+            [onnx.helper.make_node("Add", ["x", "weight"], ["out"])],
             "external_fp16",
             [x],
             [out],
             [weight],
         )
         onnx.save_model(
-            helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)]),
+            onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 17)]),
             source_path,
             save_as_external_data=True,
             all_tensors_to_one_file=True,
@@ -114,7 +121,7 @@ class TestConvertToFP16:
         onnx.checker.check_model(destination_path)
         relocated = onnx.load(destination_path)
         np.testing.assert_array_equal(
-            numpy_helper.to_array(relocated.graph.initializer[0]), expected_weight
+            onnx.numpy_helper.to_array(relocated.graph.initializer[0]), expected_weight
         )
 
     def test_default_keeps_io_types(self) -> None:
@@ -123,9 +130,9 @@ class TestConvertToFP16:
         result = convert_to_fp16(model, keep_io_types=True)
 
         for inp in result.graph.input:
-            assert inp.type.tensor_type.elem_type == TensorProto.FLOAT
+            assert inp.type.tensor_type.elem_type == onnx.TensorProto.FLOAT
         for outp in result.graph.output:
-            assert outp.type.tensor_type.elem_type == TensorProto.FLOAT
+            assert outp.type.tensor_type.elem_type == onnx.TensorProto.FLOAT
 
     def test_keep_io_types_false_converts_io(self) -> None:
         """With keep_io_types=False, model I/O becomes FP16."""
@@ -133,9 +140,9 @@ class TestConvertToFP16:
         result = convert_to_fp16(model, keep_io_types=False)
 
         for inp in result.graph.input:
-            assert inp.type.tensor_type.elem_type == TensorProto.FLOAT16
+            assert inp.type.tensor_type.elem_type == onnx.TensorProto.FLOAT16
         for outp in result.graph.output:
-            assert outp.type.tensor_type.elem_type == TensorProto.FLOAT16
+            assert outp.type.tensor_type.elem_type == onnx.TensorProto.FLOAT16
 
     def test_preserves_model_structure(self) -> None:
         """FP16 conversion preserves graph structure (node count diff ≤ 2)."""
@@ -167,13 +174,13 @@ class TestConvertToFP16:
     def test_skips_already_fp16_model(self) -> None:
         """If all floating-point initializers are already FP16, conversion is skipped."""
         # Build a model with FP16 initializers directly
-        x = helper.make_tensor_value_info("x", TensorProto.FLOAT16, [1, 4])
-        out = helper.make_tensor_value_info("out", TensorProto.FLOAT16, [1, 4])
+        x = onnx.helper.make_tensor_value_info("x", onnx.TensorProto.FLOAT16, [1, 4])
+        out = onnx.helper.make_tensor_value_info("out", onnx.TensorProto.FLOAT16, [1, 4])
         weight_data = np.array([[1.0, 2.0, 3.0, 4.0]], dtype=np.float16)
-        weight = numpy_helper.from_array(weight_data, "weight")
-        add = helper.make_node("Add", ["x", "weight"], ["out"], name="add")
-        graph = helper.make_graph([add], "fp16_model", [x], [out], [weight])
-        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+        weight = onnx.numpy_helper.from_array(weight_data, "weight")
+        add = onnx.helper.make_node("Add", ["x", "weight"], ["out"], name="add")
+        graph = onnx.helper.make_graph([add], "fp16_model", [x], [out], [weight])
+        model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 17)])
 
         original_nodes = len(model.graph.node)
         result = convert_to_fp16(model)
@@ -184,15 +191,17 @@ class TestConvertToFP16:
 
     def test_skips_fp16_model_with_int_initializers(self) -> None:
         """FP16 model with non-float initializers (e.g. INT64 shapes) should still skip."""
-        x = helper.make_tensor_value_info("x", TensorProto.FLOAT16, [1, 4])
-        out = helper.make_tensor_value_info("out", TensorProto.FLOAT16, [1, 4])
+        x = onnx.helper.make_tensor_value_info("x", onnx.TensorProto.FLOAT16, [1, 4])
+        out = onnx.helper.make_tensor_value_info("out", onnx.TensorProto.FLOAT16, [1, 4])
         weight_data = np.array([[1.0, 2.0, 3.0, 4.0]], dtype=np.float16)
-        weight = numpy_helper.from_array(weight_data, "weight")
+        weight = onnx.numpy_helper.from_array(weight_data, "weight")
         # INT64 initializer (e.g., shape tensor) — should be ignored by skip logic
-        shape_tensor = numpy_helper.from_array(np.array([1, 4], dtype=np.int64), "shape")
-        add = helper.make_node("Add", ["x", "weight"], ["out"], name="add")
-        graph = helper.make_graph([add], "fp16_mixed", [x], [out], [weight, shape_tensor])
-        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+        shape_tensor = onnx.numpy_helper.from_array(np.array([1, 4], dtype=np.int64), "shape")
+        add = onnx.helper.make_node("Add", ["x", "weight"], ["out"], name="add")
+        graph = onnx.helper.make_graph([add], "fp16_mixed", [x], [out], [weight, shape_tensor])
+        model = onnx.helper.make_model(
+            graph, opset_imports=[onnx.helper.make_opsetid("", 17)]
+        )
 
         original_nodes = len(model.graph.node)
         result = convert_to_fp16(model)

--- a/tests/unit/optim/test_fp16.py
+++ b/tests/unit/optim/test_fp16.py
@@ -15,9 +15,13 @@ Following Cardinal Rules:
 
 from __future__ import annotations
 
+import shutil
+
 import numpy as np
+import onnx
 from onnx import ModelProto, TensorProto, helper, numpy_helper
 
+import winml.modelkit.onnx
 from winml.modelkit.quant.fp16 import convert_to_fp16
 
 
@@ -62,6 +66,56 @@ class TestConvertToFP16:
 
         has_fp16 = any(init.data_type == TensorProto.FLOAT16 for init in result.graph.initializer)
         assert has_fp16, "Expected at least one FP16 initializer after conversion"
+
+    def test_path_conversion_uses_external_data_safe_shape_inference(self, tmp_path) -> None:
+        model_path = tmp_path / "model.onnx"
+        onnx.save_model(
+            _build_simple_fp32_model(),
+            model_path,
+            save_as_external_data=True,
+            all_tensors_to_one_file=True,
+            location="model.onnx.data",
+            size_threshold=0,
+        )
+
+        result = convert_to_fp16(model_path)
+
+        assert any(init.data_type == TensorProto.FLOAT16 for init in result.graph.initializer)
+
+    def test_already_fp16_external_data_path_is_relocatable(self, tmp_path) -> None:
+        source_dir = tmp_path / "source"
+        source_dir.mkdir()
+        source_path = source_dir / "source.onnx"
+        expected_weight = np.arange(1024, dtype=np.float16).reshape(1, 1024)
+        x = helper.make_tensor_value_info("x", TensorProto.FLOAT16, [1, 1024])
+        out = helper.make_tensor_value_info("out", TensorProto.FLOAT16, [1, 1024])
+        weight = numpy_helper.from_array(expected_weight, "weight")
+        graph = helper.make_graph(
+            [helper.make_node("Add", ["x", "weight"], ["out"])],
+            "external_fp16",
+            [x],
+            [out],
+            [weight],
+        )
+        onnx.save_model(
+            helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)]),
+            source_path,
+            save_as_external_data=True,
+            all_tensors_to_one_file=True,
+            location="source.onnx.data",
+            size_threshold=0,
+        )
+
+        converted = convert_to_fp16(source_path)
+        destination_path = tmp_path / "destination" / "model.onnx"
+        winml.modelkit.onnx.save_onnx(converted, destination_path, threshold_size=0)
+
+        shutil.rmtree(source_dir)
+        onnx.checker.check_model(destination_path)
+        relocated = onnx.load(destination_path)
+        np.testing.assert_array_equal(
+            numpy_helper.to_array(relocated.graph.initializer[0]), expected_weight
+        )
 
     def test_default_keeps_io_types(self) -> None:
         """Default keep_io_types=True preserves FP32 model I/O."""

--- a/tests/unit/session/test_winml_session.py
+++ b/tests/unit/session/test_winml_session.py
@@ -169,6 +169,23 @@ class TestWinMLSessionInstantiation:
         session = WinMLSession(onnx_path=simple_matmul_onnx, device="cpu", ep="cpu")
         assert session.ep_name is None
 
+    def test_explicit_cpu_bypasses_optional_provider_registry(
+        self,
+        simple_matmul_onnx: Path,
+        cpu_ep_device: EPDeviceTarget,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from winml.modelkit.session import ep_registry
+
+        registry = MagicMock()
+        monkeypatch.setattr(ep_registry.WinMLEPRegistry, "instance", registry)
+        monkeypatch.setattr(ep_registry, "resolve_builtin_cpu", lambda: cpu_ep_device)
+
+        session = WinMLSession(onnx_path=simple_matmul_onnx, device="cpu", ep="cpu")
+
+        assert session.device == "cpu"
+        registry.assert_not_called()
+
     def test_ep_name_after_compile(
         self,
         simple_matmul_onnx: Path,

--- a/tests/unit/test_quant_passes.py
+++ b/tests/unit/test_quant_passes.py
@@ -317,15 +317,18 @@ class TestFP16PassConfig:
         output_path = tmp_path / "out.onnx"
 
         calls: list[dict] = []
-        fake_model = SimpleNamespace()
-
         def fake_convert(model, *, keep_io_types, op_block_list):
-            calls.append({"keep_io_types": keep_io_types, "op_block_list": op_block_list})
+            calls.append(
+                {
+                    "model": model,
+                    "keep_io_types": keep_io_types,
+                    "op_block_list": op_block_list,
+                }
+            )
             return model
 
         # Patch the source modules that are lazily imported inside run()
         fake_onnx_mod = ModuleType("winml.modelkit.onnx")
-        fake_onnx_mod.load_onnx = lambda *a, **k: fake_model  # type: ignore[attr-defined]
         fake_onnx_mod.save_onnx = lambda *a, **k: None  # type: ignore[attr-defined]
         monkeypatch.setitem(sys.modules, "winml.modelkit.onnx", fake_onnx_mod)
 
@@ -336,7 +339,13 @@ class TestFP16PassConfig:
         result = FP16Pass(config).run(model_path, output_path)
 
         assert result.success
-        assert calls == [{"keep_io_types": False, "op_block_list": ["Gather"]}]
+        assert calls == [
+            {
+                "model": model_path,
+                "keep_io_types": False,
+                "op_block_list": ["Gather"],
+            }
+        ]
 
 
 class TestFP16Conversion:


### PR DESCRIPTION
## Summary

This L2 contribution adds CPU FP32 and FP16 recipes for `Davlan/xlm-roberta-large-ner-hrl` and fixes shared external-data FP16 conversion and explicit CPU session routing. Against baseline `24cccfb23d6e3c3b93ae9bb94399c326cee8ecea`, candidate `4d73cfbe44c8531fbbdb686ec77ef164034608ee` reached **L2 PASS** with full coverage of both required CPU precision tuples. It establishes successful build, measured CPU execution, and pinned PyTorch logit parity; it makes no L3 accuracy or accelerator-support claim.

## Model metadata

### What the model does

`Davlan/xlm-roberta-large-ner-hrl` is a multilingual named-entity recognition model that accepts tokenized text and emits a nine-class label score for each token. It is an XLM-RoBERTa-large encoder fine-tuned for DATE, person, organization, and location tagging across ten high-resource languages. **Confidence: verified.** Evidence: the Hugging Face model card and `config.json` at revision `1f929ffad9b7353f9c84b0b3f579fc3bb0b3685e`, including `architectures` and `id2label`, plus the model's `token-classification` pipeline tag.

### Primary user stories

- A user supplies multilingual news or document text to obtain token-level person, organization, location, and date spans for information extraction. **Confidence: verified.** Evidence: the pinned model-card pipeline example and label map.
- An application supplies text in one of the model's ten documented high-resource languages to identify named entities for indexing, redaction, or downstream structured processing. **Confidence: inferred.** Evidence: the pinned model-card language and training-data sections.

### Supported tasks

- `token-classification` across the checkpoint, Transformers, Optimum ONNX, and WinML surfaces. **Confidence: verified.** Evidence: the pinned pipeline tag, `XLMRobertaForTokenClassification` architecture, and the recipes and run-007 builds in this contribution.

### Model architecture

```text
XLMRobertaForTokenClassification
├── XLMRobertaModel encoder backbone
│   ├── Token + absolute-position embeddings (vocab 250002, hidden 1024)
│   └── Encoder layer x 24
│       ├── Self-attention (16 heads)
│       ├── Feed-forward (1024 -> 4096 -> 1024, GELU)
│       └── Residual + LayerNorm
└── Token-classification head (1024 -> 9 logits per token)
```

- Source/confidence: pinned `config.json` dimensions and the Transformers `XLMRobertaForTokenClassification` source contract (`verified`).

## Validation and support evidence

### Baseline

The exact current-main baseline is `24cccfb23d6e3c3b93ae9bb94399c326cee8ecea`, WinML `0.3.0`; run-007 performed a full rerun and reused no executable evidence from the older base. Recipe-free FP32 CPU build passed in 173.6 s. Its 10-iteration, 2-warmup perf result was 1027.639 ms mean, 984.919 ms p50, 0.97 samples/s, and 134.66 MB RSS delta; pinned PyTorch parity was cosine `0.999999999999962` with max absolute error `0.000013709068298339844`.

Current-main FP16 built only as **PASS_WITH_DEGRADED_FALLBACK** in 272.7 s, warning: `FP16 conversion shape inference could not serialize the model; retried with shape inference disabled`. Its perf result was 1157.584 ms mean, 1157.149 ms p50, 0.86 samples/s, and 192.96 MB RSS delta; parity was cosine `0.99999995252653` with max absolute error `0.014772191643714905`. Current-main analyze executed successfully. Its FP32 CPU eval diagnostic executed but was DATA-INCOMPATIBLE, so no metric or L3 claim is valid.

The run-007 resolved build configs now provide the exact auto-config comparison at the correct resolved-config layer; requested recipe intent is reported separately in Delta. The sealed locked-dependency Optimum probe tested both `xlm-roberta` and `xlm_roberta`: for each alias, candidate exactly matched current main before and after WinML import, and `added_by_winml` was empty on both. The runtime probe therefore establishes that vendor-native support is absent in this locked dependency baseline. That baseline capability supersedes the charter's stale static expectation and is not a candidate failure. The committed baseline floor was L0.

### Goal

- **Effort:** L2.
- **Goal ceiling:** L2, with no re-issued ceiling event.
- **Outcome target:** L2 across `CPUExecutionProvider / cpu` for FP32 and FP16.
- **Success definition:** both required tuples build from authoritative recipes, execute with measured performance and memory, and preserve the pinned PyTorch token logits on deterministic named `int32 [1,512]` inputs. Recipe-free acceptance, shared-code regression coverage, component/op analysis, and an eval diagnostic without an L3 claim are also required.

### Outcome

Run-007 reached **L2 PASS**, full coverage, with no deferred tuples, product failure, or producer repair required. Both CPU precision tuples build, run, and preserve pinned PyTorch token logits. Candidate FP16 replaces current-main's serialization-failure fallback with file-based shape inference; no numerical regression was observed.

Shipped paths are the two nested CPU recipes plus shared changes in `quant/fp16.py`, `quant/passes/fp16.py`, `session/ep_registry.py`, and `session/session.py`, with focused tests under `tests/unit/optim`, `tests/unit/session`, and `tests/unit/test_quant_passes.py`. Learner findings `xlm-roberta-005`, `xlm-roberta-006`, `xlm-roberta-007`, and `xlm-roberta-008` capture the current build/external-data contract, CPU FP16 performance direction, pinned parity, and current analysis/mapping scope. The methodology audit found no new methodology trigger or finding.

### Per-EP/device/precision results and Functional smoke Eval

| Tier | EP / Device | Precision | Verdict | Build | External data | Mean | p50 | Throughput | RSS Δ |
|---|---|---|---|---:|---:|---:|---:|---:|---:|
| L0 | CPUExecutionProvider / cpu | FP32 | PASS | 240.2 s | 2235408400 bytes | - | - | - | - |
| L0 | CPUExecutionProvider / cpu | FP16 | PASS | 283.3 s | 1117708304 bytes | - | - | - | - |
| L1 | CPUExecutionProvider / cpu | FP32 | PASS | - | - | 969.737 ms | 967.196 ms | 1.03 samples/s | 162.29 MB |
| L1 | CPUExecutionProvider / cpu | FP16 | PASS | - | - | 1131.72 ms | 1142.825 ms | 0.88 samples/s | 192.93 MB |

Both L1 rows used 2 warmups and 10 measured iterations. FP32 contains 394 FLOAT, 1 BOOL, 1 INT32, and 107 INT64 initializers. FP16 contains 394 FLOAT16, 1 BOOL, 1 INT32, and 107 INT64 initializers. Both expose `input_ids:int32[1,512], attention_mask:int32[1,512] -> logits:float[1,512,9]`.

| Tier | Precision | Verdict | Cosine | Max abs | Mean abs | Token top-1 agreement |
|---|---|---|---:|---:|---:|---:|
| L2 | FP32 | PASS | 0.999999999999962 | 0.000013709068298339844 | 0.000002654345280461712 | 1.0 |
| L2 | FP16 | PASS | 0.99999995252653 | 0.014772191643714905 | 0.0016616786597296596 | 1.0 |

#### Functional smoke Eval

Candidate `4d73cfbe44c8531fbbdb686ec77ef164034608ee` executed one deterministic first-N FP32 CPU sample from `BramVanroy/conll2003` revision `4ffbd53d9e0b92b473b9b7dcff12f53e7c17ce0c`, default config, validation split, streaming and no shuffle. Selected/processed samples: 1/1. The only applicable fan-out cap was sequence length 512; candidate-label/prompt, beam, and frame/crop caps were not applicable. Inputs were `tokens` and `ner_tags`; predictions were nine logits per token, interpreted by argmax through the checkpoint `id2label` map.

**DATA-INCOMPATIBLE diagnostic:** checkpoint IDs encode `O, DATE, PER, ORG, LOC`, while dataset IDs encode `O, PER, ORG, LOC, MISC` in a different numeric order. Raw overall F1 `1.0` and raw overall accuracy `1.0` are **invalid for support or accuracy claims**. This proves only evaluator execution on one sample; it is neither representative accuracy nor benchmark-quality evidence, and no L3 claim is made.

### Delta

The candidate changes **9 files** relative to current main: two added recipes, four shared product files, and three focused test files (332 insertions, 74 deletions). `examples/recipes/README.md` is unchanged. Current main already absorbed the static-analyze inventory behavior: concrete static targets avoid local optional-provider discovery, while auto axes and runtime unknown-op probing retain it; no redundant `commands/analyze.py` change or obsolete `sysinfo/device.py` test was carried forward.

Post-review fix `4d73cfbe44c8531fbbdb686ec77ef164034608ee` is import-only across `src/winml/modelkit/quant/fp16.py` and `tests/unit/optim/test_fp16.py`: each file now has one `import onnx` and no `from onnx` import. Behavior and tester measurements are unchanged. Focused validation passed Ruff, mypy across 435 source files, four critical tests in 5.17 s, and `git diff --check`.

The two authoritative recipes are:

- `examples/recipes/Davlan_xlm-roberta-large-ner-hrl/cpu/cpu/token-classification_fp32_config.json`
- `examples/recipes/Davlan_xlm-roberta-large-ner-hrl/cpu/cpu/token-classification_fp16_config.json`

The checked-in recipes represent contributor-requested intent. Comparing each requested recipe with its own candidate resolved `winml_build_config.json` shows no changed or removed requested values: FP32 has 28 equal leaf values and FP16 has 48 equal leaf values. In both precisions, resolution injects the same four defaults/autoconf fields that are absent from the requested recipe:

| JSON pointer | Requested recipe | Candidate resolved config | Classification |
|---|---|---|---|
| `/auto` | absent | `false` | injected default |
| `/export/compatibility/transformers_attention` | absent | `"eager"` | injected compatibility field |
| `/optim/gelu_fusion` | absent | `true` | injected optimization field |
| `/optim/matmul_add_fusion` | absent | `true` | injected optimization field |

The acceptance comparison uses the correct same-layer pair: exact-main recipe-free resolved config versus candidate resolved config.

| Precision | Resolved-config comparison | Exact JSON-pointer differences |
|---|---|---|
| FP32 | 32 records: 29 equal, 1 changed, 2 candidate-only, 0 absent from candidate | `/loader/model_class`: `"AutoModelForTokenClassification"` -> `"XLMRobertaForTokenClassification"`; `/optim/gelu_fusion`: absent -> `true`; `/optim/matmul_add_fusion`: absent -> `true` |
| FP16 | 52 records: 52 equal, 0 changed, 0 candidate-only, 0 absent from candidate | Identical resolved configs |

The FP32 loader-class change is the recipe's explicit request; the two optimization fields are resolved/autoconf additions rather than contributor-authored recipe values. Reducibility remains consistent with the charter, and the production recipe README remains untouched.

#### Bug fix explanation: external-data FP16 conversion

1. **Symptom and trigger:** converting a path-backed ONNX model with external weights above protobuf's 2 GB serialization limit caused shape inference to fail; current main completed FP16 only after disabling shape inference.
2. **Root cause:** `FP16Pass.run` eagerly loaded a `ModelProto`, and `convert_to_fp16` used in-memory shape inference, forcing serialization of the oversized graph instead of preserving path/external-data semantics.
3. **Changed symbols and mechanism:** `convert_to_fp16` now accepts a `ModelProto` or path, uses file-based shape inference for path inputs, and materializes already-FP16 external tensors before relocation; `FP16Pass.run` propagates the path.
4. **General rule:** the branch is selected from ONNX path/external-data storage, not model ID, model type, task, or checkpoint.
5. **Compatibility and blast radius:** in-memory conversion and `keep_io_types`/`op_block_list` plumbing remain supported; path conversion gains >2 GB handling, and already-FP16 path inputs become self-contained after relocation. No model-specific branch was added.
6. **Regression evidence:** candidate FP16 completed file-based shape inference and L0 PASS in 283.3 s with 394 FLOAT16 initializers and 1117708304 external-data bytes, while exact main emitted the quoted degraded-fallback warning. FP16 L2 parity remained cosine `0.99999995252653`, max/mean absolute error `0.014772191643714905`/`0.0016616786597296596`, and token agreement `1.0`. Focused optim/quant tests are included in successful partitions of 716 passed, 16 skipped, 1 xfailed and the full run's 8242 passed, 78 skipped, 3 xfailed, 1 deselected.

#### Bug fix explanation: explicit CPU session routing

1. **Symptom and trigger:** explicit `CPUExecutionProvider / cpu` sessions could initialize optional WindowsML provider/catalog discovery even though the built-in CPU provider was fully specified, exposing command lifecycle and teardown to optional-catalog failures.
2. **Root cause:** explicit CPU requests flowed through the general registry path used by auto, accelerator, and catalog-backed selection.
3. **Changed symbols and mechanism:** `resolve_builtin_cpu` in `session/ep_registry.py` resolves ORT's built-in CPU device directly; `WinMLSession.__init__` uses it only for an explicit CPU EP/device request.
4. **General rule:** routing depends on the explicit EP/device request, not checkpoint identity or model metadata.
5. **Compatibility and blast radius:** auto, accelerator, and WindowsML catalog-backed requests retain registry behavior; only explicit built-in CPU bypasses optional discovery.
6. **Regression evidence:** both candidate CPU tuples completed build, perf, and parity with finite results and clean PASS verdicts. Session tests are included in the models partition (1524 passed, 6 skipped, 2 xfailed) and the commands partition (3606 passed, 9 skipped); Ruff passed, mypy found no issues in 435 source files, and `git diff --check` passed.

### Analyze summary — component level and op level

Static analysis finished as **PASS_WITH_MAPPING_GAPS**. It analyzes graph/rule compatibility and is not runtime execution or evidence of runtime EP support.

#### Component-level summary

| Artifact | Architecture coverage | Mapping | Confidence / gap | Actionable EP findings |
|---|---|---:|---|---|
| FP32 optimized graph | embeddings; encoder layers x24; classifier | 497 mapped, 249 unmapped | Semantic regions mapped; post-optimization reshape/utility nodes remain unmapped | None; no support classification was established |

Mapped nodes are embeddings 16, repeated encoder layers 480, and classifier 1. The mapping is semantic-component based; it does not assign the 249 transformed utility nodes.

#### Op-level summary

| Artifact | Graph | Dominant ops | EP roll-up |
|---|---|---|---|
| FP32 optimized graph | 746 ops / 19 types | Reshape 243; Gemm 145; Transpose 96; Add 75; LayerNormalization 49; MatMul 48; Mul 25; Gelu 24; Softmax 24 | 12 EP/device rows; populated rule-backed rows were unknown-only |

All 12 EP/device rows yielded no supported, partial, or unsupported classifications on this rules snapshot; populated rows were unknown-only and other rows had no classifications. Therefore static analysis supports no CPU or accelerator compatibility claim. Runtime CPU support is established separately by the L0-L2 execution evidence above.

### Reproduce commands

```powershell
$OUT = Join-Path $PWD 'temp/xlm-roberta-ner-validation'
$SNAPSHOT = Join-Path $OUT 'checkpoint/snapshot'
$BASELINE_TREE = Join-Path $OUT 'baseline-tree'
$env:OUT = $OUT
$env:SNAPSHOT = $SNAPSHOT
New-Item -ItemType Directory -Force -Path $OUT | Out-Null
if ((git rev-parse HEAD).Trim() -ne '4d73cfbe44c8531fbbdb686ec77ef164034608ee') { throw 'candidate HEAD mismatch' }
python -c "from huggingface_hub import snapshot_download; snapshot_download(repo_id='Davlan/xlm-roberta-large-ner-hrl', revision='1f929ffad9b7353f9c84b0b3f579fc3bb0b3685e', local_dir=r'$SNAPSHOT')"
git worktree add --detach $BASELINE_TREE 24cccfb23d6e3c3b93ae9bb94399c326cee8ecea
if ((git -C $BASELINE_TREE rev-parse HEAD).Trim() -ne '24cccfb23d6e3c3b93ae9bb94399c326cee8ecea') { throw 'baseline HEAD mismatch' }
$BASELINE_VERSION = (python -c "import tomllib, pathlib; print(tomllib.loads((pathlib.Path(r'$BASELINE_TREE')/'pyproject.toml').read_text(encoding='utf-8'))['project']['version'])").Trim()
if ($BASELINE_VERSION -ne '0.3.0') { throw "baseline version mismatch: $BASELINE_VERSION" }
$env:PYTHONPATH = Join-Path $BASELINE_TREE 'src'
python -m winml.modelkit.cli build -m $SNAPSHOT -o (Join-Path $OUT 'baseline/fp32') --ep cpu --device cpu --precision fp32 --no-analyze --no-optimize --no-quant --no-compile --rebuild --no-color
python -m winml.modelkit.cli perf -m (Join-Path $OUT 'baseline/fp32/model.onnx') --ep cpu --device cpu --precision fp32 --iterations 10 --warmup 2 --memory -o (Join-Path $OUT 'baseline/fp32_perf.json') --overwrite --format json --no-color
$env:PYTHONPATH = Join-Path $PWD 'src'
python -m winml.modelkit.cli build -c examples/recipes/Davlan_xlm-roberta-large-ner-hrl/cpu/cpu/token-classification_fp32_config.json -m $SNAPSHOT -o (Join-Path $OUT 'candidate/fp32') --ep cpu --device cpu --rebuild --no-color
python -m winml.modelkit.cli build -c examples/recipes/Davlan_xlm-roberta-large-ner-hrl/cpu/cpu/token-classification_fp16_config.json -m $SNAPSHOT -o (Join-Path $OUT 'candidate/fp16') --ep cpu --device cpu --precision fp16 --rebuild --no-color
@'
import json
import os
from pathlib import Path
import numpy as np
import torch
from transformers import AutoModelForTokenClassification, AutoTokenizer

snapshot = Path(os.environ["SNAPSHOT"])
out = Path(os.environ["OUT"])
text = "Angela Merkel met Microsoft representatives in Berlin on 17 August 2026."
tokenizer = AutoTokenizer.from_pretrained(snapshot, local_files_only=True)
np_inputs = tokenizer(text, return_tensors="np", max_length=512, padding="max_length", truncation=True)
named = {"input_ids": np_inputs["input_ids"].astype(np.int32), "attention_mask": np_inputs["attention_mask"].astype(np.int32)}
np.savez(out / "semantic_inputs.npz", **named)
model = AutoModelForTokenClassification.from_pretrained(snapshot, local_files_only=True).eval()
with torch.no_grad():
    logits = model(input_ids=torch.from_numpy(named["input_ids"]).to(torch.int64), attention_mask=torch.from_numpy(named["attention_mask"]).to(torch.int64)).logits.numpy()
np.save(out / "reference_logits.npy", logits)
(out / "semantic_inputs.json").write_text(json.dumps({"text": text, "inputs": {k: {"shape": list(v.shape), "dtype": str(v.dtype)} for k, v in named.items()}}, indent=2), encoding="utf-8")
'@ | python -
python -m winml.modelkit.cli perf -m (Join-Path $OUT 'candidate/fp32/model.onnx') --ep cpu --device cpu --precision fp32 --input-data (Join-Path $OUT 'semantic_inputs.npz') --iterations 10 --warmup 2 --memory -o (Join-Path $OUT 'candidate/fp32_perf.json') --overwrite --format json --no-color
python -m winml.modelkit.cli perf -m (Join-Path $OUT 'candidate/fp16/model.onnx') --ep cpu --device cpu --precision fp16 --input-data (Join-Path $OUT 'semantic_inputs.npz') --iterations 10 --warmup 2 --memory -o (Join-Path $OUT 'candidate/fp16_perf.json') --overwrite --format json --no-color
@'
import json
import os
from pathlib import Path
import numpy as np
import onnxruntime as ort

out = Path(os.environ["OUT"])
reference = np.load(out / "reference_logits.npy")
inputs_file = np.load(out / "semantic_inputs.npz")
named = {name: inputs_file[name] for name in inputs_file.files}
for precision in ("fp32", "fp16"):
    session = ort.InferenceSession(str(out / "candidate" / precision / "model.onnx"), providers=["CPUExecutionProvider"])
    actual = session.run(["logits"], named)[0]
    ref_flat = reference.astype(np.float64).ravel()
    actual_flat = actual.astype(np.float64).ravel()
    result = {"precision": precision, "input_names": sorted(named), "cosine": float(np.dot(ref_flat, actual_flat) / (np.linalg.norm(ref_flat) * np.linalg.norm(actual_flat))), "max_abs": float(np.max(np.abs(reference - actual))), "mean_abs": float(np.mean(np.abs(reference - actual))), "top1_token_agreement": float(np.mean(np.argmax(reference, axis=-1) == np.argmax(actual, axis=-1)))}
    (out / "candidate" / f"{precision}_parity.json").write_text(json.dumps(result, indent=2), encoding="utf-8")
'@ | python -
python -m winml.modelkit.cli analyze --model (Join-Path $OUT 'candidate/fp32/model.onnx') --ep all --device all --output (Join-Path $OUT 'candidate/analyze_all.json') --overwrite --format json --no-run-unknown-op --no-color
python -m winml.modelkit.cli eval -m (Join-Path $OUT 'candidate/fp32/model.onnx') --model-id $SNAPSHOT --task token-classification --ep cpu --device cpu --dataset BramVanroy/conll2003 --dataset-revision 4ffbd53d9e0b92b473b9b7dcff12f53e7c17ce0c --split validation --samples 1 --no-shuffle --streaming -o (Join-Path $OUT 'candidate/eval_diagnostic.json') --overwrite --format json --no-color
@'
import json
import os
from pathlib import Path

out = Path(os.environ["OUT"])
checkpoint = json.loads((Path(os.environ["SNAPSHOT"]) / "config.json").read_text(encoding="utf-8"))["id2label"]
dataset = {"0": "O", "1": "B-PER", "2": "I-PER", "3": "B-ORG", "4": "I-ORG", "5": "B-LOC", "6": "I-LOC", "7": "B-MISC", "8": "I-MISC"}
result = {"status": "DATA-INCOMPATIBLE", "checkpoint_label_map": checkpoint, "dataset_label_map": dataset, "exact_match": checkpoint == dataset, "checkpoint_only_labels": sorted(set(checkpoint.values()) - set(dataset.values())), "dataset_only_labels": sorted(set(dataset.values()) - set(checkpoint.values())), "claim": "Operational diagnostic only; no L3 metric claim is valid."}
if result["exact_match"]:
    raise SystemExit("expected DATA-INCOMPATIBLE label maps")
(out / "candidate" / "eval_semantics.json").write_text(json.dumps(result, indent=2), encoding="utf-8")
'@ | python -
Remove-Item Env:PYTHONPATH,Env:OUT,Env:SNAPSHOT -ErrorAction SilentlyContinue
```