### PR TITLE
Add two-ONNX comparison to winml eval --mode compare

### DIFF
--- a/docs/commands/eval.md
+++ b/docs/commands/eval.md
@@ -39,8 +39,9 @@ $ winml eval [options]
 | `--label-mapping` | | `PATH` | — | Path to a JSON file mapping dataset label names to the integer class IDs the model emits: `{"label_name": id}`. |
 | `--output` | `-o` | `PATH` | — | Output JSON file path for the evaluation results. |
 | `--schema` | | flag | `false` | Print the expected dataset schema for the given `--task` and exit. Does not run evaluation. |
-| `--mode` | | `onnx\|compare` | `onnx` | Evaluation mode. `onnx` evaluates the ONNX candidate on a dataset. `compare` runs the ONNX candidate and the HuggingFace reference on identical random inputs and reports per-tensor similarity metrics — no dataset required. |
+| `--mode` | | `onnx\|compare` | `onnx` | Evaluation mode. `onnx` evaluates the ONNX candidate on a dataset. `compare` runs the ONNX candidate and a reference on identical random inputs and reports per-tensor similarity metrics — no dataset required. The reference is the HuggingFace model from `--model-id` by default, or a second ONNX file when `--reference` is given. |
 | `--input-data` | | `PATH` | — | Path to a `.npz` file of real input tensors to compare with instead of randomly generated ones (used with `--mode compare`). Keys must match the candidate model's input names. The **leading axis of each array is the sample axis**, so an archive shaped `(N, ...)` yields `N` samples (mean/std/min/max are computed across them); all inputs must share the same `N`. Each run is shaped to the candidate's batch size — a dynamic batch runs one row per sample, a static batch `B` chunks the axis into `N // B` batches (trailing rows are dropped with a warning). Note this differs from `winml perf --input-data`, which runs the **whole archive as a single batch**. |
+| `--reference` | | `TEXT` | — | Reference `.onnx` file to compare the candidate against (used with `--mode compare`). Compares two ONNX models on identical random inputs; `--model-id` and `--task` are not required in this mode. Both models run on the same `--device` / `--ep`. |
 
 ## How it works
 
@@ -80,6 +81,12 @@ Compare an ONNX candidate against its HuggingFace reference on real input tensor
 
 ```bash
 $ winml eval --mode compare -m model.onnx --model-id microsoft/resnet-50 --input-data inputs.npz
+```
+
+Compare two ONNX files directly (e.g. an fp32 baseline vs a quantized build), reporting per-output tensor-similarity metrics on identical random inputs — no `--model-id` or dataset needed:
+
+```bash
+$ winml eval --mode compare -m quantized.onnx --reference baseline.onnx
 ```
 
 Check what dataset columns are expected before running, then remap them to match your dataset:

--- a/src/winml/modelkit/commands/eval.py
+++ b/src/winml/modelkit/commands/eval.py
@@ -749,11 +749,20 @@ def display_eval_report(result: EvalResult, console: Console) -> None:
     # archive (via EvalResult.num_samples), not the unused config default.
     samples = result.num_samples if result.num_samples is not None else ds.samples
 
-    # Header
+    # Header — model_id when building from HF, otherwise the ONNX path(s). A
+    # composite model_path is a {role: path} dict; join its paths so the title
+    # stays a readable string instead of a raw dict repr.
+    if cfg.model_id:
+        eval_name = cfg.model_id
+    elif isinstance(cfg.model_path, dict):
+        eval_name = ", ".join(str(path) for path in cfg.model_path.values())
+    else:
+        eval_name = str(cfg.model_path)
+
     console.print()
     console.print(
         Panel.fit(
-            f"[bold]Evaluation: {cfg.model_id or cfg.model_path}[/bold]",
+            f"[bold]Evaluation: {eval_name}[/bold]",
             border_style="blue",
         )
     )
@@ -767,7 +776,10 @@ def display_eval_report(result: EvalResult, console: Console) -> None:
     elif ds.path:
         console.print(f"[dim]Dataset:[/dim]    {ds.path}")
     console.print(f"[dim]Samples:[/dim]    {samples}")
-    if cfg.model_path:
+    if isinstance(cfg.model_path, dict):
+        for role, path in cfg.model_path.items():
+            console.print(f"[dim]ONNX ({role}):[/dim] {path}")
+    elif cfg.model_path:
         console.print(f"[dim]ONNX:[/dim]       {cfg.model_path}")
     if cfg.reference_path:
         console.print(f"[dim]Reference:[/dim]  {cfg.reference_path}")

--- a/src/winml/modelkit/commands/eval.py
+++ b/src/winml/modelkit/commands/eval.py
@@ -198,6 +198,17 @@ logger = logging.getLogger(__name__)
         "sample axis (N samples), and all inputs must share the same N."
     ),
 )
+@click.option(
+    "--reference",
+    "reference",
+    type=str,
+    default=None,
+    help=(
+        "Reference ONNX file to compare the candidate against (use with "
+        "--mode compare). Compares two ONNX models on identical random inputs; "
+        "--model-id / --task are not required in this mode."
+    ),
+)
 @cli_utils.skip_build_option()
 @cli_utils.format_option()
 @cli_utils.build_config_option()
@@ -240,6 +251,7 @@ def eval(
     show_schema: bool,
     mode: EvalMode,
     input_data: str | None,
+    reference: str | None,
     config_file: Path | None,
     skip_build: bool,
 ) -> None:
@@ -251,6 +263,8 @@ def eval(
         winml eval -m model.onnx --model-id microsoft/resnet-50
 
         winml eval --mode compare -m cand.onnx --model-id microsoft/resnet-50 --input-data data.npz
+
+        winml eval --mode compare -m cand.onnx --reference baseline.onnx
 
     Run `winml eval --schema --task <task>` to see the dataset columns
     and options expected by each task.
@@ -287,8 +301,12 @@ def eval(
     if cfg.input_data is not None and cfg.mode != "compare":
         raise click.UsageError("--input-data is only valid with --mode compare.")
 
+    if cfg.reference_path is not None and cfg.mode != "compare":
+        raise click.UsageError("--reference is only valid with --mode compare.")
+
     # ── 2. Resolve in place ──
-    _resolve_model(cfg, model, model_id)
+    _resolve_model(cfg, model, model_id, allow_missing_model_id=cfg.reference_path is not None)
+    _resolve_reference(cfg)
     _apply_export_overrides(cfg, shape_config_path, input_specs, export_config, dynamic_axes)
     _resolve_device(cfg)
     _resolve_label_mapping(cfg)
@@ -420,11 +438,52 @@ def _resolve_model(
     cfg: WinMLEvaluationConfig,
     model: tuple[str, ...],
     model_id: str | None,
+    *,
+    allow_missing_model_id: bool = False,
 ) -> None:
     """Resolve ``-m`` / ``--model-id`` into ``cfg.model_path`` / ``cfg.model_id``."""
-    model_path, resolved_id = _resolve_model_path(model=model, model_id=model_id)
+    model_path, resolved_id = _resolve_model_path(
+        model=model, model_id=model_id, allow_missing_model_id=allow_missing_model_id
+    )
     cfg.model_path = model_path
     cfg.model_id = resolved_id
+
+
+def _resolve_reference(cfg: WinMLEvaluationConfig) -> None:
+    """Validate and normalize ``cfg.reference_path`` for two-ONNX compare.
+
+    Requires the candidate (``-m``) to be a single ONNX file (composite
+    ``role=path`` candidates and build-from-id are not supported with
+    ``--reference`` yet). Resolves Hub-hosted ONNX refs to local paths.
+    """
+    if cfg.reference_path is None:
+        return
+
+    if not isinstance(cfg.model_path, str):
+        raise click.UsageError(
+            "--reference requires the candidate (-m) to be a single ONNX file. "
+            "Composite (role=path) candidates and build-from-id are not "
+            "supported with --reference."
+        )
+
+    ref = cfg.reference_path
+    if Path(ref).suffix.lower() != ".onnx":
+        raise click.BadParameter(
+            f"--reference must be an .onnx file, got: {ref}",
+            param_hint="--reference",
+        )
+    try:
+        ref = cli_utils.normalize_model_arg(ref) or ref
+    except Exception as e:
+        raise click.ClickException(
+            f"Failed to resolve Hub-hosted reference ONNX path {ref!r}: {e}"
+        ) from e
+    if not Path(ref).exists():
+        raise click.BadParameter(
+            f"Reference ONNX file not found: {ref}",
+            param_hint="--reference",
+        )
+    cfg.reference_path = ref
 
 
 def _apply_export_overrides(
@@ -567,8 +626,14 @@ def _resolve_model_path(
     *,
     model: tuple[str, ...],
     model_id: str | None,
+    allow_missing_model_id: bool = False,
 ) -> tuple[str | dict[str, str] | None, str | None]:
-    """Turn repeated -m values + --model-id into (model_path, model_id)."""
+    """Turn repeated -m values + --model-id into (model_path, model_id).
+
+    When ``allow_missing_model_id`` is set (two-ONNX ``--mode compare``), a
+    plain ``-m <file>.onnx`` is accepted without ``--model-id`` because the
+    candidate runs as a raw ORT session with no HF config resolution.
+    """
     if not model:
         if model_id is not None:
             return None, model_id
@@ -644,6 +709,8 @@ def _resolve_model_path(
                 param_hint="-m/--model",
             )
         if model_id is None:
+            if allow_missing_model_id:
+                return value, None
             raise click.UsageError(
                 "When using an ONNX file, --model-id is required "
                 "for preprocessor and config resolution."
@@ -686,7 +753,7 @@ def display_eval_report(result: EvalResult, console: Console) -> None:
     console.print()
     console.print(
         Panel.fit(
-            f"[bold]Evaluation: {cfg.model_id}[/bold]",
+            f"[bold]Evaluation: {cfg.model_id or cfg.model_path}[/bold]",
             border_style="blue",
         )
     )
@@ -702,6 +769,8 @@ def display_eval_report(result: EvalResult, console: Console) -> None:
     console.print(f"[dim]Samples:[/dim]    {samples}")
     if cfg.model_path:
         console.print(f"[dim]ONNX:[/dim]       {cfg.model_path}")
+    if cfg.reference_path:
+        console.print(f"[dim]Reference:[/dim]  {cfg.reference_path}")
 
     # Metrics table
     console.print()

--- a/src/winml/modelkit/eval/config.py
+++ b/src/winml/modelkit/eval/config.py
@@ -113,6 +113,10 @@ class WinMLEvaluationConfig:
             randomly generated ones. The leading axis of each array is the sample
             axis, so one archive can hold ``N`` samples; all inputs must share the
             same leading length.
+        reference_path: Path to a second ``.onnx`` file used as the reference in
+            ``--mode compare``. When set, both ``model_path`` and ``reference_path``
+            run as raw ORT sessions and their output tensors are compared directly,
+            so no ``model_id`` / ``task`` / HF reference is needed.
         task: HF pipeline task. Auto-detected from model_id if omitted.
         device: Target device for inference.
         ep: Explicit execution provider (e.g., "qnn", "dml"). Overrides
@@ -132,7 +136,8 @@ class WinMLEvaluationConfig:
               labeled dataset.
             - ``"compare"``: compare ONNX vs HF reference output tensors
               on identical random inputs and report tensor-similarity
-              metrics per output tensor.
+              metrics per output tensor. When ``reference_path`` is set,
+              the reference is a second ONNX file instead of the HF model.
 
     Usage:
         config = WinMLEvaluationConfig(
@@ -144,6 +149,7 @@ class WinMLEvaluationConfig:
     model_id: str | None = None
     model_path: str | dict[str, str] | None = None
     input_data: str | None = None
+    reference_path: str | None = field(default=None, metadata={"cli_name": "reference"})
     task: str | None = None
     device: str = "auto"
     precision: str = "auto"
@@ -177,6 +183,8 @@ class WinMLEvaluationConfig:
             result["model_path"] = self.model_path
         if self.input_data is not None:
             result["input_data"] = self.input_data
+        if self.reference_path is not None:
+            result["reference_path"] = self.reference_path
         if self.task is not None:
             result["task"] = self.task
         result["device"] = self.device
@@ -229,6 +237,7 @@ class WinMLEvaluationConfig:
             model_id=data.get("model_id"),
             model_path=data.get("model_path"),
             input_data=data.get("input_data"),
+            reference_path=data.get("reference_path"),
             task=data.get("task"),
             device=data.get("device", "auto"),
             precision=data.get("precision", "auto"),

--- a/src/winml/modelkit/eval/evaluate.py
+++ b/src/winml/modelkit/eval/evaluate.py
@@ -243,6 +243,11 @@ def _load_model(config: WinMLEvaluationConfig) -> WinMLPreTrainedModel | WinMLCo
     from ..session import EPDeviceTarget, WinMLEPRegistry, resolve_device
     from ..utils import cli as cli_utils
 
+    # Two-ONNX compare: the evaluator builds both raw ORT sessions directly from
+    # config.model_path / config.reference_path — no WinMLAutoModel / HF config.
+    if config.mode == "compare" and config.reference_path is not None:
+        return None
+
     quant_override: Any = None
     if not config.quant:
         from ..config import WinMLBuildConfig
@@ -385,8 +390,14 @@ def evaluate(config: WinMLEvaluationConfig) -> EvalResult:
     mode = config.mode if config.mode is not None else "onnx"
     if mode not in EVAL_MODES:
         raise ValueError(f"Invalid mode {mode!r}; expected one of {EVAL_MODES} or None.")
+    # Two-ONNX compare: both candidate and reference run as raw ORT sessions, so
+    # HF task resolution / model_id are not required — keep task as-is.
+    onnx_compare = mode == "compare" and config.reference_path is not None
     config = replace(
-        config, mode=mode, task=_resolve_task(config), dataset=deepcopy(config.dataset)
+        config,
+        mode=mode,
+        task=config.task if onnx_compare else _resolve_task(config),
+        dataset=deepcopy(config.dataset),
     )
     if config.mode != "compare" and config.dataset.path is None:
         default = _DEFAULT_DATASETS.get(config.task) if config.task is not None else None
@@ -457,12 +468,16 @@ def print_config(config: WinMLEvaluationConfig) -> None:
     """Print effective evaluation config to the console (quantize.py style)."""
     ds = config.dataset
     output_console = Console()
-    output_console.print(f"[bold blue]Model:[/bold blue] {config.model_id}")
+    if config.model_id is not None:
+        output_console.print(f"[bold blue]Model:[/bold blue] {config.model_id}")
     if config.model_path is not None:
         output_console.print(f"[bold blue]Model path:[/bold blue] {config.model_path}")
     if config.input_data is not None:
         output_console.print(f"[bold blue]Input data:[/bold blue] {config.input_data}")
-    output_console.print(f"[bold blue]Task:[/bold blue] {config.task}")
+    if config.reference_path is not None:
+        output_console.print(f"[bold blue]Reference:[/bold blue] {config.reference_path}")
+    if config.task is not None:
+        output_console.print(f"[bold blue]Task:[/bold blue] {config.task}")
     output_console.print(f"[bold blue]Device:[/bold blue] {config.device}")
     if config.ep is not None:
         output_console.print(f"[bold blue]EP:[/bold blue] {config.ep}")

--- a/src/winml/modelkit/eval/tensor_similarity_evaluator.py
+++ b/src/winml/modelkit/eval/tensor_similarity_evaluator.py
@@ -63,6 +63,9 @@ class _ONNXSessionModel:
         """Run one sample and return raw outputs as named ``torch`` tensors."""
         import torch
 
+        # ``inputs`` may be torch tensors (fed by _inference_model); WinMLSession.run
+        # -> _prepare_inputs converts them to numpy and enforces the graph dtype, so
+        # no explicit .numpy() conversion is needed here.
         outputs = self._session.run(inputs)
         return {name: torch.from_numpy(arr) for name, arr in outputs.items()}
 

--- a/src/winml/modelkit/eval/tensor_similarity_evaluator.py
+++ b/src/winml/modelkit/eval/tensor_similarity_evaluator.py
@@ -179,6 +179,9 @@ class TensorSimilarityEvaluator:
         common_keys: list[str] | None = None
         ort_keys: set[str] = set()
         hf_keys: set[str] = set()
+        # Both sides are raw ONNX in the two-ONNX path; only the default path
+        # has an HF PyTorch reference. Label diagnostics accordingly.
+        reference_label = "reference ONNX" if self.config.reference_path else "HF reference"
 
         with torch.no_grad():
             for i in tqdm(range(len(self.data)), desc="compare", unit="sample"):
@@ -193,8 +196,9 @@ class TensorSimilarityEvaluator:
                     common_keys = [name for name in hf_out if name in ort_keys & hf_keys]
                     if not common_keys:
                         raise ValueError(
-                            f"ONNX and HF reference output names do not overlap. "
-                            f"ONNX: {sorted(ort_keys)}, HF: {sorted(hf_keys)}."
+                            f"Candidate ONNX and {reference_label} output names do not "
+                            f"overlap. candidate: {sorted(ort_keys)}, "
+                            f"reference: {sorted(hf_keys)}."
                         )
 
                 for name in common_keys:
@@ -205,7 +209,8 @@ class TensorSimilarityEvaluator:
 
         if ort_keys != hf_keys:
             logger.warning(
-                "ONNX and HF reference output names differ. ONNX: %s, HF: %s.",
+                "Candidate ONNX and %s output names differ. candidate: %s, reference: %s.",
+                reference_label,
                 sorted(ort_keys),
                 sorted(hf_keys),
             )

--- a/src/winml/modelkit/eval/tensor_similarity_evaluator.py
+++ b/src/winml/modelkit/eval/tensor_similarity_evaluator.py
@@ -5,10 +5,14 @@
 
 """Tensor-similarity evaluator.
 
-Runs an ONNX candidate and an HF PyTorch reference on identical inputs
-(random by default, drawn from :class:`RandomDataset` over the candidate's
-ONNX I/O) and reports per-output tensor-parity metrics (SQNR, PSNR, cosine,
-MSE, max absolute diff) via :class:`TensorSimilarityMetric`.
+Runs an ONNX candidate and a reference on identical inputs (random by
+default, drawn from :class:`RandomDataset` over the candidate's ONNX I/O)
+and reports per-output tensor-parity metrics (SQNR, PSNR, cosine, MSE,
+max absolute diff) via :class:`TensorSimilarityMetric`.
+
+The reference is an HF PyTorch model resolved from ``model_id`` by default.
+When ``config.reference_path`` is set, the reference is instead a second
+ONNX file and both sides run as raw ORT sessions (no HF config / task).
 
 When ``config.input_data`` is set, both sides run on real tensors from a
 ``.npz`` archive instead of random inputs.
@@ -32,8 +36,43 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class _ONNXSessionModel:
+    """Minimal raw-ORT wrapper for two-ONNX ``--mode compare``.
+
+    Exposes just the slice of the :class:`WinMLPreTrainedModel` surface that
+    the tensor-similarity loop needs — ``onnx_path``, ``io_config`` and a
+    callable returning named ``torch`` tensors — without any HF config or
+    task-specific output renaming, so both sides compare on their raw ONNX
+    output names.
+    """
+
+    def __init__(self, onnx_path: str, device: str = "auto", ep: Any | None = None) -> None:
+        from pathlib import Path
+
+        from ..session.session import WinMLSession
+
+        self.onnx_path = Path(onnx_path)
+        self._session = WinMLSession(onnx_path=self.onnx_path, device=device, ep=ep)
+
+    @property
+    def io_config(self) -> dict:
+        """ONNX I/O metadata (delegated to the session)."""
+        return self._session.io_config
+
+    def __call__(self, **inputs: Any) -> dict[str, Any]:
+        """Run one sample and return raw outputs as named ``torch`` tensors."""
+        import torch
+
+        outputs = self._session.run(inputs)
+        return {name: torch.from_numpy(arr) for name, arr in outputs.items()}
+
+
 class TensorSimilarityEvaluator:
     """Per-output tensor parity between an ONNX candidate and an HF reference."""
+
+    # Either an HF-backed model (default path) or a raw-ORT wrapper (two-ONNX
+    # compare); annotated here so both __init__ branches type-check.
+    model: WinMLPreTrainedModel | _ONNXSessionModel
 
     def __init__(
         self,
@@ -41,6 +80,20 @@ class TensorSimilarityEvaluator:
         model: WinMLPreTrainedModel | WinMLCompositeModel,
     ) -> None:
         from ..models.winml.composite_model import WinMLCompositeModel
+
+        self.config = config
+
+        # Two-ONNX compare: build both raw ORT sessions directly, bypassing the
+        # HF PyTorch reference. ``model`` is None here (see evaluate._load_model).
+        if config.reference_path is not None:
+            self.model = _ONNXSessionModel(
+                str(config.model_path), device=config.device, ep=config.ep
+            )
+            self.reference_model = _ONNXSessionModel(
+                str(config.reference_path), device=config.device, ep=config.ep
+            )
+            self.data = self.prepare_data()
+            return
 
         # Composite models must be split into their sub-components before
         # tensor-similarity comparison — the union param keeps this runtime
@@ -53,7 +106,6 @@ class TensorSimilarityEvaluator:
                 "Example: winml eval --mode compare --task <sub_task> "
                 f"--model <sub_onnx_path> --model-id {config.model_id}"
             )
-        self.config = config
         self.model = model
         self.reference_model = self._load_reference_model()
         self.data = self.prepare_data()

--- a/tests/unit/commands/test_eval.py
+++ b/tests/unit/commands/test_eval.py
@@ -1136,6 +1136,49 @@ class TestEvalFormatJson:
         assert result.exit_code != 0
 
 
+class TestDisplayEvalReportHeader:
+    """The report header/detail lines render a readable model name for every input shape."""
+
+    def _render(self, config) -> str:
+        from rich.console import Console
+
+        from winml.modelkit.commands.eval import display_eval_report
+        from winml.modelkit.eval.evaluate import EvalResult
+
+        console = Console(record=True, width=200)
+        display_eval_report(EvalResult(config=config, metrics={}, num_samples=1), console)
+        return console.export_text()
+
+    def test_composite_model_path_dict_renders_readable_not_dict_repr(self):
+        from winml.modelkit.eval import WinMLEvaluationConfig
+
+        text = self._render(
+            WinMLEvaluationConfig(
+                model_path={"encoder": "enc.onnx", "decoder": "dec.onnx"},
+                task="image-to-text",
+            )
+        )
+        # Header joins the sub-model paths; detail lines list them per role ...
+        assert "enc.onnx" in text
+        assert "dec.onnx" in text
+        assert "ONNX (encoder):" in text
+        # ... and never leak a raw Python dict repr.
+        assert "{'encoder'" not in text
+
+    def test_two_onnx_compare_shows_candidate_path_without_model_id(self):
+        from winml.modelkit.eval import WinMLEvaluationConfig
+
+        text = self._render(
+            WinMLEvaluationConfig(
+                model_path="cand.onnx",
+                reference_path="ref.onnx",
+                mode="compare",
+            )
+        )
+        assert "Evaluation: cand.onnx" in text
+        assert "ref.onnx" in text
+
+
 # ---------------------------------------------------------------------------
 # HuggingFace export overrides (--shape-config/--input-specs/--export-config/
 # --dynamic-axes) — parity with winml build/perf.

--- a/tests/unit/commands/test_eval.py
+++ b/tests/unit/commands/test_eval.py
@@ -14,7 +14,8 @@ import click
 import pytest
 from click.testing import CliRunner
 
-from winml.modelkit.commands.eval import _resolve_model_path
+from winml.modelkit.commands.eval import _resolve_model_path, _resolve_reference
+from winml.modelkit.eval import WinMLEvaluationConfig
 
 
 # ---------------------------------------------------------------------------
@@ -100,6 +101,14 @@ class TestSinglePlain:
     def test_plain_onnx_without_model_id_raises(self, onnx_file):
         with pytest.raises(click.UsageError, match="--model-id is required"):
             _resolve_model_path(model=(str(onnx_file),), model_id=None)
+
+    def test_plain_onnx_without_model_id_allowed_for_compare(self, onnx_file):
+        """allow_missing_model_id (two-ONNX compare) accepts a bare ONNX path."""
+        path, mid = _resolve_model_path(
+            model=(str(onnx_file),), model_id=None, allow_missing_model_id=True
+        )
+        assert path == str(onnx_file)
+        assert mid is None
 
     def test_plain_onnx_missing_file_raises(self, tmp_path):
         missing = tmp_path / "does-not-exist.onnx"
@@ -334,6 +343,82 @@ class TestEvalHelp:
 
         assert result.exit_code == 0, result.output
         assert "--input-data" in result.output
+
+    def test_help_mentions_reference(self, runner: CliRunner):
+        from winml.modelkit.commands.eval import eval as eval_cmd
+
+        result = runner.invoke(eval_cmd, ["--help"])
+
+        assert result.exit_code == 0, result.output
+        assert "--reference" in result.output
+
+
+class TestResolveReference:
+    def test_none_is_noop(self):
+        cfg = WinMLEvaluationConfig(model_path="m.onnx", mode="compare")
+        _resolve_reference(cfg)
+        assert cfg.reference_path is None
+
+    def test_happy_path(self, onnx_file, onnx_vision):
+        cfg = WinMLEvaluationConfig(
+            model_path=str(onnx_file),
+            reference_path=str(onnx_vision),
+            mode="compare",
+        )
+        _resolve_reference(cfg)
+        assert cfg.reference_path == str(onnx_vision)
+
+    def test_requires_onnx_candidate(self):
+        cfg = WinMLEvaluationConfig(
+            model_path=None,
+            reference_path="ref.onnx",
+            mode="compare",
+        )
+        with pytest.raises(click.UsageError, match="single ONNX file"):
+            _resolve_reference(cfg)
+
+    def test_composite_candidate_rejected(self, onnx_vision):
+        cfg = WinMLEvaluationConfig(
+            model_path={"encoder": "a.onnx"},
+            reference_path=str(onnx_vision),
+            mode="compare",
+        )
+        with pytest.raises(click.UsageError, match="single ONNX file"):
+            _resolve_reference(cfg)
+
+    def test_non_onnx_suffix_raises(self, onnx_file, tmp_path):
+        bad = tmp_path / "ref.txt"
+        bad.write_bytes(b"")
+        cfg = WinMLEvaluationConfig(
+            model_path=str(onnx_file),
+            reference_path=str(bad),
+            mode="compare",
+        )
+        with pytest.raises(click.BadParameter, match=r"must be an \.onnx file"):
+            _resolve_reference(cfg)
+
+    def test_missing_file_raises(self, onnx_file, tmp_path):
+        missing = tmp_path / "missing.onnx"
+        cfg = WinMLEvaluationConfig(
+            model_path=str(onnx_file),
+            reference_path=str(missing),
+            mode="compare",
+        )
+        with pytest.raises(click.BadParameter, match="not found"):
+            _resolve_reference(cfg)
+
+
+class TestReferenceModeGuard:
+    def test_reference_requires_compare_mode(self, runner: CliRunner, onnx_file):
+        from winml.modelkit.commands.eval import eval as eval_cmd
+
+        result = runner.invoke(
+            eval_cmd,
+            ["-m", str(onnx_file), "--reference", str(onnx_file)],
+            obj={"debug": False},
+        )
+        assert result.exit_code != 0
+        assert "--reference is only valid with --mode compare" in result.output
 
 
 class TestInputDataModeGuard:

--- a/tests/unit/eval/test_eval.py
+++ b/tests/unit/eval/test_eval.py
@@ -111,6 +111,23 @@ class TestEvaluationConfig:
         restored = WinMLEvaluationConfig.from_dict(config.to_dict())
         assert restored.input_data == "inputs.npz"
 
+    def test_reference_path_default_is_none(self):
+        """reference_path defaults to None and is omitted from to_dict."""
+        config = WinMLEvaluationConfig(model_id="test/model")
+        assert config.reference_path is None
+        assert "reference_path" not in config.to_dict()
+
+    def test_config_roundtrip_preserves_reference_path(self):
+        """reference_path survives to_dict/from_dict roundtrip."""
+        config = WinMLEvaluationConfig(
+            model_path="cand.onnx",
+            reference_path="ref.onnx",
+            mode="compare",
+        )
+        restored = WinMLEvaluationConfig.from_dict(config.to_dict())
+        assert restored.reference_path == "ref.onnx"
+        assert restored.mode == "compare"
+
     def test_eval_result_to_dict(self):
         config = WinMLEvaluationConfig(
             model_id="test/model",
@@ -299,6 +316,50 @@ class TestEvaluate:
         ):
             result = eval_mod.evaluate(config)
         assert result.config.mode == "onnx"
+
+    def test_onnx_compare_skips_task_resolution_and_dataset(self):
+        """Two-ONNX compare skips HF task resolution and default-dataset lookup."""
+        import importlib
+        import sys
+
+        eval_mod = sys.modules.get(
+            "winml.modelkit.eval.evaluate",
+        ) or importlib.import_module("winml.modelkit.eval.evaluate")
+
+        config = WinMLEvaluationConfig(
+            model_path="cand.onnx",
+            reference_path="ref.onnx",
+            mode="compare",
+        )
+
+        evaluator = MagicMock()
+        evaluator.compute.return_value = {"cosine_mean": {"logits": 1.0}}
+        with (
+            patch.object(
+                eval_mod,
+                "_resolve_task",
+                side_effect=AssertionError("task resolution must be skipped"),
+            ),
+            patch.object(eval_mod, "_load_model", return_value=None) as load_model,
+            patch.object(eval_mod, "get_evaluator_class", return_value=lambda *_a, **_k: evaluator),
+        ):
+            result = eval_mod.evaluate(config)
+
+        assert result.config.mode == "compare"
+        assert result.config.task is None
+        assert result.metrics == {"cosine_mean": {"logits": 1.0}}
+        load_model.assert_called_once()
+
+    def test_load_model_returns_none_for_onnx_compare(self):
+        """_load_model short-circuits (no model_id needed) for two-ONNX compare."""
+        from winml.modelkit.eval.evaluate import _load_model
+
+        config = WinMLEvaluationConfig(
+            model_path="cand.onnx",
+            reference_path="ref.onnx",
+            mode="compare",
+        )
+        assert _load_model(config) is None
 
     def test_no_dataset_no_default_raises(self):
         """Tasks without a default dataset raise ValueError."""

--- a/tests/unit/eval/test_tensor_similarity_evaluator.py
+++ b/tests/unit/eval/test_tensor_similarity_evaluator.py
@@ -234,3 +234,83 @@ class TestONNXSessionModel:
 
         model = _ONNXSessionModel("x.onnx")
         assert model.io_config["input_names"] == ["input"]
+
+
+# ---------------------------------------------------------------------------
+# --input-data combined with two-ONNX compare (reference_path + input_data)
+# ---------------------------------------------------------------------------
+
+
+class _FakeIOSession:
+    """Fake session exposing ``input_types`` so ``InputDataDataset`` validates,
+    and echoing a fixed named output so ``compute()`` finds overlapping outputs.
+
+    ``run`` mirrors ``WinMLSession`` by accepting torch-tensor inputs (the real
+    session converts them via ``_prepare_inputs``), so this doubles as a guard
+    that ``_ONNXSessionModel`` forwarding torch tensors is safe.
+    """
+
+    def __init__(self, onnx_path, device="auto", ep=None):
+        self.io_config = {"input_names": ["input"], "input_types": ["float32"]}
+
+    def run(self, inputs):
+        arr = np.asarray(next(iter(inputs.values()))).astype(np.float32)
+        return {"logits": arr.reshape(1, -1)[:, :3]}
+
+
+class TestONNXReferenceWithInputData:
+    def test_prepare_data_uses_input_data_over_candidate_session(self, monkeypatch, tmp_path):
+        import winml.modelkit.session.session as session_mod
+        from winml.modelkit.datasets.input_data import InputDataDataset
+
+        monkeypatch.setattr(session_mod, "WinMLSession", _FakeIOSession)
+
+        npz = tmp_path / "inputs.npz"
+        np.savez(npz, input=np.ones((3, 4), dtype=np.float32))
+
+        config = WinMLEvaluationConfig(
+            model_path="cand.onnx",
+            reference_path="ref.onnx",
+            mode="compare",
+            input_data=str(npz),
+        )
+
+        # ``model`` is None in the two-ONNX path (evaluate._load_model returns None).
+        evaluator = TensorSimilarityEvaluator(config, None)  # type: ignore[arg-type]
+
+        # Both sides are raw ORT wrappers ...
+        assert isinstance(evaluator.model, _ONNXSessionModel)
+        assert isinstance(evaluator.reference_model, _ONNXSessionModel)
+        # ... and the real-input dataset is built over the candidate session's
+        # io_config (not a RandomDataset), proving --input-data composes with
+        # --reference.
+        assert isinstance(evaluator.data, InputDataDataset)
+        assert len(evaluator.data) == 3
+        sample = evaluator.data[0]
+        assert set(sample) == {"input"}
+        assert sample["input"].shape == (1, 4)
+
+    def test_compute_runs_real_inputs_through_both_sessions(self, monkeypatch, tmp_path):
+        import winml.modelkit.session.session as session_mod
+
+        monkeypatch.setattr(session_mod, "WinMLSession", _FakeIOSession)
+
+        npz = tmp_path / "inputs.npz"
+        np.savez(npz, input=np.ones((2, 3), dtype=np.float32))
+
+        config = WinMLEvaluationConfig(
+            model_path="cand.onnx",
+            reference_path="ref.onnx",
+            mode="compare",
+            input_data=str(npz),
+        )
+        evaluator = TensorSimilarityEvaluator(config, None)  # type: ignore[arg-type]
+
+        result = evaluator.compute()
+
+        # Candidate and reference share the same fake session, so the compare
+        # loop ran end-to-end on the two real samples through both raw ORT
+        # sessions (torch tensors in, numpy out) without error and produced a
+        # per-metric table over the common "logits" output.
+        assert result
+        assert all("logits" in per_output for per_output in result.values())

--- a/tests/unit/eval/test_tensor_similarity_evaluator.py
+++ b/tests/unit/eval/test_tensor_similarity_evaluator.py
@@ -22,7 +22,10 @@ from transformers import PretrainedConfig
 from transformers.modeling_outputs import BaseModelOutput
 
 from winml.modelkit.eval import DatasetConfig, WinMLEvaluationConfig
-from winml.modelkit.eval.tensor_similarity_evaluator import TensorSimilarityEvaluator
+from winml.modelkit.eval.tensor_similarity_evaluator import (
+    TensorSimilarityEvaluator,
+    _ONNXSessionModel,
+)
 from winml.modelkit.models.winml.composite_model import WinMLCompositeModel
 
 
@@ -147,3 +150,87 @@ class TestInputDataCompare:
         # prepare_data must NOT mutate the config -- the real sample count is
         # surfaced via EvalResult.num_samples, not written back here.
         assert evaluator.config.dataset.samples == 100
+
+
+# ---------------------------------------------------------------------------
+# Two-ONNX compare (reference_path set)
+# ---------------------------------------------------------------------------
+
+
+class _FakeSession:
+    """Stand-in for WinMLSession that records construction and echoes outputs."""
+
+    created: ClassVar[list[tuple[str, str, object]]] = []
+
+    def __init__(self, onnx_path, device="auto", ep=None):
+        _FakeSession.created.append((str(onnx_path), device, ep))
+        self.io_config = {"input_names": ["input"]}
+
+    def run(self, inputs):
+        return {"logits": np.arange(3.0, dtype=np.float32).reshape(1, 3)}
+
+
+class _FakeRandomDataset:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def __len__(self):
+        return 0
+
+
+class TestONNXReferenceInit:
+    def test_builds_two_raw_sessions_honoring_device(self, monkeypatch):
+        import winml.modelkit.datasets.random_dataset as rd_mod
+        import winml.modelkit.session.session as session_mod
+
+        _FakeSession.created = []
+        monkeypatch.setattr(session_mod, "WinMLSession", _FakeSession)
+        monkeypatch.setattr(rd_mod, "RandomDataset", _FakeRandomDataset)
+
+        config = WinMLEvaluationConfig(
+            model_path="cand.onnx",
+            reference_path="ref.onnx",
+            mode="compare",
+            device="cpu",
+            ep="dml",
+            dataset=DatasetConfig(samples=5, seed=1),
+        )
+
+        # ``model`` is None in this path (evaluate._load_model returns None).
+        evaluator = TensorSimilarityEvaluator(config, None)  # type: ignore[arg-type]
+
+        assert isinstance(evaluator.model, _ONNXSessionModel)
+        assert isinstance(evaluator.reference_model, _ONNXSessionModel)
+        # Candidate first, reference second; both honor --device / --ep.
+        assert _FakeSession.created[0][0].endswith("cand.onnx")
+        assert _FakeSession.created[1][0].endswith("ref.onnx")
+        assert [c[1] for c in _FakeSession.created] == ["cpu", "cpu"]
+        assert [c[2] for c in _FakeSession.created] == ["dml", "dml"]
+        # RandomDataset is built over the candidate ONNX I/O.
+        assert evaluator.data.kwargs["model_path"].endswith("cand.onnx")
+        assert evaluator.data.kwargs["max_samples"] == 5
+        assert evaluator.data.kwargs["seed"] == 1
+
+
+class TestONNXSessionModel:
+    def test_call_returns_named_torch_tensors(self, monkeypatch):
+        import winml.modelkit.session.session as session_mod
+
+        _FakeSession.created = []
+        monkeypatch.setattr(session_mod, "WinMLSession", _FakeSession)
+
+        model = _ONNXSessionModel("x.onnx", device="cpu")
+        out = model(input=torch.zeros(1, 3))
+
+        assert set(out) == {"logits"}
+        assert isinstance(out["logits"], torch.Tensor)
+        assert out["logits"].shape == (1, 3)
+
+    def test_io_config_delegates_to_session(self, monkeypatch):
+        import winml.modelkit.session.session as session_mod
+
+        _FakeSession.created = []
+        monkeypatch.setattr(session_mod, "WinMLSession", _FakeSession)
+
+        model = _ONNXSessionModel("x.onnx")
+        assert model.io_config["input_names"] == ["input"]

--- a/tests/unit/eval/test_tensor_similarity_evaluator.py
+++ b/tests/unit/eval/test_tensor_similarity_evaluator.py
@@ -314,3 +314,43 @@ class TestONNXReferenceWithInputData:
         # per-metric table over the common "logits" output.
         assert result
         assert all("logits" in per_output for per_output in result.values())
+
+
+class _FakePathAwareSession:
+    """Fake session returning a different output name per model path, so the
+    candidate and reference disagree and compute() hits the no-overlap error."""
+
+    def __init__(self, onnx_path, device="auto", ep=None):
+        self._path = str(onnx_path)
+        self.io_config = {"input_names": ["input"], "input_types": ["float32"]}
+
+    def run(self, inputs):
+        name = "cand_out" if "cand" in self._path else "ref_out"
+        return {name: np.zeros((1, 3), dtype=np.float32)}
+
+
+class TestReferenceLabelInDiagnostics:
+    def test_non_overlapping_outputs_error_names_reference_onnx(self, monkeypatch, tmp_path):
+        import winml.modelkit.session.session as session_mod
+
+        monkeypatch.setattr(session_mod, "WinMLSession", _FakePathAwareSession)
+
+        npz = tmp_path / "inputs.npz"
+        np.savez(npz, input=np.ones((1, 3), dtype=np.float32))
+
+        config = WinMLEvaluationConfig(
+            model_path="cand.onnx",
+            reference_path="ref.onnx",
+            mode="compare",
+            input_data=str(npz),
+        )
+        evaluator = TensorSimilarityEvaluator(config, None)  # type: ignore[arg-type]
+
+        with pytest.raises(ValueError) as exc:
+            evaluator.compute()
+
+        # Two raw ONNX sides -> the diagnostic must say "reference ONNX", never
+        # the misleading "HF reference".
+        msg = str(exc.value)
+        assert "reference ONNX" in msg
+        assert "HF reference" not in msg


### PR DESCRIPTION
## Summary

Extends `winml eval --mode compare` so the reference can be a second **ONNX file** instead of only the HuggingFace PyTorch model derived from `--model-id`.

A new `--reference <path>` option points at a reference `.onnx`. When set, both the candidate (`-m`) and the reference run as **raw ORT sessions** (`WinMLSession`) on identical inputs — random by default, or the tensors from `--input-data` — and the existing tensor-similarity metrics (cosine, SQNR, PSNR, MSE, max-abs-diff) are computed over their aligned outputs. Because both are raw ONNX graphs, no HF config/task is loaded, so `--model-id` and `--task` are not required in this path. Both sessions honor `--device` / `--ep`.

## Usage

```bash
winml eval -m candidate.onnx --mode compare --reference reference.onnx
```

## Changes

- **`eval/config.py`**: add `reference_path` field (`cli_name="reference"`) with `to_dict` / `from_dict` support.
- **`commands/eval.py`**: add `--reference` option; `_resolve_reference()` normalizes hub refs and validates `.onnx` existence; `allow_missing_model_id` lets a bare ONNX candidate skip the `--model-id` requirement; guard so `--reference` only works with `--mode compare`; print the reference path.
- **`eval/evaluate.py`**: skip task resolution and load no torch model for the two-ONNX path; guard `None` model_id/task and print the reference in the config summary.
- **`eval/tensor_similarity_evaluator.py`**: add `_ONNXSessionModel` wrapper (exposes `onnx_path`, `io_config`, `__call__` returning torch tensors); build both raw sessions when `reference_path` is set, reusing the existing similarity metrics.
- **`docs/commands/eval.md`**: document `--reference`, clarify `--mode`, add a two-ONNX example.
- **Tests**: cover config round-trip, `_resolve_reference` validation, the compare-mode guard, bare-ONNX candidate handling, the two-ONNX evaluate flow, and the `_ONNXSessionModel` wrapper.

## Scope

Phase 1 supports an ONNX-file reference only. HF-local-folder and composite-model references are deferred. The branch is rebuilt on current `main`, so the diff contains only the `--reference` feature (the earlier `--input-data` work landed separately in #1221).