### PR TITLE
feat(layoutlmv3): add QA export support

### DIFF
--- a/examples/recipes/xhyi_layoutlmv3_docvqa_t11c5000/cpu/cpu/question-answering_fp16_config.json
+++ b/examples/recipes/xhyi_layoutlmv3_docvqa_t11c5000/cpu/cpu/question-answering_fp16_config.json
@@ -1,0 +1,106 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          50265
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      },
+      {
+        "name": "bbox",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512,
+          4
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          224,
+          224
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "start_logits"
+      },
+      {
+        "name": "end_logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "question-answering",
+    "model_id": "xhyi/layoutlmv3_docvqa_t11c5000",
+    "model_type": "layoutlmv3",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "question-answering",
+    "model_class": "AutoModelForQuestionAnswering",
+    "model_type": "layoutlmv3"
+  }
+}

--- a/examples/recipes/xhyi_layoutlmv3_docvqa_t11c5000/cpu/cpu/question-answering_fp32_config.json
+++ b/examples/recipes/xhyi_layoutlmv3_docvqa_t11c5000/cpu/cpu/question-answering_fp32_config.json
@@ -1,0 +1,84 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          50265
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      },
+      {
+        "name": "bbox",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512,
+          4
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          224,
+          224
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "start_logits"
+      },
+      {
+        "name": "end_logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "question-answering",
+    "model_class": "AutoModelForQuestionAnswering",
+    "model_type": "layoutlmv3"
+  }
+}

--- a/src/winml/modelkit/models/hf/__init__.py
+++ b/src/winml/modelkit/models/hf/__init__.py
@@ -49,6 +49,8 @@ from .depth_anything import DepthAnythingIOConfig as _DepthAnythingIOConfig  # t
 from .depth_pro import DepthProIOConfig as _DepthProIOConfig  # triggers registration
 from .detr import DETR_CONFIG
 from .layoutlm import LayoutLMQAIOConfig as _LayoutLMQAIOConfig  # triggers registration
+from .layoutlmv3 import LAYOUTLMV3_CONFIG
+from .layoutlmv3 import LayoutLMv3IOConfig as _LayoutLMv3IOConfig  # triggers registration
 from .marian import MARIAN_CONFIG
 from .marian import MODEL_CLASS_MAPPING as _MARIAN_CLASS_MAPPING
 from .marian import MarianDecoderIOConfig as _MarianDecoderIOConfig  # triggers registration
@@ -149,6 +151,7 @@ MODEL_BUILD_CONFIGS = {
     "clip-text-model": CLIP_CONFIG,
     "clip-vision-model": CLIP_CONFIG,
     "detr": DETR_CONFIG,
+    "layoutlmv3": LAYOUTLMV3_CONFIG,
     "marian": MARIAN_CONFIG,
     "roberta": ROBERTA_FAMILY_CONFIG,
     "mu2": MU2_CONFIG,

--- a/src/winml/modelkit/models/hf/layoutlmv3.py
+++ b/src/winml/modelkit/models/hf/layoutlmv3.py
@@ -1,0 +1,62 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""LayoutLMv3 HuggingFace Model Configuration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from optimum.exporters.onnx.model_configs import LayoutLMv3OnnxConfig
+from optimum.utils import NormalizedTextConfig
+from optimum.utils.input_generators import DummyBboxInputGenerator, DummyVisionInputGenerator
+
+from ...config import WinMLBuildConfig
+from ...export import MaxLengthTextInputGenerator, register_onnx_overwrite
+from ...export.config import WinMLExportConfig
+from ...optim import WinMLOptimizationConfig
+from .roberta import _adjust_position_embeddings
+
+
+LAYOUTLMV3_TASKS = (
+    "feature-extraction",
+    "question-answering",
+    "text-classification",
+    "token-classification",
+)
+
+
+LAYOUTLMV3_CONFIG = WinMLBuildConfig(
+    export=WinMLExportConfig(dynamo=False),
+    optim=WinMLOptimizationConfig(
+        clamp_constant_values=True,
+    ),
+)
+
+
+@register_onnx_overwrite("layoutlmv3", *LAYOUTLMV3_TASKS, library_name="transformers")
+class LayoutLMv3IOConfig(LayoutLMv3OnnxConfig):  # type: ignore[misc]  # optimum base is untyped
+    """LayoutLMv3 OnnxConfig with usable text length and TorchScript export.
+
+    LayoutLMv3 checkpoints follow the RoBERTa position-offset convention where
+    max_position_embeddings includes padding offset slots. Export dummy inputs
+    must use the usable sequence length (for example 512 from 514), otherwise
+    tracing can index past the text position embedding table.
+    """
+
+    NORMALIZED_CONFIG_CLASS = NormalizedTextConfig.with_args(
+        sequence_length="max_position_embeddings",
+        MAX_2D_POSITION_EMBEDDINGS="max_2d_position_embeddings",
+        image_size="input_size",
+        allow_new=True,
+    )
+    DUMMY_INPUT_GENERATOR_CLASSES: tuple[type[Any], ...] = (
+        MaxLengthTextInputGenerator,
+        DummyVisionInputGenerator,
+        DummyBboxInputGenerator,
+    )
+
+    def __init__(self, config: Any, task: str, **kwargs: Any) -> None:
+        _adjust_position_embeddings(config)
+        super().__init__(config, task, **kwargs)

--- a/tests/unit/export/test_onnx_config_overrides.py
+++ b/tests/unit/export/test_onnx_config_overrides.py
@@ -58,6 +58,7 @@ class TestOnnxConfigRegistration:
             ("camembert", "fill-mask", "CamemBERTIOConfig"),
             ("mpnet", "fill-mask", "MPNetIOConfig"),
             ("layoutlm", "question-answering", "LayoutLMQAIOConfig"),
+            ("layoutlmv3", "question-answering", "LayoutLMv3IOConfig"),
             ("zoedepth", "depth-estimation", "ZoeDepthIOConfig"),
         ],
         ids=[
@@ -69,6 +70,7 @@ class TestOnnxConfigRegistration:
             "camembert",
             "mpnet",
             "layoutlm-qa",
+            "layoutlmv3-qa",
             "zoedepth",
         ],
     )
@@ -184,6 +186,63 @@ class TestLayoutLMQuestionAnsweringOverride:
         ]
         assert specs["input_shapes"] == [(1, 32), (1, 32, 4), (1, 32), (1, 32)]
         assert specs["output_names"] == ["start_logits", "end_logits"]
+
+
+class TestLayoutLMv3QuestionAnsweringOverride:
+    """LayoutLMv3 QA export must use usable sequence length and page pixels."""
+
+    def _config(self):
+        from transformers import LayoutLMv3Config
+
+        return LayoutLMv3Config(
+            vocab_size=100,
+            hidden_size=64,
+            num_hidden_layers=2,
+            num_attention_heads=2,
+            intermediate_size=128,
+            max_position_embeddings=514,
+            pad_token_id=1,
+            input_size=224,
+            patch_size=16,
+            num_channels=3,
+            type_vocab_size=1,
+        )
+
+    def test_layoutlmv3_qa_dummy_inputs_use_usable_sequence_length(self) -> None:
+        """Dummy inputs must use 512 text/layout tokens, not raw 514."""
+        layoutlmv3_config = self._config()
+
+        inputs = generate_dummy_inputs("layoutlmv3", "question-answering", layoutlmv3_config)
+
+        assert set(inputs) == {"input_ids", "attention_mask", "bbox", "pixel_values"}
+        assert inputs["input_ids"].shape == (1, 512)
+        assert inputs["attention_mask"].shape == (1, 512)
+        assert inputs["bbox"].shape == (1, 512, 4)
+        assert inputs["pixel_values"].shape == (1, 3, 224, 224)
+
+    def test_layoutlmv3_qa_io_specs_include_span_outputs(self) -> None:
+        """LayoutLMv3 QA specs expose text/layout/image inputs and span logits."""
+        layoutlmv3_config = self._config()
+
+        specs = resolve_io_specs("layoutlmv3", "question-answering", layoutlmv3_config)
+
+        assert specs["input_names"] == [
+            "input_ids",
+            "attention_mask",
+            "bbox",
+            "pixel_values",
+        ]
+        assert specs["input_shapes"] == [(1, 512), (1, 512), (1, 512, 4), (1, 3, 224, 224)]
+        assert specs["output_names"] == ["start_logits", "end_logits"]
+
+    def test_layoutlmv3_build_config_disables_dynamo(self) -> None:
+        """LayoutLMv3 uses TorchScript export to avoid invalid dynamo Split attrs."""
+        from winml.modelkit.models.hf import MODEL_BUILD_CONFIGS
+
+        config = MODEL_BUILD_CONFIGS["layoutlmv3"]
+        assert config.export is not None
+        assert config.export.dynamo is False
+        assert config.optim.get("clamp_constant_values") is True
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Adds class-wide WinML export support for LayoutLMv3 checkpoints and checked-in CPU recipes for `xhyi/layoutlmv3_docvqa_t11c5000` in fp32 and fp16. The fix makes recipe-free `layoutlmv3` QA export use the usable RoBERTa-style text/layout sequence length and TorchScript export, then validates this checkpoint as a neural document-QA span scorer on CPU.

Effort/Outcome: L1 / L1. Goal: L3 attempted; highest reached is L2 PASS. L3 remains CLI-BLOCKED because current WinML eval has no end-to-end document-question-answering OCR/layout contract, and the plain SQuAD-style question-answering evaluator cannot feed LayoutLMv3's word/box/image tokenizer contract.

## Model metadata

### What the model does

`xhyi/layoutlmv3_docvqa_t11c5000` is a LayoutLMv3 document visual question-answering span scorer. It consumes tokenized question/document text, OCR/layout bounding boxes, and a page image, then emits `start_logits` and `end_logits` for an extractive answer span.

Source/confidence: Hugging Face model metadata reports `pipeline_tag=document-question-answering`; `AutoConfig` reports `model_type=layoutlmv3` and `architectures=['LayoutLMv3ForQuestionAnswering']`; WinML inspect after this change reports `input_ids`, `attention_mask`, `bbox`, `pixel_values` inputs and `start_logits`, `end_logits` outputs. Confidence: verified.

### Primary user stories

- A user supplies a document page image, OCR words with normalized bounding boxes, and a question to obtain the answer span for a document QA workflow. Confidence: verified.
- A developer exports the neural span scorer as ONNX for a larger DocVQA pipeline that owns OCR, token/box alignment, image preprocessing, and answer decoding. Confidence: mapped.

### Supported tasks

| Task | Support surface | Evidence | Confidence |
|---|---|---|---|
| `document-question-answering` | checkpoint; Transformers | HF `pipeline_tag`; `LayoutLMv3ForQuestionAnswering` architecture | verified |
| `question-answering` | Optimum ONNX; WinML | Optimum LayoutLMv3 span QA export; this PR's WinML override and recipes | verified |
| `feature-extraction` | Optimum ONNX; WinML | Optimum task support preserved by the WinML registration | mapped |
| `text-classification` | Optimum ONNX; WinML | Optimum task support preserved by the WinML registration | mapped |
| `token-classification` | Optimum ONNX; WinML | Optimum task support preserved by the WinML registration | mapped |

### Model architecture

```text
LayoutLMv3ForQuestionAnswering
├── LayoutLMv3Model
│   ├── Text/layout embeddings (word + position + 2D bbox; vocab 50265, usable seq 512)
│   ├── Visual patch embeddings (3 x 224 x 224, patch 16)
│   └── Encoder stack x 12
│       ├── Self-attention (12 heads, hidden 768)
│       ├── Feed-forward (768 -> 3072 -> 768, GELU)
│       └── Residual + LayerNorm
└── QA span head (hidden 768 -> 2)
    ├── start_logits
    └── end_logits
```

Source/confidence: pinned checkpoint config supplies hidden size 768, 12 layers, 12 attention heads, FFN width 3072, `max_position_embeddings=514`, `pad_token_id=1`, image size 224, patch size 16, and 3 channels; export metadata reports root class `LayoutLMv3ForQuestionAnswering`, 243 modules, and 90 traced modules. Confidence: verified.

## Validation and support evidence

### Baseline

- Base: `origin/main` at `26a4a82b638f2169b5a2f75758abb31a60b1774e`, WinML `0.2.0`.
- Baseline recipe-free build on main failed during ONNX validation: `Unrecognized attribute: num_outputs for operator Split ==> node_Split_35`.
- Baseline auto-config used `dynamo=true` and raw text/layout sequence length 514. That combination is not valid for this checkpoint: LayoutLMv3 follows the RoBERTa position-offset convention where `max_position_embeddings=514` with `pad_token_id=1` yields 512 usable positions.
- Optimum probe for `layoutlmv3`: vendor tasks were `feature-extraction`, `question-answering`, `text-classification`, and `token-classification`; WinML after registration exposes the same task set. This PR changes the WinML override/config behavior rather than adding a new task family.

### Goal

- Effort: L1, because the correct fix is class-wide `layoutlmv3` export/build behavior, not a checkpoint-specific recipe workaround.
- Outcome: L1, because the PR ships source support, tests, and CPU recipes.
- Goal ceiling: L3. L0, L1, and L2 are CPU-reachable and passed for fp32/fp16; L3 was attempted and is CLI-BLOCKED by the missing document-QA eval/inference contract.

### Outcome

- Shipped code:
  - `src/winml/modelkit/models/hf/layoutlmv3.py`
  - `src/winml/modelkit/models/hf/__init__.py`
  - `tests/unit/export/test_onnx_config_overrides.py`
- Shipped recipes:
  - `examples/recipes/xhyi_layoutlmv3_docvqa_t11c5000/cpu/cpu/question-answering_fp32_config.json`
  - `examples/recipes/xhyi_layoutlmv3_docvqa_t11c5000/cpu/cpu/question-answering_fp16_config.json`
- Highest Goal verdict: L2 PASS for CPU fp32 and CPU fp16. L3 is CLI-BLOCKED, not an artifact failure.
- Coverage: full for targeted CPU fp32/fp16 through L2; no accelerator EP/device recipes are claimed.
- Quality gates run locally:
  - `uv run ruff check src/ tests/` -> PASS, `All checks passed!`
  - `uv run mypy -p winml.modelkit` -> PASS, `Success: no issues found in 416 source files`
  - `uv run pytest tests/unit/export/test_onnx_config_overrides.py -q --tb=short --no-cov` -> PASS, `45 passed`
  - `uv run pytest tests/unit/models tests/unit/loader tests/unit/datasets tests/unit/export --tb=short --no-cov -m "not e2e and not npu and not gpu"` -> PASS, `1378 passed, 6 skipped, 1 xfailed`
  - `uv run pytest tests/unit/commands tests/unit/config tests/unit/build tests/unit/compiler tests/unit/session tests/unit/eval --tb=short --no-cov -m "not e2e and not npu and not gpu"` -> PASS, `2383 passed, 6 skipped, 2 deselected`
- No methodology friction observed; no skill-level files are included in this Lane B PR. `examples/recipes/README.md` is untouched.

### Per-EP/device/precision results

| Tier | EP / Device | Precision | Verdict | Evidence |
|---|---|---|---|---|
| L0 | CPUExecutionProvider / cpu | fp32 | PASS | No-recipe build passed in 30.9s; recipe build passed in 31.7s. ONNX inputs: `input_ids` int32 [1,512], `attention_mask` int32 [1,512], `bbox` int32 [1,512,4], `pixel_values` float [1,3,224,224]. Outputs: `start_logits`, `end_logits` float [1,709]. Artifact size 512.7 MB. |
| L0 | CPUExecutionProvider / cpu | fp16 | PASS | Recipe build passed in 41.8s with fp16 conversion enabled. Inputs/outputs kept fp32/fp16 IO contract as configured; initializers are FLOAT16; artifact size 260.3 MB. |
| L1 | CPUExecutionProvider / cpu | fp32 | PASS | Mean 299.64 ms; p50 297.51 ms; p90 396.07 ms; throughput 3.34 samples/s; RAM +614.9 MB; Model Precision fp32. |
| L1 | CPUExecutionProvider / cpu | fp16 | PASS | Mean 442.59 ms; p50 438.37 ms; p90 571.08 ms; throughput 2.26 samples/s; RAM +666.1 MB; Model Precision fp16. |
| L2 | CPUExecutionProvider / cpu | fp32 | PASS | PyTorch vs ONNX named-input comparison: cosine 0.99999988; max_abs 0.00002050; mean_abs 0.00000194; compared logits shape [1,709]. |
| L2 | CPUExecutionProvider / cpu | fp16 | PASS | PyTorch vs ONNX named-input comparison: cosine 0.99999994; max_abs 0.01816225; mean_abs 0.00264477; compared logits shape [1,709]. |
| L3 | CPUExecutionProvider / cpu | fp32 | CLI-BLOCKED | Plain `question-answering` eval uses a SQuAD-style context string and fails LayoutLMv3 tokenizer validation (`Words must be of type List[str] ...`). `document-question-answering` schema is not supported by `winml eval`. No dataset metric emitted. |
| L3 | CPUExecutionProvider / cpu | fp16 | CLI-BLOCKED | Same blocker as fp32: current WinML eval cannot supply pretokenized document words, bounding boxes, and page images for LayoutLMv3 DocVQA. No dataset metric emitted. |

### Delta

- Code delta:
  - Adds `LayoutLMv3IOConfig`, subclassing Optimum `LayoutLMv3OnnxConfig`, registered for `feature-extraction`, `question-answering`, `text-classification`, and `token-classification`.
  - Reuses the existing RoBERTa-family `_adjust_position_embeddings` helper so dummy text/layout inputs use 512 usable tokens when config reports 514 positions with padding offsets.
  - Adds `MODEL_BUILD_CONFIGS["layoutlmv3"]` with `export.dynamo=false` to avoid the invalid opset-17 `Split` attribute emitted by the dynamo path, and `optim.clamp_constant_values=true`.
  - Adds unit coverage for registration, LayoutLMv3 QA dummy/spec shapes, and build config defaults.
- Recipe delta versus current-main auto-config:
  - `export.dynamo`: `true` -> `false`.
  - Text/layout input sequence shapes: raw 514 -> usable 512 for `input_ids`, `attention_mask`, and `bbox`.
  - Adds explicit `bbox` [1,512,4] and `pixel_values` [1,3,224,224] input contract in forward-signature order.
  - `optim.clamp_constant_values`: enabled.
  - fp16 recipe adds `quant.mode=fp16` and `fp16_keep_io_types=true`.
- Reducibility: class-wide and metadata/config-derived; no checkpoint-id branch is used. Recipe-free build acceptance passed after the code fix.

### Analyze summary

Static `winml analyze --ep all` wrote complete JSON for both artifacts but returned nonzero, so the status is ANALYZE-PARTIAL-SUCCESS. This is static compatibility analysis, not runtime execution on accelerator providers.

#### Component-level summary

| Artifact | Architecture coverage | Mapping | Actionable EP findings |
|---|---|---|---|
| fp32 | text/layout embeddings; visual patch embeddings; 12x encoder attention/FFN; QA span head | 578 graph ops mapped by exported hierarchy scopes; no unmapped architecture region in the summary | QNN/NPU partial: Gather, Cast, Div, Erf, Add, Mul. OpenVINO/NPU partial: Abs. VitisAI/NPU rule data unknown. |
| fp16 | text/layout embeddings; visual patch embeddings; 12x encoder attention/FFN; QA span head | 581 graph ops mapped by exported hierarchy scopes; no unmapped architecture region in the summary | Same static findings as fp32. |

#### Op-level summary

| Artifact | Graph | Dominant ops | EP roll-up |
|---|---|---|---|
| fp32 | 578 ops / 29 types | Add 145; MatMul 98; Transpose 50; Reshape 49; Mul 42; Div 41 | QNN/NPU partial ops as above, unknown Min/Concat, unsupported none. OpenVINO/NPU partial Abs, unknown Min/Concat, unsupported none. VitisAI/NPU all 29 op types unknown. |
| fp16 | 581 ops / 29 types | Add 145; MatMul 98; Transpose 50; Reshape 49; Mul 42; Div 41 | Same static EP classification as fp32. |

Host runtime providers for local execution were `AzureExecutionProvider` and `CPUExecutionProvider`; accelerator rows above are rule analysis only.

### Reproduce commands

```powershell
$OUT = "temp/layoutlmv3-docvqa-repro"

uv run winml inspect -m xhyi/layoutlmv3_docvqa_t11c5000 --format json

uv run winml build `
  -m xhyi/layoutlmv3_docvqa_t11c5000 `
  -o "$OUT/no_recipe_cpu_fp32" `
  --ep cpu --device cpu --precision fp32 `
  --no-analyze --no-compile --rebuild

uv run winml build `
  -c examples/recipes/xhyi_layoutlmv3_docvqa_t11c5000/cpu/cpu/question-answering_fp32_config.json `
  -m xhyi/layoutlmv3_docvqa_t11c5000 `
  -o "$OUT/cpu/fp32" `
  --ep cpu --device cpu --precision fp32 `
  --no-analyze --no-compile --rebuild

uv run winml build `
  -c examples/recipes/xhyi_layoutlmv3_docvqa_t11c5000/cpu/cpu/question-answering_fp16_config.json `
  -m xhyi/layoutlmv3_docvqa_t11c5000 `
  -o "$OUT/cpu/fp16" `
  --ep cpu --device cpu --precision fp16 `
  --no-analyze --no-compile --rebuild

uv run winml perf -m "$OUT/cpu/fp32/model.onnx" --ep cpu --device cpu
uv run winml perf -m "$OUT/cpu/fp16/model.onnx" --ep cpu --device cpu

uv run winml analyze --model "$OUT/cpu/fp32/model.onnx" --ep all --output "$OUT/cpu/fp32/analyze_all.json" --overwrite --format json
uv run winml analyze --model "$OUT/cpu/fp16/model.onnx" --ep all --output "$OUT/cpu/fp16/analyze_all.json" --overwrite --format json

uv run winml eval --schema --task question-answering
uv run winml eval --schema --task document-question-answering

uv run ruff check src/ tests/
uv run mypy -p winml.modelkit
uv run pytest tests/unit/export/test_onnx_config_overrides.py -q --tb=short --no-cov
uv run pytest tests/unit/models tests/unit/loader tests/unit/datasets tests/unit/export --tb=short --no-cov -m "not e2e and not npu and not gpu"
uv run pytest tests/unit/commands tests/unit/config tests/unit/build tests/unit/compiler tests/unit/session tests/unit/eval --tb=short --no-cov -m "not e2e and not npu and not gpu"
```
