### PR TITLE
fix(export): bind keyword inputs and add OWLv2 recipes

### DIFF
--- a/examples/recipes/google_owlv2-base-patch16-finetuned/cpu/cpu/zero-shot-object-detection_fp16_config.json
+++ b/examples/recipes/google_owlv2-base-patch16-finetuned/cpu/cpu/zero-shot-object-detection_fp16_config.json
@@ -1,0 +1,97 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          16
+        ],
+        "value_range": [
+          0,
+          49408
+        ]
+      },
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          960,
+          960
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          16
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      },
+      {
+        "name": "pred_boxes"
+      },
+      {
+        "name": "text_embeds"
+      },
+      {
+        "name": "image_embeds"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "zero-shot-object-detection",
+    "model_id": "google/owlv2-base-patch16-finetuned",
+    "model_type": "owlv2",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "zero-shot-object-detection",
+    "model_class": "AutoModelForZeroShotObjectDetection",
+    "model_type": "owlv2"
+  }
+}

--- a/examples/recipes/google_owlv2-base-patch16-finetuned/cpu/cpu/zero-shot-object-detection_fp32_config.json
+++ b/examples/recipes/google_owlv2-base-patch16-finetuned/cpu/cpu/zero-shot-object-detection_fp32_config.json
@@ -1,0 +1,75 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          16
+        ],
+        "value_range": [
+          0,
+          49408
+        ]
+      },
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          960,
+          960
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          16
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      },
+      {
+        "name": "pred_boxes"
+      },
+      {
+        "name": "text_embeds"
+      },
+      {
+        "name": "image_embeds"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "zero-shot-object-detection",
+    "model_class": "AutoModelForZeroShotObjectDetection",
+    "model_type": "owlv2"
+  }
+}

--- a/src/winml/modelkit/export/htp/exporter.py
+++ b/src/winml/modelkit/export/htp/exporter.py
@@ -20,6 +20,7 @@ Key Features:
 from __future__ import annotations
 
 import contextlib
+import inspect
 import logging
 import sys
 import time
@@ -445,8 +446,12 @@ class HTPExporter:
         output_path = str(Path(output_path).resolve())
         Path(output_path).parent.mkdir(parents=True, exist_ok=True)
 
-        # Input names from config, fallback to inputs dict keys
+        # Input names from config, fallback to inputs dict keys. Keyword inputs
+        # invoke forward() by name, but the TorchScript exporter assigns these
+        # ONNX names positionally to the traced graph inputs. Align names with
+        # forward() order so a config's tensor order cannot swap graph bindings.
         input_names = export_config.get_input_names() or list(inputs.keys())
+        input_names = self._resolve_keyword_input_names(model, inputs, input_names)
 
         # Output names: infer from traced hierarchy, validate against config
         traced_outputs = self._hierarchy_builder.get_outputs() if self._hierarchy_builder else None
@@ -494,6 +499,54 @@ class HTPExporter:
                 torch.onnx.export(model, export_args, output_path, **onnx_kwargs)
             else:
                 torch.onnx.export(model, (), output_path, kwargs=inputs, **onnx_kwargs)
+
+    @staticmethod
+    def _resolve_keyword_input_names(
+        model: nn.Module,
+        inputs: dict[str, torch.Tensor],
+        configured_input_names: list[str],
+    ) -> list[str]:
+        """Return ONNX names in the order produced by keyword tracing.
+
+        ``torch.onnx.export`` invokes the model safely with keyword arguments,
+        then applies ``input_names`` positionally to graph inputs emitted in
+        ``forward`` signature order. Reorder only when every configured,
+        generated input has an unambiguous signature match. Models implementing
+        ``get_export_args`` own a separate positional protocol, so their config
+        order remains authoritative.
+        """
+        if hasattr(model, "get_export_args"):
+            return configured_input_names
+
+        try:
+            parameters = inspect.signature(model.forward).parameters
+        except (TypeError, ValueError):
+            logger.debug(
+                "Could not inspect %s.forward; preserving configured input order.",
+                type(model).__name__,
+            )
+            return configured_input_names
+
+        configured_set = set(configured_input_names)
+        generated_set = set(inputs)
+        forward_input_names = [
+            name for name in parameters if name in configured_set and name in generated_set
+        ]
+        if (
+            len(forward_input_names) == len(configured_input_names)
+            and set(forward_input_names) == configured_set
+        ):
+            return forward_input_names
+
+        logger.debug(
+            "Could not align every configured input for %s.forward; "
+            "preserving configured input order. configured=%s generated=%s forward=%s",
+            type(model).__name__,
+            configured_input_names,
+            list(inputs),
+            list(parameters),
+        )
+        return configured_input_names
 
     @staticmethod
     def _get_optimum_patcher(model: nn.Module, task: str | None) -> Any:

--- a/tests/unit/export/test_pytorch_export.py
+++ b/tests/unit/export/test_pytorch_export.py
@@ -87,10 +87,20 @@ class MismatchedInputOrderModel(nn.Module):
         self.vision_conv = nn.Conv2d(3, 8, kernel_size=3, padding=1)
         self.pool = nn.AdaptiveAvgPool2d(1)
 
-    def forward(self, text_input, pixel_values):
-        text_out = self.text_fc(text_input)
+    def forward(self, input_ids, pixel_values, attention_mask):
+        text_out = self.text_fc(input_ids.float() * attention_mask.float())
         vis_out = self.pool(self.vision_conv(pixel_values)).squeeze(-1).squeeze(-1)
         return text_out + vis_out
+
+
+class PositionalExportOrderModel(nn.Module):
+    """Model whose explicit positional export protocol owns input ordering."""
+
+    def get_export_args(self, inputs):
+        return inputs["narrow"], inputs["wide"]
+
+    def forward(self, wide, narrow):
+        return torch.cat((wide, narrow), dim=1)
 
 
 # =============================================================================
@@ -350,20 +360,21 @@ class TestExportPytorch:
         assert not _all_value_info_have_shape(onnx_model)
 
     def test_mismatched_input_order_exports_successfully(self, tmp_path) -> None:
-        """Export succeeds when InputTensorSpec order differs from forward() param order.
+        """ONNX names bind correctly when specs differ from forward() order.
 
         Regression test for CLIP bug: OnnxConfig listed pixel_values before input_ids,
-        but CLIPModel.forward() expected input_ids first. With positional args this
-        caused 'not enough values to unpack (expected 4, got 2)'. The fix uses
-        kwargs= in torch.onnx.export so name-based binding makes order irrelevant.
+        but a multimodal forward expects text inputs first. Keyword arguments make
+        invocation order-independent; ONNX input names must separately follow the
+        forward signature because torch.onnx.export assigns them positionally.
         """
         model = MismatchedInputOrderModel()
 
-        # Intentionally list pixel_values FIRST — opposite of forward(text_input, pixel_values)
+        # Intentionally list pixel_values FIRST — opposite of forward().
         config = WinMLExportConfig(
             input_tensors=[
                 InputTensorSpec(name="pixel_values", dtype="float32", shape=(1, 3, 8, 8)),
-                InputTensorSpec(name="text_input", dtype="float32", shape=(1, 16)),
+                InputTensorSpec(name="input_ids", dtype="int32", shape=(1, 16)),
+                InputTensorSpec(name="attention_mask", dtype="int32", shape=(1, 16)),
             ],
         )
 
@@ -374,9 +385,37 @@ class TestExportPytorch:
 
         onnx_model = onnx.load(str(tmp_path / "model.onnx"))
         onnx.checker.check_model(onnx_model)
-        input_names = {i.name for i in onnx_model.graph.input}
-        assert "pixel_values" in input_names
-        assert "text_input" in input_names
+        input_bindings = {
+            tensor.name: (
+                onnx.TensorProto.DataType.Name(tensor.type.tensor_type.elem_type),
+                tuple(dim.dim_value for dim in tensor.type.tensor_type.shape.dim),
+            )
+            for tensor in onnx_model.graph.input
+        }
+        assert input_bindings == {
+            "input_ids": ("INT32", (1, 16)),
+            "pixel_values": ("FLOAT", (1, 3, 8, 8)),
+            "attention_mask": ("INT32", (1, 16)),
+        }
+
+    def test_get_export_args_preserves_configured_positional_names(self, tmp_path) -> None:
+        """An explicit get_export_args protocol keeps config order authoritative."""
+        model = PositionalExportOrderModel()
+        config = WinMLExportConfig(
+            input_tensors=[
+                InputTensorSpec(name="narrow", dtype="float32", shape=(1, 3)),
+                InputTensorSpec(name="wide", dtype="float32", shape=(1, 5)),
+            ],
+        )
+
+        export_pytorch(model, tmp_path / "model.onnx", config)
+
+        onnx_model = onnx.load(str(tmp_path / "model.onnx"))
+        input_shapes = {
+            tensor.name: tuple(dim.dim_value for dim in tensor.type.tensor_type.shape.dim)
+            for tensor in onnx_model.graph.input
+        }
+        assert input_shapes == {"narrow": (1, 3), "wide": (1, 5)}
 
 
 class TestStaleExternalDataCleanup:


### PR DESCRIPTION
## Summary

This adds CPU fp32/fp16 support for `google/owlv2-base-patch16-finetuned`, an open-vocabulary zero-shot object detector, together with a class-wide exporter repair for keyword-generated multi-input models. The shipped Effort/Outcome is L2, and both required CPU tuples reached **L2 PASS** with semantic-input performance and all-four-output parity against the pinned PyTorch checkpoint. `winml eval` remains **CLI-BLOCKED** for both tuples because no zero-shot-object-detection evaluator exists; no task metric is fabricated.

## Model metadata

### What the model does

OWLv2 is an open-vocabulary, text-conditioned object detector. It accepts an image and one or more text queries and returns per-patch query logits, normalized bounding boxes, and text/image embeddings for locating objects not limited to a fixed training label set.

- Evidence: Hugging Face model card for `google/owlv2-base-patch16-finetuned` pinned at `d69b086b07123308a4e198343ab2824e1af7774a`; pinned `config.json` with `architectures=["Owlv2ForObjectDetection"]` and `model_type="owlv2"`; Transformers `Owlv2ForObjectDetection.forward` source.
- Confidence: **verified**.

### Primary user stories

- A user supplies an image and natural-language candidate object labels to obtain scored bounding boxes for zero-shot text-conditioned object localization. Evidence: pinned model-card usage example and intended-use section. Confidence: **verified**.
- A researcher supplies images and previously unseen category descriptions to study open-vocabulary detector robustness, generalization, bias, and constraints. Evidence: pinned model-card intended-use section. Confidence: **verified**.

### Supported tasks

| Task | Support surfaces | Evidence | Confidence |
|---|---|---|---|
| zero-shot-object-detection | checkpoint; Transformers; Optimum ONNX; WinML | Pinned Hub `pipeline_tag`; Transformers `Owlv2ForObjectDetection`; Optimum TasksManager vendor registration for `owlv2`; `winml inspect` resolution to `OwlV2OnnxConfig` | **verified** |
| feature-extraction | Transformers; Optimum ONNX | Transformers `Owlv2Model`/`Owlv2TextModel`/`Owlv2VisionModel`; Optimum TasksManager vendor registration | **mapped** |

### Model architecture

```text
Owlv2ForObjectDetection
├── OWLv2 multimodal backbone
│   ├── Causal text encoder: token + position embeddings → 12 layers (512 hidden, 8 heads, 2048 FFN) → 512 projection
│   └── ViT-B/16 image encoder: 960×960 image → 60×60 patches + class token → 12 layers (768 hidden, 12 heads, 3072 FFN)
├── Patch-text fusion: class-token-conditioned patch map + normalized text embeddings
├── Class head: patch/query similarity logits + learned shift/scale
├── Objectness head: MLP → 1 score per patch
└── Box head: MLP + grid bias → normalized cxcywh per patch
```

- Source/confidence: pinned checkpoint configuration and resolved nested text/vision configs, Transformers `Owlv2ForObjectDetection` source, and the exported ONNX hierarchy (**verified**).

## Validation and support evidence

### Baseline

Fresh baseline validation used current `main` commit `38767add6f91c7b10b6394fae3af6f437e02effd` with WinML `0.2.0`. Optimum advertised `feature-extraction` and `zero-shot-object-detection` both before and after WinML registration, with no WinML-added task: **VENDOR-ONLY**.

- Auto-config resolved `zero-shot-object-detection`, `AutoModelForZeroShotObjectDetection`, and `OwlV2OnnxConfig`, but emitted `/export/input_tensors` as `[pixel_values,input_ids,attention_mask]`.
- Recipe-free build returned process exit 0 in **122.981 s**, but failed the L0 floor: the graph bound `pixel_values` to `INT32 [1,16]` and `input_ids` to `FLOAT [1,3,960,960]`, opposite `Owlv2ForObjectDetection.forward(input_ids, pixel_values, attention_mask)`. An exit-zero export was therefore not valid task coverage.
- Semantic named-input perf failed with exit 1: `Invalid rank for input: pixel_values Got: 4 Expected: 2`. Random graph-shaped perf returned p50 **3034.894 ms**, throughput **0.33 samples/s**, and RSS total delta **1426.47 MB**, but is invalid task evidence because it follows the swapped graph bindings.
- Eval was **CLI-BLOCKED** before data/model execution: `zero-shot-object-detection` was absent from `TASK_SCHEMAS` and `_EVALUATOR_REGISTRY`. The pinned COCO mirror is object-detection data, but a valid evaluator must derive candidate text queries from category names, run grounded post-processing, and score COCO mAP; the fixed-label object-detection evaluator is not semantically interchangeable. The generalized evaluator gap is filed as [winml-cli #1147](https://github.com/microsoft/winml-cli/issues/1147).

Baseline Goal floor: **L0**.

### Goal

- **Effort:** L2 — repair the class-of-models keyword-input name binding, add a regression test, and add the two required recipes.
- **Goal ceiling:** L2.
- **Outcome commitment:** L2 for CPU/cpu fp32 and fp16.
- **Success definition:** for both tuples, perform fresh config/build with exact named ONNX structure, run processor-generated semantic image+text perf, and compare all four raw outputs against pinned PyTorch revision `d69b086b07123308a4e198343ab2824e1af7774a`.
- No ceiling change or re-issued charter occurred.

### Outcome

- **Shipped tier:** L2.
- **Highest Goal verdict:** **L2 PASS**.
- **Coverage:** full; both required CPU/cpu precision tuples passed; deferred tuples: none.
- **Supplementary eval:** **CLI-BLOCKED** for both tuples; no task metric fabricated.
- **Shipped paths:** the shared exporter repair and regression test, plus fp32/fp16 recipes under `examples/recipes/google_owlv2-base-patch16-finetuned/cpu/cpu/`.
- **Model findings:** `owlv2-004` records faithful fp32/fp16 CPU export/perf/parity and the fp16 box-delta caveat; `owlv2-005` records the zero-shot evaluator gap, why fixed-label evaluation is invalid, and the filed issue [winml-cli #1147](https://github.com/microsoft/winml-cli/issues/1147).
- **Methodology finding:** `_meta-084` distinguishes recipe ordering defects from generalized keyword-export binding defects and requires recipe-free semantic acceptance while preserving explicit positional export protocols.
- **Lane A provenance:** these findings and the corresponding producer/tester/reviewer contract refinements are in source-branch commit [`7cdfad2a05fc20d2e7ed96db93e666df20689485`](https://github.com/gim-home/ModelKitArtifacts/commit/7cdfad2a05fc20d2e7ed96db93e666df20689485). This exact post-merge source-branch commit updates `owlv2-005.feature_gaps_filed` to [winml-cli #1147](https://github.com/microsoft/winml-cli/issues/1147). It remains on the source branch because ModelKitArtifacts PR [#159](https://github.com/gim-home/ModelKitArtifacts/pull/159) is already merged; no Lane A files are included in this model PR.

### Per-EP/device/precision results — including perf and eval data

#### Goal ladder

| Tier | Verdict | Evidence |
|---|---|---|
| L0 | **PASS** | Both exact CPU/cpu precision tuples were freshly configured, built, and structurally validated. fp32/fp16 build times were **100.8660367 s / 116.974988 s**; both expose `input_ids INT32 [1,16]`, `pixel_values FLOAT [1,3,960,960]`, and `attention_mask INT32 [1,16]`, plus `logits`, `pred_boxes`, `text_embeds`, and `image_embeds`. |
| L1 | **PASS** | Both tuples completed 10 warmups and 100 measured processor-generated semantic-input iterations with memory capture. |
| L2 | **PASS** | Both tuples compared `logits`, `pred_boxes`, `text_embeds`, and `image_embeds` against pinned PyTorch on identical semantic inputs. |

#### Performance

| Tier | EP / Device | Precision | Verdict | Mean | p50 | p90 / p95 / p99 | Std | Warmup mean | Throughput | RAM Δ (load + inference) | VRAM local/shared Δ |
|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|
| L1 | CPUExecutionProvider / cpu | fp32 | **PASS** | **2864.275 ms** | **2868.799 ms** | 2990.744 / 3090.821 / 4458.42 ms | 227.563 ms | 3129.52 ms | **0.35 samples/s** | **1423.95 MB** (504.39 + 919.56) | 0.0 / 0.0 MB |
| L1 | CPUExecutionProvider / cpu | fp16 | **PASS** | **3958.256 ms** | **3943.525 ms** | 4091.145 / 4127.269 / 4566.801 ms | 94.429 ms | 4021.603 ms | **0.25 samples/s** | **3634.66 MB** (618.49 + 3016.17) | 0.0 / 0.0 MB |

#### L2 all-output parity

Parity is against PyTorch checkpoint revision `d69b086b07123308a4e198343ab2824e1af7774a` on the same processor-generated inputs, before `post_process_grounded_object_detection`.

| Precision | Output | Shape | Cosine similarity | Max abs diff | Mean abs diff | RMSE | Additional task-facing measure |
|---|---|---|---:|---:|---:|---:|---|
| fp32 | logits | `[1,3600,1]` | 0.9999999999973036 | 0.0002536773681640625 | 0.00003874407874213324 | 0.00005066664507799361 | sigmoid probability max Δ 1.0459867096952605e-09 |
| fp32 | pred_boxes | `[1,3600,4]` | 0.9999999999978494 | 0.000020384788513183594 | 6.614572420302365e-07 | 1.2354488877881363e-06 | mean raw normalized cxcywh IoU 0.9999946354690188; center L2 4.988567341990188e-07; size L2 1.6024903863345032e-06 |
| fp32 | text_embeds | `[1,1,512]` | 0.9999999999998044 | 1.1920928955078125e-07 | 2.1396012961361066e-08 | 2.7659271996813866e-08 | row cosine min/mean 0.9999999999998042 |
| fp32 | image_embeds | `[1,60,60,768]` | 0.9999999999992097 | 0.00016033649444580078 | 7.003135723185441e-07 | 1.258130226559189e-06 | row cosine min 0.9999999999611946; mean 0.9999999999992424 |
| fp16 | logits | `[1,3600,1]` | 0.9999985234500899 | 0.4004535675048828 | 0.03721526781717936 | 0.047675061767347246 | sigmoid probability max Δ 4.985980597621861e-07 |
| fp16 | pred_boxes | `[1,3600,4]` | 0.9999983128330443 | **0.016967952251434326** | 0.0005751266507690565 | 0.001102209982320831 | mean raw normalized cxcywh IoU **0.9954116316743082**; center L2 0.00043634357334799317; size L2 0.0013853381709355733 |
| fp16 | text_embeds | `[1,1,512]` | 0.9999997517780107 | 0.0001614093780517578 | 0.00002433118910527554 | 0.000031142131733688554 | row cosine min/mean 0.9999997517780105 |
| fp16 | image_embeds | `[1,60,60,768]` | 0.99999922301875 | 0.18775832653045654 | 0.0006581207882101428 | 0.0012534093656211827 | row cosine min 0.9999292538054624; mean 0.9999992292296191 |

The fp16 `pred_boxes` max-absolute delta **0.016967952251434326** fails the strict auxiliary `0.005` absolute check. L2 remains PASS because all outputs are present and the task-facing box criterion passes: mean raw normalized-box IoU is **0.9954116316743082** against the `0.99` threshold. This does **not** claim dataset mAP, query derivation, threshold stability, target-size rescaling, or final detection-list equivalence.

#### Eval

| EP / Device | Precision | Verdict | Dataset | Revision | Subset | Exit | Metric |
|---|---|---|---|---|---|---:|---|
| CPUExecutionProvider / cpu | fp32 | **CLI-BLOCKED** | `detection-datasets/coco` | `cf0b22332314a937e9dc8a1957b21725430bb41d` | none | 1 | none |
| CPUExecutionProvider / cpu | fp16 | **CLI-BLOCKED** | `detection-datasets/coco` | `cf0b22332314a937e9dc8a1957b21725430bb41d` | none | 1 | none |

Both tuples returned the same error before dataset/model execution:

> `Error: Evaluation failed: Task 'zero-shot-object-detection' is not supported. Supported tasks: compare-tensor, depth-estimation, feature-extraction, fill-mask, image-classification, image-feature-extraction, image-segmentation, image-to-text, keypoint-detection, mask-generation, next-sentence-prediction, object-detection, question-answering, sentence-similarity, sequence-classification, text-classification, token-classification, zero-shot-classification, zero-shot-image-classification.`

Block reason: no zero-shot-object-detection schema or evaluator exists; fixed-label object detection is semantically non-interchangeable. Filed gap: [winml-cli #1147](https://github.com/microsoft/winml-cli/issues/1147).

### Delta

#### Recipe versus fresh auto-config

| Recipe | JSON pointer | Auto-config baseline | Shipped | Reason |
|---|---|---|---|---|
| fp32 | `/export/input_tensors` | `[pixel_values,input_ids,attention_mask]` | `[input_ids,pixel_values,attention_mask]` | Match the resolved `Owlv2ForObjectDetection.forward` order and remain independently safe for positional ONNX naming. |
| fp16 | `/export/input_tensors` | `[pixel_values,input_ids,attention_mask]` | `[input_ids,pixel_values,attention_mask]` | Same ordering repair. |
| fp16 | `/quant` | `null` | generated `mode=fp16` configuration with `fp16_keep_io_types=true` | Produce the required exact fp16 CPU candidate while retaining fp32 I/O. |

All checkpoint dimensions and loader fields remain checkpoint-derived. The production recipe README is untouched.

#### General exporter change

`HTPExporter._resolve_keyword_input_names` and `HTPExporter._convert_model_to_onnx` now derive ONNX `input_names` for keyword-generated multi-input exports from the inspected `forward` signature filtered to the configured/generated input set. If inspection is unavailable or incomplete, configured order is preserved without guessing. Models with explicit `get_export_args()` retain their configured positional protocol; a dedicated regression test covers that behavior.

This is consistent with the charter's class-of-models fix. Recipe-free acceptance passed in **106.191 s** with exact semantic bindings (`input_ids INT32 [1,16]`, `pixel_values FLOAT [1,3,960,960]`, `attention_mask INT32 [1,16]`), so acceptance is not dependent on the model-specific recipe ordering.

### Analyze summary — component level and op level

**ANALYZE-PARTIAL-SUCCESS:** public static rule analysis produced all 11 classification rows for each artifact, but the process exited 1 after host OpenVINO plugin registration failed with Error 126 (`onnxruntime_providers_shared.dll` missing). These classifications are static rule analysis, not accelerator runtime execution or fresh accelerator support.

Rules provenance: public WinML CLI release **v0.2.0**, [`rules-v0.2.0.zip`](https://github.com/microsoft/winml-cli/releases/download/v0.2.0/rules-v0.2.0.zip), containing 1,746 parquet rule files for TensorRT RTX GPU, OpenVINO CPU/GPU/NPU, and QNN GPU/NPU.

#### Component-level summary

| Artifact | Architecture coverage | Mapping | Actionable EP findings |
|---|---|---|---|
| fp32 | 12x causal text Transformer; 12x ViT-B/16 image Transformer; patch/text fusion; class, objectness, and box heads | **1007 mapped, 0 partial, 0 unmapped**; confidence `mapped` | TensorRT RTX and OpenVINO CPU/GPU/NPU unknown: Cast, Einsum, Sqrt. QNN GPU/NPU partial: Add, Div, Erf, Mul; unknown: Cast, Einsum, Sqrt; none unsupported. |
| fp16 | same regions | **1012 mapped, 0 partial, 0 unmapped**; confidence `mapped` | TensorRT RTX and OpenVINO CPU/GPU/NPU unknown: Cast, Einsum, Sqrt. QNN GPU/NPU partial: Add, Div, Erf, Expand, Mul; unknown: Cast, Einsum, Sqrt; none unsupported. |

#### Op-level summary

| Artifact | Graph | Dominant operators | EP roll-up |
|---|---|---|---|
| fp32 | **1007 operators / 27 types** | Reshape 235; Add 231; MatMul 199; Transpose 121; Mul 81; LayerNormalization 52; Sigmoid 25; Softmax 24 | TensorRT RTX/OpenVINO/QNN findings as above; no fully-supported EP group established by the rules. |
| fp16 | **1012 operators / 27 types** | Reshape 235; Add 231; MatMul 199; Transpose 121; Mul 81; LayerNormalization 52; Sigmoid 25; Softmax 24 | TensorRT RTX/OpenVINO/QNN findings as above; no fully-supported EP group established by the rules. |

Rule-less results for CPUExecutionProvider/CPU, CUDAExecutionProvider/GPU, DmlExecutionProvider/GPU, MIGraphXExecutionProvider/GPU, and VitisAIExecutionProvider/NPU classify all operator types as unknown.

### Reproduce commands

The checkpoint and dataset are pinned below. The exact Hub revision is first materialized into `$SNAPSHOT` with `huggingface_hub.snapshot_download`; every WinML checkpoint load, processor load, and PyTorch reference then consumes that local snapshot. `$INPUTS` is a named semantic NPZ generated from a constant 960×960 RGB image and the text query `a photo of a cat`; this preserves the validation surface used for perf and parity.

```powershell
$MODEL_ID = 'google/owlv2-base-patch16-finetuned'
$REV = 'd69b086b07123308a4e198343ab2824e1af7774a'
$OUT = 'artifacts/google_owlv2-base-patch16-finetuned-repro'
$SNAPSHOT = Join-Path $OUT 'checkpoint_snapshot'
$INPUTS = Join-Path $OUT 'semantic_inputs.npz'
New-Item -ItemType Directory -Force $OUT | Out-Null

winml --version
git rev-parse HEAD
python -c "from huggingface_hub import snapshot_download; snapshot_download(repo_id='$MODEL_ID', revision='$REV', local_dir=r'$SNAPSHOT')"
python -c "from pathlib import Path; import numpy as np; from PIL import Image; from transformers import AutoProcessor; out=Path(r'$INPUTS'); p=AutoProcessor.from_pretrained(r'$SNAPSHOT', use_fast=False); x=p(text=[['a photo of a cat']], images=Image.new('RGB',(960,960),(127,127,127)), return_tensors='np'); np.savez(out, input_ids=x['input_ids'].astype(np.int32), pixel_values=x['pixel_values'].astype(np.float32), attention_mask=x['attention_mask'].astype(np.int32))"

# Recipe-free baseline/acceptance: proves the shared exporter fix is not recipe-dependent.
winml build -m $SNAPSHOT -o $OUT/recipe-free --ep cpu --device cpu --no-analyze --no-optimize --no-quant --no-compile --rebuild --no-color

winml build -c examples/recipes/google_owlv2-base-patch16-finetuned/cpu/cpu/zero-shot-object-detection_fp32_config.json -m $SNAPSHOT -o $OUT/fp32 --ep cpu --device cpu -p fp32 --no-analyze --no-compile --rebuild --no-color
winml build -c examples/recipes/google_owlv2-base-patch16-finetuned/cpu/cpu/zero-shot-object-detection_fp16_config.json -m $SNAPSHOT -o $OUT/fp16 --ep cpu --device cpu -p fp16 --no-analyze --no-compile --rebuild --no-color
winml perf -m $OUT/fp32/model.onnx --ep cpu --device cpu --precision fp32 --input-data $INPUTS --iterations 3 --warmup 1 --memory --output $OUT/perf_fp32.json --overwrite --format json --no-color
winml perf -m $OUT/fp16/model.onnx --ep cpu --device cpu --precision fp16 --input-data $INPUTS --iterations 3 --warmup 1 --memory --output $OUT/perf_fp16.json --overwrite --format json --no-color

$env:SNAPSHOT = $SNAPSHOT
$env:INPUTS = $INPUTS
$env:FP32_ONNX = Join-Path $OUT 'fp32/model.onnx'
$env:FP16_ONNX = Join-Path $OUT 'fp16/model.onnx'
@'
import os
import numpy as np
import onnxruntime as ort
import torch
from transformers import AutoModelForZeroShotObjectDetection

inputs_np = dict(np.load(os.environ['INPUTS']))
model = AutoModelForZeroShotObjectDetection.from_pretrained(os.environ['SNAPSHOT']).eval()
inputs_pt = {name: torch.from_numpy(value) for name, value in inputs_np.items()}
with torch.no_grad():
    reference = model(**inputs_pt)
reference_by_name = {
    'logits': reference.logits.detach().cpu().numpy(),
    'pred_boxes': reference.pred_boxes.detach().cpu().numpy(),
    'text_embeds': reference.text_embeds.detach().cpu().numpy(),
    'image_embeds': reference.image_embeds.detach().cpu().numpy(),
}
for precision, model_path in [('fp32', os.environ['FP32_ONNX']), ('fp16', os.environ['FP16_ONNX'])]:
    session = ort.InferenceSession(model_path, providers=['CPUExecutionProvider'])
    actual = dict(zip([output.name for output in session.get_outputs()], session.run(None, inputs_np)))
    for name, expected in reference_by_name.items():
        observed = actual[name].astype(np.float64).ravel()
        expected = expected.astype(np.float64).ravel()
        cosine = np.dot(observed, expected) / (np.linalg.norm(observed) * np.linalg.norm(expected))
        print(precision, name, 'cosine=', float(cosine), 'max_abs=', float(np.max(np.abs(observed - expected))))
'@ | python -
Remove-Item Env:SNAPSHOT,Env:INPUTS,Env:FP32_ONNX,Env:FP16_ONNX

$RULES_ZIP = Join-Path $OUT 'rules-v0.2.0.zip'
$RULES = Join-Path $OUT 'rules-v0.2.0'
Invoke-WebRequest 'https://github.com/microsoft/winml-cli/releases/download/v0.2.0/rules-v0.2.0.zip' -OutFile $RULES_ZIP -UseBasicParsing
Expand-Archive -Path $RULES_ZIP -DestinationPath $RULES -Force
$env:WINMLCLI_RULES_DIR = (Resolve-Path $RULES).Path
winml analyze --model $OUT/fp32/model.onnx --ep all --device all --htp-metadata $OUT/fp32/export_htp_metadata.json --output $OUT/analyze_fp32.json --overwrite --format json --no-color
winml analyze --model $OUT/fp16/model.onnx --ep all --device all --htp-metadata $OUT/fp16/export_htp_metadata.json --output $OUT/analyze_fp16.json --overwrite --format json --no-color
Remove-Item Env:WINMLCLI_RULES_DIR
winml eval -m $OUT/fp32/model.onnx --model-id $SNAPSHOT --task zero-shot-object-detection --dataset detection-datasets/coco --dataset-revision cf0b22332314a937e9dc8a1957b21725430bb41d --split val --samples 1 --no-shuffle --streaming --ep cpu --device cpu --output $OUT/eval_fp32.json --overwrite --format json --no-color
winml eval -m $OUT/fp16/model.onnx --model-id $SNAPSHOT --task zero-shot-object-detection --dataset detection-datasets/coco --dataset-revision cf0b22332314a937e9dc8a1957b21725430bb41d --split val --samples 1 --no-shuffle --streaming --ep cpu --device cpu --output $OUT/eval_fp16.json --overwrite --format json --no-color
```
