### PR TITLE
recipe(owlvit): add verified CPU fp32 and fp16 support

### DIFF
--- a/examples/recipes/google_owlvit-base-patch16/cpu/cpu/zero-shot-object-detection_fp16_config.json
+++ b/examples/recipes/google_owlvit-base-patch16/cpu/cpu/zero-shot-object-detection_fp16_config.json
@@ -11,57 +11,29 @@
     "hierarchy_tag_format": "full",
     "input_tensors": [
       {
-        "name": "input_ids",
-        "dtype": "int32",
-        "shape": [
-          1,
-          16
-        ],
-        "value_range": [
-          0,
-          49408
-        ]
-      },
-      {
         "name": "pixel_values",
         "dtype": "float32",
-        "shape": [
-          1,
-          3,
-          768,
-          768
-        ],
-        "value_range": [
-          0,
-          1
-        ]
+        "shape": [1, 3, 768, 768],
+        "value_range": [0, 1]
+      },
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [1, 16],
+        "value_range": [0, 49408]
       },
       {
         "name": "attention_mask",
         "dtype": "int32",
-        "shape": [
-          1,
-          16
-        ],
-        "value_range": [
-          0,
-          2
-        ]
+        "shape": [1, 16],
+        "value_range": [0, 2]
       }
     ],
     "output_tensors": [
-      {
-        "name": "logits"
-      },
-      {
-        "name": "pred_boxes"
-      },
-      {
-        "name": "text_embeds"
-      },
-      {
-        "name": "image_embeds"
-      }
+      { "name": "logits" },
+      { "name": "pred_boxes" },
+      { "name": "text_embeds" },
+      { "name": "image_embeds" }
     ]
   },
   "optim": {},

--- a/examples/recipes/google_owlvit-base-patch16/cpu/cpu/zero-shot-object-detection_fp32_config.json
+++ b/examples/recipes/google_owlvit-base-patch16/cpu/cpu/zero-shot-object-detection_fp32_config.json
@@ -1,0 +1,47 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [1, 3, 768, 768],
+        "value_range": [0, 1]
+      },
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [1, 16],
+        "value_range": [0, 49408]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [1, 16],
+        "value_range": [0, 2]
+      }
+    ],
+    "output_tensors": [
+      { "name": "logits" },
+      { "name": "pred_boxes" },
+      { "name": "text_embeds" },
+      { "name": "image_embeds" }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "zero-shot-object-detection",
+    "model_class": "AutoModelForZeroShotObjectDetection",
+    "model_type": "owlvit"
+  }
+}

--- a/examples/recipes/google_owlvit-base-patch16/zero-shot-object-detection_fp16_config.json
+++ b/examples/recipes/google_owlvit-base-patch16/zero-shot-object-detection_fp16_config.json
@@ -1,0 +1,97 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          16
+        ],
+        "value_range": [
+          0,
+          49408
+        ]
+      },
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          768,
+          768
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          16
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      },
+      {
+        "name": "pred_boxes"
+      },
+      {
+        "name": "text_embeds"
+      },
+      {
+        "name": "image_embeds"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "zero-shot-object-detection",
+    "model_id": "google/owlvit-base-patch16",
+    "model_type": "owlvit",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "zero-shot-object-detection",
+    "model_class": "AutoModelForZeroShotObjectDetection",
+    "model_type": "owlvit"
+  }
+}

--- a/src/winml/modelkit/export/htp/exporter.py
+++ b/src/winml/modelkit/export/htp/exporter.py
@@ -20,6 +20,7 @@ Key Features:
 from __future__ import annotations
 
 import contextlib
+import inspect
 import logging
 import sys
 import time
@@ -445,8 +446,12 @@ class HTPExporter:
         output_path = str(Path(output_path).resolve())
         Path(output_path).parent.mkdir(parents=True, exist_ok=True)
 
-        # Input names from config, fallback to inputs dict keys
+        # Input names from config, fallback to inputs dict keys. Keyword inputs
+        # invoke forward() by name, but the TorchScript exporter assigns these
+        # ONNX names positionally to the traced graph inputs. Align names with
+        # forward() order so a config's tensor order cannot swap graph bindings.
         input_names = export_config.get_input_names() or list(inputs.keys())
+        input_names = self._resolve_keyword_input_names(model, inputs, input_names)
 
         # Output names: infer from traced hierarchy, validate against config
         traced_outputs = self._hierarchy_builder.get_outputs() if self._hierarchy_builder else None
@@ -494,6 +499,54 @@ class HTPExporter:
                 torch.onnx.export(model, export_args, output_path, **onnx_kwargs)
             else:
                 torch.onnx.export(model, (), output_path, kwargs=inputs, **onnx_kwargs)
+
+    @staticmethod
+    def _resolve_keyword_input_names(
+        model: nn.Module,
+        inputs: dict[str, torch.Tensor],
+        configured_input_names: list[str],
+    ) -> list[str]:
+        """Return ONNX names in the order produced by keyword tracing.
+
+        ``torch.onnx.export`` invokes the model safely with keyword arguments,
+        then applies ``input_names`` positionally to graph inputs emitted in
+        ``forward`` signature order. Reorder only when every configured,
+        generated input has an unambiguous signature match. Models implementing
+        ``get_export_args`` own a separate positional protocol, so their config
+        order remains authoritative.
+        """
+        if hasattr(model, "get_export_args"):
+            return configured_input_names
+
+        try:
+            parameters = inspect.signature(model.forward).parameters
+        except (TypeError, ValueError):
+            logger.debug(
+                "Could not inspect %s.forward; preserving configured input order.",
+                type(model).__name__,
+            )
+            return configured_input_names
+
+        configured_set = set(configured_input_names)
+        generated_set = set(inputs)
+        forward_input_names = [
+            name for name in parameters if name in configured_set and name in generated_set
+        ]
+        if (
+            len(forward_input_names) == len(configured_input_names)
+            and set(forward_input_names) == configured_set
+        ):
+            return forward_input_names
+
+        logger.debug(
+            "Could not align every configured input for %s.forward; "
+            "preserving configured input order. configured=%s generated=%s forward=%s",
+            type(model).__name__,
+            configured_input_names,
+            list(inputs),
+            list(parameters),
+        )
+        return configured_input_names
 
     @staticmethod
     def _get_optimum_patcher(model: nn.Module, task: str | None) -> Any:

--- a/tests/unit/export/test_pytorch_export.py
+++ b/tests/unit/export/test_pytorch_export.py
@@ -87,10 +87,20 @@ class MismatchedInputOrderModel(nn.Module):
         self.vision_conv = nn.Conv2d(3, 8, kernel_size=3, padding=1)
         self.pool = nn.AdaptiveAvgPool2d(1)
 
-    def forward(self, text_input, pixel_values):
-        text_out = self.text_fc(text_input)
+    def forward(self, input_ids, pixel_values, attention_mask):
+        text_out = self.text_fc(input_ids.float() * attention_mask.float())
         vis_out = self.pool(self.vision_conv(pixel_values)).squeeze(-1).squeeze(-1)
         return text_out + vis_out
+
+
+class PositionalExportOrderModel(nn.Module):
+    """Model whose explicit positional export protocol owns input ordering."""
+
+    def get_export_args(self, inputs):
+        return inputs["narrow"], inputs["wide"]
+
+    def forward(self, wide, narrow):
+        return torch.cat((wide, narrow), dim=1)
 
 
 # =============================================================================
@@ -365,20 +375,21 @@ class TestExportPytorch:
         assert not _all_value_info_have_shape(onnx_model)
 
     def test_mismatched_input_order_exports_successfully(self, tmp_path) -> None:
-        """Export succeeds when InputTensorSpec order differs from forward() param order.
+        """ONNX names bind correctly when specs differ from forward() order.
 
         Regression test for CLIP bug: OnnxConfig listed pixel_values before input_ids,
-        but CLIPModel.forward() expected input_ids first. With positional args this
-        caused 'not enough values to unpack (expected 4, got 2)'. The fix uses
-        kwargs= in torch.onnx.export so name-based binding makes order irrelevant.
+        but a multimodal forward expects text inputs first. Keyword arguments make
+        invocation order-independent; ONNX input names must separately follow the
+        forward signature because torch.onnx.export assigns them positionally.
         """
         model = MismatchedInputOrderModel()
 
-        # Intentionally list pixel_values FIRST — opposite of forward(text_input, pixel_values)
+        # Intentionally list pixel_values FIRST — opposite of forward().
         config = WinMLExportConfig(
             input_tensors=[
                 InputTensorSpec(name="pixel_values", dtype="float32", shape=(1, 3, 8, 8)),
-                InputTensorSpec(name="text_input", dtype="float32", shape=(1, 16)),
+                InputTensorSpec(name="input_ids", dtype="int32", shape=(1, 16)),
+                InputTensorSpec(name="attention_mask", dtype="int32", shape=(1, 16)),
             ],
         )
 
@@ -389,9 +400,37 @@ class TestExportPytorch:
 
         onnx_model = onnx.load(str(tmp_path / "model.onnx"))
         onnx.checker.check_model(onnx_model)
-        input_names = {i.name for i in onnx_model.graph.input}
-        assert "pixel_values" in input_names
-        assert "text_input" in input_names
+        input_bindings = {
+            tensor.name: (
+                onnx.TensorProto.DataType.Name(tensor.type.tensor_type.elem_type),
+                tuple(dim.dim_value for dim in tensor.type.tensor_type.shape.dim),
+            )
+            for tensor in onnx_model.graph.input
+        }
+        assert input_bindings == {
+            "input_ids": ("INT32", (1, 16)),
+            "pixel_values": ("FLOAT", (1, 3, 8, 8)),
+            "attention_mask": ("INT32", (1, 16)),
+        }
+
+    def test_get_export_args_preserves_configured_positional_names(self, tmp_path) -> None:
+        """An explicit get_export_args protocol keeps config order authoritative."""
+        model = PositionalExportOrderModel()
+        config = WinMLExportConfig(
+            input_tensors=[
+                InputTensorSpec(name="narrow", dtype="float32", shape=(1, 3)),
+                InputTensorSpec(name="wide", dtype="float32", shape=(1, 5)),
+            ],
+        )
+
+        export_pytorch(model, tmp_path / "model.onnx", config)
+
+        onnx_model = onnx.load(str(tmp_path / "model.onnx"))
+        input_shapes = {
+            tensor.name: tuple(dim.dim_value for dim in tensor.type.tensor_type.shape.dim)
+            for tensor in onnx_model.graph.input
+        }
+        assert input_shapes == {"narrow": (1, 3), "wide": (1, 5)}
 
 
 class TestStaleExternalDataCleanup:


### PR DESCRIPTION
## Summary

Adds verified CPU support for `google/owlvit-base-patch16` zero-shot object detection in fp32 and fp16, and fixes a class-wide exporter defect that could attach keyword-input ONNX names to the wrong tensor shapes. The contribution is Effort L1 / Outcome L1: shared input-name binding code, focused regressions, and exact nested CPU recipes. Goal L2 passes for both precisions; Goal L3 is CLI-BLOCKED because `winml eval` does not support `zero-shot-object-detection`.

## Model metadata

### What the model does

OWL-ViT performs open-vocabulary object detection: it embeds an image and one or more text queries into a shared representation, then returns a class score and normalized bounding box for each image patch so objects can be localized from natural-language labels not fixed at training time.

- Evidence/confidence: pinned checkpoint revision `4b420debb9c806fc4caf9ecc8efb72208c0db892`, `OwlViTForObjectDetection` in Transformers 4.57.6, and its concrete forward/output contract (`verified`).

### Primary user stories

- A user supplies an image and natural-language object labels to obtain scored bounding boxes locating matching objects without training a closed-set detector for those labels. (`verified` from the pinned model card and concrete Transformers example.)

### Supported tasks

| Task | Support surfaces | Confidence |
|---|---|---|
| `zero-shot-object-detection` | checkpoint, Transformers, Optimum ONNX, WinML | verified |

The checkpoint declares the task; Transformers resolves `OwlViTForObjectDetection` and `OwlViTProcessor`; Optimum registers vendor ONNX support; `winml inspect` resolves `AutoModelForZeroShotObjectDetection`, `OwlViTOnnxConfig`, and the generic WinML inference class.

### Model architecture

`OwlViTForObjectDetection` wraps a CLIP-like dual encoder with 12-layer text and vision Transformers, reshapes 768 × 768 image patches into a 48 × 48 feature map, and applies independent class and box heads to 2,304 patch queries.

```text
OwlViTForObjectDetection
├── OwlViTModel shared multimodal backbone
│   ├── OwlViTTextTransformer: token/position embeddings + encoder blocks x 12 + projection to 512
│   └── OwlViTVisionTransformer: 16 x 16 patch embedding + encoder blocks x 12 + projection to 512
├── Patch feature fusion: vision tokens × broadcast class token + LayerNorm → 48 x 48 x 768
├── OwlViTClassPredictionHead: projected/normalized patch embeddings × text-query embeddings + learned scale/shift
└── OwlViTBoxPredictionHead: MLP box deltas + patch-grid bias + sigmoid
```

- Source/confidence: pinned checkpoint config and concrete Transformers source (`verified`).

## Validation and support evidence

### Baseline

- Current `main`: `5deebd422e95f28fe8fd912ee50ce874710187b3`; WinML CLI `0.2.0`.
- Optimum probe: `owlvit` has vendor tasks `feature-extraction` and `zero-shot-object-detection`; WinML adds no override (`VENDOR-ONLY`).
- Recipe-free CPU build exited 0 and reported `Build complete in 101.6s`; the graph had 1,007 nodes at opset 17.
- The baseline was not semantically correct: ONNX `pixel_values` carried `INT32[1,16]`, while `input_ids` carried `FLOAT[1,3,768,768]`. Export success therefore did not establish valid input binding.
- Baseline perf emitted mean `1620.309 ms`, p50 `1620.510 ms`, `0.62 samples/s`, and RSS delta `1259.54 MB`, then exited with Windows status `-1073741819`; those numbers are runtime-floor evidence only because the graph names were misbound.
- Baseline eval schema exited 2: `Task 'zero-shot-object-detection' is not supported by winml eval`.
- Starting auto-config correctly described the intended tensors but listed `pixel_values` before `input_ids`; keyword invocation was name-safe while ONNX `input_names` remained positional.

### Goal

- **Effort:** L1 — generalized shared exporter binding plus regression tests.
- **Committed Goal ceiling:** L3 — CPU makes L0, L1, and L2 reachable; L3 was attempted.
- **Outcome:** L1 — shared code, tests, and CPU fp32/fp16 recipes.
- Success required semantic named-input structure for both precisions, CPU runtime/perf and memory, named-input PyTorch parity, and either a real task metric or the exact L3 CLI blocker.

### Outcome

- Shipped [fp32 recipe](examples/recipes/google_owlvit-base-patch16/cpu/cpu/zero-shot-object-detection_fp32_config.json), [fp16 recipe](examples/recipes/google_owlvit-base-patch16/cpu/cpu/zero-shot-object-detection_fp16_config.json), shared exporter repair, and focused regressions.
- Highest Goal verdict: **L2 PASS** for fp32 and fp16. **L3 CLI-BLOCKED**; existing feature gap: #1147.
- Coverage: **full** for the chartered CPU tuples; no deferred EP/device/precision tuple.
- Durable OwlViT finding appended separately in `gim-home/ModelKitArtifacts#177` (draft Lane A PR).
- Methodology declaration: **No methodology friction observed.** The current contracts already require the semantic binding, positional-protocol, no-recipe, precision, and blocker checks used here.

### Per-EP/device/precision results — including perf and eval data

#### Goal ladder

| Tier | CPU fp32 | CPU fp16 |
|---|---|---|
| L0 build + structure | PASS — 1,025 nodes, correct named inputs, 417 FLOAT initializers | PASS — 1,030 nodes, correct named inputs, 417 FLOAT16 initializers; external weights 50.0% of fp32 |
| L1 runtime/perf | PASS | PASS |
| L2 PyTorch parity | PASS — minimum cosine `0.999999999996339`; maximum absolute delta `0.0003089905` | PASS — minimum cosine `0.9999972712410103`; maximum absolute delta `0.21773243` |
| L3 task metric | CLI-BLOCKED — task absent from `winml eval` | CLI-BLOCKED — task absent from `winml eval` |

#### Perf

A deterministic named-input CPU harness exited cleanly. `winml perf --memory` independently produced closely matching complete JSON and the memory phases below before a host-native post-result exit `-1073741819`; that abnormal exit is retained rather than hidden.

| EP / device | Precision | Verdict | Mean | p50 | Throughput | RAM Δ | VRAM Δ |
|---|---|---|---:|---:|---:|---:|---:|
| CPUExecutionProvider / cpu | fp32 | PASS | `1831.759 ms` | `1833.853 ms` | `0.546 samples/s` | `+1257.45 MB` | `0 MB` |
| CPUExecutionProvider / cpu | fp16 | PASS | `2324.970 ms` | `2313.103 ms` | `0.430 samples/s` | `+1977.68 MB` | `0 MB` |

The CLI's independent figures were fp32 mean/p50 `1834.173/1886.136 ms`, fp16 mean/p50 `2319.768/2190.031 ms`, and reported model precisions `fp32`/`fp16` respectively.

#### Eval

| EP / device | Precision | Verdict | Dataset / revision / subset | Metric |
|---|---|---|---|---|
| CPUExecutionProvider / cpu | fp32 | CLI-BLOCKED | — | — |
| CPUExecutionProvider / cpu | fp16 | CLI-BLOCKED | — | — |

Exact blocker: `Error: Task 'zero-shot-object-detection' is not supported by winml eval.` The task registry gap is tracked by #1147; no dataset or metric was fabricated.

### Delta

- [src/winml/modelkit/export/htp/exporter.py](src/winml/modelkit/export/htp/exporter.py): `HTPExporter._resolve_keyword_input_names()` orders ONNX names by the complete, unambiguous `inspect.signature(model.forward)` intersection for keyword tracing. It falls back safely for incomplete matches and preserves models with explicit `get_export_args()` positional protocols.
- [tests/unit/export/test_pytorch_export.py](tests/unit/export/test_pytorch_export.py): verifies exact ONNX name → dtype/shape bindings for mismatched config order and preservation of explicit positional order. The complete file passes: `28 passed`.
- Recipe-free acceptance passes: `Build complete in 84.2s`, with `input_ids INT32[1,16]`, `pixel_values FLOAT[1,3,768,768]`, and `attention_mask INT32[1,16]`.
- The fp32 recipe is the effective current auto-config under the required `cpu/cpu` coverage path. The fp16 recipe adds `quant.mode: fp16`; its artifact has 417 FLOAT16 initializers and `304,811,008` external-data bytes versus fp32 `609,623,040`.
- Reducibility matches the charter: the fix is class-wide and signature-derived, with no model ID or `model_type == "owlvit"` branch.
- `examples/recipes/README.md` remains untouched.

### Analyze summary — component level and op level

Static public-rule analysis completed for both artifacts; this is compatibility analysis, not runtime execution.

#### Component-level summary

| Artifact | Architecture coverage | Mapping | Actionable EP findings |
|---|---|---|---|
| fp32 | 12× vision encoder; 12× text encoder; patch fusion; class head; box head | 785 mapped, 240 optimizer helper nodes unmapped; confidence mapped | Class-head `Einsum` and selected `Cast`/`Sqrt` signatures remain unknown in rule-backed data |
| fp16 | same regions | 785 mapped, 245 optimizer helper nodes unmapped; confidence mapped | Same unknown signatures; five additional fp16 `Cast` nodes |

The unmapped nodes are optimizer-generated reshape/fusion helpers that lost semantic scope names; they remain explicit rather than being guessed into components.

#### Op-level summary

| Artifact | Graph | Dominant ops | EP roll-up |
|---|---|---|---|
| fp32 | 1,025 ops / 28 types | Reshape 411; Gemm 150; Transpose 121; Add 79; Mul 77 | NvTensorRTRTX/QNN/OpenVINO: no partial or unsupported types; unknown `Einsum` and selected `Cast`/`Sqrt` signatures |
| fp16 | 1,030 ops / 28 types | Reshape 411; Gemm 150; Transpose 121; Add 79; Mul 77 | same classification; five extra `Cast` nodes |

Rule-less/all-unknown groups: CPU, CUDA, MIGraphX, DML, and VitisAI.

### Reproduce commands

```powershell
$OUT='temp/owlvit-repro'
winml --version
git rev-parse HEAD
winml build -m google/owlvit-base-patch16 -o $OUT/baseline --ep cpu --device cpu --no-analyze --no-optimize --no-quant --no-compile --rebuild --no-color
winml build -c examples/recipes/google_owlvit-base-patch16/cpu/cpu/zero-shot-object-detection_fp32_config.json -m google/owlvit-base-patch16 -o $OUT/fp32 --ep cpu --device cpu --precision fp32 --rebuild --no-color
winml build -c examples/recipes/google_owlvit-base-patch16/cpu/cpu/zero-shot-object-detection_fp16_config.json -m google/owlvit-base-patch16 -o $OUT/fp16 --ep cpu --device cpu --precision fp16 --rebuild --no-color
winml analyze --model $OUT/fp32/model.onnx --ep all --device all --htp-metadata $OUT/fp32/export_htp_metadata.json --output $OUT/analyze-fp32.json --overwrite --no-color
winml perf -m $OUT/fp32/model.onnx --ep cpu --device cpu --precision fp32 --iterations 5 --warmup 1 --memory --no-color
winml perf -m $OUT/fp16/model.onnx --ep cpu --device cpu --precision fp16 --iterations 5 --warmup 1 --memory --no-color
winml eval --schema --task zero-shot-object-detection --no-color
```
