### PR TITLE
fix(genai): prefer device-native EPs over cross-device accelerators

### DIFF
--- a/src/winml/modelkit/commands/_perf_genai.py
+++ b/src/winml/modelkit/commands/_perf_genai.py
@@ -101,7 +101,15 @@ def resolve_genai_ep(device: str) -> EPNameOrAlias | None:
     eps = resolve_eps(resolved_device)
     if not eps:
         return None
-    return EP_NAME_TO_ALIAS[eps[0]]
+
+    # Prefer EPs whose *primary* device (first entry in EP_SUPPORTED_DEVICES)
+    # matches the resolved device.  Multi-device EPs like OpenVINO advertise
+    # cpu/gpu support but their primary target is npu — when the user says
+    # ``--device cpu`` or ``--device gpu`` they expect the native EP for that
+    # device, not a cross-device accelerator that also happens to support it.
+    native = [ep for ep in eps if EP_SUPPORTED_DEVICES[ep][0] == resolved_device]
+    best = native[0] if native else eps[0]
+    return EP_NAME_TO_ALIAS[best]
 
 
 def genai_output_path(bundle_dir: str | Path) -> Path:

--- a/tests/unit/commands/test_perf_genai.py
+++ b/tests/unit/commands/test_perf_genai.py
@@ -178,9 +178,13 @@ class TestResolveGenaiEp:
             ("npu", "npu", ["QNNExecutionProvider", "OpenVINOExecutionProvider"], "qnn"),
             ("npu", "npu", ["VitisAIExecutionProvider"], "vitisai"),
             ("gpu", "gpu", ["DmlExecutionProvider"], "dml"),
-            # cpu matches ONNX: OpenVINO-on-CPU when available, else plain CPU.
-            ("cpu", "cpu", ["OpenVINOExecutionProvider", "CPUExecutionProvider"], "openvino"),
+            # gpu: prefer native GPU EPs over cross-device accelerators.
+            ("gpu", "gpu", ["OpenVINOExecutionProvider", "DmlExecutionProvider"], "dml"),
+            # cpu: prefer CPUExecutionProvider over cross-device accelerators.
+            ("cpu", "cpu", ["OpenVINOExecutionProvider", "CPUExecutionProvider"], "cpu"),
             ("cpu", "cpu", ["CPUExecutionProvider"], "cpu"),
+            # Edge case: only a cross-device EP available for this device.
+            ("cpu", "cpu", ["OpenVINOExecutionProvider"], "openvino"),
         ],
     )
     def test_resolves_best_available_ep_alias(


### PR DESCRIPTION
## Summary

On OpenVINO hosts, `resolve_genai_ep("cpu")` incorrectly resolved to `"openvino"` instead of `"cpu"`, causing `test_device_cpu_overrides_device_and_ep` to fail (born-broken since #1046).

## Root Cause

`resolve_eps("cpu")` returns EPs in `_DEVICE_EP_MAP` priority order derived from `EP_SUPPORTED_DEVICES` declaration order. Since `OpenVINOExecutionProvider` declares `("npu", "gpu", "cpu")` and appears before `CPUExecutionProvider`, the old code blindly took `eps[0]` → `"openvino"`.

## Fix (generic)

Prefer EPs whose **primary device** (first entry in `EP_SUPPORTED_DEVICES`) matches the resolved device. Multi-device EPs like OpenVINO target `npu` primarily — when the user says `--device cpu` or `--device gpu` they expect the native EP, not a cross-device accelerator.

| `--device` | Before (OV host) | After |
|---|---|---|
| `cpu` | `openvino` ❌ | `cpu` ✅ |
| `gpu` | `openvino` (if OV first) | `dml`/`cuda` ✅ |
| `npu` | `qnn`/`openvino` | unchanged (all primary=npu) |

Falls back to `eps[0]` when no device-native EP is available.

## Verification

- Unit tests updated (11 pass, including new GPU cross-device case)
- E2E `test_device_cpu_overrides_device_and_ep` passes on OV host
- Ruff clean