### PR TITLE
fix(fp16): support facebook mms-lid-256

### DIFF
--- a/examples/recipes/facebook_mms-lid-256/cpu/cpu/audio-classification_fp16_config.json
+++ b/examples/recipes/facebook_mms-lid-256/cpu/cpu/audio-classification_fp16_config.json
@@ -1,0 +1,62 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          16000
+        ],
+        "value_range": [
+          -1,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "audio-classification",
+    "model_id": "facebook/mms-lid-256",
+    "model_type": "wav2vec2",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "audio-classification",
+    "model_class": "AutoModelForAudioClassification",
+    "model_type": "wav2vec2"
+  }
+}

--- a/examples/recipes/facebook_mms-lid-256/cpu/cpu/audio-classification_fp32_config.json
+++ b/examples/recipes/facebook_mms-lid-256/cpu/cpu/audio-classification_fp32_config.json
@@ -1,0 +1,40 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          16000
+        ],
+        "value_range": [
+          -1,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "audio-classification",
+    "model_class": "AutoModelForAudioClassification",
+    "model_type": "wav2vec2"
+  }
+}

--- a/src/winml/modelkit/quant/fp16.py
+++ b/src/winml/modelkit/quant/fp16.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from google.protobuf.message import EncodeError
+
 
 if TYPE_CHECKING:
     from onnx import ModelProto
@@ -64,11 +66,24 @@ def convert_to_fp16(
     if op_block_list:
         logger.info("  Keeping ops in FP32: %s", op_block_list)
 
-    converted: ModelProto = convert_float_to_float16(
-        model,
-        keep_io_types=keep_io_types,
-        op_block_list=op_block_list,
-    )
+    try:
+        converted: ModelProto = convert_float_to_float16(
+            model,
+            keep_io_types=keep_io_types,
+            op_block_list=op_block_list,
+        )
+    except EncodeError:
+        logger.warning(
+            "FP16 conversion shape inference could not serialize the model; "
+            "retrying with shape inference disabled. This can happen for "
+            "large ONNX models that use external data."
+        )
+        converted = convert_float_to_float16(
+            model,
+            keep_io_types=keep_io_types,
+            disable_shape_infer=True,
+            op_block_list=op_block_list,
+        )
 
     # ORT's converter appends Cast nodes at the end of the node list (for
     # keep_io_types), which breaks topological ordering. Re-sort the graph

--- a/tests/unit/test_quant_passes.py
+++ b/tests/unit/test_quant_passes.py
@@ -11,9 +11,11 @@ from types import ModuleType, SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
 import pytest
+from google.protobuf.message import EncodeError
 
 from winml.modelkit.quant import WinMLQuantizationConfig
 from winml.modelkit.quant.config import QuantizeResult
+from winml.modelkit.quant.fp16 import convert_to_fp16
 from winml.modelkit.quant.passes import BaseQuantPass, DynamicPass, FP16Pass, RTNPass, StaticPass
 
 
@@ -335,6 +337,47 @@ class TestFP16PassConfig:
 
         assert result.success
         assert calls == [{"keep_io_types": False, "op_block_list": ["Gather"]}]
+
+
+class TestFP16Conversion:
+    def test_retries_without_shape_inference_when_proto_serialization_fails(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Large external-data models can exceed protobuf's in-memory serialize limit."""
+        calls: list[dict] = []
+        model = SimpleNamespace(graph=SimpleNamespace(initializer=[], node=[]))
+
+        def fake_convert(model_arg, **kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                raise EncodeError("Failed to serialize proto")
+            return model_arg
+
+        monkeypatch.setattr(
+            "onnxruntime.transformers.float16.convert_float_to_float16",
+            fake_convert,
+        )
+        monkeypatch.setattr(
+            "onnxruntime.transformers.onnx_model.OnnxModel.graph_topological_sort",
+            lambda graph: None,
+        )
+
+        assert (
+            convert_to_fp16(
+                model,
+                keep_io_types=True,
+                op_block_list=["Softmax"],
+            )
+            is model
+        )
+        assert calls == [
+            {"keep_io_types": True, "op_block_list": ["Softmax"]},
+            {
+                "keep_io_types": True,
+                "disable_shape_infer": True,
+                "op_block_list": ["Softmax"],
+            },
+        ]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Summary

Adds WinML support coverage for `facebook/mms-lid-256`, a standard `Wav2Vec2ForSequenceClassification` audio-classification model, with CPU `fp32` and `fp16` recipes. While validating the required `fp16` tuple, the build exposed a shared FP16 conversion failure for large external-data ONNX models; this PR fixes that path by retrying ORT FP16 conversion with shape inference disabled only after protobuf serialization raises `EncodeError`.

Highest local Goal verdict: L2 PASS on CPU for both `fp32` and `fp16`. Goal L3 was attempted and is CLI-BLOCKED because `winml eval` has no `audio-classification` evaluator yet (#1175).

### Model metadata

**What the model does**

`facebook/mms-lid-256` is an audio language-identification classifier. It takes a raw 16 kHz waveform tensor (`input_values`) and returns logits over 256 language labels. Evidence: pinned Hugging Face checkpoint `edc73fd00996e671dfc59d16436a29b12b10588a`, `pipeline_tag=audio-classification`, and `config.json` with `architectures=["Wav2Vec2ForSequenceClassification"]` (`verified`).

**Primary user stories**

- A user supplies speech audio to obtain the predicted spoken language for routing ASR or localization workflows (`verified` from checkpoint task and label count).
- A developer exports the language-ID model to ONNX/WinML to run a local pre-ASR classifier before selecting a downstream speech recognizer (`mapped` from task and WinML build target).

**Supported tasks**

- `audio-classification`: checkpoint-advertised, Transformers, Optimum ONNX, and WinML inspect/build support (`verified`).
- `winml eval` task metric: not currently supported for `audio-classification`; tracked in #1175 (`CLI-BLOCKED`).

**Model architecture**

```text
Wav2Vec2ForSequenceClassification
|-- Wav2Vec2Model
|   |-- Conv feature encoder (7 temporal conv stages; raw waveform -> latent frames)
|   |-- Feature projection (hidden size 1280)
|   |-- Positional convolution embedding
|   `-- Stable-LayerNorm Transformer encoder x 48
|       |-- Self-attention (16 heads, hidden 1280)
|       |-- Feed-forward (1280 -> 5120 -> 1280, GELU)
|       |-- MMS adapter layer
|       `-- Residual + LayerNorm
|-- Projector (1280 -> 1024)
`-- Classification head (1024 -> 256 language logits)
```

- Source/confidence: pinned checkpoint config plus exported HTP metadata (`verified` for dimensions and module classes; `mapped` for ONNX component regions).

### Validation and support evidence

#### Baseline

- Base commit: `26a4a82b638f2169b5a2f75758abb31a60b1774e` (`origin/main`)
- WinML version: `0.2.0`
- Inspect resolved `model_type=wav2vec2`, `task=audio-classification`, loader `AutoModelForAudioClassification`, exporter `Wav2Vec2OnnxConfig`, input `input_values [1,16000] float32`, output `logits`.
- Optimum probe: vendor-supported wav2vec2 ONNX tasks included `audio-classification`, `audio-frame-classification`, `audio-xvector`, `automatic-speech-recognition`, and `feature-extraction`; WinML added no extra wav2vec2 task registration for this checkpoint.
- Recipe-free `fp32` baseline build on main passed, producing `logits [1,256]`; recipe-free `fp32` perf passed with avg 189.62 ms, P50 180.39 ms, throughput 5.27 samples/s, and total RAM delta +3758.3 MB.
- Starting auto-config CPU recipes matched the shipped loader/task/shape settings. The only recipe delta is `/export/dynamo: true -> false`, used to keep the verified TorchScript/opset-17 path instead of the dynamo path that warns it kept opset 18.
- `fp16` validation exposed the shared source gap: before the code fix, the `fp16` build failed in `FP16Pass` with `google.protobuf.message.EncodeError: Failed to serialize proto` while ORT shape inference tried to serialize the >2 GB loaded model.

#### Goal

- Effort: L2 shared-infra fix plus model recipes.
- Goal ceiling: L3 attempted.
- Outcome: source fix plus CPU `fp32`/`fp16` recipe coverage.
- Success definition: CPU build/structure and perf pass for both required precisions; numerical parity vs PyTorch is measured for both; task eval is either a metric or an explicit CLI blocker with a filed feature gap.

#### Outcome

- L0 PASS: both checked-in CPU recipes built successfully.
- L1 PASS: both CPU artifacts ran through `winml perf`.
- L2 PASS: named-input PyTorch vs ONNX logits matched closely and preserved top-1.
- L3 CLI-BLOCKED: `audio-classification` is not registered in `winml eval`; feature gap filed as #1175.
- Coverage: full for targeted CPU build/perf/L2 tuples (`cpu/cpu/fp32`, `cpu/cpu/fp16`); no accelerator runtime tuple is claimed.

Shipped files:

- `examples/recipes/facebook_mms-lid-256/cpu/cpu/audio-classification_fp32_config.json`
- `examples/recipes/facebook_mms-lid-256/cpu/cpu/audio-classification_fp16_config.json`
- `src/winml/modelkit/quant/fp16.py`
- `tests/unit/test_quant_passes.py`

#### Per-EP/device/precision results - including perf and eval data

| Tier | EP / Device | Precision | Verdict | Evidence |
|---|---|---:|---|---|
| L0 build | CPUExecutionProvider / cpu | fp32 | PASS | Recipe build complete in 171.5s; input `input_values FLOAT [1,16000]`; output `logits FLOAT [1,256]`; 911 FLOAT initializers; external data 3,864,155,136 bytes. |
| L0 build | CPUExecutionProvider / cpu | fp16 | PASS | Recipe build complete in 173.1s; fallback warning emitted; 911 FLOAT16 initializers; FP32 I/O preserved; external data 1,932,077,056 bytes. |
| L1 perf | CPUExecutionProvider / cpu | fp32 | PASS | Avg 177.43 ms; P50 170.13 ms; P90 201.72 ms; throughput 5.64 samples/s; model load +3649.1 MB RAM; inference +109.5 MB; total +3758.6 MB. |
| L1 perf | CPUExecutionProvider / cpu | fp16 | PASS | Avg 209.99 ms; P50 207.51 ms; P90 229.00 ms; throughput 4.76 samples/s; model load +3733.8 MB RAM; inference +41.6 MB; total +3775.4 MB. |
| L2 PyTorch parity | CPUExecutionProvider / cpu | fp32 | PASS | Cosine 0.9999999999980981; max_abs 1.049041748046875e-05; mean_abs 3.0488627089653164e-06; top1 96 == 96. |
| L2 PyTorch parity | CPUExecutionProvider / cpu | fp16 | PASS | Cosine 0.9999995380702843; max_abs 0.008114099502563477; mean_abs 0.001441885131498566; top1 96 == 96. |
| L3 eval | CPUExecutionProvider / cpu | fp32 | CLI-BLOCKED | `Evaluation failed: Task 'audio-classification' is not supported.` |
| L3 eval | CPUExecutionProvider / cpu | fp16 | CLI-BLOCKED | `Evaluation failed: Task 'audio-classification' is not supported.` |

Provider snapshot for local runtime: `['AzureExecutionProvider', 'CPUExecutionProvider']`.

#### Delta

- Source delta: `convert_to_fp16()` now catches protobuf `EncodeError` from ORT FP16 conversion and retries with `disable_shape_infer=True`. This is data-driven and contains no model-id or model-type branch.
- Unit test delta: added `TestFP16Conversion::test_retries_without_shape_inference_when_proto_serialization_fails`.
- Recipe delta vs `winml config --ep cpu --device cpu`: `/export/dynamo` changes from `true` to `false` for both `fp32` and `fp16`; task, loader, model type, input tensor, output tensor, and quant fields match auto-config.
- No-recipe acceptance after the source fix: `winml build -m facebook/mms-lid-256 --ep cpu --device cpu --precision fp16 --no-analyze --no-compile --rebuild` passed in 267.3s and produced an fp16 artifact after the same fallback warning.
- `examples/recipes/README.md` remains untouched.

#### Analyze summary - component level and op level

Static rule analysis completed with exit 1 because QNN rows report partial support. The JSON outputs were complete; this is compatibility analysis, not runtime execution.

**Component-level summary**

| Artifact | Architecture coverage | Mapping | Actionable EP findings |
|---|---|---|---|
| fp32 | conv feature encoder; feature projection; positional conv; 48x encoder attention/FFN/adapter/residual blocks; projector/classification head | 2049 optimized ONNX nodes mapped by scope; 0 unmapped | QNN NPU/GPU partial ops occur in GELU-related regions: `Div`, `Erf`, `Add`, `Mul`. |
| fp16 | same architecture coverage plus boundary Cast nodes for FP32 I/O preservation | 2051 optimized ONNX nodes mapped by scope; 0 unmapped | Same QNN partial ops: `Div`, `Erf`, `Add`, `Mul`. |

**Op-level summary**

| Artifact | Graph | Dominant ops | EP roll-up |
|---|---|---|---|
| fp32 | 2049 ops / 15 types | Add 587; MatMul 482; Mul 208; Transpose 207; Reshape 192; LayerNormalization 153 | TensorRT GPU and OpenVINO NPU/GPU/CPU fully supported by rules; QNN NPU/GPU partial for `Div`, `Erf`, `Add`, `Mul`; CPU/DML/CUDA/MIGraphX/VitisAI rule-less unknown. |
| fp16 | 2051 ops / 16 types | Add 587; MatMul 482; Mul 208; Transpose 207; Reshape 192; LayerNormalization 153; Cast 2 | TensorRT GPU and OpenVINO NPU/GPU/CPU fully supported by rules; QNN NPU/GPU partial for `Div`, `Erf`, `Add`, `Mul`; CPU/DML/CUDA/MIGraphX/VitisAI rule-less unknown. |

#### Quality gates

- `uv run ruff check src/ tests/` - PASS (`All checks passed!`)
- `uv run mypy -p winml.modelkit` - PASS (`Success: no issues found in 415 source files`)
- `uv run pytest tests/unit/test_quant_passes.py tests/unit/optim/test_fp16.py tests/unit/build --tb=short --no-cov -m "not e2e and not npu and not gpu"` - PASS (`118 passed`)
- `uv run pytest tests/unit/optim tests/unit/commands tests/unit/config tests/unit/build tests/unit/compiler tests/unit/session tests/unit/eval --tb=short --no-cov -m "not e2e and not npu and not gpu"` - PASS (`2930 passed, 22 skipped, 2 deselected, 1 xfailed`)

#### Reproduce commands

```powershell
$OUT='temp/facebook-mms-lid-256-repro'

uv run winml inspect -m facebook/mms-lid-256 --format json

uv run winml build -c examples/recipes/facebook_mms-lid-256/cpu/cpu/audio-classification_fp32_config.json -m facebook/mms-lid-256 -o "$OUT\cpu\fp32" --ep cpu --device cpu --precision fp32 --no-analyze --no-compile --rebuild
uv run winml build -c examples/recipes/facebook_mms-lid-256/cpu/cpu/audio-classification_fp16_config.json -m facebook/mms-lid-256 -o "$OUT\cpu\fp16" --ep cpu --device cpu --precision fp16 --no-analyze --no-compile --rebuild

uv run winml perf -m "$OUT\cpu\fp32\model.onnx" --ep cpu --device cpu
uv run winml perf -m "$OUT\cpu\fp16\model.onnx" --ep cpu --device cpu

uv run winml analyze --model "$OUT\cpu\fp32\model.onnx" --ep all --device all --output "$OUT\cpu\fp32\analyze_all.json" --overwrite --format json
uv run winml analyze --model "$OUT\cpu\fp16\model.onnx" --ep all --device all --output "$OUT\cpu\fp16\analyze_all.json" --overwrite --format json

uv run winml eval --schema --task audio-classification
uv run winml eval -m "$OUT\cpu\fp32\model.onnx" --model-id facebook/mms-lid-256 --task audio-classification --ep cpu --device cpu
uv run winml eval -m "$OUT\cpu\fp16\model.onnx" --model-id facebook/mms-lid-256 --task audio-classification --ep cpu --device cpu

uv run ruff check src/ tests/
uv run mypy -p winml.modelkit
uv run pytest tests/unit/optim tests/unit/commands tests/unit/config tests/unit/build tests/unit/compiler tests/unit/session tests/unit/eval --tb=short --no-cov -m "not e2e and not npu and not gpu"
```
