### PR TITLE
feat(inference): support direct ONNX inpainting models

### DIFF
--- a/examples/recipes/opencv_inpainting_lama/cpu/cpu/inpainting_fp16_config.json
+++ b/examples/recipes/opencv_inpainting_lama/cpu/cpu/inpainting_fp16_config.json
@@ -25,5 +25,18 @@
   "compile": null,
   "loader": {
     "task": "inpainting"
+  },
+  "runtime": {
+    "pipeline": "inpainting",
+    "options": {
+      "image_input_name": "image",
+      "mask_input_name": "mask",
+      "output_name": "output",
+      "image_color_order": "bgr",
+      "image_value_range": [0, 1],
+      "mask_semantics": "nonzero-is-hole",
+      "output_color_order": "bgr",
+      "output_value_range": [0, 255]
+    }
   }
 }

--- a/examples/recipes/opencv_inpainting_lama/cpu/cpu/inpainting_fp16_config.json
+++ b/examples/recipes/opencv_inpainting_lama/cpu/cpu/inpainting_fp16_config.json
@@ -1,0 +1,29 @@
+{
+  "skip_optimize": true,
+  "export": null,
+  "optim": {},
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "inpainting"
+  }
+}

--- a/examples/recipes/opencv_inpainting_lama/cpu/cpu/inpainting_fp32_config.json
+++ b/examples/recipes/opencv_inpainting_lama/cpu/cpu/inpainting_fp32_config.json
@@ -1,0 +1,10 @@
+{
+  "skip_optimize": true,
+  "export": null,
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "inpainting"
+  }
+}

--- a/examples/recipes/opencv_inpainting_lama/cpu/cpu/inpainting_fp32_config.json
+++ b/examples/recipes/opencv_inpainting_lama/cpu/cpu/inpainting_fp32_config.json
@@ -6,5 +6,18 @@
   "compile": null,
   "loader": {
     "task": "inpainting"
+  },
+  "runtime": {
+    "pipeline": "inpainting",
+    "options": {
+      "image_input_name": "image",
+      "mask_input_name": "mask",
+      "output_name": "output",
+      "image_color_order": "bgr",
+      "image_value_range": [0, 1],
+      "mask_semantics": "nonzero-is-hole",
+      "output_color_order": "bgr",
+      "output_value_range": [0, 255]
+    }
   }
 }

--- a/src/winml/modelkit/build/common.py
+++ b/src/winml/modelkit/build/common.py
@@ -31,10 +31,12 @@ logger = logging.getLogger(__name__)
 def ensure_pre_quantized_stamped(
     config: WinMLBuildConfig, onnx_path: Path, *, force: bool = False
 ) -> None:
-    """Stamp ``config.skip_optimize`` (and clear ``config.quant``) once.
+    """Stamp ``config.skip_optimize`` and suppress incompatible quantization.
 
-    Sets ``config.skip_optimize = True`` and clears ``config.quant`` if the
-    input ONNX is already quantized.
+    Sets ``config.skip_optimize = True`` when the input ONNX is already
+    quantized. QDQ/QOperator quantization is suppressed, but an explicit FP16
+    conversion is preserved because it converts the graph's remaining float
+    tensors rather than re-quantizing integer weights.
 
     This is the **single defensive detection point** for the library entry
     points (``build_onnx_model``, ``build_hf_model``). When
@@ -50,20 +52,25 @@ def ensure_pre_quantized_stamped(
             ``is_quantized_onnx`` (used to honor the legacy
             ``skip_optimize=True`` kwarg from direct callers).
     """
+
+    def _clear_incompatible_quant() -> None:
+        if config.quant is not None and config.quant.mode != "fp16":
+            config.quant = None
+
     if config.skip_optimize:
-        config.quant = None
+        _clear_incompatible_quant()
         return
     if force:
         config.skip_optimize = True
-        config.quant = None
+        _clear_incompatible_quant()
         return
 
     if is_quantized_onnx(onnx_path):
         config.skip_optimize = True
-        config.quant = None
+        _clear_incompatible_quant()
         logger.info(
             "Pre-quantized model detected (QDQ or QOperator nodes present). "
-            "Skipping optimize + quantize stages."
+            "Skipping graph optimization and incompatible quantization."
         )
 
 

--- a/src/winml/modelkit/build/hf.py
+++ b/src/winml/modelkit/build/hf.py
@@ -399,6 +399,7 @@ def build_hf_model(
         source="hf",
         model_id=model_label,
         task=task,
+        runtime=config.runtime.to_dict() if config.runtime is not None else None,
         cache_key=cache_key,
         config_hash=cache_key.rsplit("_", 1)[-1] if cache_key and "_" in cache_key else None,
         timestamp=datetime.datetime.now(datetime.timezone.utc).isoformat(),

--- a/src/winml/modelkit/build/hf.py
+++ b/src/winml/modelkit/build/hf.py
@@ -254,14 +254,15 @@ def build_hf_model(
     is_pre_quantized = config.skip_optimize
 
     if is_pre_quantized:
-        logger.info("Skipping optimize + quantize stages (config.skip_optimize=True)")
+        logger.info("Skipping optimize stage (config.skip_optimize=True)")
         stages_skipped.append("optimize")
         # Skip the ORT-based graph optimization (no kernel for QOperator
         # ops like ConvInteger on the host EP). The autoconf re-optim/
         # analyze loop is disabled too -- ``run_optimize_analyze_loop``
         # forces ``max_optim_iterations=0`` when ``skip_optimize=True``,
         # so ``_run_analyze_loop`` is not invoked. The model still flows
-        # through later stages (quantize-skip + compile) for validation.
+        # through later stages. In particular, an explicit FP16 conversion
+        # still converts the graph's remaining float tensors before compile.
         current_path, _, analyze_iterations, analyze_unsupported_nodes, analyze_details = (
             run_optimize_analyze_loop(
                 model_path=current_path,
@@ -304,15 +305,14 @@ def build_hf_model(
     # =========================================================================
     # [4] QUANTIZE (optional — config.quant=None means skip)
     # =========================================================================
-    # No defensive ``is_quantized_onnx`` re-check here: when the model is
-    # pre-quantized, ``ensure_pre_quantized_stamped`` has already set
-    # ``config.quant = None`` at stage [3], so this branch naturally
-    # falls through to the ``quant is None`` skip path.
+    # No defensive ``is_quantized_onnx`` re-check here. The stage-[3]
+    # stamping suppresses incompatible integer quantization while preserving
+    # an explicit FP16 conversion of the graph's remaining float tensors.
     quant_result = None
-    if is_pre_quantized:
+    if is_pre_quantized and (config.quant is None or config.quant.mode != "fp16"):
         if "quantize" not in stages_skipped:
             stages_skipped.append("quantize")
-        logger.info("Quantize skipped (pre-quantized model)")
+        logger.info("Quantize skipped (incompatible with pre-quantized model)")
     elif config.quant is not None:
         logger.info("Quantizing model...")
         t0 = time.monotonic()

--- a/src/winml/modelkit/build/onnx.py
+++ b/src/winml/modelkit/build/onnx.py
@@ -165,14 +165,15 @@ def build_onnx_model(
     is_pre_quantized = config.skip_optimize
 
     if is_pre_quantized:
-        logger.info("Skipping optimize + quantize stages (config.skip_optimize=True)")
+        logger.info("Skipping optimize stage (config.skip_optimize=True)")
         stages_skipped.append("optimize")
         # Skip the ORT-based graph optimization (no kernel for QOperator
         # ops like ConvInteger on the host EP). The autoconf re-optim/
         # analyze loop is disabled too -- ``run_optimize_analyze_loop``
         # forces ``max_optim_iterations=0`` when ``skip_optimize=True``,
         # so ``_run_analyze_loop`` is not invoked. The model still flows
-        # through later stages (quantize-skip + compile) for validation.
+        # through later stages. In particular, an explicit FP16 conversion
+        # still converts the graph's remaining float tensors before compile.
         current_path, _, analyze_iters, analyze_unsupported, analyze_details = (
             run_optimize_analyze_loop(
                 model_path=current_path,
@@ -210,16 +211,15 @@ def build_onnx_model(
     # =========================================================================
     # [2] QUANTIZE (optional — config.quant=None means skip)
     # =========================================================================
-    # No defensive ``is_quantized_onnx`` re-check here: when the model is
-    # pre-quantized, ``ensure_pre_quantized_stamped`` has already set
-    # ``config.quant = None`` at stage [1], so this branch naturally
-    # falls through to the ``quant is None`` skip path.
+    # No defensive ``is_quantized_onnx`` re-check here. The stage-[1]
+    # stamping suppresses incompatible integer quantization while preserving
+    # an explicit FP16 conversion of the graph's remaining float tensors.
     quant_result = None
-    if is_pre_quantized:
+    if is_pre_quantized and (config.quant is None or config.quant.mode != "fp16"):
         # Already handled above -- skip quantize for pre-quantized models
         if "quantize" not in stages_skipped:
             stages_skipped.append("quantize")
-        logger.info("Quantize skipped (pre-quantized model)")
+        logger.info("Quantize skipped (incompatible with pre-quantized model)")
     elif config.quant is not None:
         logger.info("Quantizing model...")
         t0 = time.monotonic()

--- a/src/winml/modelkit/build/onnx.py
+++ b/src/winml/modelkit/build/onnx.py
@@ -307,6 +307,8 @@ def build_onnx_model(
         timestamp=datetime.datetime.now(datetime.timezone.utc).isoformat(),
         elapsed_seconds=round(elapsed, 3),
         final_artifact=final_path.name,
+        task=config.loader.task,
+        runtime=config.runtime.to_dict() if config.runtime is not None else None,
         stages=manifest_stages,
         analyze_iterations=analyze_iters,
         analyze_unsupported_node_count=analyze_unsupported,

--- a/src/winml/modelkit/commands/build.py
+++ b/src/winml/modelkit/commands/build.py
@@ -945,8 +945,9 @@ def build(
                 no_compile=no_compile,
             )
             if model:
-                is_single_config = not isinstance(config_or_configs, list)
-                direct_onnx = is_single_config and config_or_configs.export is None
+                direct_onnx = (
+                    not isinstance(config_or_configs, list) and config_or_configs.export is None
+                )
                 source_model_input = resolve_model_input(
                     model,
                     discover_repo_onnx=direct_onnx,
@@ -2237,6 +2238,7 @@ def _build_onnx_pipeline(
         source="onnx",
         model_id=source_model_id,
         task=config.loader.task,
+        runtime=config.runtime.to_dict() if config.runtime is not None else None,
         input_onnx=str(onnx_path),
         final_artifact=final_path.name,
         extras={

--- a/src/winml/modelkit/commands/build.py
+++ b/src/winml/modelkit/commands/build.py
@@ -38,7 +38,7 @@ from ..utils.console import (
     print_stages_header,
 )
 from ..utils.logging import configure_logging
-from ..utils.model_input import ModelInputKind, classify_model_input
+from ..utils.model_input import ModelInputKind, classify_model_input, resolve_model_input
 
 
 if TYPE_CHECKING:
@@ -935,12 +935,7 @@ def build(
         # Hub-hosted ONNX (e.g. ``onnx-community/sam3-tracker-ONNX/onnx/...``)
         # is downloaded once and treated as a local .onnx file thereafter.
         model_input = None
-        if model:
-            model = cli_utils.normalize_model_arg(model)
-            if model:
-                model_input = classify_model_input(model)
-                if model_input.kind is ModelInputKind.INVALID:
-                    raise click.UsageError(model_input.error or f"Invalid model input: {model}")
+        source_model_input = None
 
         # Load or auto-generate config
         if config_file is not None:
@@ -949,6 +944,19 @@ def build(
                 no_quant=not quant,
                 no_compile=no_compile,
             )
+            if model:
+                is_single_config = not isinstance(config_or_configs, list)
+                direct_onnx = is_single_config and config_or_configs.export is None
+                source_model_input = resolve_model_input(
+                    model,
+                    discover_repo_onnx=direct_onnx,
+                )
+                if source_model_input.kind is ModelInputKind.INVALID:
+                    raise click.UsageError(
+                        source_model_input.error or f"Invalid model input: {model}"
+                    )
+                model = source_model_input.local_path or model
+                model_input = classify_model_input(model)
             if export_overrides:
                 from ..config import merge_export_overrides
 
@@ -976,6 +984,12 @@ def build(
         else:
             if not model:
                 raise click.UsageError("-m/--model is required when -c is not provided.")
+            source_model_input = resolve_model_input(model, discover_repo_onnx=True)
+            if source_model_input.kind is ModelInputKind.INVALID:
+                invalid_message = source_model_input.error or f"Invalid model input: {model}"
+                raise click.UsageError(invalid_message)
+            model = source_model_input.local_path or model
+            model_input = classify_model_input(model)
             from ..config import generate_build_config
 
             # When ``model`` resolves to an .onnx file (either a local path or
@@ -1031,7 +1045,11 @@ def build(
                 resolved_quant, _ = resolve_quant_compile_config(
                     device=device, precision=precision, ep=ep
                 )
-                if cfg.skip_optimize or not quant or resolved_quant is None:
+                if (
+                    not quant
+                    or resolved_quant is None
+                    or (cfg.skip_optimize and resolved_quant.mode != "fp16")
+                ):
                     cfg.quant = None
                 elif cfg.quant is None:
                     # Populate calibration identifiers from the loader/model
@@ -1103,6 +1121,12 @@ def build(
         # on the key being present, matching the module-mode path which passes
         # allow_unsupported_nodes explicitly regardless of its value.
         extra_kwargs["allow_unsupported_nodes"] = allow_unsupported_nodes
+        source_kind = source_model_input.kind if source_model_input is not None else None
+        if source_kind is ModelInputKind.HUB_ONNX:
+            assert source_model_input is not None
+            extra_kwargs["source_model_id"] = source_model_input.hf_id
+            extra_kwargs["source_onnx_file"] = source_model_input.artifact_path
+            extra_kwargs["source_revision"] = source_model_input.revision
 
         # ---- OPTIMIZED (GENAI BUNDLE) EXPORT ----
         # ``--export-type optimized`` builds the family's registered
@@ -1779,7 +1803,7 @@ def _run_quantize_stage(
     from ..quant import quantize_onnx
     from ..utils.console import StageLive
 
-    if config.skip_optimize:
+    if config.skip_optimize and (config.quant is None or config.quant.mode != "fp16"):
         config.quant = None
         return current_path
 
@@ -2116,6 +2140,9 @@ def _build_onnx_pipeline(
 
     max_iters: int = extra_kwargs.pop("hack_max_optim_iterations", 3)
     allow_unsupported_nodes: bool = extra_kwargs.pop("allow_unsupported_nodes", False)
+    source_model_id: str | None = extra_kwargs.pop("source_model_id", None)
+    source_onnx_file: str | None = extra_kwargs.pop("source_onnx_file", None)
+    source_revision: str | None = extra_kwargs.pop("source_revision", None)
 
     # ── Validate + setup ─────────────────────────────────────────
     if not onnx_path.exists():
@@ -2203,5 +2230,24 @@ def _build_onnx_pipeline(
     # ── Finalize ─────────────────────────────────────────────────
     if current_path != final_path:
         copy_onnx_model(current_path, final_path)
+
+    from ..utils import MANIFEST_FILENAME, WinMLManifest
+
+    manifest = WinMLManifest(
+        source="onnx",
+        model_id=source_model_id,
+        task=config.loader.task,
+        input_onnx=str(onnx_path),
+        final_artifact=final_path.name,
+        extras={
+            key: value
+            for key, value in {
+                "hub_onnx_file": source_onnx_file,
+                "hub_revision": source_revision,
+            }.items()
+            if value is not None
+        },
+    )
+    manifest.save(output_dir / MANIFEST_FILENAME)
 
     return stage_timings

--- a/src/winml/modelkit/config/__init__.py
+++ b/src/winml/modelkit/config/__init__.py
@@ -26,6 +26,7 @@ from ..utils.config_utils import merge_config
 from .build import (
     SubmoduleClassNotFoundError,
     WinMLBuildConfig,
+    WinMLRuntimeConfig,
     generate_build_config,
     generate_hf_build_config,
     generate_onnx_build_config,
@@ -48,6 +49,7 @@ __all__ = [
     "PrecisionPolicy",
     "SubmoduleClassNotFoundError",
     "WinMLBuildConfig",
+    "WinMLRuntimeConfig",
     "expand_precision",
     "extract_activation_bits",
     "extract_weight_bits",

--- a/src/winml/modelkit/config/build.py
+++ b/src/winml/modelkit/config/build.py
@@ -459,10 +459,15 @@ def generate_onnx_build_config(
         )
 
         if is_quantized_onnx(onnx_path_resolved):
-            # Skip optimize+quantize, compile with resolved policy.
+            # Skip graph optimization and incompatible re-quantization, but
+            # preserve explicit FP16 conversion of the graph's float tensors.
             # ``skip_optimize`` is the single source of truth — downstream
             # pipelines must read this flag and not re-detect.
-            config.quant = None
+            config.quant = (
+                resolved_quant
+                if resolved_quant is not None and resolved_quant.mode == "fp16"
+                else None
+            )
             config.skip_optimize = True
             config.compile = resolved_compile
             logger.info("Quantized model (QDQ) detected")

--- a/src/winml/modelkit/config/build.py
+++ b/src/winml/modelkit/config/build.py
@@ -81,6 +81,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "WinMLBuildConfig",
+    "WinMLRuntimeConfig",
     "generate_build_config",
     "generate_hf_build_config",
     "generate_onnx_build_config",
@@ -93,6 +94,38 @@ logger = logging.getLogger(__name__)
 # =============================================================================
 # WINML BUILD CONFIG DATACLASS
 # =============================================================================
+
+
+@dataclass
+class WinMLRuntimeConfig:
+    """Runtime adapter selection and task-specific options.
+
+    The build system persists this data unchanged into the artifact manifest.
+    Runtime adapters own validation of their option schema, which keeps this
+    plumbing reusable without introducing model- or task-specific branches.
+    """
+
+    pipeline: str
+    options: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> WinMLRuntimeConfig:
+        """Create runtime configuration from a recipe dictionary."""
+        return cls(
+            pipeline=data.get("pipeline", ""),
+            options=dict(data.get("options", {})),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert runtime configuration to a JSON-safe dictionary."""
+        return {"pipeline": self.pipeline, "options": copy.deepcopy(self.options)}
+
+    def validate(self) -> None:
+        """Validate the generic runtime envelope."""
+        if not self.pipeline.strip():
+            raise ValueError("runtime.pipeline must be a non-empty string")
+        if not isinstance(self.options, dict):
+            raise TypeError("runtime.options must be an object")
 
 
 @dataclass
@@ -137,6 +170,7 @@ class WinMLBuildConfig:
     quant: WinMLQuantizationConfig | None = field(default_factory=WinMLQuantizationConfig)
     compile: WinMLCompileConfig | None = field(default_factory=WinMLCompileConfig)
     eval: WinMLEvaluationConfig | None = None
+    runtime: WinMLRuntimeConfig | None = None
     auto: bool = True
     # Stamped True by generate_*_build_config (or by the build_*_model
     # entry-point defensive fallback) when the input ONNX is already
@@ -164,6 +198,7 @@ class WinMLBuildConfig:
         quant_data = config_dict.get("quant")
         compile_data = config_dict.get("compile")
         eval_data = config_dict.get("eval")
+        runtime_data = config_dict.get("runtime")
         eval_cfg = None
         if eval_data is not None:
             eval_cfg = WinMLEvaluationConfig.from_dict(eval_data)
@@ -178,6 +213,9 @@ class WinMLBuildConfig:
                 WinMLCompileConfig.from_dict(compile_data) if compile_data is not None else None
             ),
             eval=eval_cfg,
+            runtime=(
+                WinMLRuntimeConfig.from_dict(runtime_data) if runtime_data is not None else None
+            ),
             auto=config_dict.get("auto", True),
             skip_optimize=config_dict.get("skip_optimize", False),
         )
@@ -203,6 +241,8 @@ class WinMLBuildConfig:
             result["loader"] = loader_dict
         if self.eval is not None:
             result["eval"] = self.eval.to_dict()
+        if self.runtime is not None:
+            result["runtime"] = self.runtime.to_dict()
         return result
 
     def validate(self) -> None:
@@ -253,6 +293,12 @@ class WinMLBuildConfig:
             not self.compile.ep_config or not self.compile.ep_config.provider
         ):
             errors.append("compile.ep_config.provider is required when compile is enabled")
+
+        if self.runtime is not None:
+            try:
+                self.runtime.validate()
+            except (TypeError, ValueError) as exc:
+                errors.append(str(exc))
 
         if errors:
             raise ValueError("Invalid WinMLBuildConfig:\n" + "\n".join(f"  - {e}" for e in errors))

--- a/src/winml/modelkit/inference/engine.py
+++ b/src/winml/modelkit/inference/engine.py
@@ -323,8 +323,7 @@ class InferenceEngine:
                 no effect on raw .onnx files or pre-built build directories
                 (no build/analyze step runs in those paths).
         """
-        # Hub-hosted ONNX (e.g. ``onnx-community/sam3-tracker-ONNX/onnx/...``)
-        # is downloaded once and treated as a local .onnx path thereafter.
+        # Hub-hosted ONNX is downloaded once and treated as a local path.
         from ..utils.model_input import resolve_model_input
 
         model_path = resolve_model_input(
@@ -406,13 +405,15 @@ class InferenceEngine:
         Falls back to ``load()`` only when the task cannot be determined
         without a full model load.
         """
-        # Hub-hosted ONNX (e.g. ``onnx-community/sam3-tracker-ONNX/onnx/...``)
-        # is downloaded once and treated as a local .onnx path thereafter.
-        from ..utils.model_input import resolve_model_input
+        # An explicit task is sufficient to display its schema. Do not run
+        # optional bare-repository discovery here: a single-ONNX repository
+        # discovery downloads model weights, violating schema-only's contract.
+        if task is None:
+            from ..utils.model_input import resolve_model_input
 
-        model_path = resolve_model_input(
-            str(model_path), discover_repo_onnx=True
-        ).local_path or str(model_path)
+            model_path = resolve_model_input(
+                str(model_path), discover_repo_onnx=True
+            ).local_path or str(model_path)
 
         self._model_path = str(model_path)
         self._device = device
@@ -971,7 +972,8 @@ class InferenceEngine:
         from ..models.winml import get_winml_class
 
         winml_class = get_winml_class(None, task or "")
-        self._model = winml_class(onnx_path=onnx_path, config=None, device=device)
+        self._model = winml_class(onnx_path=onnx_path, config=None, device=device, ep=ep)
+        self._model._runtime_config = manifest.get("runtime") if manifest is not None else None
         self._task = task or getattr(self._model, "task", None)
 
         if model_id:

--- a/src/winml/modelkit/inference/engine.py
+++ b/src/winml/modelkit/inference/engine.py
@@ -327,7 +327,9 @@ class InferenceEngine:
         # is downloaded once and treated as a local .onnx path thereafter.
         from ..utils.model_input import resolve_model_input
 
-        model_path = resolve_model_input(str(model_path)).local_path or str(model_path)
+        model_path = resolve_model_input(
+            str(model_path), discover_repo_onnx=True
+        ).local_path or str(model_path)
 
         self._model_path = str(model_path)
         self._ep = ep
@@ -408,7 +410,9 @@ class InferenceEngine:
         # is downloaded once and treated as a local .onnx path thereafter.
         from ..utils.model_input import resolve_model_input
 
-        model_path = resolve_model_input(str(model_path)).local_path or str(model_path)
+        model_path = resolve_model_input(
+            str(model_path), discover_repo_onnx=True
+        ).local_path or str(model_path)
 
         self._model_path = str(model_path)
         self._device = device

--- a/src/winml/modelkit/inference/inpainting.py
+++ b/src/winml/modelkit/inference/inpainting.py
@@ -20,6 +20,13 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class _InpaintingContract:
+    """Model-side ONNX tensor contract for the inpainting adapter.
+
+    Caller masks use the public canonical convention where nonzero pixels are
+    holes. ``mask_semantics`` declares how those same holes are encoded in the
+    model's ONNX mask input.
+    """
+
     image_input_name: str
     mask_input_name: str
     output_name: str
@@ -81,7 +88,8 @@ class _InpaintingContract:
         mask_semantics = options["mask_semantics"]
         if mask_semantics not in {"nonzero-is-hole", "zero-is-hole"}:
             raise ValueError(
-                "Inpainting mask_semantics must be 'nonzero-is-hole' or 'zero-is-hole'."
+                "Inpainting mask_semantics describes the model-side ONNX mask tensor and "
+                "must be 'nonzero-is-hole' or 'zero-is-hole'."
             )
         for name in ("image_input_name", "mask_input_name", "output_name"):
             if not isinstance(options[name], str) or not options[name].strip():
@@ -102,9 +110,11 @@ class _InpaintingContract:
 class WinMLInpaintingPipeline:
     """Prepare an image/mask pair and postprocess a direct ONNX result.
 
-    Tensor roles, color order, value ranges, mask polarity, and output semantics
-    come from a checked build/runtime contract. ONNX shape metadata is used only
-    to validate that explicit contract and determine spatial dimensions.
+    The public mask input always uses nonzero pixels for holes. Tensor roles,
+    color order, value ranges, model-side ONNX mask polarity, and output
+    semantics come from a checked build/runtime contract. ONNX shape metadata
+    is used only to validate that explicit contract and determine spatial
+    dimensions.
     """
 
     def __init__(
@@ -177,6 +187,7 @@ class WinMLInpaintingPipeline:
         return np.ascontiguousarray(pixels.transpose(2, 0, 1)[None, ...])
 
     def _prepare_mask(self, mask: Image.Image, size: tuple[int, int]) -> np.ndarray:
+        """Convert a canonical nonzero-is-hole caller mask to the ONNX contract."""
         grayscale = np.asarray(mask.convert("L").resize(size, Image.Resampling.NEAREST))
         binary = (grayscale > 0).astype(np.float32)
         if self._contract.mask_semantics == "zero-is-hole":

--- a/src/winml/modelkit/inference/inpainting.py
+++ b/src/winml/modelkit/inference/inpainting.py
@@ -1,0 +1,146 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Pipeline adapter for direct-ONNX image-inpainting models."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import torch
+from PIL import Image
+
+
+if TYPE_CHECKING:
+    from ..models.winml.base import WinMLPreTrainedModel
+
+
+class WinMLInpaintingPipeline:
+    """Prepare an image/mask pair and postprocess a direct ONNX result.
+
+    The adapter derives spatial sizes and tensor roles from ONNX metadata. It
+    implements the OpenCV inpainting interchange contract: float32 NCHW BGR
+    image values in ``[0, 1]`` and a float32 NCHW binary mask. The first
+    three-channel output is converted back to an RGB PIL image.
+    """
+
+    def __init__(self, model: WinMLPreTrainedModel) -> None:
+        self.model = model
+        self._inputs, self._output_name = self._resolve_contract(model.io_config)
+
+    def _sanitize_parameters(self, **_kwargs: Any) -> tuple[dict, dict, dict]:
+        """Expose the standard pipeline parameter-discovery contract."""
+        return {}, {}, {}
+
+    @staticmethod
+    def _resolve_contract(
+        io_config: dict[str, Any],
+    ) -> tuple[dict[str, tuple[str, list[Any]]], str]:
+        names = list(io_config.get("input_names", []))
+        shapes = list(io_config.get("input_shapes", []))
+        output_names = list(io_config.get("output_names", []))
+        output_shapes = list(io_config.get("output_shapes", []))
+        try:
+            entries = list(zip(names, shapes, strict=True))
+            outputs = list(zip(output_names, output_shapes, strict=True))
+        except ValueError as exc:
+            raise ValueError("Inpainting ONNX I/O metadata is incomplete.") from exc
+
+        def _pick(preferred_name: str, channels: int) -> tuple[str, list[Any]] | None:
+            by_name = next((entry for entry in entries if entry[0].lower() == preferred_name), None)
+            if by_name is not None and len(by_name[1]) == 4 and by_name[1][1] == channels:
+                return by_name
+            return next(
+                (entry for entry in entries if len(entry[1]) == 4 and entry[1][1] == channels),
+                None,
+            )
+
+        image = _pick("image", 3)
+        mask = _pick("mask", 1)
+        if image is None or mask is None or image[0] == mask[0]:
+            raise ValueError(
+                "Inpainting requires distinct 4-D image (3-channel) and mask "
+                "(1-channel) ONNX inputs."
+            )
+        image_size = WinMLInpaintingPipeline._spatial_size(image[1], "image")
+        mask_size = WinMLInpaintingPipeline._spatial_size(mask[1], "mask")
+        if image_size != mask_size:
+            raise ValueError("Inpainting image and mask inputs must have the same spatial size.")
+
+        output = next(
+            (
+                entry
+                for entry in outputs
+                if entry[0].lower() in {"output", "image", "images"}
+                and len(entry[1]) == 4
+                and entry[1][1] == 3
+            ),
+            None,
+        )
+        if output is None:
+            output = next(
+                (entry for entry in outputs if len(entry[1]) == 4 and entry[1][1] == 3),
+                None,
+            )
+        if output is None:
+            raise ValueError("Inpainting requires a 4-D 3-channel ONNX image output.")
+        output_size = WinMLInpaintingPipeline._spatial_size(output[1], "output")
+        if output_size != image_size:
+            raise ValueError("Inpainting output must match the image input spatial size.")
+
+        return {"image": image, "mask": mask}, output[0]
+
+    @staticmethod
+    def _spatial_size(shape: list[Any], role: str) -> tuple[int, int]:
+        if len(shape) != 4 or not isinstance(shape[2], int) or not isinstance(shape[3], int):
+            raise ValueError(f"Inpainting {role} input requires fixed NCHW height and width.")
+        return shape[3], shape[2]
+
+    @staticmethod
+    def _prepare_image(image: Image.Image, size: tuple[int, int]) -> np.ndarray:
+        rgb = np.asarray(image.convert("RGB").resize(size, Image.Resampling.BILINEAR))
+        bgr = rgb[..., ::-1].astype(np.float32) / 255.0
+        return np.ascontiguousarray(bgr.transpose(2, 0, 1)[None, ...])
+
+    @staticmethod
+    def _prepare_mask(mask: Image.Image, size: tuple[int, int]) -> np.ndarray:
+        grayscale = np.asarray(mask.convert("L").resize(size, Image.Resampling.NEAREST))
+        binary = (grayscale > 0).astype(np.float32)
+        return binary[None, None, ...]
+
+    @staticmethod
+    def _to_image(output: Any) -> Image.Image:
+        if isinstance(output, torch.Tensor):
+            array = output.detach().cpu().numpy()
+        else:
+            array = np.asarray(output)
+        if array.ndim != 4 or array.shape[0] != 1 or array.shape[1] != 3:
+            raise ValueError(
+                f"Inpainting output must have shape [1, 3, height, width], got {list(array.shape)}."
+            )
+        image = array[0].transpose(1, 2, 0)
+        if image.size and float(np.nanmax(image)) <= 1.0:
+            image = image * 255.0
+        rgb = np.clip(image[..., ::-1], 0, 255).astype(np.uint8)
+        return Image.fromarray(rgb, mode="RGB")
+
+    def __call__(self, inputs: dict[str, Image.Image], **_kwargs: Any) -> Image.Image:
+        """Run inpainting for a decoded ``{"image": ..., "mask": ...}`` input."""
+        image_name, image_shape = self._inputs["image"]
+        mask_name, mask_shape = self._inputs["mask"]
+        model_inputs = {
+            image_name: self._prepare_image(
+                inputs["image"], self._spatial_size(image_shape, "image")
+            ),
+            mask_name: self._prepare_mask(inputs["mask"], self._spatial_size(mask_shape, "mask")),
+        }
+        outputs = self.model(**model_inputs)
+        if not isinstance(outputs, dict) or not outputs:
+            raise ValueError("Inpainting model returned no named ONNX outputs.")
+        if self._output_name not in outputs:
+            raise ValueError(
+                f"Inpainting model did not return expected ONNX output '{self._output_name}'."
+            )
+        return self._to_image(outputs[self._output_name])

--- a/src/winml/modelkit/inference/inpainting.py
+++ b/src/winml/modelkit/inference/inpainting.py
@@ -2,10 +2,11 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
-"""Pipeline adapter for direct-ONNX image-inpainting models."""
+"""Data-driven pipeline adapter for direct-ONNX image-inpainting models."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -17,26 +18,113 @@ if TYPE_CHECKING:
     from ..models.winml.base import WinMLPreTrainedModel
 
 
+@dataclass(frozen=True)
+class _InpaintingContract:
+    image_input_name: str
+    mask_input_name: str
+    output_name: str
+    image_color_order: str
+    image_value_range: tuple[float, float]
+    mask_semantics: str
+    output_color_order: str
+    output_value_range: tuple[float, float]
+
+    @classmethod
+    def from_runtime_config(cls, runtime_config: dict[str, Any] | None) -> _InpaintingContract:
+        """Validate and materialize the explicit runtime contract."""
+        if not isinstance(runtime_config, dict) or runtime_config.get("pipeline") != "inpainting":
+            raise ValueError(
+                "Inpainting requires runtime.pipeline='inpainting' and explicit runtime.options."
+            )
+        options = runtime_config.get("options")
+        if not isinstance(options, dict):
+            raise TypeError("Inpainting runtime.options must be an object.")
+
+        required = {
+            "image_input_name",
+            "mask_input_name",
+            "output_name",
+            "image_color_order",
+            "image_value_range",
+            "mask_semantics",
+            "output_color_order",
+            "output_value_range",
+        }
+        missing = sorted(required - options.keys())
+        unknown = sorted(options.keys() - required)
+        if missing or unknown:
+            details = []
+            if missing:
+                details.append(f"missing: {', '.join(missing)}")
+            if unknown:
+                details.append(f"unknown: {', '.join(unknown)}")
+            raise ValueError(f"Invalid inpainting runtime options ({'; '.join(details)}).")
+
+        def _color_order(name: str) -> str:
+            value = options[name]
+            if value not in {"rgb", "bgr"}:
+                raise ValueError(f"Inpainting {name} must be 'rgb' or 'bgr'.")
+            return str(value)
+
+        def _value_range(name: str) -> tuple[float, float]:
+            value = options[name]
+            if not isinstance(value, list) or len(value) != 2:
+                raise ValueError(f"Inpainting {name} must be a two-number array.")
+            result = (float(value[0]), float(value[1]))
+            if result not in {(0.0, 1.0), (-1.0, 1.0), (0.0, 255.0)}:
+                raise ValueError(
+                    f"Unsupported inpainting {name} {value}; supported ranges are "
+                    "[0, 1], [-1, 1], and [0, 255]."
+                )
+            return result
+
+        mask_semantics = options["mask_semantics"]
+        if mask_semantics not in {"nonzero-is-hole", "zero-is-hole"}:
+            raise ValueError(
+                "Inpainting mask_semantics must be 'nonzero-is-hole' or 'zero-is-hole'."
+            )
+        for name in ("image_input_name", "mask_input_name", "output_name"):
+            if not isinstance(options[name], str) or not options[name].strip():
+                raise ValueError(f"Inpainting {name} must be a non-empty string.")
+
+        return cls(
+            image_input_name=options["image_input_name"],
+            mask_input_name=options["mask_input_name"],
+            output_name=options["output_name"],
+            image_color_order=_color_order("image_color_order"),
+            image_value_range=_value_range("image_value_range"),
+            mask_semantics=mask_semantics,
+            output_color_order=_color_order("output_color_order"),
+            output_value_range=_value_range("output_value_range"),
+        )
+
+
 class WinMLInpaintingPipeline:
     """Prepare an image/mask pair and postprocess a direct ONNX result.
 
-    The adapter derives spatial sizes and tensor roles from ONNX metadata. It
-    implements the OpenCV inpainting interchange contract: float32 NCHW BGR
-    image values in ``[0, 1]`` and a float32 NCHW binary mask. The first
-    three-channel output is converted back to an RGB PIL image.
+    Tensor roles, color order, value ranges, mask polarity, and output semantics
+    come from a checked build/runtime contract. ONNX shape metadata is used only
+    to validate that explicit contract and determine spatial dimensions.
     """
 
-    def __init__(self, model: WinMLPreTrainedModel) -> None:
+    def __init__(
+        self,
+        model: WinMLPreTrainedModel,
+        *,
+        runtime_config: dict[str, Any] | None,
+    ) -> None:
         self.model = model
-        self._inputs, self._output_name = self._resolve_contract(model.io_config)
+        self._contract = _InpaintingContract.from_runtime_config(runtime_config)
+        self._inputs, self._output_name = self._resolve_io(model.io_config, self._contract)
 
     def _sanitize_parameters(self, **_kwargs: Any) -> tuple[dict, dict, dict]:
         """Expose the standard pipeline parameter-discovery contract."""
         return {}, {}, {}
 
     @staticmethod
-    def _resolve_contract(
+    def _resolve_io(
         io_config: dict[str, Any],
+        contract: _InpaintingContract,
     ) -> tuple[dict[str, tuple[str, list[Any]]], str]:
         names = list(io_config.get("input_names", []))
         shapes = list(io_config.get("input_shapes", []))
@@ -48,44 +136,27 @@ class WinMLInpaintingPipeline:
         except ValueError as exc:
             raise ValueError("Inpainting ONNX I/O metadata is incomplete.") from exc
 
-        def _pick(preferred_name: str, channels: int) -> tuple[str, list[Any]] | None:
-            by_name = next((entry for entry in entries if entry[0].lower() == preferred_name), None)
-            if by_name is not None and len(by_name[1]) == 4 and by_name[1][1] == channels:
-                return by_name
-            return next(
-                (entry for entry in entries if len(entry[1]) == 4 and entry[1][1] == channels),
-                None,
-            )
-
-        image = _pick("image", 3)
-        mask = _pick("mask", 1)
+        image = next((entry for entry in entries if entry[0] == contract.image_input_name), None)
+        mask = next((entry for entry in entries if entry[0] == contract.mask_input_name), None)
         if image is None or mask is None or image[0] == mask[0]:
             raise ValueError(
-                "Inpainting requires distinct 4-D image (3-channel) and mask "
-                "(1-channel) ONNX inputs."
+                "The inpainting runtime contract names inputs that are absent or not distinct."
+            )
+        if len(image[1]) != 4 or image[1][1] != 3 or len(mask[1]) != 4 or mask[1][1] != 1:
+            raise ValueError(
+                "Inpainting contract inputs must identify a 4-D 3-channel image and "
+                "a 4-D 1-channel mask."
             )
         image_size = WinMLInpaintingPipeline._spatial_size(image[1], "image")
         mask_size = WinMLInpaintingPipeline._spatial_size(mask[1], "mask")
         if image_size != mask_size:
             raise ValueError("Inpainting image and mask inputs must have the same spatial size.")
 
-        output = next(
-            (
-                entry
-                for entry in outputs
-                if entry[0].lower() in {"output", "image", "images"}
-                and len(entry[1]) == 4
-                and entry[1][1] == 3
-            ),
-            None,
-        )
-        if output is None:
-            output = next(
-                (entry for entry in outputs if len(entry[1]) == 4 and entry[1][1] == 3),
-                None,
+        output = next((entry for entry in outputs if entry[0] == contract.output_name), None)
+        if output is None or len(output[1]) != 4 or output[1][1] != 3:
+            raise ValueError(
+                "The inpainting runtime contract must identify a 4-D 3-channel ONNX output."
             )
-        if output is None:
-            raise ValueError("Inpainting requires a 4-D 3-channel ONNX image output.")
         output_size = WinMLInpaintingPipeline._spatial_size(output[1], "output")
         if output_size != image_size:
             raise ValueError("Inpainting output must match the image input spatial size.")
@@ -98,20 +169,21 @@ class WinMLInpaintingPipeline:
             raise ValueError(f"Inpainting {role} input requires fixed NCHW height and width.")
         return shape[3], shape[2]
 
-    @staticmethod
-    def _prepare_image(image: Image.Image, size: tuple[int, int]) -> np.ndarray:
+    def _prepare_image(self, image: Image.Image, size: tuple[int, int]) -> np.ndarray:
         rgb = np.asarray(image.convert("RGB").resize(size, Image.Resampling.BILINEAR))
-        bgr = rgb[..., ::-1].astype(np.float32) / 255.0
-        return np.ascontiguousarray(bgr.transpose(2, 0, 1)[None, ...])
+        pixels = rgb[..., ::-1] if self._contract.image_color_order == "bgr" else rgb
+        low, high = self._contract.image_value_range
+        pixels = pixels.astype(np.float32) / 255.0 * (high - low) + low
+        return np.ascontiguousarray(pixels.transpose(2, 0, 1)[None, ...])
 
-    @staticmethod
-    def _prepare_mask(mask: Image.Image, size: tuple[int, int]) -> np.ndarray:
+    def _prepare_mask(self, mask: Image.Image, size: tuple[int, int]) -> np.ndarray:
         grayscale = np.asarray(mask.convert("L").resize(size, Image.Resampling.NEAREST))
         binary = (grayscale > 0).astype(np.float32)
+        if self._contract.mask_semantics == "zero-is-hole":
+            binary = 1.0 - binary
         return binary[None, None, ...]
 
-    @staticmethod
-    def _to_image(output: Any) -> Image.Image:
+    def _to_image(self, output: Any) -> Image.Image:
         if isinstance(output, torch.Tensor):
             array = output.detach().cpu().numpy()
         else:
@@ -121,9 +193,11 @@ class WinMLInpaintingPipeline:
                 f"Inpainting output must have shape [1, 3, height, width], got {list(array.shape)}."
             )
         image = array[0].transpose(1, 2, 0)
-        if image.size and float(np.nanmax(image)) <= 1.0:
-            image = image * 255.0
-        rgb = np.clip(image[..., ::-1], 0, 255).astype(np.uint8)
+        low, high = self._contract.output_value_range
+        image = (image - low) / (high - low) * 255.0
+        if self._contract.output_color_order == "bgr":
+            image = image[..., ::-1]
+        rgb = np.clip(image, 0, 255).astype(np.uint8)
         return Image.fromarray(rgb, mode="RGB")
 
     def __call__(self, inputs: dict[str, Image.Image], **_kwargs: Any) -> Image.Image:

--- a/src/winml/modelkit/inference/pipeline.py
+++ b/src/winml/modelkit/inference/pipeline.py
@@ -38,6 +38,18 @@ _HF_PIPELINE_TASK_MAP: dict[str, str] = {
 }
 
 
+def _create_inpainting_pipeline(model: WinMLPreTrainedModel) -> Any:
+    """Create the built-in direct-ONNX inpainting adapter."""
+    from .inpainting import WinMLInpaintingPipeline
+
+    return WinMLInpaintingPipeline(model)
+
+
+_CUSTOM_PIPELINE_FACTORIES = {
+    "inpainting": _create_inpainting_pipeline,
+}
+
+
 def create_pipeline(
     task: str,
     model: WinMLPreTrainedModel | WinMLCompositeModel,
@@ -57,6 +69,12 @@ def create_pipeline(
     Returns:
         A configured ``transformers.Pipeline`` ready for inference.
     """
+    custom_factory = _CUSTOM_PIPELINE_FACTORIES.get(task)
+    if custom_factory is not None:
+        pipe = custom_factory(model)
+        logger.info("Created WinML pipeline: task=%s model=%s", task, model_id)
+        return pipe
+
     from transformers import pipeline
 
     kwargs: dict[str, Any] = {

--- a/src/winml/modelkit/inference/pipeline.py
+++ b/src/winml/modelkit/inference/pipeline.py
@@ -38,11 +38,17 @@ _HF_PIPELINE_TASK_MAP: dict[str, str] = {
 }
 
 
-def _create_inpainting_pipeline(model: WinMLPreTrainedModel) -> Any:
+def _create_inpainting_pipeline(
+    model: WinMLPreTrainedModel | WinMLCompositeModel,
+) -> Any:
     """Create the built-in direct-ONNX inpainting adapter."""
+    from ..models.winml.base import WinMLPreTrainedModel
     from .inpainting import WinMLInpaintingPipeline
 
-    return WinMLInpaintingPipeline(model)
+    if not isinstance(model, WinMLPreTrainedModel):
+        raise TypeError("The inpainting runtime pipeline requires a single ONNX model.")
+
+    return WinMLInpaintingPipeline(model, runtime_config=model.runtime_config)
 
 
 _CUSTOM_PIPELINE_FACTORIES = {

--- a/src/winml/modelkit/inference/tasks.py
+++ b/src/winml/modelkit/inference/tasks.py
@@ -150,6 +150,16 @@ def _encode_mask_png(mask: Any) -> str:
     return base64.b64encode(buf.getvalue()).decode("ascii")
 
 
+def _postprocess_inpainting(raw: Any, **_kwargs: Any) -> dict[str, Any]:
+    """Encode an inpainted PIL image as a JSON-safe PNG payload."""
+    return {
+        "image": _encode_mask_png(raw),
+        "format": "png",
+        "width": raw.width,
+        "height": raw.height,
+    }
+
+
 def _postprocess_segmentation(raw: Any, **_kwargs: Any) -> Any:
     """Convert segmentation masks to predictions with coverage score and mask.
 
@@ -286,6 +296,19 @@ TASK_REGISTRY: dict[str, TaskInputSpec] = {
             InputField(name="image", type="image", required=True, description="Input image"),
         ],
         mapping=PipelineMapping(pipe_input="image"),
+    ),
+    "inpainting": TaskInputSpec(
+        user_inputs=[
+            InputField(name="image", type="image", required=True, description="Input image"),
+            InputField(
+                name="mask",
+                type="image",
+                required=True,
+                description="Binary mask; non-zero pixels are replaced",
+            ),
+        ],
+        mapping=PipelineMapping(pipe_input=["image", "mask"]),
+        postprocess=_postprocess_inpainting,
     ),
     # -- Single text --------------------------------------------------------
     "text-classification": TaskInputSpec(

--- a/src/winml/modelkit/inference/tasks.py
+++ b/src/winml/modelkit/inference/tasks.py
@@ -304,7 +304,7 @@ TASK_REGISTRY: dict[str, TaskInputSpec] = {
                 name="mask",
                 type="image",
                 required=True,
-                description="Binary mask; hole polarity is defined by the runtime contract",
+                description="Binary mask; nonzero pixels identify holes (the replaced region)",
             ),
         ],
         mapping=PipelineMapping(pipe_input=["image", "mask"]),

--- a/src/winml/modelkit/inference/tasks.py
+++ b/src/winml/modelkit/inference/tasks.py
@@ -304,7 +304,7 @@ TASK_REGISTRY: dict[str, TaskInputSpec] = {
                 name="mask",
                 type="image",
                 required=True,
-                description="Binary mask; non-zero pixels are replaced",
+                description="Binary mask; hole polarity is defined by the runtime contract",
             ),
         ],
         mapping=PipelineMapping(pipe_input=["image", "mask"]),

--- a/src/winml/modelkit/loader/onnx_hub.py
+++ b/src/winml/modelkit/loader/onnx_hub.py
@@ -19,10 +19,93 @@ The function exposed here, :func:`resolve_hf_onnx_path`, is called by
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ResolvedHubOnnx:
+    """A downloaded Hub ONNX artifact and its immutable provenance."""
+
+    local_path: Path
+    repo_id: str
+    filename: str
+    revision: str
+
+
+def resolve_hf_repo_onnx(
+    repo_id: str,
+    *,
+    revision: str | None = None,
+    cache_dir: str | Path | None = None,
+    token: str | bool | None = None,
+) -> ResolvedHubOnnx | None:
+    """Resolve a non-Transformers Hub repository containing one ONNX graph.
+
+    Repositories with a usable Transformers ``model_type`` remain normal HF
+    model IDs. A repository without that metadata is routed to direct ONNX only
+    when exactly one ``.onnx`` sibling exists. Multiple graphs are deliberately
+    rejected because selecting one by filename or ordering would be a hidden,
+    model-specific policy.
+
+    The repository listing resolves the requested branch/tag to a commit SHA,
+    and that SHA is used for the artifact download. This prevents a moving Hub
+    revision from changing between discovery and download.
+    """
+    from huggingface_hub import HfApi
+    from huggingface_hub.errors import HfHubHTTPError
+
+    try:
+        info = HfApi().model_info(
+            repo_id=repo_id,
+            revision=revision,
+            files_metadata=False,
+            token=token,
+        )
+    except HfHubHTTPError as exc:
+        # Discovery is an optional preflight before the existing Transformers
+        # path. Auth, gated-repo, missing-repo, and transient Hub HTTP errors
+        # must therefore fall through so the authoritative downstream loader
+        # can preserve its established diagnostics and mocked/offline behavior.
+        logger.debug("Could not inspect %s for a direct ONNX artifact: %s", repo_id, exc)
+        return None
+    config = info.config if isinstance(info.config, dict) else {}
+    if config.get("model_type"):
+        return None
+
+    onnx_files = sorted(
+        sibling.rfilename
+        for sibling in (info.siblings or [])
+        if sibling.rfilename.lower().endswith(".onnx")
+    )
+    if not onnx_files:
+        return None
+    if len(onnx_files) > 1:
+        listing = "\n".join(f"  - {repo_id}/{filename}" for filename in onnx_files)
+        raise ValueError(
+            f"Hub repo '{repo_id}' has no usable Transformers model_type and contains "
+            f"multiple ONNX files. Pass an explicit artifact path:\n{listing}"
+        )
+
+    resolved_revision = info.sha or revision
+    if not resolved_revision:
+        raise ValueError(f"Could not resolve an immutable revision for Hub repo '{repo_id}'.")
+    filename = onnx_files[0]
+    local_path = resolve_hf_onnx_path(
+        f"{repo_id}/{filename}",
+        revision=resolved_revision,
+        cache_dir=cache_dir,
+        token=token,
+    )
+    return ResolvedHubOnnx(
+        local_path=local_path,
+        repo_id=repo_id,
+        filename=filename,
+        revision=resolved_revision,
+    )
 
 
 def resolve_hf_onnx_path(
@@ -79,9 +162,7 @@ def resolve_hf_onnx_path(
         # ``.onnx`` files so the user can pick the right one without leaving
         # the terminal. Re-raise as ``FileNotFoundError`` so callers that
         # already handle local-file-missing errors get a consistent type.
-        hint = _format_available_onnx_files(
-            repo_id, revision=revision, token=token
-        )
+        hint = _format_available_onnx_files(repo_id, revision=revision, token=token)
         raise FileNotFoundError(
             f"ONNX file '{filename}' not found in Hub repo '{repo_id}'.\n{hint}"
         ) from e
@@ -171,5 +252,7 @@ def _format_available_onnx_files(
 
 
 __all__ = [
+    "ResolvedHubOnnx",
     "resolve_hf_onnx_path",
+    "resolve_hf_repo_onnx",
 ]

--- a/src/winml/modelkit/loader/onnx_hub.py
+++ b/src/winml/modelkit/loader/onnx_hub.py
@@ -56,7 +56,9 @@ def resolve_hf_repo_onnx(
     revision from changing between discovery and download.
     """
     from huggingface_hub import HfApi
-    from huggingface_hub.errors import HfHubHTTPError
+    from huggingface_hub.errors import HfHubHTTPError, OfflineModeIsEnabled
+    from requests.exceptions import ConnectionError as RequestsConnectionError
+    from requests.exceptions import Timeout as RequestsTimeout
 
     try:
         info = HfApi().model_info(
@@ -65,7 +67,7 @@ def resolve_hf_repo_onnx(
             files_metadata=False,
             token=token,
         )
-    except HfHubHTTPError as exc:
+    except (HfHubHTTPError, OfflineModeIsEnabled, RequestsConnectionError, RequestsTimeout) as exc:
         # Discovery is an optional preflight before the existing Transformers
         # path. Auth, gated-repo, missing-repo, and transient Hub HTTP errors
         # must therefore fall through so the authoritative downstream loader

--- a/src/winml/modelkit/models/auto.py
+++ b/src/winml/modelkit/models/auto.py
@@ -202,7 +202,7 @@ class WinMLAutoModel:
             logger.info("Skipping build (compiled model or explicit skip). Using original ONNX.")
             # TODO: run analyze_onnx for validation/lint
             winml_class = get_winml_class(None, resolved_task)
-            return winml_class(
+            model = winml_class(
                 onnx_path=onnx_path,
                 config=None,
                 device=device,
@@ -210,6 +210,9 @@ class WinMLAutoModel:
                 ep=ep,
                 provider_options=provider_options,
             )
+            model._build_config = config
+            model._runtime_config = config.runtime.to_dict() if config.runtime is not None else None
+            return model
 
         # Resolve output directory and cache key
         task_abbrev = get_task_abbrev(resolved_task) if resolved_task else "onnx"
@@ -247,7 +250,7 @@ class WinMLAutoModel:
         winml_class = get_winml_class(None, resolved_task)
         logger.info("Creating inference wrapper: %s", winml_class.__name__)
 
-        return winml_class(
+        model = winml_class(
             onnx_path=result.final_onnx_path,
             config=None,  # No HF PretrainedConfig for bare ONNX builds
             device=device,
@@ -255,6 +258,9 @@ class WinMLAutoModel:
             ep=ep,
             provider_options=provider_options,
         )
+        model._build_config = config
+        model._runtime_config = config.runtime.to_dict() if config.runtime is not None else None
+        return model
 
     @classmethod
     def from_pretrained(
@@ -528,6 +534,7 @@ class WinMLAutoModel:
             provider_options=provider_options,
         )
         model._build_config = config  # resolved build config (task, quant, compile)
+        model._runtime_config = config.runtime.to_dict() if config.runtime is not None else None
         return model
 
     @classmethod

--- a/src/winml/modelkit/models/auto.py
+++ b/src/winml/modelkit/models/auto.py
@@ -336,7 +336,7 @@ class WinMLAutoModel:
         # is downloaded once and treated as a local .onnx path thereafter.
         from ..utils.model_input import resolve_model_input
 
-        model_id = resolve_model_input(model_id).local_path or model_id
+        model_id = resolve_model_input(model_id, discover_repo_onnx=True).local_path or model_id
 
         # =====================================================================
         # ONNX FAST PATH -- skip HF loading and export when given an .onnx file

--- a/src/winml/modelkit/models/winml/base.py
+++ b/src/winml/modelkit/models/winml/base.py
@@ -89,6 +89,7 @@ class WinMLPreTrainedModel(PreTrainedModel, ABC):
 
         # Set by WinMLAutoModel.from_pretrained() after construction
         self._build_config: Any = None
+        self._runtime_config: dict[str, Any] | None = None
 
         # Create WinMLSession (delegates ORT operations)
         self._session = WinMLSession(
@@ -257,6 +258,11 @@ class WinMLPreTrainedModel(PreTrainedModel, ABC):
         TODO: derive from _build_config.quant.weight_type when ready.
         """
         return None
+
+    @property
+    def runtime_config(self) -> dict[str, Any] | None:
+        """Data-driven runtime adapter contract attached by build/load plumbing."""
+        return self._runtime_config
 
     @property
     def dtype(self) -> torch.dtype:

--- a/src/winml/modelkit/utils/cli.py
+++ b/src/winml/modelkit/utils/cli.py
@@ -1215,7 +1215,7 @@ def normalize_model_arg(value: str | None) -> str | None:
         return None
     from .model_input import resolve_model_input
 
-    return resolve_model_input(value).local_path or value
+    return resolve_model_input(value, discover_repo_onnx=True).local_path or value
 
 
 def is_cli_provided(ctx: click.Context, param_name: str) -> bool:

--- a/src/winml/modelkit/utils/manifest.py
+++ b/src/winml/modelkit/utils/manifest.py
@@ -118,6 +118,7 @@ class WinMLManifest:
 
     model_id: str | None = None
     task: str | None = None
+    runtime: dict[str, Any] | None = None
     cache_key: str | None = None
     config_hash: str | None = None
     input_onnx: str | None = None

--- a/src/winml/modelkit/utils/model_input.py
+++ b/src/winml/modelkit/utils/model_input.py
@@ -76,6 +76,9 @@ class ModelInput:
             ``HF_ID``.
         hf_id: HuggingFace repo id (``org/name``) for ``HF_ID`` /
             ``HUB_ONNX``. ``None`` otherwise.
+        artifact_path: Path inside the Hub repository for ``HUB_ONNX``.
+        revision: Immutable Hub commit used to download a discovered repository
+            artifact, or the caller-provided revision for an explicit artifact.
         error: Human-readable reason the value is ``INVALID``. ``None`` for
             every valid kind.
     """
@@ -84,6 +87,8 @@ class ModelInput:
     raw: str
     local_path: str | None = None
     hf_id: str | None = None
+    artifact_path: str | None = None
+    revision: str | None = None
     error: str | None = None
 
 
@@ -194,6 +199,7 @@ def resolve_model_input(
     revision: str | None = None,
     cache_dir: str | Path | None = None,
     token: str | bool | None = None,
+    discover_repo_onnx: bool = False,
 ) -> ModelInput:
     """Classify + download Hub-hosted ONNX refs in one call.
 
@@ -213,6 +219,25 @@ def resolve_model_input(
         kind implies a filesystem path.
     """
     mi = classify_model_input(value)
+    if mi.kind is ModelInputKind.HF_ID and discover_repo_onnx:
+        from ..loader.onnx_hub import resolve_hf_repo_onnx
+
+        discovered = resolve_hf_repo_onnx(
+            value,
+            revision=revision,
+            cache_dir=cache_dir,
+            token=token,
+        )
+        if discovered is not None:
+            return ModelInput(
+                kind=ModelInputKind.HUB_ONNX,
+                raw=value,
+                local_path=str(discovered.local_path),
+                hf_id=discovered.repo_id,
+                artifact_path=discovered.filename,
+                revision=discovered.revision,
+            )
+        return mi
     if mi.kind is not ModelInputKind.HUB_ONNX:
         return mi
 
@@ -222,7 +247,13 @@ def resolve_model_input(
     from ..loader.onnx_hub import resolve_hf_onnx_path
 
     local = resolve_hf_onnx_path(value, revision=revision, cache_dir=cache_dir, token=token)
-    return replace(mi, local_path=str(local))
+    parts = [part for part in value.split("/") if part]
+    return replace(
+        mi,
+        local_path=str(local),
+        artifact_path="/".join(parts[2:]),
+        revision=revision,
+    )
 
 
 __all__ = [

--- a/tests/unit/build/test_hf.py
+++ b/tests/unit/build/test_hf.py
@@ -836,6 +836,25 @@ class TestBuildHfPreQuantized:
         mock_pipeline["optimize"].assert_not_called()
         mock_pipeline["quantize"].assert_not_called()
 
+    def test_post_export_qdq_preserves_explicit_fp16_conversion(
+        self, tmp_path: Path, sample_config, mock_pipeline
+    ) -> None:
+        """QDQ/QOperator exports still convert their remaining float tensors to FP16."""
+        mock_pipeline["is_quantized_onnx"].return_value = True
+        sample_config.quant.mode = "fp16"
+
+        result = build_hf_model(
+            config=sample_config,
+            output_dir=tmp_path / "output",
+            pytorch_model=mock_pipeline["model"],
+        )
+
+        assert "optimize" in result.stages_skipped
+        assert "quantize" in result.stages_completed
+        assert "quantize" not in result.stages_skipped
+        mock_pipeline["optimize"].assert_not_called()
+        mock_pipeline["quantize"].assert_called_once()
+
     def test_post_export_qdq_still_exports(
         self, tmp_path: Path, sample_config, mock_pipeline
     ) -> None:

--- a/tests/unit/build/test_onnx.py
+++ b/tests/unit/build/test_onnx.py
@@ -363,6 +363,25 @@ class TestBuildOnnxPreQuantized:
         assert "quantize" in result.stages_completed
         mock_onnx_pipeline["quantize"].assert_called_once()
 
+    def test_pre_quantized_preserves_explicit_fp16_conversion(
+        self, tmp_path: Path, fake_onnx: Path, sample_onnx_config, mock_onnx_pipeline
+    ) -> None:
+        """QDQ/QOperator graphs still convert their remaining float tensors to FP16."""
+        mock_onnx_pipeline["is_quantized_onnx"].return_value = True
+        sample_onnx_config.quant.mode = "fp16"
+
+        result = build_onnx_model(
+            fake_onnx,
+            config=sample_onnx_config,
+            output_dir=tmp_path / "output",
+        )
+
+        assert "optimize" in result.stages_skipped
+        assert "quantize" in result.stages_completed
+        assert "quantize" not in result.stages_skipped
+        mock_onnx_pipeline["optimize"].assert_not_called()
+        mock_onnx_pipeline["quantize"].assert_called_once()
+
     def test_pre_quantized_skips_optimize_and_quantize(
         self, tmp_path: Path, fake_onnx: Path, sample_onnx_config, mock_onnx_pipeline
     ) -> None:

--- a/tests/unit/commands/test_build.py
+++ b/tests/unit/commands/test_build.py
@@ -623,6 +623,46 @@ class TestBuildFlagPassthrough:
         assert quant is not None
         assert quant.mode == "fp16"
 
+    def test_precision_fp16_preserved_for_prequantized_onnx(
+        self, tmp_path: Path, mock_run_single_build: MagicMock
+    ):
+        """Pre-quantized ONNX still converts remaining float tensors to FP16."""
+        onnx_path = tmp_path / "prequantized.onnx"
+        onnx_path.write_bytes(b"fake")
+        config_path = tmp_path / "prequantized_fp16.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "skip_optimize": True,
+                    "loader": {"task": "inpainting"},
+                    "export": None,
+                    "optim": {},
+                    "quant": {"mode": "fp16"},
+                    "compile": None,
+                }
+            )
+        )
+
+        result = _invoke(
+            [
+                "-c",
+                str(config_path),
+                "-m",
+                str(onnx_path),
+                "-o",
+                str(tmp_path / "out"),
+                "--device",
+                "cpu",
+                "--precision",
+                "fp16",
+            ]
+        )
+
+        assert result.exit_code == 0, result.output
+        quant = mock_run_single_build.call_args.kwargs["config"].quant
+        assert quant is not None
+        assert quant.mode == "fp16"
+
     def test_precision_alone_triggers_quant_patch(
         self, tmp_path: Path, mock_run_single_build: MagicMock
     ):

--- a/tests/unit/config/test_build_onnx.py
+++ b/tests/unit/config/test_build_onnx.py
@@ -255,6 +255,30 @@ class TestGenerateBuildConfigOnnxPath:
         assert config.quant is None
         assert config.compile is None
 
+    def test_quantized_onnx_preserves_explicit_fp16_conversion(self, tmp_path) -> None:
+        """Pre-quantized integer weights do not suppress requested FP16 float conversion."""
+        onnx_file = tmp_path / "quantized.onnx"
+        onnx_file.write_bytes(b"fake")
+
+        with (
+            patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
+            patch("winml.modelkit.onnx.is_quantized_onnx", return_value=True),
+            patch(
+                "winml.modelkit.sysinfo.resolve_check_device_ep",
+                return_value=("cpu", ["cpu"], ["CPUExecutionProvider"]),
+            ),
+        ):
+            config = generate_onnx_build_config(
+                str(onnx_file),
+                device="cpu",
+                precision="fp16",
+            )
+
+        assert config.skip_optimize is True
+        assert config.quant is not None
+        assert config.quant.mode == "fp16"
+        assert config.compile is None
+
     def test_compiled_onnx_skips_all(self, tmp_path) -> None:
         """Compiled ONNX (EPContext) sets quant=None and compile=None."""
         onnx_file = tmp_path / "compiled.onnx"

--- a/tests/unit/config/test_build_onnx.py
+++ b/tests/unit/config/test_build_onnx.py
@@ -315,6 +315,23 @@ class TestGenerateBuildConfigOnnxPath:
     # Config structure invariants
     # -----------------------------------------------------------------
 
+    def test_runtime_contract_round_trips_in_onnx_override(self, tmp_path) -> None:
+        onnx_file = tmp_path / "model.onnx"
+        onnx_file.write_bytes(b"fake")
+        runtime = {"pipeline": "inpainting", "options": {"contract": "test"}}
+
+        with (
+            patch("winml.modelkit.onnx.is_compiled_onnx", return_value=True),
+            patch("winml.modelkit.onnx.is_quantized_onnx", return_value=False),
+        ):
+            config = generate_onnx_build_config(
+                onnx_file,
+                task="inpainting",
+                override={"runtime": runtime},
+            )
+
+        assert config.to_dict()["runtime"] == runtime
+
     def test_export_always_none(self, tmp_path) -> None:
         """All ONNX model states produce export=None."""
         onnx_file = tmp_path / "model.onnx"

--- a/tests/unit/inference/test_engine.py
+++ b/tests/unit/inference/test_engine.py
@@ -366,15 +366,8 @@ class TestLoadSchemaOnly:
         engine.load_schema_only(tmp_path, task="image-classification")
         assert engine._task == "image-classification"
 
-    def test_hub_onnx_ref_is_resolved_before_routing(self, tmp_path: Any) -> None:
-        """A Hub-style ONNX ref (``<org>/<repo>/<path>.onnx``) must be
-        resolved to a local path BEFORE the .onnx-suffix-and-exists check,
-        otherwise it falls through to the HF model-id branch and tries to
-        load a Hub-ONNX path string as if it were a transformers config.
-
-        Regression test for ``winml run`` and ``winml serve`` on Hub refs
-        like ``onnx-community/sam3-tracker-ONNX/onnx/...``.
-        """
+    def test_explicit_task_does_not_download_hub_onnx_ref(self, tmp_path: Any) -> None:
+        """Schema-only display must not download an explicit Hub ONNX artifact."""
         from unittest.mock import patch
 
         local = tmp_path / "vision_encoder_int8.onnx"
@@ -382,22 +375,44 @@ class TestLoadSchemaOnly:
         hub_ref = "onnx-community/sam3-tracker-ONNX/onnx/vision_encoder_int8.onnx"
 
         engine = InferenceEngine()
-        # ``WinMLSession.load_schema_only`` now routes Hub-ONNX resolution
-        # through the unified ``resolve_model_input`` (in
-        # ``winml.modelkit.utils.model_input``). Patch the underlying
-        # downloader so the lazy ``from ..loader.onnx_hub import
-        # resolve_hf_onnx_path`` picks up the mock at call time.
         with patch(
             "winml.modelkit.loader.onnx_hub.resolve_hf_onnx_path",
             return_value=local,
         ) as mock_resolve:
             engine.load_schema_only(hub_ref, task="mask-generation")
-        mock_resolve.assert_called_once()
-        # After resolution the engine should treat the input as a local
-        # ONNX file (not as an HF model id), which means _model_id is the
-        # resolved local path string, not the original Hub ref.
-        assert engine._model_id == str(local)
+        mock_resolve.assert_not_called()
+        assert engine._model_id == hub_ref
         assert engine._task == "mask-generation"
+
+    def test_explicit_task_does_not_download_bare_repo_onnx(self) -> None:
+        """Schema-only needs only the explicit task, never repository weights."""
+        engine = InferenceEngine()
+        with patch("winml.modelkit.loader.onnx_hub.resolve_hf_onnx_path") as mock_download:
+            engine.load_schema_only("opencv/inpainting_lama", task="inpainting")
+
+        mock_download.assert_not_called()
+        assert engine._model_id == "opencv/inpainting_lama"
+        assert engine._task == "inpainting"
+
+    def test_build_dir_preserves_runtime_contract(self, tmp_path: Any) -> None:
+        """Build-directory loading attaches the manifest's runtime contract."""
+        import json
+
+        runtime = {"pipeline": "inpainting", "options": {"contract": "test"}}
+        (tmp_path / "build_manifest.json").write_text(
+            json.dumps({"task": "inpainting", "runtime": runtime})
+        )
+        (tmp_path / "model.onnx").write_bytes(b"fake")
+        fake_model = MagicMock()
+
+        with patch(
+            "winml.modelkit.models.winml.get_winml_class",
+            return_value=lambda **_kwargs: fake_model,
+        ):
+            engine = InferenceEngine()
+            engine._load_from_build_dir(tmp_path, task=None, device="cpu", ep=None)
+
+        assert fake_model._runtime_config == runtime
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/inference/test_inpainting_pipeline.py
+++ b/tests/unit/inference/test_inpainting_pipeline.py
@@ -76,6 +76,43 @@ class TestWinMLInpaintingPipeline:
         )
         np.testing.assert_array_equal(np.asarray(output), pixels)
 
+    @pytest.mark.parametrize(
+        ("mask_semantics", "model_hole_value", "model_background_value"),
+        [
+            pytest.param("nonzero-is-hole", 1.0, 0.0, id="model-nonzero-is-hole"),
+            pytest.param("zero-is-hole", 0.0, 1.0, id="model-zero-is-hole"),
+        ],
+    )
+    def test_maps_canonical_caller_hole_to_model_mask_semantics(
+        self,
+        mask_semantics: str,
+        model_hole_value: float,
+        model_background_value: float,
+    ) -> None:
+        runtime = {
+            **_LAMA_RUNTIME,
+            "options": {**_LAMA_RUNTIME["options"], "mask_semantics": mask_semantics},
+        }
+        model = _EchoInpaintingModel()
+        pipeline = WinMLInpaintingPipeline(model, runtime_config=runtime)  # type: ignore[arg-type]
+        caller_mask = np.array([[0, 255], [0, 0]], dtype=np.uint8)
+
+        pipeline(
+            {
+                "image": Image.new("RGB", (2, 2)),
+                "mask": Image.fromarray(caller_mask, mode="L"),
+            }
+        )
+
+        model_mask = model.inputs["edit_region"][0, 0]
+        assert model_mask[0, 1] == model_hole_value
+        np.testing.assert_array_equal(
+            model_mask[[0, 1, 1], [0, 0, 1]],
+            np.full(3, model_background_value, dtype=np.float32),
+        )
+        model_holes = model_mask > 0 if mask_semantics == "nonzero-is-hole" else model_mask == 0
+        np.testing.assert_array_equal(model_holes, caller_mask > 0)
+
     def test_requires_image_and_mask_tensor_roles(self) -> None:
         model = _EchoInpaintingModel()
         model.io_config = {

--- a/tests/unit/inference/test_inpainting_pipeline.py
+++ b/tests/unit/inference/test_inpainting_pipeline.py
@@ -1,0 +1,89 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Tests for the generic direct-ONNX inpainting pipeline."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+from winml.modelkit.inference.inpainting import WinMLInpaintingPipeline
+
+
+class _EchoInpaintingModel:
+    io_config: ClassVar[dict] = {
+        "input_names": ["source_pixels", "edit_region"],
+        "input_shapes": [[1, 3, 2, 2], [1, 1, 2, 2]],
+        "output_names": ["completed_image"],
+        "output_shapes": [[1, 3, 2, 2]],
+    }
+
+    def __init__(self) -> None:
+        self.inputs: dict[str, np.ndarray] = {}
+
+    def __call__(self, **kwargs):
+        self.inputs = kwargs
+        return {"completed_image": torch.from_numpy(kwargs["source_pixels"] * 255.0)}
+
+
+class TestWinMLInpaintingPipeline:
+    def test_prepares_bgr_image_and_binary_mask(self) -> None:
+        model = _EchoInpaintingModel()
+        pipeline = WinMLInpaintingPipeline(model)  # type: ignore[arg-type]
+        pixels = np.full((2, 2, 3), [10, 20, 30], dtype=np.uint8)
+        mask = np.array([[0, 1], [127, 255]], dtype=np.uint8)
+
+        output = pipeline(
+            {
+                "image": Image.fromarray(pixels, mode="RGB"),
+                "mask": Image.fromarray(mask, mode="L"),
+            }
+        )
+
+        assert model.inputs["source_pixels"].shape == (1, 3, 2, 2)
+        np.testing.assert_allclose(
+            model.inputs["source_pixels"][0, :, 0, 0],
+            np.array([30, 20, 10], dtype=np.float32) / 255.0,
+        )
+        np.testing.assert_array_equal(
+            model.inputs["edit_region"],
+            np.array([[[[0, 1], [1, 1]]]], dtype=np.float32),
+        )
+        np.testing.assert_array_equal(np.asarray(output), pixels)
+
+    def test_requires_image_and_mask_tensor_roles(self) -> None:
+        model = _EchoInpaintingModel()
+        model.io_config = {
+            "input_names": ["pixels"],
+            "input_shapes": [[1, 3, 2, 2]],
+            "output_names": ["output"],
+            "output_shapes": [[1, 3, 2, 2]],
+        }
+        with pytest.raises(ValueError, match=r"image .* and mask"):
+            WinMLInpaintingPipeline(model)  # type: ignore[arg-type]
+
+    def test_requires_matching_image_output(self) -> None:
+        model = _EchoInpaintingModel()
+        model.io_config = {
+            **model.io_config,
+            "output_names": ["embedding"],
+            "output_shapes": [[1, 128]],
+        }
+        with pytest.raises(ValueError, match="3-channel ONNX image output"):
+            WinMLInpaintingPipeline(model)  # type: ignore[arg-type]
+
+    def test_selects_named_image_output(self) -> None:
+        model = _EchoInpaintingModel()
+        model.io_config = {
+            **model.io_config,
+            "output_names": ["scores", "completed_image"],
+            "output_shapes": [[1, 10], [1, 3, 2, 2]],
+        }
+        pipeline = WinMLInpaintingPipeline(model)  # type: ignore[arg-type]
+        assert pipeline._output_name == "completed_image"

--- a/tests/unit/inference/test_inpainting_pipeline.py
+++ b/tests/unit/inference/test_inpainting_pipeline.py
@@ -16,6 +16,25 @@ from PIL import Image
 from winml.modelkit.inference.inpainting import WinMLInpaintingPipeline
 
 
+_LAMA_RUNTIME = {
+    "pipeline": "inpainting",
+    "options": {
+        "image_input_name": "source_pixels",
+        "mask_input_name": "edit_region",
+        "output_name": "completed_image",
+        "image_color_order": "bgr",
+        "image_value_range": [0, 1],
+        "mask_semantics": "nonzero-is-hole",
+        "output_color_order": "bgr",
+        "output_value_range": [0, 255],
+    },
+}
+
+
+def _make_pipeline(model: _EchoInpaintingModel) -> WinMLInpaintingPipeline:
+    return WinMLInpaintingPipeline(model, runtime_config=_LAMA_RUNTIME)  # type: ignore[arg-type]
+
+
 class _EchoInpaintingModel:
     io_config: ClassVar[dict] = {
         "input_names": ["source_pixels", "edit_region"],
@@ -35,7 +54,7 @@ class _EchoInpaintingModel:
 class TestWinMLInpaintingPipeline:
     def test_prepares_bgr_image_and_binary_mask(self) -> None:
         model = _EchoInpaintingModel()
-        pipeline = WinMLInpaintingPipeline(model)  # type: ignore[arg-type]
+        pipeline = _make_pipeline(model)
         pixels = np.full((2, 2, 3), [10, 20, 30], dtype=np.uint8)
         mask = np.array([[0, 1], [127, 255]], dtype=np.uint8)
 
@@ -65,8 +84,8 @@ class TestWinMLInpaintingPipeline:
             "output_names": ["output"],
             "output_shapes": [[1, 3, 2, 2]],
         }
-        with pytest.raises(ValueError, match=r"image .* and mask"):
-            WinMLInpaintingPipeline(model)  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="absent or not distinct"):
+            _make_pipeline(model)
 
     def test_requires_matching_image_output(self) -> None:
         model = _EchoInpaintingModel()
@@ -75,8 +94,8 @@ class TestWinMLInpaintingPipeline:
             "output_names": ["embedding"],
             "output_shapes": [[1, 128]],
         }
-        with pytest.raises(ValueError, match="3-channel ONNX image output"):
-            WinMLInpaintingPipeline(model)  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="3-channel ONNX output"):
+            _make_pipeline(model)
 
     def test_selects_named_image_output(self) -> None:
         model = _EchoInpaintingModel()
@@ -85,5 +104,60 @@ class TestWinMLInpaintingPipeline:
             "output_names": ["scores", "completed_image"],
             "output_shapes": [[1, 10], [1, 3, 2, 2]],
         }
-        pipeline = WinMLInpaintingPipeline(model)  # type: ignore[arg-type]
+        pipeline = _make_pipeline(model)
         assert pipeline._output_name == "completed_image"
+
+    def test_requires_explicit_runtime_contract(self) -> None:
+        with pytest.raises(ValueError, match=r"explicit runtime\.options"):
+            WinMLInpaintingPipeline(  # type: ignore[arg-type]
+                _EchoInpaintingModel(), runtime_config=None
+            )
+
+    def test_rejects_unsupported_contract_instead_of_guessing(self) -> None:
+        runtime = {
+            **_LAMA_RUNTIME,
+            "options": {**_LAMA_RUNTIME["options"], "image_value_range": [0, 2]},
+        }
+        with pytest.raises(ValueError, match="Unsupported inpainting image_value_range"):
+            WinMLInpaintingPipeline(  # type: ignore[arg-type]
+                _EchoInpaintingModel(), runtime_config=runtime
+            )
+
+    def test_applies_declared_non_lama_rgb_range_and_mask_contract(self) -> None:
+        class _AlternateContractModel(_EchoInpaintingModel):
+            def __call__(self, **kwargs):
+                self.inputs = kwargs
+                return {"completed_image": torch.from_numpy(kwargs["source_pixels"])}
+
+        runtime = {
+            "pipeline": "inpainting",
+            "options": {
+                **_LAMA_RUNTIME["options"],
+                "image_color_order": "rgb",
+                "image_value_range": [-1, 1],
+                "mask_semantics": "zero-is-hole",
+                "output_color_order": "rgb",
+                "output_value_range": [-1, 1],
+            },
+        }
+        model = _AlternateContractModel()
+        pipeline = WinMLInpaintingPipeline(model, runtime_config=runtime)  # type: ignore[arg-type]
+        pixels = np.full((2, 2, 3), [10, 20, 30], dtype=np.uint8)
+        mask = np.array([[0, 255], [255, 0]], dtype=np.uint8)
+
+        output = pipeline(
+            {
+                "image": Image.fromarray(pixels, mode="RGB"),
+                "mask": Image.fromarray(mask, mode="L"),
+            }
+        )
+
+        np.testing.assert_allclose(
+            model.inputs["source_pixels"][0, :, 0, 0],
+            np.array([10, 20, 30], dtype=np.float32) / 255.0 * 2.0 - 1.0,
+        )
+        np.testing.assert_array_equal(
+            model.inputs["edit_region"],
+            np.array([[[[1, 0], [0, 1]]]], dtype=np.float32),
+        )
+        np.testing.assert_allclose(np.asarray(output), pixels, atol=1)

--- a/tests/unit/inference/test_tasks.py
+++ b/tests/unit/inference/test_tasks.py
@@ -187,14 +187,13 @@ class TestInpaintingRegistry:
         assert all(field.required for field in spec.user_inputs)
         assert spec.mapping.pipe_input == ["image", "mask"]
 
-    def test_mask_description_defers_polarity_to_runtime_contract(self) -> None:
+    def test_mask_description_defines_canonical_caller_polarity(self) -> None:
         mask = next(
             field for field in TASK_REGISTRY["inpainting"].user_inputs if field.name == "mask"
         )
 
-        assert "runtime contract" in mask.description
-        assert "non-zero pixels are replaced" not in mask.description
-        assert "zero pixels are replaced" not in mask.description
+        assert "nonzero pixels identify holes" in mask.description
+        assert "replaced region" in mask.description
 
     def test_has_png_postprocess(self) -> None:
         assert TASK_REGISTRY["inpainting"].postprocess is _postprocess_inpainting

--- a/tests/unit/inference/test_tasks.py
+++ b/tests/unit/inference/test_tasks.py
@@ -187,5 +187,14 @@ class TestInpaintingRegistry:
         assert all(field.required for field in spec.user_inputs)
         assert spec.mapping.pipe_input == ["image", "mask"]
 
+    def test_mask_description_defers_polarity_to_runtime_contract(self) -> None:
+        mask = next(
+            field for field in TASK_REGISTRY["inpainting"].user_inputs if field.name == "mask"
+        )
+
+        assert "runtime contract" in mask.description
+        assert "non-zero pixels are replaced" not in mask.description
+        assert "zero pixels are replaced" not in mask.description
+
     def test_has_png_postprocess(self) -> None:
         assert TASK_REGISTRY["inpainting"].postprocess is _postprocess_inpainting

--- a/tests/unit/inference/test_tasks.py
+++ b/tests/unit/inference/test_tasks.py
@@ -22,6 +22,7 @@ from winml.modelkit.inference import TASK_REGISTRY
 # Private helpers under test
 from winml.modelkit.inference.tasks import (
     _masked_mean_pool,
+    _postprocess_inpainting,
     _postprocess_segmentation,
     _postprocess_sentence_similarity,
 )
@@ -177,3 +178,14 @@ class TestSegmentationRegistry:
 
     def test_semantic_alias(self) -> None:
         assert TASK_REGISTRY["semantic-segmentation"].postprocess is _postprocess_segmentation
+
+
+class TestInpaintingRegistry:
+    def test_requires_image_and_mask(self) -> None:
+        spec = TASK_REGISTRY["inpainting"]
+        assert [field.name for field in spec.user_inputs] == ["image", "mask"]
+        assert all(field.required for field in spec.user_inputs)
+        assert spec.mapping.pipe_input == ["image", "mask"]
+
+    def test_has_png_postprocess(self) -> None:
+        assert TASK_REGISTRY["inpainting"].postprocess is _postprocess_inpainting

--- a/tests/unit/loader/test_onnx_hub.py
+++ b/tests/unit/loader/test_onnx_hub.py
@@ -317,6 +317,26 @@ class TestResolveHfRepoOnnx:
         ):
             assert resolve_hf_repo_onnx("org/private") is None
 
+    def test_offline_mode_falls_back_to_existing_hf_loader(self) -> None:
+        """Optional discovery preserves the established cached/offline HF path."""
+        from huggingface_hub.errors import OfflineModeIsEnabled
+
+        with patch(
+            "huggingface_hub.HfApi.model_info",
+            side_effect=OfflineModeIsEnabled("offline"),
+        ):
+            assert resolve_hf_repo_onnx("microsoft/resnet-50") is None
+
+    def test_connection_failure_falls_back_to_existing_hf_loader(self) -> None:
+        """A connectivity-only preflight failure is deferred to the normal loader."""
+        from requests.exceptions import ConnectionError
+
+        with patch(
+            "huggingface_hub.HfApi.model_info",
+            side_effect=ConnectionError("network unavailable"),
+        ):
+            assert resolve_hf_repo_onnx("microsoft/resnet-50") is None
+
     def test_multiple_onnx_requires_explicit_path(self) -> None:
         siblings = [
             type("Sibling", (), {"rfilename": name})() for name in ("a.onnx", "nested/b.onnx")

--- a/tests/unit/loader/test_onnx_hub.py
+++ b/tests/unit/loader/test_onnx_hub.py
@@ -22,6 +22,7 @@ import pytest
 from winml.modelkit.loader.onnx_hub import (
     _split_hf_onnx_path,
     resolve_hf_onnx_path,
+    resolve_hf_repo_onnx,
 )
 
 
@@ -183,9 +184,7 @@ class TestResolveHfOnnxPathDiscovery:
             ) as mock_list,
             pytest.raises(FileNotFoundError) as exc_info,
         ):
-            resolve_hf_onnx_path(
-                "onnx-community/sam3-tracker-ONNX/onnx/vision_encoder.onnx"
-            )
+            resolve_hf_onnx_path("onnx-community/sam3-tracker-ONNX/onnx/vision_encoder.onnx")
 
         msg = str(exc_info.value)
         # Names the bad path and the repo
@@ -202,8 +201,7 @@ class TestResolveHfOnnxPathDiscovery:
         mock_list.assert_called_once()
         assert (
             mock_list.call_args.args[0] == "onnx-community/sam3-tracker-ONNX"
-            or mock_list.call_args.kwargs.get("repo_id")
-            == "onnx-community/sam3-tracker-ONNX"
+            or mock_list.call_args.kwargs.get("repo_id") == "onnx-community/sam3-tracker-ONNX"
         )
 
     def test_missing_file_listing_failure_falls_back_gracefully(self) -> None:
@@ -254,3 +252,81 @@ class TestResolveHfOnnxPathDiscovery:
         msg = str(exc_info.value)
         assert "No .onnx files were found" in msg
         assert "org/pytorch-only" in msg
+
+
+class TestResolveHfRepoOnnx:
+    """Bare Hub repositories resolve only for an unambiguous ONNX sibling."""
+
+    def test_single_onnx_uses_resolved_commit(self, tmp_path: Path) -> None:
+        downloaded = tmp_path / "model.onnx"
+        downloaded.write_bytes(b"onnx")
+        info = type(
+            "Info",
+            (),
+            {
+                "config": {},
+                "sha": "abc123",
+                "siblings": [type("Sibling", (), {"rfilename": "weights/model.onnx"})()],
+            },
+        )()
+
+        with (
+            patch("huggingface_hub.HfApi.model_info", return_value=info),
+            patch(
+                "winml.modelkit.loader.onnx_hub.resolve_hf_onnx_path",
+                return_value=downloaded,
+            ) as mock_download,
+        ):
+            result = resolve_hf_repo_onnx("org/repo", revision="release")
+
+        assert result is not None
+        assert result.local_path == downloaded
+        assert result.filename == "weights/model.onnx"
+        assert result.revision == "abc123"
+        mock_download.assert_called_once_with(
+            "org/repo/weights/model.onnx",
+            revision="abc123",
+            cache_dir=None,
+            token=None,
+        )
+
+    def test_transformers_repository_is_not_reclassified(self) -> None:
+        info = type(
+            "Info",
+            (),
+            {
+                "config": {"model_type": "bert"},
+                "sha": "abc123",
+                "siblings": [type("Sibling", (), {"rfilename": "model.onnx"})()],
+            },
+        )()
+        with patch("huggingface_hub.HfApi.model_info", return_value=info):
+            assert resolve_hf_repo_onnx("org/bert") is None
+
+    def test_http_error_falls_back_to_existing_hf_loader(self) -> None:
+        """Optional discovery must not replace established HF loader errors."""
+        from huggingface_hub.errors import HfHubHTTPError
+        from requests import Response
+
+        response = Response()
+        response.status_code = 401
+        response.url = "https://huggingface.co/api/models/org/private"
+        with patch(
+            "huggingface_hub.HfApi.model_info",
+            side_effect=HfHubHTTPError("unauthorized", response=response),
+        ):
+            assert resolve_hf_repo_onnx("org/private") is None
+
+    def test_multiple_onnx_requires_explicit_path(self) -> None:
+        siblings = [
+            type("Sibling", (), {"rfilename": name})() for name in ("a.onnx", "nested/b.onnx")
+        ]
+        info = type("Info", (), {"config": {}, "sha": "abc123", "siblings": siblings})()
+        with (
+            patch("huggingface_hub.HfApi.model_info", return_value=info),
+            pytest.raises(ValueError, match="multiple ONNX files") as exc_info,
+        ):
+            resolve_hf_repo_onnx("org/ambiguous")
+
+        assert "org/ambiguous/a.onnx" in str(exc_info.value)
+        assert "org/ambiguous/nested/b.onnx" in str(exc_info.value)

--- a/tests/unit/models/auto/test_auto_onnx.py
+++ b/tests/unit/models/auto/test_auto_onnx.py
@@ -198,6 +198,39 @@ class TestFromOnnx:
 
         assert result is mock_instance
 
+    def test_programmatic_onnx_preserves_runtime_contract(
+        self, fake_onnx: Path, tmp_path: Path
+    ) -> None:
+        """An explicit config reaches the returned runtime wrapper unchanged."""
+        from winml.modelkit.config import WinMLBuildConfig
+
+        runtime = {"pipeline": "inpainting", "options": {"contract": "test"}}
+        explicit_config = WinMLBuildConfig.from_dict(
+            {
+                "loader": {"task": "inpainting"},
+                "export": None,
+                "quant": None,
+                "compile": None,
+                "runtime": runtime,
+            }
+        )
+        with (
+            patch("winml.modelkit.onnx.is_compiled_onnx", return_value=True),
+            patch("winml.modelkit.onnx.is_quantized_onnx", return_value=False),
+            patch("winml.modelkit.models.auto.get_winml_class") as mock_get_class,
+        ):
+            model = MagicMock()
+            mock_get_class.return_value = lambda **_kwargs: model
+            result = WinMLAutoModel.from_onnx(
+                fake_onnx,
+                task="inpainting",
+                config=explicit_config,
+                skip_build=True,
+            )
+
+        assert result is model
+        assert model._runtime_config == runtime
+
 
 class TestFromPretrainedDelegatesToFromOnnx:
     """Test that from_pretrained delegates .onnx files to from_onnx."""

--- a/tests/unit/utils/test_manifest.py
+++ b/tests/unit/utils/test_manifest.py
@@ -74,6 +74,7 @@ class TestWinMLManifestRoundTrip:
             source="hf",
             model_id="microsoft/resnet-50",
             task="image-classification",
+            runtime={"pipeline": "custom", "options": {"threshold": 0.5}},
             final_artifact="model.onnx",
             elapsed_seconds=12.345,
             stages=[
@@ -91,6 +92,7 @@ class TestWinMLManifestRoundTrip:
         assert restored.source == original.source
         assert restored.model_id == original.model_id
         assert restored.task == original.task
+        assert restored.runtime == original.runtime
         assert restored.elapsed_seconds == original.elapsed_seconds
         assert len(restored.stages) == 2
         assert restored.stages[0].name == "export"

--- a/tests/unit/utils/test_model_input.py
+++ b/tests/unit/utils/test_model_input.py
@@ -315,3 +315,17 @@ class TestResolveModelInput:
         assert mi.hf_id == "org/repo"
         assert mi.artifact_path == "nested/model.onnx"
         assert mi.revision == "abc123"
+
+    def test_optional_bare_repo_discovery_falls_back_offline(self) -> None:
+        """Offline discovery leaves a normal HF ID available to cached loaders."""
+        from huggingface_hub.errors import OfflineModeIsEnabled
+
+        with patch(
+            "huggingface_hub.HfApi.model_info",
+            side_effect=OfflineModeIsEnabled("offline"),
+        ):
+            mi = resolve_model_input("microsoft/resnet-50", discover_repo_onnx=True)
+
+        assert mi.kind is ModelInputKind.HF_ID
+        assert mi.hf_id == "microsoft/resnet-50"
+        assert mi.local_path is None

--- a/tests/unit/utils/test_model_input.py
+++ b/tests/unit/utils/test_model_input.py
@@ -13,7 +13,7 @@ together replace the previous trio of detectors (``is_hub_model``,
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from winml.modelkit.utils.model_input import (
     ModelInputKind,
@@ -294,3 +294,24 @@ class TestResolveModelInput:
         assert mi.kind == "hub_onnx"
         assert mi.local_path == str(downloaded)
         assert mi.hf_id == "onnx-community/sam3-tracker-ONNX"
+
+    def test_bare_repo_discovery_preserves_provenance(self, tmp_path: Path) -> None:
+        downloaded = tmp_path / "model.onnx"
+        downloaded.write_bytes(b"")
+        resolved = MagicMock(
+            local_path=downloaded,
+            repo_id="org/repo",
+            filename="nested/model.onnx",
+            revision="abc123",
+        )
+        with patch(
+            "winml.modelkit.loader.onnx_hub.resolve_hf_repo_onnx",
+            return_value=resolved,
+        ):
+            mi = resolve_model_input("org/repo", discover_repo_onnx=True)
+
+        assert mi.kind is ModelInputKind.HUB_ONNX
+        assert mi.local_path == str(downloaded)
+        assert mi.hf_id == "org/repo"
+        assert mi.artifact_path == "nested/model.onnx"
+        assert mi.revision == "abc123"


### PR DESCRIPTION
## Summary

This adds generic direct-ONNX LaMa inpainting support for `opencv/inpainting_lama`, including bare Hugging Face repository resolution, an explicit persisted image+mask runtime contract, and CPU recipes for fp32 and fp16. The contribution ships at Effort/Outcome L2 and reaches the committed Goal ceiling of **L1 PASS** for both required CPU tuples. The published graph is already INT8-prequantized, so “fp32” and “fp16” identify the precision of its remaining floating initializers rather than pure-float models.

## Model metadata

### What the model does

LaMa performs image inpainting: it accepts a 512 x 512 RGB image and a 512 x 512 single-channel binary mask, synthesizes replacement RGB content for the masked region, and returns an inpainted 512 x 512 RGB image (**verified**).

Evidence: the [model card pinned to revision `aee6d22f0a13e5e35af1c9a1c3afd62841fc6f3f`](https://huggingface.co/opencv/inpainting_lama/tree/aee6d22f0a13e5e35af1c9a1c3afd62841fc6f3f), pinned `lama.py` `Lama.infer()` wrapper, and published ONNX `image`, `mask`, and `output` contract.

### Primary user stories

- A user supplies a photograph and a painted binary mask to obtain a completed image with the masked object or damaged region filled in (**verified**; pinned demo and model card).

### Supported tasks

- **inpainting** — checkpoint support surface (**verified**). The pinned model card and demo explicitly define image-inpainting behavior. The repository has no `config.json`, `pipeline_tag`, Transformers class, or Optimum registration; no such surface is claimed.

### Model architecture

```text
Lama (repository inference wrapper; not a torch.nn.Module)
├── Runtime preprocessing: RGB image blob + thresholded binary mask (512 x 512)
├── Published ONNX LaMa generator
│   ├── Image/mask composition and padded FFC convolution/downsampling stages (model.0-4)
│   ├── FFC residual blocks x 18 (model.5-22)
│   │   ├── Local↔global convolution branches
│   │   └── Fourier unit transforms and residual additions
│   ├── Upsampling decoder: ConvTranspose + BatchNorm + ReLU x 3 (model.23-32)
│   └── Padded RGB Conv + Sigmoid output (model.33-35)
└── Runtime postprocessing: HWC uint8 conversion and aspect-ratio resize
```

- Source/confidence: pinned `lama.py` and published ONNX graph scopes, I/O, and topology (**mapped**).

## Validation and support evidence

### Baseline

The replacement charter freezes WinML **`winml, version 0.2.0`** at current `main` commit **`4daf0f19097d03e92aeb3c4f9713b7d037e0be3d`**. The repaired feature head is **`f03add820f384ce725e83400d53d108ff43aad0a`**, based directly on that commit; tester r5 refreshed revision, semantic-contract, analyze, component/op, and quality evidence at this head and retained earlier build/perf/eval measurements only where artifact-integrity and affected-scope checks established valid carryover.

The baseline below is intentionally run in a detached clean worktree at the frozen current-main SHA. It distinguishes the canonical bare repository-ID failure from the successful direct-ONNX diagnostic; the direct-file result proves generic graph ingestion/execution only and does **not** upgrade bare-ID support on current `main`.

```powershell
git fetch origin main
$BASELINE_REPO = Join-Path (Get-Location) '.winml-repro/current-main-4daf0f1'
git worktree add --detach $BASELINE_REPO 4daf0f19097d03e92aeb3c4f9713b7d037e0be3d
Push-Location $BASELINE_REPO
uv sync --frozen

& .\.venv\Scripts\winml.exe --version
# winml, version 0.2.0

git rev-parse HEAD
# 4daf0f19097d03e92aeb3c4f9713b7d037e0be3d

$BASELINE_OUT = Join-Path (Get-Location) '.winml-repro/bare-repository-id'
& .\.venv\Scripts\winml.exe build -m 'opencv/inpainting_lama' -o $BASELINE_OUT --ep cpu --device cpu --no-analyze --no-optimize --no-quant --no-compile --rebuild --no-color
# exit 2 after 23.170 s; no model artifact:
# Unrecognized model in opencv/inpainting_lama (the repository has no config.json model_type).

$PINNED_ONNX = Join-Path (Get-Location) '.winml-repro/inpainting_lama_2025jan.onnx'
Invoke-WebRequest -UseBasicParsing -Uri 'https://huggingface.co/opencv/inpainting_lama/resolve/aee6d22f0a13e5e35af1c9a1c3afd62841fc6f3f/inpainting_lama_2025jan.onnx' -OutFile $PINNED_ONNX
if ((Get-FileHash $PINNED_ONNX -Algorithm SHA256).Hash.ToLowerInvariant() -ne '7df918ac3921d3daf0aae1d219776cf0dc4e4935f035af81841b40adcf74fdf2') { throw 'Pinned ONNX SHA-256 mismatch' }
$DIRECT_OUT = Join-Path (Get-Location) '.winml-repro/direct-onnx-diagnostic'
& .\.venv\Scripts\winml.exe build -m $PINNED_ONNX -o $DIRECT_OUT --ep cpu --device cpu --no-analyze --no-optimize --no-quant --no-compile --rebuild --no-color
# exit 0; Build complete; model.onnx is 92,591,623 bytes and retains the pinned SHA-256.

Pop-Location
```

- **Bare repository build: FAIL (exit 2 after 23.170 s).** No model artifact was produced. The repository has no `config.json` `model_type`, so current `main` reports `Unrecognized model in opencv/inpainting_lama`.
- **Starting auto-config behavior:** direct-ONNX `winml config` generated a recipe with `skip_optimize: true`, `export: null`, empty `optim`, `quant: null`, `compile: null`, and loader task `inpainting`; it had no runtime contract. The diagnostic direct-ONNX build above succeeded and preserved the published 92,591,623-byte graph, but this does not upgrade the failing bare-repository workflow.
- **Perf floor:** the diagnostic direct-ONNX CPU run exited 0 after 36.239 s with mean/p50 **2594.816/2591.605 ms**, **0.39 samples/s**, and RSS total delta **654.06 MB**. The coarse detector reported `w8a8` because the published graph is prequantized.
- **Eval floor:** exit 1 before dataset/model execution because `inpainting` is unsupported by `winml eval`. The pinned `mattmdjaga/human_parsing_dataset` revision `db120bb5c18c146a8fbd2160f7575a288269fe7d` train sample is schema-probe-only; it has no authoritative image+mask+restored-target inpainting metric, and no metric validity is claimed.
- **Optimum probe: UNREGISTERED.** No vendor registration, post-WinML registration, or WinML-added registration was found.
- The baseline Goal floor was L0.

### Goal

- **Effort:** L2 — generalized class-of-models code support.
- **Committed Goal ceiling:** L1.
- **Outcome:** L2.
- **Success definition:** both exact CPU fp32/fp16 tuples freshly build and execute semantic image+mask inference through the public runtime with concrete performance evidence.
- This replacement charter re-issued the baseline after `main` moved from `38767add6f91c7b10b6394fae3af6f437e02effd` to `4daf0f19097d03e92aeb3c4f9713b7d037e0be3d`; the Effort, Goal ceiling, Outcome, and success definition did not change.

### Outcome

- **Shipped tier:** L2.
- **Highest reached Goal verdict:** **L1 PASS**; the ceiling was reached and not downgraded.
- **Coverage:** full; **deferred tuples:** none.
- Checked-in recipes: `examples/recipes/opencv_inpainting_lama/cpu/cpu/inpainting_fp32_config.json` and `examples/recipes/opencv_inpainting_lama/cpu/cpu/inpainting_fp16_config.json`.
- Shipped code covers deterministic bare-repository ONNX resolution with immutable revision provenance and ambiguity rejection; offline/connectivity fallback for optional discovery; recipe-free/export-null direct ONNX builds; consistent prequantized/FP16 stage behavior; and generic, persisted, fail-closed inpainting runtime dispatch.
- Recipe-free bare-ID acceptance passed in **6.066265 s**, producing the pinned `inpainting_lama_2025jan.onnx` artifact and recording the repository ID, selected artifact, and immutable Hub revision in the build manifest.
- The public `inpainting` caller contract is canonical: **nonzero mask pixels identify holes (the replaced region)**. Persisted `runtime.options.mask_semantics` does not redefine caller input; it declares the **model-side ONNX mask tensor polarity**. After binarizing the caller mask, the adapter preserves it for `nonzero-is-hole` (hole → 1, background → 0) and inverts it for `zero-is-hole` (hole → 0, background → 1), preserving the same semantic hole region.
- Fresh tester-r5 semantic-contract evidence exercised one fixed caller mask through the public pipeline adapter under both model-side polarities. In each case, decoded model-side hole coordinates exactly matched caller nonzero coordinates `[[0,1],[1,1],[1,2]]`; the focused semantic-contract regressions passed **3 tests**, the complete task/inpainting files passed **28 tests**, and the broader affected suite passed **369 tests**.
- The refreshed learner audit confirms existing findings `lama-001` through `lama-004`, `_task-inpainting-001`, and `_meta-085` through `_meta-088` without adding, retiring, or rewriting finding IDs. The inpainting-eval gap remains tracked by [microsoft/winml-cli#1158](https://github.com/microsoft/winml-cli/issues/1158); skill-only evidence remains isolated in [Draft PR gim-home/ModelKitArtifacts#170](https://github.com/gim-home/ModelKitArtifacts/pull/170).

The L1 ceiling remains the formal result. Supplementary L2 used the published ONNX artifact at revision `aee6d22f0a13e5e35af1c9a1c3afd62841fc6f3f` because the checkpoint publishes no PyTorch weights or loadable PyTorch implementation; no PyTorch result is fabricated.

| Candidate | Reference | Verdict | Cosine similarity | Max abs | Mean abs | RMSE | PSNR (dB) | Unmasked max abs |
|---|---|---|---:|---:|---:|---:|---:|---:|
| mixed INT8+fp32 | pinned published ONNX | PASS | 1.0 | 0.0 | 0.0 | 0.0 | ∞ | 0.0 |
| mixed INT8+fp16 | pinned published ONNX | PASS | 0.9847547323069161 | 134.32603454589844 | 9.53465276117015 | 28.621334963655865 | 18.997005881260385 | 0.0623779296875 |

The public runtime adapter exactly matched direct candidate output for both tuples: fp32 cosine **0.9999999999999999**, max abs **0.0**; fp16 cosine **1.0**, max abs **0.0**. Against the pinned source ONNX through that adapter, fp32 remained exact and fp16 measured cosine **0.9847192758836978**, max abs **135.0**, mean abs **9.529802958170572**, and RMSE **28.638184333305173**.

#### Quality results

Tester r5 validated the current head **`f03add820f384ce725e83400d53d108ff43aad0a`**. Build/artifact, CLI perf, semantic runtime perf, supplementary ONNX-reference, and eval evidence was retained only under the tester's explicit carryover checks; semantic-contract, analyze, component/op, quality, and provenance evidence was freshly rerun or refreshed.

| Current-head check | Result |
|---|---|
| Canonical caller-mask and both model-side polarity regressions | PASS — 3 passed in 1.27 s |
| Complete task + inpainting test files | PASS — 28 passed in 1.31 s |
| Broader affected suite | PASS — 369 passed in 18.87 s |
| `mypy -p winml.modelkit` | PASS — no issues in 407 source files |
| Ruff on all 27 changed Python files | PASS — all checks passed |
| Ruff format check on all 27 changed Python files | PASS — 27 files already formatted |
| `git diff --check origin/main...HEAD` | PASS |

The current repair changed public contract documentation/error wording and focused tests, not `_prepare_mask()` executable conversion, recipes, model artifacts, perf/session code, or eval support. Tester r5 reverified source/recipe/artifact hashes and affected scope before retaining the concrete build, perf, runtime, ONNX-reference, and eval evidence below.

### Per-EP/device/precision results — including perf and eval data

#### Goal ladder

| Tier | Verdict | Evidence |
|---|---|---|
| L0 | PASS | Both exact required tuples freshly built and passed ONNX structural, named-I/O, initializer-transition, runtime-contract, and immutable-provenance validation. |
| L1 | PASS | Both tuples completed CLI perf and semantic image+mask inference through `InferenceEngine` → persisted manifest contract → `WinMLInpaintingPipeline` → CPU model → PNG postprocessing, with exact adapter/direct parity. |

#### Build and CLI perf

CLI perf used 3 warmups and 20 measured iterations with the same named semantic inputs.

| Tier | EP / Device | Precision | Verdict | Build time | Graph semantics | Mean | p50 | Throughput | RAM Δ | VRAM Δ | Task metric |
|---|---|---|---|---:|---|---:|---:|---:|---:|---:|---|
| L0/L1 | CPUExecutionProvider / cpu | fp32 | PASS | 7.0649837 s | 606 FLOAT + 598 INT8 + 299 INT64 initializers; FLOAT I/O; 18,001 nodes | 2569.827 ms | 2555.584 ms | 0.39 samples/s | +656.16 MB total; +183.07 MB model load | +0.0 MB local / +0.0 MB shared | — |
| L0/L1 | CPUExecutionProvider / cpu | fp16 | PASS | 10.0799193 s | 606 FLOAT16 + 598 INT8 + 299 INT64 initializers; FLOAT I/O; 18,436 nodes | 2589.314 ms | 2582.497 ms | 0.39 samples/s | +728.93 MB total; +193.34 MB model load | +0.0 MB local / +0.0 MB shared | — |

Both artifacts retain the source graph’s 598 INT8 initializers. The coarse CLI precision detector consequently reports `w8a8`; tuple identity is established by requested precision plus the audited residual FLOAT→FLOAT16 transition.

Supplementary public-runtime measurements used 2 warmups and 5 measured iterations:

| EP / Device | Precision | Runtime mean | Runtime p50 | Runtime throughput | Runtime RAM Δ | Output |
|---|---|---:|---:|---:|---:|---|
| CPUExecutionProvider / cpu | fp32 | 2594.686 ms | 2601.28 ms | 0.3853442811112959 samples/s | +1103.91796875 MB | PNG, 512 x 512, 42,667 bytes |
| CPUExecutionProvider / cpu | fp16 | 2668.932 ms | 2679.08 ms | 0.37464229996198944 samples/s | +1178.15625 MB | PNG, 512 x 512, 49,083 bytes |

#### Eval support evidence

| Tier | EP / Device | Precision | Verdict | Dataset / revision / subset | Split / samples | Task metric | Blocker |
|---|---|---|---|---|---|---|---|
| L3 supplementary | CPUExecutionProvider / cpu | fp32 | CLI-BLOCKED | `mattmdjaga/human_parsing_dataset` / `db120bb5c18c146a8fbd2160f7575a288269fe7d` / none | train / 1 | none | Exit 1 after 0.6550235000322573 s: `Task 'inpainting' is not supported`; no output was produced. Schema probe exit 2 has the same unsupported-task registry gap. |
| L3 supplementary | CPUExecutionProvider / cpu | fp16 | CLI-BLOCKED | `mattmdjaga/human_parsing_dataset` / `db120bb5c18c146a8fbd2160f7575a288269fe7d` / none | train / 1 | none | Exit 1 after 0.6559123999904841 s: `Task 'inpainting' is not supported`; no output was produced. Schema probe exit 2 has the same unsupported-task registry gap. |

The dataset is a schema probe only and does not establish an authoritative restored-target contract or canonical inpainting metric. This is an evaluator-registry plus metric-dataset-contract gap, not an EP, export, precision, build, or runtime failure.

### Delta

#### Recipes and configuration

Relative to the replacement charter’s generated baseline recipe, both checked-in recipes add the explicit `/runtime` contract; fp16 additionally changes `/quant` from `null` to an explicit FP16 conversion configuration.

| Recipe | JSON pointer | Baseline value | Shipped value |
|---|---|---|---|
| fp32 and fp16 | `/runtime` | `null` | `{"pipeline":"inpainting","options":{"image_input_name":"image","mask_input_name":"mask","output_name":"output","image_color_order":"bgr","image_value_range":[0,1],"mask_semantics":"nonzero-is-hole","output_color_order":"bgr","output_value_range":[0,255]}}` |
| fp16 only | `/quant` | `null` | explicit `mode: fp16` configuration below |

```json
{
  "mode": "fp16",
  "samples": 10,
  "calibration_method": "minmax",
  "weight_type": "uint8",
  "activation_type": "uint8",
  "per_channel": false,
  "symmetric": false,
  "weight_symmetric": null,
  "activation_symmetric": null,
  "save_calibration": false,
  "distribution": "uniform",
  "seed": null,
  "calibration_load_path": null,
  "calibration_save_path": null,
  "op_types_to_quantize": null,
  "nodes_to_exclude": null,
  "fp16_keep_io_types": true,
  "fp16_op_block_list": null
}
```

The public task schema defines one caller-side convention: nonzero mask pixels are holes. The persisted runtime contract separately declares exact image/mask/output tensor roles, BGR image `[0,1]`, **model-side ONNX mask tensor polarity**, and BGR output `[0,255]`. For the checked-in LaMa recipes, `mask_semantics: "nonzero-is-hole"` means the canonical caller mask is passed through after binarization. A different model declaring `zero-is-hole` receives the inverted ONNX tensor while the caller-designated hole region remains unchanged. Both schemas validated, actual builds persisted the contract in resolved configuration and manifests, and reducibility is consistent with the charter. The fp32 recipe has no additional delta; the fp16 recipe converts only the remaining floating tensors while preserving prequantized INT8 weights. The production recipe README remains unchanged.

The actual public pipeline passed all four fail-closed contract checks: missing contract, unsupported image range, absent/non-distinct tensor roles, and an unknown model-specific option all raised their expected `ValueError` rather than guessing semantics.

#### Code

| Path | Symbols | Class-wide behavior change |
|---|---|---|
| `src/winml/modelkit/loader/onnx_hub.py` | `ResolvedHubOnnx`, `resolve_hf_repo_onnx()` | Discovers exactly one ONNX sibling for config-less Hub repositories, pins resolution/download, rejects ambiguity, and falls back safely on optional-preflight connectivity failures. |
| `src/winml/modelkit/utils/model_input.py` | `ModelInput`, `resolve_model_input()` | Adds opt-in bare-repository ONNX discovery and carries repository, artifact, and revision provenance. |
| `src/winml/modelkit/commands/build.py` | `build()`, `_run_quantize_stage()`, `_build_onnx_pipeline()` | Routes recipe-free/export-null repositories through direct ONNX, records provenance/runtime metadata, and preserves explicit FP16 conversion for prequantized graphs. |
| `src/winml/modelkit/config/build.py` | `WinMLRuntimeConfig`, `WinMLBuildConfig`, `generate_onnx_build_config()` | Adds validated serializable runtime metadata and suppresses incompatible requantization while retaining explicit FP16 conversion. |
| `src/winml/modelkit/build/common.py` | `ensure_pre_quantized_stamped()` | Clears only incompatible quantization modes and preserves `mode=fp16`. |
| `src/winml/modelkit/build/onnx.py` | `build_onnx_model()` | Skips optimization for prequantized inputs while still converting remaining floating tensors when FP16 is explicit. |
| `src/winml/modelkit/build/hf.py` | `build_hf_model()` | Applies the same prequantized/FP16 semantics in the Python HF path. |
| `src/winml/modelkit/utils/cli.py` | `normalize_model_arg()` | Resolves an unambiguous bare direct-ONNX Hub repository. |
| `src/winml/modelkit/models/auto.py` | `WinMLAutoModel.from_pretrained()` | Recognizes bare direct-ONNX Hub repositories and retains runtime metadata. |
| `src/winml/modelkit/inference/engine.py` | `InferenceEngine.load()`, `InferenceEngine.load_schema_only()` | Resolves repositories for normal inference, restores manifest runtime metadata, and avoids artifact download for explicit-task schema-only loading. |
| `src/winml/modelkit/inference/tasks.py` | `TASK_REGISTRY`, `_postprocess_inpainting()` | Registers the generic two-image inpainting contract and JSON-safe PNG output; the public mask description fixes caller polarity as nonzero-is-hole. |
| `src/winml/modelkit/inference/pipeline.py` | `_CUSTOM_PIPELINE_FACTORIES`, `create_pipeline()` | Dispatches registered non-Transformers task pipelines and passes persisted runtime metadata. |
| `src/winml/modelkit/inference/inpainting.py` | `WinMLInpaintingPipeline`, `_prepare_mask()` | Implements a fail-closed metadata-driven adapter: canonical caller nonzero holes are encoded into the persisted model-side ONNX mask polarity without changing the semantic hole region. |
| `src/winml/modelkit/utils/manifest.py` | `WinMLManifest` | Persists optional runtime metadata while retaining schema-version-1 compatibility. |
| `src/winml/modelkit/models/winml/base.py` | `WinMLPreTrainedModel.runtime_config` | Carries the runtime contract on programmatic wrappers. |

The committed diff also adds or updates focused tests for build paths, config generation, inference, task registration, Hub resolution, auto-model loading, manifests, and model-input resolution.

### Analyze summary — component level and op level

**ANALYZE-PARTIAL-SUCCESS:** both literal tester-owned `analyze --ep all --device all` processes exited **1** because OpenVINO plugin registration failed with Error 126 (`onnxruntime_providers_shared.dll` was missing). Each process nevertheless emitted complete fail-closed JSON with **11 unique nonempty classification rows**, including all **six required public rule-backed targets**, complete graph metadata, and 100% component mapping. This is static rule analysis, not runtime execution; every emitted EP row has `runtime_support=false`.

#### Component-level summary

| Artifact | Architecture coverage | Mapping | Confidence | Actionable EP findings |
|---|---|---|---|---|
| fp32 | mask/composite; encoder scopes 0-4; 18 FFC residual scopes 5-22; decoder scopes 23-33; output scopes 34-35 | 18,001 mapped; 0 partial; 0 unmapped | verified | QNN NPU/GPU partial: Shape, Transpose. OpenVINO NPU partial: Sqrt; unsupported: Add, Cast, Div. OpenVINO GPU/CPU unsupported: Add, Cast, Div, Sqrt. |
| fp16 | mask/composite; encoder scopes 0-4; 18 FFC residual scopes 5-22; decoder scopes 23-33; output scopes 34-35 | 18,436 mapped; 0 partial; 0 unmapped | verified | QNN NPU/GPU partial: Shape, Transpose. OpenVINO NPU partial: Sqrt; unsupported: Add, Cast, Div. OpenVINO GPU/CPU unsupported: Add, Cast, Div, Sqrt. |

There are no component-mapping gaps. The nonzero process exits are retained; complete component/op payloads do not establish runtime compatibility.

#### Op-level summary

| Artifact | Graph | Dominant ops | EP roll-up |
|---|---|---|---|
| fp32 | 18,001 ops / 30 types | Constant 7,054; Reshape 1,570; Concat 1,360; Slice 1,322; Shape 1,188; Cast 782; Transpose 638; Unsqueeze 504 | 11 nonempty rows, six rule-backed. QNN NPU/GPU partial: Shape, Transpose. OpenVINO NPU partial: Sqrt; unsupported: Add, Cast, Div. OpenVINO GPU/CPU unsupported: Add, Cast, Div, Sqrt. Other rows retain unknown operations; no runtime-support claim. |
| fp16 | 18,436 ops / 30 types | Constant 7,054; Reshape 1,570; Concat 1,360; Slice 1,322; Cast 1,217; Shape 1,188; Transpose 638; Unsqueeze 504 | 11 nonempty rows, six rule-backed. QNN NPU/GPU partial: Shape, Transpose. OpenVINO NPU partial: Sqrt; unsupported: Add, Cast, Div. OpenVINO GPU/CPU unsupported: Add, Cast, Div, Sqrt. Other rows retain unknown operations; no runtime-support claim. |

### Reproduce commands

The block starts with tester-owned portable build/perf/eval commands. The rules setup downloads the official `v0.2.0` release asset verified through the public GitHub release API: asset `rules-v0.2.0.zip`, published SHA-256 `6dcabbe7f5493fbc2bd23de195ab6e35b3578d510f18c2e220bc5538a1f232cc`, six expected EP directories, and 1,746 Parquet files. The pinned package expands those EP directories directly at the selected root, so `WINMLCLI_RULES_DIR` is set deterministically to that resolved expansion path. The two tester-owned analyze invocations include literal `--ep all --device all`; on the tester host each exited 1 for the OpenVINO Error 126 above while still emitting the complete 11-row static payload.

```powershell
$OUT='temp/opencv-inpainting-lama-repro'
$env:OUT=$OUT; python -c "import os,numpy as np; from pathlib import Path; y,x=np.mgrid[0:512,0:512]; image=np.empty((1,3,512,512),dtype=np.float32); image[0,0]=x/511; image[0,1]=y/511; image[0,2]=((x+y)%256)/255; mask=np.zeros((1,1,512,512),dtype=np.float32); mask[0,0,160:352,176:336]=1; p=Path(os.environ['OUT']); p.mkdir(parents=True,exist_ok=True); np.savez(p/'semantic_inputs.npz',image=image,mask=mask)"
winml build -c examples/recipes/opencv_inpainting_lama/cpu/cpu/inpainting_fp32_config.json -m opencv/inpainting_lama -o $OUT/fp32 --ep cpu --device cpu --precision fp32 --no-analyze --no-compile --rebuild --no-color
winml build -c examples/recipes/opencv_inpainting_lama/cpu/cpu/inpainting_fp16_config.json -m opencv/inpainting_lama -o $OUT/fp16 --ep cpu --device cpu --precision fp16 --no-analyze --no-compile --rebuild --no-color

$RULES_ASSET_URL='https://github.com/microsoft/winml-cli/releases/download/v0.2.0/rules-v0.2.0.zip'
$RULES_ZIP=Join-Path $OUT 'rules-v0.2.0.zip'
$RULES_EXPANDED=Join-Path $OUT 'rules-v0.2.0'
Invoke-WebRequest -UseBasicParsing -Uri $RULES_ASSET_URL -OutFile $RULES_ZIP
$EXPECTED_RULES_SHA256='6dcabbe7f5493fbc2bd23de195ab6e35b3578d510f18c2e220bc5538a1f232cc'
$ACTUAL_RULES_SHA256=(Get-FileHash $RULES_ZIP -Algorithm SHA256).Hash.ToLowerInvariant()
if ($ACTUAL_RULES_SHA256 -ne $EXPECTED_RULES_SHA256) { throw "rules-v0.2.0.zip SHA-256 mismatch: $ACTUAL_RULES_SHA256" }
if (Test-Path $RULES_EXPANDED) { Remove-Item $RULES_EXPANDED -Recurse -Force }
Expand-Archive -Path $RULES_ZIP -DestinationPath $RULES_EXPANDED -Force
$EXPECTED_EP_DIRS=@('NvTensorRTRTXExecutionProvider_GPU','OpenVINOExecutionProvider_CPU','OpenVINOExecutionProvider_GPU','OpenVINOExecutionProvider_NPU','QNNExecutionProvider_GPU','QNNExecutionProvider_NPU')
$ACTUAL_EP_DIRS=@(Get-ChildItem $RULES_EXPANDED -Directory | Sort-Object Name | Select-Object -ExpandProperty Name)
if (($ACTUAL_EP_DIRS -join "`n") -ne (($EXPECTED_EP_DIRS | Sort-Object) -join "`n")) { throw "Unexpected rules package layout: $($ACTUAL_EP_DIRS -join ', ')" }
$RULE_FILES=@(Get-ChildItem $RULES_EXPANDED -Recurse -File -Filter '*.parquet')
if ($RULE_FILES.Count -ne 1746) { throw "Unexpected rules file count: $($RULE_FILES.Count)" }
$env:WINMLCLI_RULES_DIR=(Resolve-Path $RULES_EXPANDED).Path
winml analyze --model $OUT/fp32/model.onnx --ep all --device all --output $OUT/analyze_fp32.json --overwrite --format json --no-color
winml analyze --model $OUT/fp16/model.onnx --ep all --device all --output $OUT/analyze_fp16.json --overwrite --format json --no-color
Remove-Item Env:WINMLCLI_RULES_DIR

winml perf -m $OUT/fp32/model.onnx --ep cpu --device cpu --precision fp32 --input-data $OUT/semantic_inputs.npz --iterations 20 --warmup 3 --memory --output $OUT/perf_fp32.json --overwrite --format json --no-color
winml perf -m $OUT/fp16/model.onnx --ep cpu --device cpu --precision fp16 --input-data $OUT/semantic_inputs.npz --iterations 20 --warmup 3 --memory --output $OUT/perf_fp16.json --overwrite --format json --no-color
winml eval -m $OUT/fp32/model.onnx --model-id opencv/inpainting_lama --task inpainting --dataset mattmdjaga/human_parsing_dataset --dataset-revision db120bb5c18c146a8fbd2160f7575a288269fe7d --split train --samples 1 --no-shuffle --device cpu --ep cpu --output $OUT/eval_fp32.json --overwrite --format json --no-color
winml eval -m $OUT/fp16/model.onnx --model-id opencv/inpainting_lama --task inpainting --dataset mattmdjaga/human_parsing_dataset --dataset-revision db120bb5c18c146a8fbd2160f7575a288269fe7d --split train --samples 1 --no-shuffle --device cpu --ep cpu --output $OUT/eval_fp16.json --overwrite --format json --no-color
```
