### PR TITLE
recipe(vitpose): add synthpose huge cpu recipe

### DIFF
--- a/examples/recipes/stanfordmimi_synthpose-vitpose-huge-hf/cpu/cpu/keypoint-detection_fp32_config.json
+++ b/examples/recipes/stanfordmimi_synthpose-vitpose-huge-hf/cpu/cpu/keypoint-detection_fp32_config.json
@@ -1,0 +1,42 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          256,
+          192
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "heatmaps"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "keypoint-detection",
+    "model_class": "VitPoseForPoseEstimation",
+    "model_type": "vitpose"
+  }
+}


### PR DESCRIPTION
## Summary

Adds a verified CPU fp32 `keypoint-detection` recipe for `stanfordmimi/synthpose-vitpose-huge-hf`. The model already resolves through the existing VitPose exporter and `VitPoseForPoseEstimation` loader on `main`; this PR records the checked-in CPU/cpu/fp32 coverage claim and keeps the failed fp16 attempt out of the diff.

Highest verified outcome on this host is L1 for CPU fp32: build, structural validation, analyze, and CPU perf all ran successfully.

## Model metadata

### What the model does

`stanfordmimi/synthpose-vitpose-huge-hf` is a VitPose pose-estimation model. It consumes an RGB image tensor (`pixel_values`) and emits dense keypoint heatmaps for 52 SynthPose keypoints.

### Primary user stories

- A user supplies a normalized RGB person image to obtain keypoint heatmaps for pose estimation.
- A developer exports a large VitPose checkpoint to ONNX and runs WinML CPU inference for keypoint-detection smoke testing.

### Supported tasks

| Task | Support surface | Evidence | Confidence |
|---|---|---|---|
| keypoint-detection | checkpoint, Transformers, Optimum ONNX, WinML recipe | `architectures=["VitPoseForPoseEstimation"]`; `winml inspect` resolves `keypoint-detection`; fp32 recipe builds and perfs | verified |

### Model architecture

```text
VitPoseForPoseEstimation
|-- VitPoseBackbone
|   |-- Patch embedding over 256 x 192 RGB input
|   |-- Transformer encoder stack x 32
|   |   |-- Self-attention (16 heads, hidden size 1280)
|   |   |-- Feed-forward / GELU
|   |   `-- LayerNorm + residual paths
`-- Pose heatmap head
    |-- Deconvolution / upsampling path
    `-- Heatmaps output (52 x 64 x 48)
```

Source/confidence: pinned checkpoint config and exported hierarchy metadata (`verified`).

## Validation and support evidence

### Baseline

- Base commit: `26a4a82b638f2169b5a2f75758abb31a60b1774e`
- WinML version: `0.2.0`
- Baseline inspect/config on `main` resolved task `keypoint-detection`, loader `VitPoseForPoseEstimation`, model type `vitpose`, and exporter `VitPoseOnnxConfig`.
- Starting `winml config -m stanfordmimi/synthpose-vitpose-huge-hf` emitted the same I/O contract as the shipped recipe, with `export.dynamo: true` and a static uint8/uint16 quantization block.

### Goal

- Effort: L0 recipe-only; existing VitPose code path already supports this architecture.
- Goal ceiling attempted: L1 on reachable CPU fp32; CPU fp16 was attempted and failed in the fp16 conversion stage.
- Outcome: CPU fp32 recipe shipped; CPU fp16 recipe omitted because the exact tuple did not pass.

### Outcome

- Recipe path: `examples/recipes/stanfordmimi_synthpose-vitpose-huge-hf/cpu/cpu/keypoint-detection_fp32_config.json`.
- Static checks: `uv run ruff check src/ tests/` -> all checks passed; `uv run mypy -p winml.modelkit` -> success, no issues in 415 source files.
- Affected unit-test scope: no Python source or test files changed; this is a recipe-only diff.
- Methodology friction observed: none. The only tuple failure was model-size-related fp16 conversion failure, and no unsupported recipe is shipped.

### Per-EP/device/precision results

| Tier | EP / Device | Precision | Verdict | Mean | P50 | Throughput | RAM delta | Task metric |
|---|---|---|---|---:|---:|---:|---:|---|
| L0 | CPUExecutionProvider / cpu | fp32 | PASS | - | - | - | - | - |
| L1 | CPUExecutionProvider / cpu | fp32 | PASS | 172.85 ms | 165.56 ms | 5.79 samples/s | +2486.8 MB total | - |
| L0 | CPUExecutionProvider / cpu | fp16 | FAIL | - | - | - | - | fp16 conversion failed before artifact |
| L3 | CPUExecutionProvider / cpu | fp32 | EVAL-BLOCKED-DATA-PROVENANCE | - | - | - | - | no authoritative SynthPose 52-keypoint eval dataset/label mapping declared in this recipe |

CPU fp32 structural validation: ONNX IR 8, opset 17, input `pixel_values [1, 3, 256, 192]`, output `heatmaps [1, 52, 64, 48]`. External data layout is valid: `model.onnx` and `model.onnx.data` are in the same output directory.

CPU fp16 failure evidence: fp16 conversion entered ONNX shape inference and failed with `google.protobuf.message.EncodeError: Failed to serialize proto` on the large external-data model. The fp16 candidate recipe was removed from the final diff.

Provider snapshot during validation: `['AzureExecutionProvider', 'CPUExecutionProvider']`. The checked-in recipe only claims CPU/cpu/fp32.

### Delta

Recipe-vs-auto-config changes:

| JSON pointer | Baseline value | Shipped value | Reason |
|---|---|---|---|
| `/export/dynamo` | `true` | `false` | Matches existing checked-in CPU recipe convention and the verified build command |
| `/quant` | static uint8/uint16 | `null` | CPU fp32 recipe, no quantization |

No source code changed. `examples/recipes/README.md` is unchanged.

### Analyze summary

Static rule analysis completed with usable results and exited nonzero only because VitisAI had no rule data.

Component-level summary:

| Artifact | Architecture coverage | Mapping | Actionable EP findings |
|---|---|---|---|
| fp32 | patch embedding; 32x VitPose encoder attention/FFN; pose heatmap head | export hierarchy tags cover the backbone and head regions | QNN partial: Add, Mul, Div, Erf; QNN/OpenVINO unknown: ConvTranspose |

Op-level summary:

| Artifact | Graph | Dominant ops | EP roll-up |
|---|---|---|---|
| fp32 | 1103 ops / 13 types | Add 290; MatMul 256; Reshape 130; Transpose 130; Mul 128 | QNN: 10 supported op types, 4 partial, 1 unknown; OpenVINO: 12 supported op types, 1 unknown; VitisAI: rule data unavailable |

### Reproduce commands

```powershell
$OUT = "temp/repro_stanfordmimi_synthpose-vitpose-huge-hf_fp32"
uv run winml inspect -m stanfordmimi/synthpose-vitpose-huge-hf --format json
uv run winml build -m stanfordmimi/synthpose-vitpose-huge-hf -c examples/recipes/stanfordmimi_synthpose-vitpose-huge-hf/cpu/cpu/keypoint-detection_fp32_config.json -o $OUT --ep cpu --device cpu --no-analyze --no-optimize --no-quant --no-compile --rebuild
uv run python -c "import onnx; m=onnx.load('$OUT/model.onnx', load_external_data=False); print(m.ir_version, [(i.name, [d.dim_value or d.dim_param for d in i.type.tensor_type.shape.dim]) for i in m.graph.input], [(o.name, [d.dim_value or d.dim_param for d in o.type.tensor_type.shape.dim]) for o in m.graph.output])"
uv run winml perf -m $OUT/model.onnx --ep cpu --device cpu
uv run winml analyze --model $OUT/model.onnx --ep all --output $OUT/analyze_all.json
uv run ruff check src/ tests/
uv run mypy -p winml.modelkit
```
