### PR TITLE
recipe(ms-marco-MiniLM-L12-v2): add CPU fp32 and fp16 recipes

### DIFF
--- a/examples/recipes/cross-encoder_ms-marco-MiniLM-L12-v2/cpu/cpu/text-classification_fp16_config.json
+++ b/examples/recipes/cross-encoder_ms-marco-MiniLM-L12-v2/cpu/cpu/text-classification_fp16_config.json
@@ -1,0 +1,88 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          30522
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      },
+      {
+        "name": "token_type_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "text-classification",
+    "model_id": "cross-encoder/ms-marco-MiniLM-L12-v2",
+    "model_type": "bert",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "text-classification",
+    "model_class": "AutoModelForSequenceClassification",
+    "model_type": "bert"
+  }
+}

--- a/examples/recipes/cross-encoder_ms-marco-MiniLM-L12-v2/cpu/cpu/text-classification_fp32_config.json
+++ b/examples/recipes/cross-encoder_ms-marco-MiniLM-L12-v2/cpu/cpu/text-classification_fp32_config.json
@@ -1,0 +1,66 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          30522
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      },
+      {
+        "name": "token_type_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "text-classification",
+    "model_class": "AutoModelForSequenceClassification",
+    "model_type": "bert"
+  }
+}


### PR DESCRIPTION
Add verified CPU recipes (fp32 + fp16) for `cross-encoder/ms-marco-MiniLM-L12-v2`, a BERT-based cross-encoder fine-tuned on MS MARCO for passage reranking. Effort L0, Goal L1 (build + perf), Outcome L0 (recipe only). Complements existing L4-v2 and L6-v2 recipes in the same cross-encoder family.

## Model metadata

**What the model does:** Cross-encoder reranker that scores query-passage relevance for information retrieval, fine-tuned from MiniLM-L12 on the MS MARCO passage ranking dataset.

**Primary user stories:**
- User supplies a query-passage pair to obtain a relevance score for passage reranking in search pipelines.

**Supported tasks:**
- `text-classification` — Optimum vendor-supported (BertForSequenceClassification); winml resolves via TasksManager.

**Model architecture:**

```text
BertForSequenceClassification
├── Embeddings (vocab 30522 x 384)
├── Encoder stack x 12
│   ├── Self-attention (12 heads, 384 dim)
│   ├── Feed-forward (384 → 1536 → 384, GELU)
│   └── Residual + LayerNorm
└── Classification head (384 → 1: relevance logit, Tanh)
```

- Source/confidence: pinned checkpoint `config.json` (`architectures: ["BertForSequenceClassification"]`, `model_type: "bert"`) (`verified`).

## Validation and support evidence

### Baseline

- **main commit**: `5deebd42` | **winml**: `0.2.0`
- **Optimum probe**: VENDOR-ONLY — `text-classification` registered by Optimum for `bert`; winml adds nothing.
- **Build**: ✅ PASS (auto-config, no recipe) — `AutoModelForSequenceClassification` / `text-classification`
- **Perf**: ✅ PASS — CPU avg 68.10 ms, 14.68 samples/sec
- **Goal floor**: L1 (build + perf inherited from main)

### Goal

- **Effort**: L0 — recipe only, no source edits.
- **Goal ceiling**: L1 — baseline already demonstrates L0 + L1.
- **Outcome**: L0 — recipe + report.

### Outcome

Highest reached: **L1 PASS**. Coverage: **full**. Deferred tuples: none.

Shipped recipes:
- `examples/recipes/cross-encoder_ms-marco-MiniLM-L12-v2/cpu/cpu/text-classification_fp32_config.json`
- `examples/recipes/cross-encoder_ms-marco-MiniLM-L12-v2/cpu/cpu/text-classification_fp16_config.json`

### Per-EP/device/precision results

| Tier | EP / Device | Precision | Verdict | Mean | p50 | Throughput | RAM Δ |
|---|---|---|---|---|---|---|---|
| L0 | CPUExecutionProvider / cpu | fp32 | PASS | — | — | — | — |
| L1 | CPUExecutionProvider / cpu | fp32 | PASS | 57.86 ms | 57.67 ms | 17.55 samples/sec | +178.4 MB |
| L0 | CPUExecutionProvider / cpu | fp16 | PASS | — | — | — | — |
| L1 | CPUExecutionProvider / cpu | fp16 | PASS | — | — | 8.43 samples/sec | — |

### Delta

Recipe delta vs `winml config`: **identical** — filed for verified `cpu/cpu` coverage. Production recipe README unchanged.

### Analyze summary — component level and op level

Static rule analysis completed; this is compatibility analysis, not runtime execution.

#### Component-level summary

| Artifact | Architecture coverage | Mapping | Actionable EP findings |
|---|---|---|---|
| fp32 | embeddings (3x Gather); 12x encoder attention/FFN (Gemm, MatMul, Softmax, Gelu, LayerNorm); classification heas (after autoconf: gelu_fusion, matmul_add_fusion) | None actionable — CPU is rule-less |

#### Op-level summary

| Artifact | Graph | Dominant ops | EP roll-up |
|---|---|---|---|
| fp32 | 388 ops / 16 types | Reshape 120; Gemm 74; Transpose 48; Add 38; LayerNormalization 25; Mul 24; MatMul 24 | CPU: all 16 types unknown (rule-less EP) |

Rule-less EPs (CPU): all operator types classified as unknown — no runtime check rules available.

### Reproduce commands

```powershell
# fp32
winml build -m cross-encoder/ms-marco-MiniLM-L12-v2 `
  -c examples/recipes/cross-encoder_ms-marco-MiniLM-L12-v2/cpu/cpu/text-classification_fp32_config.json `
  -o $OUT --ep cpu --device cpu
winml perf -m $OUT/model.onnx --ep cpu --device cpu

# fp16
winml build -m cross-encoder/ms-marco-MiniLM-L12-v2 `
  -c examples/recipes/cross-encoder_ms-marco-MiniLM-L12-v2/cpu/cpu/text-classification_fp16_config.json `
  -o $OUT_FP16 --ep cpu --device cpu -p fp16
winml perf -m $OUT_FP16/model.onnx --ep cpu --device cpu
```