### PR TITLE
ci(e2e): move daily E2E Test schedule to 02:00 (UTC+8)

### DIFF
--- a/.pipelines/Modelkit E2E Test.yml
+++ b/.pipelines/Modelkit E2E Test.yml
@@ -18,7 +18,7 @@
 # Trigger model:
 #   * Manual queue-time runs (with selectable parameters) for ad-hoc
 #     validation.
-#   * Daily scheduled run at 08:00 Beijing time (00:00 UTC) on `main`.
+#   * Daily scheduled run at 02:00 Beijing time (18:00 UTC) on `main`.
 #   * CI trigger on `release/*` branches — fires on the initial push
 #     that creates a new release branch so each new release branch gets
 #     an automatic E2E run. (Subsequent pushes to a release branch will
@@ -37,8 +37,8 @@ trigger:
       - release/*
 
 schedules:
-  - cron: '0 0 * * *'
-    displayName: 'Daily run — 08:00 (UTC+8) every day'
+  - cron: '0 18 * * *'
+    displayName: 'Daily run — 02:00 (UTC+8) every day'
     branches:
       include:
         - main


### PR DESCRIPTION
## What

Change the daily scheduled trigger of the **Modelkit E2E Test** pipeline from **08:00 (UTC+8)** to **02:00 (UTC+8)**.

## Why

Run the daily E2E validation earlier (overnight in Beijing time) so results are ready before the workday starts.

## Changes

`.pipelines/Modelkit E2E Test.yml`:
- `cron`: `0 0 * * *` → `0 18 * * *` (02:00 UTC+8 = 18:00 UTC the previous day)
- `displayName`: `Daily run — 08:00 (UTC+8) every day` → `Daily run — 02:00 (UTC+8) every day`
- Header comment updated: `08:00 Beijing time (00:00 UTC)` → `02:00 Beijing time (18:00 UTC)`

No change to trigger frequency (still daily on `main`, `always: true`), branch scope, or job logic.