### PR TITLE
recipe(beit): add CPU image classification recipes

### DIFF
--- a/examples/recipes/microsoft_beit-base-patch16-224/cpu/cpu/image-classification_fp16_config.json
+++ b/examples/recipes/microsoft_beit-base-patch16-224/cpu/cpu/image-classification_fp16_config.json
@@ -1,0 +1,42 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          224,
+          224
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "image-classification",
+    "model_class": "AutoModelForImageClassification",
+    "model_type": "beit"
+  }
+}

--- a/examples/recipes/microsoft_beit-base-patch16-224/cpu/cpu/image-classification_fp32_config.json
+++ b/examples/recipes/microsoft_beit-base-patch16-224/cpu/cpu/image-classification_fp32_config.json
@@ -1,0 +1,42 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          224,
+          224
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "image-classification",
+    "model_class": "AutoModelForImageClassification",
+    "model_type": "beit"
+  }
+}


### PR DESCRIPTION
### Summary

Adds verified CPU coverage recipes for `microsoft/beit-base-patch16-224` image classification, covering both fp32 and fp16 under `examples/recipes/microsoft_beit-base-patch16-224/cpu/cpu/`. BEiT is already supported by vendor Optimum/WinML defaults, so this is a recipe-only L0 contribution: the recipes preserve the current auto-config behavior and make the exact CPU tuples reproducible from checked-in config. Highest verified goal is L3 on CPU for both fp32 and fp16.

### Model metadata

#### What the model does

BEiT base image-classification checkpoint that consumes RGB images as pixel tensors and produces 1000 ImageNet-class logits. The checkpoint metadata advertises image-classification, the config selects `BeitForImageClassification`, and the WinML/Optimum probes resolve the same image-classification task. Confidence: verified.

Evidence: pinned checkpoint revision `f02e8f77db4703e3fbd3766e3375a4619c5a4863`; checkpoint `pipeline_tag=image-classification`; `AutoConfig` reports `architectures=["BeitForImageClassification"]`, `image_size=224`, `patch_size=16`, and `num_labels=1000`; `winml inspect` resolves `AutoModelForImageClassification`, `BeitOnnxConfig`, and `WinMLModelForImageClassification`.

#### Primary user stories

- A user supplies one or more RGB images to obtain ranked ImageNet classification logits for each image. Confidence: verified.
- A user supplies image tensors to obtain BEiT visual representations for downstream feature extraction workflows supported by the model type. Confidence: mapped.

#### Supported tasks

| Task | Support surface | Evidence | Confidence |
|---|---|---|---|
| image-classification | checkpoint, transformers, optimum-onnx, winml | checkpoint pipeline tag; `BeitForImageClassification`; Optimum vendor task; `winml inspect` default support | verified |
| feature-extraction | transformers, optimum-onnx | Optimum vendor task; `BeitModel` backbone | mapped |

#### Model architecture

BEiT image classifier with 16x16 patch embeddings over 224x224 RGB input, a 12-layer transformer encoder (hidden size 768, 12 attention heads, 3072-wide GELU MLP, relative position bias), mean pooling over patch tokens, and a 1000-way linear classifier. Confidence: verified.

```text
BeitForImageClassification
|-- BeitModel
|   |-- BeitEmbeddings (RGB 224x224 -> 14x14 patches, hidden 768; cls token)
|   |-- BeitEncoder x 12
|   |   |-- LayerNorm -> self-attention (12 heads, relative position bias)
|   |   |-- residual/drop path
|   |   |-- LayerNorm -> MLP (768 -> 3072 -> 768, GELU)
|   |   \-- residual/drop path
|   |-- final layernorm is Identity when use_mean_pooling=true
|   \-- BeitPooler (mean pool patch tokens + LayerNorm)
\-- classifier (768 -> 1000 logits)
```

### Validation and support evidence

#### Baseline

Baseline was measured on current `origin/main` commit `5deebd422e95f28fe8fd912ee50ce874710187b3` with `winml, version 0.2.0`. Optimum probe for `model_type=beit` returned vendor tasks `feature-extraction` and `image-classification`; WinML registration did not add overrides, so the verdict is `VENDOR-ONLY`.

Recipe-free baseline build passed on CPU with `AutoModelForImageClassification`, `BeitOnnxConfig`, opset 17, 5,766 ONNX nodes, and 100.0% hierarchy tag coverage. Baseline CPU perf passed at 33.67 ms average, 33.68 ms p50, 29.70 samples/sec, and +394.8 MB RAM total. Baseline CPU eval passed on the default `timm/mini-imagenet` test split with 10 samples and accuracy 1.0. Baseline goal floor is L3.

#### Goal

- Effort: L0, recipe-only.
- Goal ceiling: L3, because current main already reaches L3 and the shipped recipes must preserve that behavior for exact CPU precision tuples.
- Outcome: L0, checked-in recipes only.
- Target EPs: `cpu`.
- Precision plan: `cpu/cpu/fp32`, `cpu/cpu/fp16`.
- Success definition: each CPU tuple builds from its checked-in recipe, runs perf, matches the HF reference numerically, and completes image-classification eval.

#### Outcome

Highest reached verdict: L3 PASS for both CPU tuples. Coverage: full for the committed target set; no deferred tuples. Shipped recipe paths:

- `examples/recipes/microsoft_beit-base-patch16-224/cpu/cpu/image-classification_fp32_config.json`
- `examples/recipes/microsoft_beit-base-patch16-224/cpu/cpu/image-classification_fp16_config.json`

Methodology declaration: no methodology friction observed. Learner finding `beit-001` was recorded in local skill knowledge for future BEiT runs; it is not included in this Lane B model PR.

#### Per-EP/device/precision results

| Tier | EP / Device | Precision | Verdict | Evidence |
|---|---|---|---|---|
| L0 build | CPUExecutionProvider / cpu | fp32 | PASS | Build complete in 32.1s; final artifact is fp32; input `pixel_values [1,3,224,224]`; output `logits [1,1000]`; external data colocated with `model.onnx`; FLOAT initializers present. |
| L0 build | CPUExecutionProvider / cpu | fp16 | PASS | Build complete in 31.2s with `--precision fp16`; FP16 stage produced 175.7 MB artifact; input/output I/O preserved as fp32; FLOAT16 initializers present; external data colocated with `model.onnx`. |
| L1 perf | CPUExecutionProvider / cpu | fp32 | PASS | Avg 41.82 ms; p50 41.77 ms; p95 43.05 ms; throughput 23.91 samples/sec; RAM total +395.9 MB; `Model Precision: fp32`. |
| L1 perf | CPUExecutionProvider / cpu | fp16 | PASS | Avg 57.88 ms; p50 63.88 ms; p95 66.43 ms; throughput 17.28 samples/sec; RAM total +413.9 MB; `Model Precision: fp16`. |
| L2 compare | CPUExecutionProvider / cpu | fp32 | PASS | `winml eval --mode compare`, 5 samples: logits cosine mean 0.999999999905, max-abs diff mean 5.9557e-05, SQNR mean 97.05 dB. |
| L2 compare | CPUExecutionProvider / cpu | fp16 | PASS | `winml eval --mode compare`, 5 samples: logits cosine mean 0.999994572095, max-abs diff mean 0.0131404, SQNR mean 49.92 dB. |
| L3 eval | CPUExecutionProvider / cpu | fp32 | PASS | `timm/mini-imagenet`, test split, 10 samples, accuracy 0.9, 13.53 samples/sec. |
| L3 eval | CPUExecutionProvider / cpu | fp16 | PASS | `timm/mini-imagenet`, test split, 10 samples, accuracy 0.9, 9.83 samples/sec. |

#### Delta

Both checked-in recipes are JSON-identical to the CPU auto-config generated by:

```powershell
winml config -m microsoft/beit-base-patch16-224 -t image-classification --ep cpu --device cpu
```

There are no changed JSON pointers relative to auto-config. The contribution is the verified coverage claim for the exact `cpu/cpu/fp32` and `cpu/cpu/fp16` tuples. The fp16 tuple is proven by the build command's `--precision fp16` flag and artifact evidence, not by a different recipe body. No source files were changed, no code fix was required, and `examples/recipes/README.md` is unchanged.

Reducibility check: consistent with the charter. Auto-config already derives the task, loader model class, exporter, opset, input tensor, output tensor, and model type from checkpoint metadata and vendor Optimum support; no class-wide code gap or per-checkpoint override is being hidden in the recipes.

#### Analyze summary

Static rule analysis completed with partial-support exit status because some non-target accelerator rows have partial operators. This is compatibility analysis, not runtime execution, and it does not change the CPU runtime verdict above.

Component-level summary:

| Artifact | Architecture coverage | Mapping | Actionable EP findings |
|---|---|---|---|
| fp32 | patch embeddings; 12x encoder attention/MLP with relative position bias and GELU; mean pooler; classifier | 5,766 tagged ONNX nodes, 0 untagged, mapped confidence | QNN NPU/GPU partial GELU-related ops: Add, Div, Erf, Mul |
| fp16 | patch embeddings; 12x encoder attention/MLP with relative position bias and GELU; mean pooler; classifier | 5,766 tagged ONNX nodes, 0 untagged, mapped confidence | QNN NPU/GPU partial GELU-related ops: Add, Div, Erf, Mul |

Op-level summary:

| Artifact | Graph | Dominant ops | EP roll-up |
|---|---|---|---|
| fp32 | 440 operators / 14 unique types | Add 108; MatMul 96; Mul 72; Reshape 49; Transpose 49 | NvTensorRTRTX GPU and OpenVINO NPU/GPU/CPU fully supported by rules; QNN NPU/GPU partial as above |
| fp16 | 442 operators / 15 unique types | Add 108; MatMul 96; Mul 72; Reshape 49; Transpose 49; Cast 2 | NvTensorRTRTX GPU and OpenVINO NPU/GPU/CPU fully supported by rules; QNN NPU/GPU partial as above |

Rule-less all-unknown rows: CUDA GPU, MIGraphX GPU, DML GPU, CPUExecutionProvider CPU, and VitisAI NPU.

#### Reproduce commands

```powershell
$OUT="temp/beit-repro"

winml build -c examples/recipes/microsoft_beit-base-patch16-224/cpu/cpu/image-classification_fp32_config.json -m microsoft/beit-base-patch16-224 -o "$OUT/cpu/fp32" --ep cpu --device cpu --precision fp32 --no-analyze --no-compile --rebuild
winml perf -m "$OUT/cpu/fp32/model.onnx" --ep cpu --device cpu
winml eval -m "$OUT/cpu/fp32/model.onnx" --model-id microsoft/beit-base-patch16-224 --task image-classification --mode compare --ep cpu --device cpu --samples 5
winml eval -m "$OUT/cpu/fp32/model.onnx" --model-id microsoft/beit-base-patch16-224 --task image-classification --ep cpu --device cpu --samples 10
winml analyze --model "$OUT/cpu/fp32/model.onnx" --ep all --device all --output "$OUT/cpu/fp32/analyze_all.json" --overwrite --format json

winml build -c examples/recipes/microsoft_beit-base-patch16-224/cpu/cpu/image-classification_fp16_config.json -m microsoft/beit-base-patch16-224 -o "$OUT/cpu/fp16" --ep cpu --device cpu --precision fp16 --no-analyze --no-compile --rebuild
winml perf -m "$OUT/cpu/fp16/model.onnx" --ep cpu --device cpu
winml eval -m "$OUT/cpu/fp16/model.onnx" --model-id microsoft/beit-base-patch16-224 --task image-classification --mode compare --ep cpu --device cpu --samples 5
winml eval -m "$OUT/cpu/fp16/model.onnx" --model-id microsoft/beit-base-patch16-224 --task image-classification --ep cpu --device cpu --samples 10
winml analyze --model "$OUT/cpu/fp16/model.onnx" --ep all --device all --output "$OUT/cpu/fp16/analyze_all.json" --overwrite --format json

uv run ruff check src/ tests/
uv run mypy -p winml.modelkit
uv run pytest tests/unit/commands tests/unit/config tests/unit/build tests/unit/compiler tests/unit/session tests/unit/eval --tb=short --no-cov -m "not e2e and not npu and not gpu"
```
