### PR TITLE
recipe(deberta-v2): add mxbai rerank xsmall cpu recipes

### DIFF
--- a/examples/recipes/mixedbread-ai_mxbai-rerank-xsmall-v1/cpu/cpu/text-classification_fp16_config.json
+++ b/examples/recipes/mixedbread-ai_mxbai-rerank-xsmall-v1/cpu/cpu/text-classification_fp16_config.json
@@ -1,0 +1,54 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          128100
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "text-classification",
+    "model_class": "AutoModelForSequenceClassification",
+    "model_type": "deberta-v2"
+  }
+}

--- a/examples/recipes/mixedbread-ai_mxbai-rerank-xsmall-v1/cpu/cpu/text-classification_fp32_config.json
+++ b/examples/recipes/mixedbread-ai_mxbai-rerank-xsmall-v1/cpu/cpu/text-classification_fp32_config.json
@@ -1,0 +1,54 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          128100
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "text-classification",
+    "model_class": "AutoModelForSequenceClassification",
+    "model_type": "deberta-v2"
+  }
+}


### PR DESCRIPTION
## Summary

Adds verified CPU fp32 and fp16 `text-classification` recipes for `mixedbread-ai/mxbai-rerank-xsmall-v1`. The model already resolves through the existing DeBERTa-v2 sequence-classification path on `main`; this PR records checked-in CPU/cpu coverage for both precisions.

Highest verified outcome on this host is L1 for CPU fp32 and CPU fp16: build, structural validation, analyze, and CPU perf all ran successfully.

## Model metadata

### What the model does

`mixedbread-ai/mxbai-rerank-xsmall-v1` is a DeBERTa-v2 reranking sequence-classification model. It consumes tokenized text or text-pair inputs (`input_ids`, `attention_mask`) and emits a single `logits` score used to rank candidate passages or documents.

### Primary user stories

- A user supplies a query/document pair to obtain a reranking score for retrieval pipelines.
- A developer exports a compact DeBERTa-v2 reranker to ONNX and runs WinML CPU inference for text-classification smoke testing.

### Supported tasks

| Task | Support surface | Evidence | Confidence |
|---|---|---|---|
| text-classification | checkpoint, Transformers, Optimum ONNX, WinML recipes | `architectures=["DebertaV2ForSequenceClassification"]`; `winml inspect` resolves `text-classification`; fp32/fp16 recipes build and perf | verified |

### Model architecture

```text
DebertaV2ForSequenceClassification
|-- DebertaV2Model
|   |-- Embeddings (vocab 128100, hidden size 384)
|   |-- Encoder stack x 12
|   |   |-- Disentangled self-attention (6 heads)
|   |   |-- Feed-forward / GELU
|   |   `-- LayerNorm + residual paths
`-- Sequence-classification / reranking head (384 -> 1)
```

Source/confidence: pinned checkpoint config and exported hierarchy metadata (`verified`).

## Validation and support evidence

### Baseline

- Base commit: `26a4a82b638f2169b5a2f75758abb31a60b1774e`
- WinML version: `0.2.0`
- Baseline inspect/config on `main` resolved task `text-classification`, loader `AutoModelForSequenceClassification`, model type `deberta-v2`, and exporter `DebertaV2OnnxConfig`.
- Recipe-free baseline build on `main` passed, but the `dynamo` export path produced no usable module hierarchy metadata and warned to pass `--no-dynamo`.
- Starting `winml config -m mixedbread-ai/mxbai-rerank-xsmall-v1` emitted the same I/O contract as the shipped recipes, with `export.dynamo: true` and a static uint8/uint16 quantization block.

### Goal

- Effort: L0 recipe-only; existing DeBERTa-v2 code path already supports this architecture.
- Goal ceiling attempted: L1 on reachable CPU fp32 and fp16.
- Outcome: CPU fp32 and CPU fp16 recipes shipped.

### Outcome

- Recipe paths:
  - `examples/recipes/mixedbread-ai_mxbai-rerank-xsmall-v1/cpu/cpu/text-classification_fp32_config.json`
  - `examples/recipes/mixedbread-ai_mxbai-rerank-xsmall-v1/cpu/cpu/text-classification_fp16_config.json`
- Static checks: `uv run ruff check src/ tests/` -> all checks passed; `uv run mypy -p winml.modelkit` -> success, no issues in 415 source files.
- Affected unit-test scope: no Python source or test files changed; this is a recipe-only diff.
- Methodology friction observed: none.

### Per-EP/device/precision results

| Tier | EP / Device | Precision | Verdict | Mean | P50 | Throughput | RAM delta | Task metric |
|---|---|---|---|---:|---:|---:|---:|---|
| L0 | CPUExecutionProvider / cpu | fp32 | PASS | - | - | - | - | - |
| L1 | CPUExecutionProvider / cpu | fp32 | PASS | 129.95 ms | 136.57 ms | 7.70 samples/s | +241.5 MB total | - |
| L0 | CPUExecutionProvider / cpu | fp16 | PASS | - | - | - | - | - |
| L1 | CPUExecutionProvider / cpu | fp16 | PASS | 103.96 ms | 108.83 ms | 9.62 samples/s | +270.4 MB total | - |
| L3 | CPUExecutionProvider / cpu | fp32/fp16 | EVAL-BLOCKED-DATA-PROVENANCE | - | - | - | - | no authoritative reranking eval dataset/label mapping declared in these recipes |

CPU fp32 structural validation: ONNX IR 8, opset 17, inputs `input_ids [1, 512]` and `attention_mask [1, 512]`, output `logits [1, 1]`.

CPU fp16 structural validation: ONNX IR 8, opset 17, inputs `input_ids [1, 512]` and `attention_mask [1, 512]`, output `logits [1, 1]`; 228 FLOAT16 initializers and 0 FLOAT32 initializers. `winml perf` printed `Model Precision: fp16`.

Provider snapshot during validation: `['AzureExecutionProvider', 'CPUExecutionProvider']`. The checked-in recipes only claim CPU/cpu coverage.

### Delta

Recipe-vs-auto-config changes:

| JSON pointer | Baseline value | Shipped value | Reason |
|---|---|---|---|
| `/export/dynamo` | `true` | `false` | Baseline warned that dynamo produced no usable module hierarchy metadata; `--no-dynamo` path gave full hierarchy tags |
| `/optim/clamp_constant_values` | absent | `true` | Matches existing `mxbai-rerank-base-v1` CPU recipe convention |
| `/quant` | static uint8/uint16 | `null` | CPU fp32/fp16 recipes; fp16 conversion is driven by `--precision fp16` |

No source code changed. `examples/recipes/README.md` is unchanged.

### Analyze summary

Static rule analysis completed with usable QNN/OpenVINO results and exited nonzero only because VitisAI had no rule data.

Component-level summary:

| Artifact | Architecture coverage | Mapping | Actionable EP findings |
|---|---|---|---|
| fp32 | embeddings; 12x DeBERTa-v2 encoder attention/FFN; reranking head | 1621/1621 nodes tagged during export | QNN partial: Add, Div, Erf, Mul |
| fp16 | embeddings; 12x DeBERTa-v2 encoder attention/FFN; reranking head | 1621/1621 nodes tagged during export | QNN partial: Add, Div, Erf, Mul; QNN/OpenVINO unknown: Cast |

Op-level summary:

| Artifact | Graph | Dominant ops | EP roll-up |
|---|---|---|---|
| fp32 | 620 ops / 17 types | Add 133; MatMul 120; Reshape 120; Transpose 72; Div 49 | QNN: 607 supported / 13 partial / 0 unsupported / 0 unknown; OpenVINO: 620 supported / 0 partial / 0 unsupported / 0 unknown |
| fp16 | 621 ops / 17 types | Add 133; MatMul 120; Reshape 120; Transpose 72; Div 49 | QNN: 607 supported / 13 partial / 0 unsupported / 1 unknown; OpenVINO: 620 supported / 0 partial / 0 unsupported / 1 unknown |

### Reproduce commands

```powershell
$OUT32 = "temp/repro_mixedbread-ai_mxbai-rerank-xsmall-v1_fp32"
$OUT16 = "temp/repro_mixedbread-ai_mxbai-rerank-xsmall-v1_fp16"
uv run winml inspect -m mixedbread-ai/mxbai-rerank-xsmall-v1 --format json
uv run winml build -m mixedbread-ai/mxbai-rerank-xsmall-v1 -c examples/recipes/mixedbread-ai_mxbai-rerank-xsmall-v1/cpu/cpu/text-classification_fp32_config.json -o $OUT32 --ep cpu --device cpu --no-analyze --no-optimize --no-quant --no-compile --rebuild
uv run winml build -m mixedbread-ai/mxbai-rerank-xsmall-v1 -c examples/recipes/mixedbread-ai_mxbai-rerank-xsmall-v1/cpu/cpu/text-classification_fp16_config.json -o $OUT16 --ep cpu --device cpu --precision fp16 --no-analyze --no-optimize --no-compile --rebuild
uv run python -c "import onnx; m=onnx.load('$OUT32/model.onnx', load_external_data=False); print(m.ir_version, [(i.name, [d.dim_value or d.dim_param for d in i.type.tensor_type.shape.dim]) for i in m.graph.input], [(o.name, [d.dim_value or d.dim_param for d in o.type.tensor_type.shape.dim]) for o in m.graph.output])"
uv run python -c "import onnx; m=onnx.load('$OUT16/model.onnx', load_external_data=False); print(m.ir_version, sum(1 for init in m.graph.initializer if init.data_type==10), [(i.name, [d.dim_value or d.dim_param for d in i.type.tensor_type.shape.dim]) for i in m.graph.input], [(o.name, [d.dim_value or d.dim_param for d in o.type.tensor_type.shape.dim]) for o in m.graph.output])"
uv run winml perf -m $OUT32/model.onnx --ep cpu --device cpu
uv run winml perf -m $OUT16/model.onnx --ep cpu --device cpu
uv run winml analyze --model $OUT32/model.onnx --ep all --output $OUT32/analyze_all.json
uv run winml analyze --model $OUT16/model.onnx --ep all --output $OUT16/analyze_all.json
uv run ruff check src/ tests/
uv run mypy -p winml.modelkit
```
