### PR TITLE
fix(layoutlm): resolve invoices question answering support

### DIFF
--- a/docs/commands/eval.md
+++ b/docs/commands/eval.md
@@ -160,6 +160,22 @@ Evaluate a composite model from pre-exported ONNX files. Some tasks (e.g., `imag
 $ winml eval -m encoder=encoder.onnx -m decoder=decoder.onnx --model-id microsoft/trocr-base-printed
 ```
 
+### Document question answering OCR
+
+Document datasets can provide `words` and `boxes` columns directly. That precomputed
+path does not import pytesseract or require a native OCR program. If a dataset provides
+only an image, install the document extra and native Tesseract 5.x as described in
+[Optional document OCR](../getting-started/installation.md#optional-document-ocr), then
+verify the executable before running eval:
+
+```powershell
+tesseract --version
+```
+
+Image-only validation fails during dataset validation when the version command cannot
+run. OCR-backed result JSON includes `ocr_engine_version` without recording the
+executable's machine-specific path; precomputed results are unchanged.
+
 ## Model build cache
 
 Evaluation reuses persistent model build artifacts by default. Pass
@@ -184,6 +200,7 @@ model-build pipeline from the runtime compilation cache.
 - **Export overrides only apply when eval builds from a HuggingFace ID.** `--shape-config`, `--input-specs`, `--export-config`, and `--dynamic-axes` shape the ONNX export that `eval` generates when `-m` is a HuggingFace model ID. When `-m` is a pre-built `.onnx` file, there is no export step, so these flags are ignored and the command prints a warning.
 - **The PyTorch runtime accepts only Hugging Face checkpoints.** `--runtime pytorch` cannot be combined with ONNX files, composite models, GenAI bundles, compare/reference/input-data modes, EP selection, or ONNX build/export controls. Use `--device cpu`, `--device gpu` with CUDA, or `--device auto`.
 - **Column names vary across datasets.** If the evaluator raises a missing-column error, run `winml eval --schema --task <task>` to inspect the expected schema and use `--column` to remap dataset field names to the expected names.
+- **Image-only document QA needs native OCR.** Install `winml-cli[document]` and native Tesseract 5.x, then confirm `tesseract --version` succeeds. To avoid a native OCR dependency, provide precomputed `words` and `boxes` columns.
 
 ## See also
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -41,6 +41,24 @@ uv pip install winml-cli
     uv sync
     ```
 
+### Optional document OCR
+
+Image-only document question answering requires both the Python document extra and a
+separate native Tesseract 5.x executable. The native program is not bundled in the
+Python wheel and winml-cli does not download it at runtime.
+
+```powershell
+uv pip install "winml-cli[document]"
+winget install --id UB-Mannheim.TesseractOCR --version 5.4.0.20240606 --exact
+tesseract --version
+```
+
+The evaluator accepts Tesseract 5.x; real-media validation is tested with Tesseract
+5.5.3. The versioned Windows package above installs supported Tesseract 5.4.0. Restart
+the terminal after installation if `tesseract --version` is not found on `PATH`.
+Datasets that provide precomputed `words` and `boxes` do not require pytesseract or the
+native executable.
+
 ## Verify
 
 ```bash

--- a/examples/recipes/DmitrySpartak_layoutlm-invoices/cpu/cpu/question-answering_fp16_config.json
+++ b/examples/recipes/DmitrySpartak_layoutlm-invoices/cpu/cpu/question-answering_fp16_config.json
@@ -1,0 +1,104 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          50265
+        ]
+      },
+      {
+        "name": "bbox",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512,
+          4
+        ],
+        "value_range": [
+          0,
+          1000
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      },
+      {
+        "name": "token_type_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "start_logits"
+      },
+      {
+        "name": "end_logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "question-answering",
+    "model_id": "DmitrySpartak/layoutlm-invoices",
+    "model_type": "layoutlm",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "loader": {
+    "task": "question-answering",
+    "model_class": "LayoutLMForQuestionAnswering",
+    "model_type": "layoutlm"
+  },
+  "compile": null
+}

--- a/examples/recipes/DmitrySpartak_layoutlm-invoices/cpu/cpu/question-answering_fp32_config.json
+++ b/examples/recipes/DmitrySpartak_layoutlm-invoices/cpu/cpu/question-answering_fp32_config.json
@@ -1,0 +1,81 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          50265
+        ]
+      },
+      {
+        "name": "bbox",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512,
+          4
+        ],
+        "value_range": [
+          0,
+          1000
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      },
+      {
+        "name": "token_type_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "start_logits"
+      },
+      {
+        "name": "end_logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": null,
+  "loader": {
+    "task": "question-answering",
+    "model_class": "LayoutLMForQuestionAnswering",
+    "model_type": "layoutlm"
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ dependencies = [
 ]
 
 optional-dependencies.audio = [ "soundfile>=0.13" ]
+optional-dependencies.document = [ "pytesseract==0.3.13" ]
 optional-dependencies.openvino = [ "openvino>=2023" ]
 optional-dependencies.qnn = [
   # 2.1+ is a plugin-only wheel under ``onnxruntime_qnn``. Older releases

--- a/src/winml/modelkit/eval/base_evaluator.py
+++ b/src/winml/modelkit/eval/base_evaluator.py
@@ -134,12 +134,17 @@ class WinMLEvaluator:
             dataset = dataset.select(range(actual_samples))
 
         assert self.config.task is not None, "config.task is required for evaluation"
+        self.validate_data(dataset)
+        return self.align_labels(dataset, ds)
+
+    def validate_data(self, dataset: Dataset) -> None:
+        """Validate dataset columns for the configured task."""
+        assert self.config.task is not None, "config.task is required for evaluation"
         validate_dataset_columns(
             dataset,
             self.config.task,
             self.config.dataset.columns_mapping,
         )
-        return self.align_labels(dataset, ds)
 
     def prepare_pipeline(self) -> Pipeline:
         """Create HF pipeline for inference. Subclasses override to configure."""

--- a/src/winml/modelkit/eval/evaluate.py
+++ b/src/winml/modelkit/eval/evaluate.py
@@ -76,6 +76,8 @@ _EVALUATOR_REGISTRY: dict[str, str] = {
         "winml.modelkit.eval.image_segmentation_evaluator:WinMLImageSegmentationEvaluator",
     "question-answering":
         "winml.modelkit.eval.question_answering_evaluator:WinMLQuestionAnsweringEvaluator",
+    "document-question-answering":
+        "winml.modelkit.eval.question_answering_evaluator:WinMLQuestionAnsweringEvaluator",
     "feature-extraction":
         "winml.modelkit.eval.feature_extraction_evaluator:WinMLFeatureExtractionEvaluator",
     "sentence-similarity":

--- a/src/winml/modelkit/eval/metrics/__init__.py
+++ b/src/winml/modelkit/eval/metrics/__init__.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from .binary_segmentation import BinarySegmentationMetric
     from .classification import ClassificationMetric
     from .depth import DepthMetric
+    from .document_qa import ANLSMetric
     from .keypoint import KeypointAPMetric
     from .knn_accuracy import KNNAccuracyMetric
     from .mean_average_precision import MAPMetric
@@ -28,6 +29,7 @@ if TYPE_CHECKING:
 # this package does not pull in numpy / scipy / torch / torchmetrics for callers
 # that do not actually use the metric in question.
 _LAZY_ATTRS: dict[str, str] = {
+    "ANLSMetric": ".document_qa:ANLSMetric",
     "BinarySegmentationMetric": ".binary_segmentation:BinarySegmentationMetric",
     "ClassificationMetric": ".classification:ClassificationMetric",
     "DepthMetric": ".depth:DepthMetric",
@@ -60,6 +62,7 @@ def __dir__() -> list[str]:
 
 __all__ = [
     "IGNORE_INDEX",
+    "ANLSMetric",
     "BinarySegmentationMetric",
     "ClassificationMetric",
     "DepthMetric",

--- a/src/winml/modelkit/eval/metrics/document_qa.py
+++ b/src/winml/modelkit/eval/metrics/document_qa.py
@@ -1,0 +1,60 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+"""Average normalized Levenshtein similarity for document QA."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from rapidfuzz.distance import Levenshtein
+
+
+def _normalize_text(value: str) -> str:
+    """Normalize case and whitespace before scoring."""
+    return " ".join(re.sub(r"\s+", " ", value.casefold()).strip().split())
+
+
+def _normalized_levenshtein_similarity(prediction: str, reference: str) -> float:
+    """Return thresholded normalized Levenshtein similarity."""
+    prediction = _normalize_text(prediction)
+    reference = _normalize_text(reference)
+    if not prediction and not reference:
+        return 1.0
+    denominator = max(len(prediction), len(reference))
+    similarity = 1.0 - Levenshtein.distance(prediction, reference) / denominator
+    return similarity if similarity >= 0.5 else 0.0
+
+
+class ANLSMetric:
+    """Aggregate best-reference ANLS over document QA predictions."""
+
+    def __init__(self) -> None:
+        self._scores: list[float] = []
+        self._skipped_samples = 0
+
+    def update(self, prediction: str, references: str | list[str]) -> None:
+        """Score one prediction against one or more accepted references."""
+        if isinstance(references, str):
+            references = [references]
+        references = [reference for reference in references if isinstance(reference, str)]
+        if not references:
+            self._skipped_samples += 1
+            return
+        self._scores.append(
+            max(
+                _normalized_levenshtein_similarity(prediction or "", reference)
+                for reference in references
+            )
+        )
+
+    def compute(self) -> dict[str, Any]:
+        """Return ANLS and explicit processed/skipped sample counts."""
+        return {
+            "anls": round(sum(self._scores) / len(self._scores), 4) if self._scores else None,
+            "n_samples": len(self._scores),
+            "skipped_samples": self._skipped_samples,
+        }

--- a/src/winml/modelkit/eval/question_answering_evaluator.py
+++ b/src/winml/modelkit/eval/question_answering_evaluator.py
@@ -366,6 +366,18 @@ class WinMLQuestionAnsweringEvaluator(WinMLEvaluator):
         tokenizer = self.pipe.tokenizer
         if tokenizer is None:
             raise ValueError("Document question answering requires a tokenizer.")
+        supported_input_names = set(getattr(tokenizer, "model_input_names", [])) | {
+            "input_ids",
+            "attention_mask",
+            "bbox",
+            "token_type_ids",
+        }
+        unsupported_input_names = sorted(input_names - supported_input_names)
+        if unsupported_input_names:
+            raise ValueError(
+                "Document question answering currently supports text-and-layout model inputs; "
+                f"it cannot produce declared input(s): {', '.join(unsupported_input_names)}."
+            )
         max_length = self._fixed_seq_length() or tokenizer.model_max_length
         if not isinstance(max_length, int) or max_length <= 0:
             raise ValueError("Document QA requires a finite tokenizer or model sequence length.")

--- a/src/winml/modelkit/eval/question_answering_evaluator.py
+++ b/src/winml/modelkit/eval/question_answering_evaluator.py
@@ -21,6 +21,11 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _DOCUMENT_COLUMN_KEYS = {"words_column", "boxes_column", "image_column"}
+_TESSERACT_INSTALL_HINT = (
+    "Install the document extra and native Tesseract 5.x, then verify the executable with "
+    "`tesseract --version`. On Windows, run `winget install --id "
+    "UB-Mannheim.TesseractOCR --version 5.4.0.20240606 --exact`."
+)
 
 
 def _is_true(value: str | None) -> bool:
@@ -235,6 +240,41 @@ class WinMLQuestionAnsweringEvaluator(WinMLEvaluator):
                 f"document question answering is missing required data: {details}; "
                 f"dataset has {sorted(columns)}"
             )
+        if not has_precomputed:
+            self._require_tesseract_runtime()
+
+    def _require_tesseract_runtime(self) -> tuple[Any, str]:
+        runtime = getattr(self, "_tesseract_runtime", None)
+        if runtime is not None:
+            return cast("tuple[Any, str]", runtime)
+        try:
+            import pytesseract  # type: ignore[import-untyped]
+        except ImportError as error:
+            raise RuntimeError(
+                "Image-only document QA requires the optional OCR dependency. "
+                f"Install winml-cli[document]. {_TESSERACT_INSTALL_HINT}"
+            ) from error
+        try:
+            version = str(pytesseract.get_tesseract_version()).splitlines()[0].strip()
+        except pytesseract.TesseractNotFoundError as error:
+            raise RuntimeError(
+                "Native Tesseract executable was not found or could not run its version "
+                f"command. {_TESSERACT_INSTALL_HINT} Alternatively, provide precomputed "
+                "words and boxes."
+            ) from error
+        if not version:
+            raise RuntimeError(
+                "Native Tesseract returned an empty version. "
+                f"{_TESSERACT_INSTALL_HINT}"
+            )
+        if version.partition(".")[0] != "5":
+            raise RuntimeError(
+                f"Native Tesseract {version} is unsupported; version 5.x is required. "
+                f"{_TESSERACT_INSTALL_HINT}"
+            )
+        runtime = (pytesseract, version)
+        self._tesseract_runtime = runtime
+        return runtime
 
     def _document_words_and_boxes(
         self,
@@ -258,13 +298,7 @@ class WinMLQuestionAnsweringEvaluator(WinMLEvaluator):
         else:
             if mapping.get("ocr_engine", "tesseract").casefold() != "tesseract":
                 raise ValueError("ocr_engine currently supports only 'tesseract'.")
-            try:
-                import pytesseract  # type: ignore[import-untyped]
-            except ImportError as error:
-                raise RuntimeError(
-                    "Image-only document QA requires the optional OCR dependency. "
-                    "Install winml-cli[document] and native Tesseract, or provide words and boxes."
-                ) from error
+            pytesseract, tesseract_version = self._require_tesseract_runtime()
             if image is None or image_size is None:
                 raise ValueError(
                     "Image-only document QA requires a PIL image with width and height."
@@ -273,8 +307,8 @@ class WinMLQuestionAnsweringEvaluator(WinMLEvaluator):
                 data = pytesseract.image_to_data(image, output_type=pytesseract.Output.DICT)
             except pytesseract.TesseractNotFoundError as error:
                 raise RuntimeError(
-                    "Native Tesseract was not found. Install Tesseract or provide precomputed "
-                    "words and boxes."
+                    "Native Tesseract failed after validation. Verify `tesseract --version` or "
+                    "provide precomputed words and boxes."
                 ) from error
             words = []
             absolute_boxes = []
@@ -297,6 +331,7 @@ class WinMLQuestionAnsweringEvaluator(WinMLEvaluator):
                 coordinate_system="absolute",
             )
             source = "tesseract"
+            self._last_ocr_version = tesseract_version
 
         if not words or len(words) != len(boxes):
             raise ValueError("Document OCR must produce equal non-zero word and box counts.")
@@ -341,10 +376,13 @@ class WinMLQuestionAnsweringEvaluator(WinMLEvaluator):
         windows_processed = 0
         ocr_samples = 0
         precomputed_samples = 0
+        ocr_version = None
         for row in self.data:
             words, boxes, source = self._document_words_and_boxes(row)
             ocr_samples += source == "tesseract"
             precomputed_samples += source == "precomputed"
+            if source == "tesseract":
+                ocr_version = self._last_ocr_version
             question = str(row[mapping.get("question_column", "question")])
             encoding = tokenizer(
                 question.split(),
@@ -400,12 +438,15 @@ class WinMLQuestionAnsweringEvaluator(WinMLEvaluator):
                 windows_processed += 1
             metric.update(prediction, self._references(row[mapping.get("label_column", "answers")]))
 
-        return {
+        result = {
             **metric.compute(),
             "windows_processed": windows_processed,
             "ocr_samples": ocr_samples,
             "precomputed_samples": precomputed_samples,
         }
+        if ocr_version is not None:
+            result["ocr_engine_version"] = ocr_version
+        return result
 
     def compute(self) -> dict[str, Any]:
         """Run QA evaluation with automatic SQuAD v2 detection.

--- a/src/winml/modelkit/eval/question_answering_evaluator.py
+++ b/src/winml/modelkit/eval/question_answering_evaluator.py
@@ -246,7 +246,7 @@ class WinMLQuestionAnsweringEvaluator(WinMLEvaluator):
         if runtime is not None:
             return cast("tuple[Any, str]", runtime)
         try:
-            import pytesseract  # type: ignore[import-not-found]
+            import pytesseract  # type: ignore[import-untyped]
         except ImportError as error:
             raise RuntimeError(
                 "Image-only document QA requires the optional OCR dependency. "

--- a/src/winml/modelkit/eval/question_answering_evaluator.py
+++ b/src/winml/modelkit/eval/question_answering_evaluator.py
@@ -59,9 +59,7 @@ def _normalize_boxes(
         parsed.append((min(x0, x1), min(y0, y1), max(x0, x1), max(y0, y1)))
 
     use_absolute = coordinate_system == "absolute" or (
-        coordinate_system == "auto"
-        and image_size is not None
-        and any(value > 1000 for box in parsed for value in box)
+        coordinate_system == "auto" and image_size is not None
     )
     if use_absolute and image_size is None:
         raise ValueError("Absolute document boxes require an image with width and height.")
@@ -248,7 +246,7 @@ class WinMLQuestionAnsweringEvaluator(WinMLEvaluator):
         if runtime is not None:
             return cast("tuple[Any, str]", runtime)
         try:
-            import pytesseract  # type: ignore[import-untyped]
+            import pytesseract  # type: ignore[import-not-found]
         except ImportError as error:
             raise RuntimeError(
                 "Image-only document QA requires the optional OCR dependency. "

--- a/src/winml/modelkit/eval/question_answering_evaluator.py
+++ b/src/winml/modelkit/eval/question_answering_evaluator.py
@@ -167,7 +167,21 @@ class WinMLQuestionAnsweringEvaluator(WinMLEvaluator):
         If io_config is unavailable or the shape cannot be resolved, the
         tokenizer keeps its own default max length and a warning is logged.
         """
-        pipe = super().prepare_pipeline()
+        if self._is_document_mode():
+            from ..inference.pipeline import create_pipeline
+
+            pipe = cast(
+                "Pipeline",
+                create_pipeline(
+                    "question-answering",
+                    self.model,
+                    self.config.model_id,
+                    device=self.config.pipeline_device,
+                    trust_remote_code=self.config.trust_remote_code,
+                ),
+            )
+        else:
+            pipe = super().prepare_pipeline()
 
         if pipe.tokenizer is not None:
             io_config = getattr(self.model, "io_config", None) or {}
@@ -366,7 +380,7 @@ class WinMLQuestionAnsweringEvaluator(WinMLEvaluator):
         tokenizer = self.pipe.tokenizer
         if tokenizer is None:
             raise ValueError("Document question answering requires a tokenizer.")
-        supported_input_names = set(getattr(tokenizer, "model_input_names", [])) | {
+        supported_input_names = {
             "input_ids",
             "attention_mask",
             "bbox",

--- a/src/winml/modelkit/eval/question_answering_evaluator.py
+++ b/src/winml/modelkit/eval/question_answering_evaluator.py
@@ -8,15 +8,135 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, cast
 
 from .base_evaluator import WinMLEvaluator, _ensure_evaluate_transformers_compat
 
 
 if TYPE_CHECKING:
+    from datasets import Dataset
     from transformers.pipelines.base import Pipeline
 
 logger = logging.getLogger(__name__)
+
+_DOCUMENT_COLUMN_KEYS = {"words_column", "boxes_column", "image_column"}
+
+
+def _is_true(value: str | None) -> bool:
+    return value is not None and value.casefold() in {"1", "true", "yes", "on"}
+
+
+def _bounded_int(mapping: dict[str, str], key: str, default: int, minimum: int = 1) -> int:
+    try:
+        value = int(mapping.get(key, default))
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"{key} must be an integer.") from error
+    if value < minimum:
+        raise ValueError(f"{key} must be at least {minimum}.")
+    return value
+
+
+def _normalize_boxes(
+    boxes: Sequence[Sequence[int | float]],
+    *,
+    image_size: tuple[int, int] | None,
+    coordinate_system: str,
+) -> list[list[int]]:
+    """Normalize xyxy boxes to integer LayoutLM coordinates in [0, 1000]."""
+    if coordinate_system not in {"auto", "absolute", "normalized"}:
+        raise ValueError("box_coords must be one of: auto, absolute, normalized.")
+    parsed: list[tuple[float, float, float, float]] = []
+    for box in boxes:
+        if not isinstance(box, Sequence) or isinstance(box, (str, bytes)) or len(box) != 4:
+            raise ValueError("Each document box must contain four xyxy coordinates.")
+        x0, y0, x1, y1 = (float(value) for value in box)
+        parsed.append((min(x0, x1), min(y0, y1), max(x0, x1), max(y0, y1)))
+
+    use_absolute = coordinate_system == "absolute" or (
+        coordinate_system == "auto"
+        and image_size is not None
+        and any(value > 1000 for box in parsed for value in box)
+    )
+    if use_absolute and image_size is None:
+        raise ValueError("Absolute document boxes require an image with width and height.")
+    width, height = image_size or (1000, 1000)
+    if width <= 0 or height <= 0:
+        raise ValueError("Document image dimensions must be positive.")
+
+    normalized: list[list[int]] = []
+    for x0, y0, x1, y1 in parsed:
+        if use_absolute:
+            x0, x1 = x0 * 1000 / width, x1 * 1000 / width
+            y0, y1 = y0 * 1000 / height, y1 * 1000 / height
+        normalized.append(
+            [round(max(0, min(1000, value))) for value in (x0, y0, x1, y1)]
+        )
+    return normalized
+
+
+def _align_token_boxes(
+    encoding: Any,
+    feature_index: int,
+    word_boxes: Sequence[Sequence[int]],
+    sep_token_id: int | None,
+) -> list[list[int]]:
+    """Propagate document word boxes to subwords in one overflow feature."""
+    input_ids = encoding["input_ids"][feature_index].tolist()
+    sequence_ids = encoding.sequence_ids(feature_index)
+    word_ids = encoding.word_ids(feature_index)
+    aligned: list[list[int]] = []
+    for token_id, sequence_id, word_id in zip(input_ids, sequence_ids, word_ids, strict=True):
+        if sequence_id == 1 and word_id is not None:
+            if word_id >= len(word_boxes):
+                raise ValueError("Tokenizer word alignment exceeds the available document boxes.")
+            aligned.append(list(word_boxes[word_id]))
+        elif sep_token_id is not None and token_id == sep_token_id:
+            aligned.append([1000, 1000, 1000, 1000])
+        else:
+            aligned.append([0, 0, 0, 0])
+    return aligned
+
+
+def _decode_document_span(
+    start_logits: Any,
+    end_logits: Any,
+    sequence_ids: Sequence[int | None],
+    word_ids: Sequence[int | None],
+    words: Sequence[str],
+    max_answer_words: int,
+) -> tuple[float, str]:
+    """Decode the best valid contiguous document-word span."""
+    import numpy as np
+
+    starts = np.asarray(start_logits).reshape(-1)
+    ends = np.asarray(end_logits).reshape(-1)
+    if len(starts) != len(sequence_ids) or len(ends) != len(sequence_ids):
+        raise ValueError("Question-answering logits do not match the tokenized feature length.")
+
+    best_score = float("-inf")
+    best_answer = ""
+    for start_index, (start_sequence, start_word) in enumerate(
+        zip(sequence_ids, word_ids, strict=True)
+    ):
+        if start_sequence != 1 or start_word is None:
+            continue
+        for end_index in range(start_index, len(sequence_ids)):
+            end_word = word_ids[end_index]
+            if sequence_ids[end_index] != 1 or end_word is None:
+                break
+            word_count = end_word - start_word + 1
+            if word_count < 1:
+                continue
+            if word_count > max_answer_words:
+                break
+            if end_word >= len(words):
+                raise ValueError("Tokenizer word alignment exceeds the available document words.")
+            score = float(starts[start_index] + ends[end_index])
+            if score > best_score:
+                best_score = score
+                best_answer = " ".join(words[start_word : end_word + 1])
+    return best_score, best_answer
 
 
 class WinMLQuestionAnsweringEvaluator(WinMLEvaluator):
@@ -62,6 +182,231 @@ class WinMLQuestionAnsweringEvaluator(WinMLEvaluator):
 
         return pipe
 
+    def _is_document_mode(self) -> bool:
+        mapping = self.config.dataset.columns_mapping
+        if _is_true(mapping.get("document_mode")):
+            return True
+        input_names = set((getattr(self.model, "io_config", None) or {}).get("input_names", []))
+        return "bbox" in input_names and bool(_DOCUMENT_COLUMN_KEYS & mapping.keys())
+
+    def prepare_data(self) -> Dataset:
+        """Load ordinary QA samples or one explicitly selected document row."""
+        mapping = self.config.dataset.columns_mapping
+        if not self._is_document_mode() or "sample_index" not in mapping:
+            return super().prepare_data()
+
+        sample_index = _bounded_int(mapping, "sample_index", 0, minimum=0)
+        dataset_config = self.config.dataset
+        original_samples = dataset_config.samples
+        original_shuffle = dataset_config.shuffle
+        dataset_config.samples = sample_index + 1
+        dataset_config.shuffle = False
+        try:
+            dataset = super().prepare_data()
+        finally:
+            dataset_config.samples = original_samples
+            dataset_config.shuffle = original_shuffle
+        if sample_index >= len(dataset):
+            raise ValueError(
+                f"sample_index {sample_index} is outside the loaded dataset of {len(dataset)} rows."
+            )
+        return dataset.select([sample_index])
+
+    def validate_data(self, dataset: Dataset) -> None:
+        """Validate either the existing text schema or document QA columns."""
+        if not self._is_document_mode():
+            super().validate_data(dataset)
+            return
+
+        from ..utils.eval_utils import DatasetValidationError
+
+        mapping = self.config.dataset.columns_mapping
+        columns = set(dataset.column_names)
+        question_column = mapping.get("question_column", "question")
+        label_column = mapping.get("label_column", "answers")
+        words_column = mapping.get("words_column", "words")
+        boxes_column = mapping.get("boxes_column", "boxes")
+        image_column = mapping.get("image_column", "image")
+        missing = [name for name in (question_column, label_column) if name not in columns]
+        has_precomputed = words_column in columns and boxes_column in columns
+        if missing or (not has_precomputed and image_column not in columns):
+            details = ", ".join(missing) if missing else "words+boxes or image"
+            raise DatasetValidationError(
+                f"document question answering is missing required data: {details}; "
+                f"dataset has {sorted(columns)}"
+            )
+
+    def _document_words_and_boxes(
+        self,
+        row: dict[str, Any],
+    ) -> tuple[list[str], list[list[int]], str]:
+        mapping = self.config.dataset.columns_mapping
+        words_column = mapping.get("words_column", "words")
+        boxes_column = mapping.get("boxes_column", "boxes")
+        image_column = mapping.get("image_column", "image")
+        image = row.get(image_column)
+        image_size = getattr(image, "size", None)
+
+        if words_column in row and boxes_column in row:
+            words = [str(word) for word in row[words_column]]
+            boxes = _normalize_boxes(
+                row[boxes_column],
+                image_size=image_size,
+                coordinate_system=mapping.get("box_coords", "auto").casefold(),
+            )
+            source = "precomputed"
+        else:
+            if mapping.get("ocr_engine", "tesseract").casefold() != "tesseract":
+                raise ValueError("ocr_engine currently supports only 'tesseract'.")
+            try:
+                import pytesseract  # type: ignore[import-untyped]
+            except ImportError as error:
+                raise RuntimeError(
+                    "Image-only document QA requires the optional OCR dependency. "
+                    "Install winml-cli[document] and native Tesseract, or provide words and boxes."
+                ) from error
+            if image is None or image_size is None:
+                raise ValueError(
+                    "Image-only document QA requires a PIL image with width and height."
+                )
+            try:
+                data = pytesseract.image_to_data(image, output_type=pytesseract.Output.DICT)
+            except pytesseract.TesseractNotFoundError as error:
+                raise RuntimeError(
+                    "Native Tesseract was not found. Install Tesseract or provide precomputed "
+                    "words and boxes."
+                ) from error
+            words = []
+            absolute_boxes = []
+            for text, left, top, width, height in zip(
+                data["text"],
+                data["left"],
+                data["top"],
+                data["width"],
+                data["height"],
+                strict=True,
+            ):
+                text = str(text).strip()
+                if not text:
+                    continue
+                words.append(text)
+                absolute_boxes.append([left, top, left + width, top + height])
+            boxes = _normalize_boxes(
+                absolute_boxes,
+                image_size=image_size,
+                coordinate_system="absolute",
+            )
+            source = "tesseract"
+
+        if not words or len(words) != len(boxes):
+            raise ValueError("Document OCR must produce equal non-zero word and box counts.")
+        return words, boxes, source
+
+    @staticmethod
+    def _references(value: Any) -> list[str]:
+        if isinstance(value, dict):
+            value = value.get("text", [])
+        if isinstance(value, str):
+            return [value]
+        if isinstance(value, Sequence):
+            return [str(reference) for reference in value]
+        return []
+
+    def _compute_document(self) -> dict[str, Any]:
+        import torch
+
+        from .metrics import ANLSMetric
+
+        input_names = set((getattr(self.model, "io_config", None) or {}).get("input_names", []))
+        if "bbox" not in input_names:
+            raise ValueError(
+                "Document question answering requires a model with a declared bbox input."
+            )
+
+        mapping = self.config.dataset.columns_mapping
+        max_windows = _bounded_int(mapping, "max_windows", 1)
+        doc_stride = _bounded_int(mapping, "doc_stride", 128, minimum=0)
+        max_answer_words = _bounded_int(mapping, "max_answer_words", 64)
+        top_k = _bounded_int(mapping, "top_k", 1)
+        if top_k != 1:
+            raise ValueError("Document QA evaluation currently requires top_k=1.")
+        tokenizer = self.pipe.tokenizer
+        if tokenizer is None:
+            raise ValueError("Document question answering requires a tokenizer.")
+        max_length = self._fixed_seq_length() or tokenizer.model_max_length
+        if not isinstance(max_length, int) or max_length <= 0:
+            raise ValueError("Document QA requires a finite tokenizer or model sequence length.")
+
+        metric = ANLSMetric()
+        windows_processed = 0
+        ocr_samples = 0
+        precomputed_samples = 0
+        for row in self.data:
+            words, boxes, source = self._document_words_and_boxes(row)
+            ocr_samples += source == "tesseract"
+            precomputed_samples += source == "precomputed"
+            question = str(row[mapping.get("question_column", "question")])
+            encoding = tokenizer(
+                question.split(),
+                words,
+                is_split_into_words=True,
+                truncation="only_second",
+                max_length=max_length,
+                stride=doc_stride,
+                padding="max_length",
+                return_overflowing_tokens=True,
+                return_tensors="pt",
+            )
+            feature_count = min(len(encoding["input_ids"]), max_windows)
+            best_score = float("-inf")
+            prediction = ""
+            for feature_index in range(feature_count):
+                aligned_boxes = _align_token_boxes(
+                    encoding,
+                    feature_index,
+                    boxes,
+                    tokenizer.sep_token_id,
+                )
+                model_inputs: dict[str, Any] = {}
+                for input_name in input_names:
+                    if input_name == "bbox":
+                        model_inputs[input_name] = torch.tensor([aligned_boxes], dtype=torch.long)
+                    elif input_name == "token_type_ids" and input_name not in encoding:
+                        model_inputs[input_name] = torch.zeros_like(
+                            encoding["input_ids"][feature_index : feature_index + 1]
+                        )
+                    elif input_name in encoding and isinstance(encoding[input_name], torch.Tensor):
+                        model_inputs[input_name] = encoding[input_name][
+                            feature_index : feature_index + 1
+                        ]
+                    else:
+                        raise ValueError(
+                            f"Tokenizer did not produce declared model input '{input_name}'."
+                        )
+                device = getattr(self.pipe, "device", "cpu")
+                model_inputs = {name: value.to(device) for name, value in model_inputs.items()}
+                with torch.no_grad():
+                    outputs = self.model(**model_inputs)
+                score, answer = _decode_document_span(
+                    outputs.start_logits[0].detach().cpu().numpy(),
+                    outputs.end_logits[0].detach().cpu().numpy(),
+                    encoding.sequence_ids(feature_index),
+                    encoding.word_ids(feature_index),
+                    words,
+                    max_answer_words,
+                )
+                if score > best_score:
+                    best_score, prediction = score, answer
+                windows_processed += 1
+            metric.update(prediction, self._references(row[mapping.get("label_column", "answers")]))
+
+        return {
+            **metric.compute(),
+            "windows_processed": windows_processed,
+            "ocr_samples": ocr_samples,
+            "precomputed_samples": precomputed_samples,
+        }
+
     def compute(self) -> dict[str, Any]:
         """Run QA evaluation with automatic SQuAD v2 detection.
 
@@ -70,6 +415,9 @@ class WinMLQuestionAnsweringEvaluator(WinMLEvaluator):
         QuestionAnsweringEvaluator.  Works with both SQuAD v1 (100 samples
         default) and v2 datasets — metric selection is automatic.
         """
+        if self._is_document_mode():
+            return self._compute_document()
+
         _ensure_evaluate_transformers_compat()
         from evaluate.evaluator.question_answering import QuestionAnsweringEvaluator
 

--- a/src/winml/modelkit/inference/pipeline.py
+++ b/src/winml/modelkit/inference/pipeline.py
@@ -521,6 +521,7 @@ def _create_extractive_question_answering_pipeline(
 
 _COMPAT_PIPELINE_FACTORIES = {
     "question-answering": _create_extractive_question_answering_pipeline,
+    "document-question-answering": _create_extractive_question_answering_pipeline,
 }
 
 

--- a/src/winml/modelkit/inference/pipeline.py
+++ b/src/winml/modelkit/inference/pipeline.py
@@ -521,7 +521,6 @@ def _create_extractive_question_answering_pipeline(
 
 _COMPAT_PIPELINE_FACTORIES = {
     "question-answering": _create_extractive_question_answering_pipeline,
-    "document-question-answering": _create_extractive_question_answering_pipeline,
 }
 
 

--- a/src/winml/modelkit/loader/resolution.py
+++ b/src/winml/modelkit/loader/resolution.py
@@ -178,8 +178,8 @@ _FEATURE_MODALITY_BY_MAIN_INPUT: dict[str, str] = {
 }
 
 
-_ARCHITECTURE_SUFFIX_TASKS: dict[str, str] = {
-    "ForQuestionAnswering": "question-answering",
+_ARCHITECTURE_SUFFIX_TASKS: dict[str, tuple[str, ...]] = {
+    "ForQuestionAnswering": ("document-question-answering", "question-answering"),
 }
 
 
@@ -189,9 +189,21 @@ def _infer_task_from_architecture_suffix(config: PretrainedConfig) -> str | None
     if not architectures:
         return None
     arch_name = architectures[0]
-    for suffix, task in _ARCHITECTURE_SUFFIX_TASKS.items():
+    for suffix, tasks in _ARCHITECTURE_SUFFIX_TASKS.items():
         if arch_name.endswith(suffix):
-            return task
+            from transformers.models.auto.modeling_auto import (
+                MODEL_FOR_DOCUMENT_QUESTION_ANSWERING_MAPPING_NAMES,
+                MODEL_FOR_QUESTION_ANSWERING_MAPPING_NAMES,
+            )
+
+            model_type = getattr(config, "model_type", None)
+            if (
+                "document-question-answering" in tasks
+                and model_type in MODEL_FOR_DOCUMENT_QUESTION_ANSWERING_MAPPING_NAMES
+                and model_type not in MODEL_FOR_QUESTION_ANSWERING_MAPPING_NAMES
+            ):
+                return "document-question-answering"
+            return tasks[-1]
     return None
 
 

--- a/src/winml/modelkit/loader/resolution.py
+++ b/src/winml/modelkit/loader/resolution.py
@@ -269,6 +269,7 @@ class TaskSource(str, Enum):
     MODEL_ID_DEFAULT = "model-id-default"  # MODEL_TASK_MAPPING model-id default
     SENTINEL_DEFAULT = "sentinel-default"  # (model_type, None) sentinel
     TASKS_MANAGER = "tasks-manager"  # Optimum inference (incl. fill-mask upgrade)
+    ARCHITECTURE_SUFFIX = "architecture-suffix"  # class-name suffix fallback
     WRAPPED_LIBRARY = "wrapped-library"  # no architectures -> first supported task
     PIPELINE_TAG = "pipeline-tag"  # Hub pipeline_tag fallback
     HF_TASK_DEFAULT = "hf-task-default"  # last-resort default
@@ -431,23 +432,22 @@ def resolve_composite_load_task(
 _SEQ2SEQ_GENERATION_TASK = "text2text-generation"
 
 
-def _infer_task_from_architecture(config: PretrainedConfig) -> str:
-    """Optimum task inferred from ``config.architectures[0]``.
+def _infer_task_from_architecture(config: PretrainedConfig) -> tuple[str, TaskSource]:
+    """Optimum task and provenance inferred from ``config.architectures[0]``.
 
     Includes the encoder-decoder fill-mask -> text2text-generation correction.
     """
     model_class = _resolve_model_class_from_config(config)
     try:
         task = _detect_task_from_model_class(model_class)
+        source = TaskSource.TASKS_MANAGER
     except ValueError:
         suffix_task = _infer_task_from_architecture_suffix(config)
         if suffix_task is None:
             raise
         task = suffix_task
-    return _upgrade_fill_mask_for_seq2seq(
-        task,
-        config,
-    )
+        source = TaskSource.ARCHITECTURE_SUFFIX
+    return _upgrade_fill_mask_for_seq2seq(task, config), source
 
 
 def _composite_components_for_task(model_type: str, task: str) -> CompositeComponents | None:
@@ -549,7 +549,7 @@ def resolve_task(
             # Task inferred from the architecture: surface it modality-aware, consistent
             # with the detection path (Stage 3), so e.g. a ViT backbone is
             # image-feature-extraction rather than the modality-blind feature-extraction.
-            opt_task = _infer_task_from_architecture(config)
+            opt_task, _ = _infer_task_from_architecture(config)
             surfaced = _resolve_task_modality(config, opt_task)
         # A WinML build variant (model_type_override) may name a custom wrapper
         # registered in MODEL_CLASS_MAPPING rather than a transformers class —
@@ -645,8 +645,7 @@ def resolve_task(
     # 1c. TasksManager (reads config.architectures)
     if opt_task is None:
         try:
-            opt_task = _infer_task_from_architecture(config)
-            source = TaskSource.TASKS_MANAGER
+            opt_task, source = _infer_task_from_architecture(config)
         except ValueError:
             opt_task = None
 

--- a/src/winml/modelkit/loader/resolution.py
+++ b/src/winml/modelkit/loader/resolution.py
@@ -184,11 +184,14 @@ _ARCHITECTURE_SUFFIX_TASKS: dict[str, str] = {
 
 
 def _infer_task_from_architecture_suffix(config: PretrainedConfig) -> str | None:
-    """Infer task from architecture head suffix when Optimum has no mapping."""
-    for arch_name in getattr(config, "architectures", None) or []:
-        for suffix, task in _ARCHITECTURE_SUFFIX_TASKS.items():
-            if arch_name.endswith(suffix):
-                return task
+    """Infer task from the primary architecture suffix when Optimum has no mapping."""
+    architectures = getattr(config, "architectures", None)
+    if not architectures:
+        return None
+    arch_name = architectures[0]
+    for suffix, task in _ARCHITECTURE_SUFFIX_TASKS.items():
+        if arch_name.endswith(suffix):
+            return task
     return None
 
 

--- a/src/winml/modelkit/loader/resolution.py
+++ b/src/winml/modelkit/loader/resolution.py
@@ -178,6 +178,20 @@ _FEATURE_MODALITY_BY_MAIN_INPUT: dict[str, str] = {
 }
 
 
+_ARCHITECTURE_SUFFIX_TASKS: dict[str, str] = {
+    "ForQuestionAnswering": "question-answering",
+}
+
+
+def _infer_task_from_architecture_suffix(config: PretrainedConfig) -> str | None:
+    """Infer task from architecture head suffix when Optimum has no mapping."""
+    for arch_name in getattr(config, "architectures", None) or []:
+        for suffix, task in _ARCHITECTURE_SUFFIX_TASKS.items():
+            if arch_name.endswith(suffix):
+                return task
+    return None
+
+
 def _resolve_task_modality(config: PretrainedConfig, task: str) -> str:
     """Upgrade a modality-blind ``feature-extraction`` to its modality-aware variant.
 
@@ -419,8 +433,16 @@ def _infer_task_from_architecture(config: PretrainedConfig) -> str:
 
     Includes the encoder-decoder fill-mask -> text2text-generation correction.
     """
+    model_class = _resolve_model_class_from_config(config)
+    try:
+        task = _detect_task_from_model_class(model_class)
+    except ValueError:
+        suffix_task = _infer_task_from_architecture_suffix(config)
+        if suffix_task is None:
+            raise
+        task = suffix_task
     return _upgrade_fill_mask_for_seq2seq(
-        _detect_task_from_model_class(_resolve_model_class_from_config(config)),
+        task,
         config,
     )
 

--- a/src/winml/modelkit/loader/task.py
+++ b/src/winml/modelkit/loader/task.py
@@ -250,6 +250,8 @@ TASK_SYNONYM_EXTENSIONS: dict[str, str] = {
     # collapse to feature-extraction is guarded by tests/unit/loader/test_task_boundary.py.
     # next-sentence-prediction has the same I/O as text-classification: input_ids -> logits
     "next-sentence-prediction": "text-classification",
+    # Layout-aware extractive QA uses the same Optimum ONNX contract as text QA.
+    "document-question-answering": "question-answering",
     # mask-generation is registered via register_onnx_overwrite for SAM2.
     # Optimum incorrectly maps it to "feature-extraction"; preserve as-is.
     "mask-generation": "mask-generation",

--- a/src/winml/modelkit/models/hf/layoutlm.py
+++ b/src/winml/modelkit/models/hf/layoutlm.py
@@ -13,6 +13,7 @@ from optimum.utils import NormalizedTextConfig
 from optimum.utils.input_generators import DummyBboxInputGenerator, DummyVisionInputGenerator
 
 from ...export import MaxLengthTextInputGenerator, register_onnx_overwrite
+from .roberta import _adjust_position_embeddings
 
 
 if TYPE_CHECKING:
@@ -29,8 +30,18 @@ class ZeroTokenTypeLayoutLMTextInputGenerator(MaxLengthTextInputGenerator):
         int_dtype: str = "int64",
         float_dtype: str = "fp32",
     ) -> torch.Tensor:
-        """Generate LayoutLM text inputs, replacing token_type_ids with zeros."""
-        tensor = cast(
+        """Generate LayoutLM text inputs within the configured token-type range."""
+        if input_name == "token_type_ids":
+            return cast(
+                "torch.Tensor",
+                self.random_int_tensor(
+                    [self.batch_size, self.sequence_length],
+                    max_value=self.normalized_config.type_vocab_size,
+                    framework=framework,
+                    dtype=int_dtype,
+                ),
+            )
+        return cast(
             "torch.Tensor",
             super().generate(
                 input_name,
@@ -39,9 +50,6 @@ class ZeroTokenTypeLayoutLMTextInputGenerator(MaxLengthTextInputGenerator):
                 float_dtype=float_dtype,
             ),
         )
-        if input_name == "token_type_ids":
-            return tensor.new_zeros(tensor.shape)
-        return tensor
 
 
 @register_onnx_overwrite("layoutlm", "question-answering", library_name="transformers")
@@ -59,6 +67,7 @@ class LayoutLMQAIOConfig(LayoutLMOnnxConfig):  # type: ignore[misc]  # optimum b
     # recipe's `value_range` instead.
     NORMALIZED_CONFIG_CLASS = NormalizedTextConfig.with_args(
         sequence_length="max_position_embeddings",
+        type_vocab_size="type_vocab_size",
         allow_new=True,
     )
     DUMMY_INPUT_GENERATOR_CLASSES: tuple[type[Any], ...] = (
@@ -66,3 +75,7 @@ class LayoutLMQAIOConfig(LayoutLMOnnxConfig):  # type: ignore[misc]  # optimum b
         DummyVisionInputGenerator,
         DummyBboxInputGenerator,
     )
+
+    def __init__(self, config: Any, task: str, **kwargs: Any) -> None:
+        _adjust_position_embeddings(config)
+        super().__init__(config, task, **kwargs)

--- a/src/winml/modelkit/models/winml/__init__.py
+++ b/src/winml/modelkit/models/winml/__init__.py
@@ -44,6 +44,7 @@ TASK_TO_WINML_CLASS: dict[str, str] = {
     # Not yet implemented — falls back to WinMLModelForGenericTask at runtime
     "token-classification": "WinMLModelForTokenClassification",
     "question-answering": "WinMLModelForQuestionAnswering",
+    "document-question-answering": "WinMLModelForQuestionAnswering",
     "text-generation": "WinMLModelForCausalLM",
     "text2text-generation": "WinMLModelForSeq2SeqLM",
     "fill-mask": "WinMLModelForMaskedLM",

--- a/src/winml/modelkit/models/winml/question_answering.py
+++ b/src/winml/modelkit/models/winml/question_answering.py
@@ -45,6 +45,7 @@ class WinMLModelForQuestionAnswering(WinMLPreTrainedModel):
         input_ids: torch.Tensor | np.ndarray | None = None,
         attention_mask: torch.Tensor | np.ndarray | None = None,
         token_type_ids: torch.Tensor | np.ndarray | None = None,
+        bbox: torch.Tensor | np.ndarray | None = None,
         **kwargs: Any,
     ) -> QuestionAnsweringModelOutput:
         """Run question answering inference.
@@ -56,6 +57,8 @@ class WinMLModelForQuestionAnswering(WinMLPreTrainedModel):
                 if the model actually has this input.  Models like
                 DeBERTa-v3 omit this input; it is silently dropped when
                 not in the ONNX graph's input list.
+            bbox: Normalized token boxes (B, seq_len, 4). Only passed to ONNX
+                when the model declares a bbox input.
             **kwargs: Ignored. Accepted for HF pipeline compatibility —
                 the pipeline may forward extra keys (e.g. ``offset_mapping``,
                 ``overflow_to_sample_mapping``) that are not needed for
@@ -70,6 +73,8 @@ class WinMLModelForQuestionAnswering(WinMLPreTrainedModel):
         inputs: dict[str, Any] = {"input_ids": input_ids, "attention_mask": attention_mask}
         if token_type_ids is not None and "token_type_ids" in self.io_config.get("input_names", []):
             inputs["token_type_ids"] = token_type_ids
+        if bbox is not None and "bbox" in self.io_config.get("input_names", []):
+            inputs["bbox"] = bbox
 
         formatted = self._format_inputs(**inputs)
         outputs = self._run_inference(formatted)

--- a/src/winml/modelkit/utils/eval_utils.py
+++ b/src/winml/modelkit/utils/eval_utils.py
@@ -183,6 +183,74 @@ _QUESTION_ANSWERING_SCHEMA = TaskSchema(
             remap_hint="<your_answers_column>",
         ),
     ),
+    params=(
+        SchemaItem(
+            "document_mode",
+            "use OCR words and normalized bounding boxes",
+            default="false",
+            remap_hint="<true|false>",
+        ),
+        SchemaItem(
+            "words_column",
+            "precomputed OCR words (preferred when paired with boxes_column)",
+            default="words",
+            remap_hint="<your_words_column>",
+        ),
+        SchemaItem(
+            "boxes_column",
+            "precomputed OCR boxes in xyxy format",
+            default="boxes",
+            remap_hint="<your_boxes_column>",
+        ),
+        SchemaItem(
+            "image_column",
+            "document image used when precomputed OCR is unavailable",
+            default="image",
+            remap_hint="<your_image_column>",
+        ),
+        SchemaItem(
+            "ocr_engine",
+            "OCR engine for image-only rows",
+            default="tesseract",
+            remap_hint="<tesseract>",
+        ),
+        SchemaItem(
+            "box_coords",
+            "precomputed box coordinate system",
+            default="auto",
+            remap_hint="<auto|absolute|normalized>",
+        ),
+        SchemaItem(
+            "max_windows",
+            "maximum tokenizer overflow windows per question",
+            default="1",
+            remap_hint="<int>",
+        ),
+        SchemaItem(
+            "sample_index",
+            "zero-based dataset row selected before document evaluation",
+            default="0",
+            remap_hint="<int>",
+        ),
+        SchemaItem(
+            "doc_stride",
+            "overlap between tokenizer document windows",
+            default="128",
+            remap_hint="<int>",
+        ),
+        SchemaItem(
+            "max_answer_words",
+            "maximum contiguous OCR words in an answer",
+            default="64",
+            remap_hint="<int>",
+        ),
+        SchemaItem(
+            "top_k",
+            "number of answer spans retained per question",
+            default="1",
+            remap_hint="<int>",
+        ),
+    ),
 )
 
 _FEATURE_EXTRACTION_SCHEMA = TaskSchema(

--- a/src/winml/modelkit/utils/eval_utils.py
+++ b/src/winml/modelkit/utils/eval_utils.py
@@ -216,7 +216,7 @@ _QUESTION_ANSWERING_SCHEMA = TaskSchema(
         ),
         SchemaItem(
             "box_coords",
-            "precomputed box coordinate system",
+            "precomputed box coordinates; auto means absolute with an image, normalized without",
             default="auto",
             remap_hint="<auto|absolute|normalized>",
         ),
@@ -525,6 +525,7 @@ TASK_SCHEMAS: dict[str, TaskSchema] = {
     "object-detection": _OBJECT_DETECTION_SCHEMA,
     "image-segmentation": _IMAGE_SEGMENTATION_SCHEMA,
     "question-answering": _QUESTION_ANSWERING_SCHEMA,
+    "document-question-answering": _QUESTION_ANSWERING_SCHEMA,
     "feature-extraction": _FEATURE_EXTRACTION_SCHEMA,
     "sentence-similarity": _FEATURE_EXTRACTION_SCHEMA,
     "image-feature-extraction": _IMAGE_FEATURE_EXTRACTION_SCHEMA,

--- a/tests/unit/commands/test_build_validate_task.py
+++ b/tests/unit/commands/test_build_validate_task.py
@@ -152,6 +152,23 @@ class TestValidateTaskSupportedForModel:
                 task="next-sentence-prediction",
             )
 
+    def test_accepts_document_question_answering_for_layoutlm(self) -> None:
+        mock_config = MagicMock()
+        mock_config.model_type = "layoutlm"
+
+        with (
+            patch("winml.modelkit.loader.load_hf_config", return_value=mock_config),
+            patch("winml.modelkit.export.io.ensure_hf_models_registered"),
+            patch(
+                "winml.modelkit.loader.task.get_supported_tasks",
+                return_value=["question-answering"],
+            ),
+        ):
+            _validate_task_supported_for_model(
+                model_id="document/layoutlm-qa",
+                task="document-question-answering",
+            )
+
     def test_accepts_mask_generation_via_synonym_extensions(self) -> None:
         """``mask-generation`` is preserved in ``TASK_SYNONYM_EXTENSIONS`` for SAM2.
 

--- a/tests/unit/eval/test_document_qa_metric.py
+++ b/tests/unit/eval/test_document_qa_metric.py
@@ -1,0 +1,49 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+"""Tests for average normalized Levenshtein similarity."""
+
+from __future__ import annotations
+
+import pytest
+
+from winml.modelkit.eval.metrics.document_qa import (
+    ANLSMetric,
+    _normalized_levenshtein_similarity,
+)
+
+
+@pytest.mark.parametrize(
+    ("prediction", "reference", "expected"),
+    [
+        ("ITC Limited", "ITC Limited", 1.0),
+        ("  itc   LIMITED ", "ITC Limited", 1.0),
+        ("", "", 1.0),
+        ("", "invoice", 0.0),
+        ("abc", "xyz", 0.0),
+        ("invoicf", "invoice", pytest.approx(6 / 7)),
+    ],
+)
+def test_similarity_normalization_and_threshold(prediction, reference, expected):
+    assert _normalized_levenshtein_similarity(prediction, reference) == expected
+
+
+def test_metric_uses_best_reference_and_aggregates():
+    metric = ANLSMetric()
+    metric.update("ITC Limited", ["Other Company", "itc limited"])
+    metric.update("invoice", "invoicf")
+
+    assert metric.compute() == {
+        "anls": pytest.approx((1 + 6 / 7) / 2, abs=1e-4),
+        "n_samples": 2,
+        "skipped_samples": 0,
+    }
+
+
+def test_metric_reports_empty_and_skipped_samples():
+    metric = ANLSMetric()
+    metric.update("unused", [])
+
+    assert metric.compute() == {"anls": None, "n_samples": 0, "skipped_samples": 1}

--- a/tests/unit/eval/test_eval.py
+++ b/tests/unit/eval/test_eval.py
@@ -341,6 +341,42 @@ class TestGetEvaluatorClass:
 class TestEvaluate:
     """Tests for evaluate() entry point."""
 
+    def test_inferred_document_qa_reaches_evaluator_without_explicit_task(self):
+        import importlib
+        import sys
+
+        from winml.modelkit.eval.question_answering_evaluator import (
+            WinMLQuestionAnsweringEvaluator,
+        )
+
+        eval_mod = sys.modules.get(
+            "winml.modelkit.eval.evaluate",
+        ) or importlib.import_module("winml.modelkit.eval.evaluate")
+        config = WinMLEvaluationConfig(
+            model_id="test/layoutlm",
+            dataset=DatasetConfig(path="test/documents"),
+        )
+
+        with (
+            patch.object(
+                eval_mod,
+                "_infer_task",
+                return_value="document-question-answering",
+            ),
+            patch.object(eval_mod, "_load_model", return_value=MagicMock()),
+            patch.object(WinMLQuestionAnsweringEvaluator, "__init__", return_value=None),
+            patch.object(
+                WinMLQuestionAnsweringEvaluator,
+                "compute",
+                return_value={"anls": 1.0},
+            ),
+        ):
+            result = eval_mod.evaluate(config)
+
+        assert config.task is None
+        assert result.config.task == "document-question-answering"
+        assert result.metrics == {"anls": 1.0}
+
     def test_invalid_mode_raises(self):
         """evaluate() rejects unknown mode values with a clear error."""
         import importlib

--- a/tests/unit/eval/test_eval.py
+++ b/tests/unit/eval/test_eval.py
@@ -363,7 +363,7 @@ class TestEvaluate:
                 "_infer_task",
                 return_value="document-question-answering",
             ),
-            patch.object(eval_mod, "_load_model", return_value=MagicMock()),
+            patch.object(eval_mod, "load_model", return_value=MagicMock()),
             patch.object(WinMLQuestionAnsweringEvaluator, "__init__", return_value=None),
             patch.object(
                 WinMLQuestionAnsweringEvaluator,

--- a/tests/unit/eval/test_question_answering_evaluator.py
+++ b/tests/unit/eval/test_question_answering_evaluator.py
@@ -330,7 +330,12 @@ class TestDocumentCompute:
             }
         )
 
-        result = evaluator.compute()
+        with patch.object(
+            WinMLQuestionAnsweringEvaluator,
+            "_require_tesseract_runtime",
+            side_effect=AssertionError("precomputed data must not require native OCR"),
+        ):
+            result = evaluator.compute()
 
         assert result == {
             "anls": 1.0,
@@ -407,6 +412,7 @@ class TestDocumentCompute:
         )
         pytesseract = SimpleNamespace(
             image_to_data=image_to_data,
+            get_tesseract_version=MagicMock(return_value="5.5.3"),
             Output=SimpleNamespace(DICT="dict"),
             TesseractNotFoundError=RuntimeError,
         )
@@ -418,22 +424,66 @@ class TestDocumentCompute:
         assert words == ["ITC", "Limited"]
         assert boxes == [[100, 100, 250, 300], [300, 100, 500, 300]]
         assert source == "tesseract"
+        assert evaluator._last_ocr_version == "5.5.3"
 
-    def test_missing_native_tesseract_has_actionable_error(self):
+    def test_missing_native_tesseract_fails_during_data_validation(self):
         evaluator, _, _ = self._make_document_evaluator({})
         evaluator.config.dataset.columns_mapping = {"document_mode": "true"}
         not_found = type("TesseractNotFoundError", (Exception,), {})
         pytesseract = SimpleNamespace(
-            image_to_data=MagicMock(side_effect=not_found()),
-            Output=SimpleNamespace(DICT="dict"),
+            get_tesseract_version=MagicMock(side_effect=not_found()),
             TesseractNotFoundError=not_found,
+        )
+        dataset = SimpleNamespace(column_names=["question", "answers", "image"])
+
+        with (
+            patch.dict(sys.modules, {"pytesseract": pytesseract}),
+            pytest.raises(RuntimeError, match=r"tesseract --version.*winget install"),
+        ):
+            evaluator.validate_data(dataset)
+
+    def test_image_compute_records_native_tesseract_version(self):
+        evaluator, _, _ = self._make_document_evaluator(
+            {
+                "question": "What is the company?",
+                "image": SimpleNamespace(size=(200, 100)),
+                "answers": ["ITC Limited"],
+            }
+        )
+        evaluator.config.dataset.columns_mapping = {"document_mode": "true"}
+        pytesseract = SimpleNamespace(
+            image_to_data=MagicMock(
+                return_value={
+                    "text": ["ITC", "Limited"],
+                    "left": [20, 60],
+                    "top": [10, 10],
+                    "width": [30, 40],
+                    "height": [20, 20],
+                }
+            ),
+            get_tesseract_version=MagicMock(return_value="5.5.3"),
+            Output=SimpleNamespace(DICT="dict"),
+            TesseractNotFoundError=RuntimeError,
+        )
+
+        with patch.dict(sys.modules, {"pytesseract": pytesseract}):
+            result = evaluator.compute()
+
+        assert result["ocr_engine_version"] == "5.5.3"
+        assert result["ocr_samples"] == 1
+
+    def test_unsupported_native_tesseract_version_is_rejected(self):
+        evaluator, _, _ = self._make_document_evaluator({})
+        pytesseract = SimpleNamespace(
+            get_tesseract_version=MagicMock(return_value="4.1.3"),
+            TesseractNotFoundError=RuntimeError,
         )
 
         with (
             patch.dict(sys.modules, {"pytesseract": pytesseract}),
-            pytest.raises(RuntimeError, match="Native Tesseract was not found"),
+            pytest.raises(RuntimeError, match=r"4\.1\.3 is unsupported.*5\.x is required"),
         ):
-            evaluator._document_words_and_boxes({"image": SimpleNamespace(size=(10, 10))})
+            evaluator._require_tesseract_runtime()
 
     def test_missing_python_ocr_extra_has_actionable_error(self):
         evaluator, _, _ = self._make_document_evaluator({})

--- a/tests/unit/eval/test_question_answering_evaluator.py
+++ b/tests/unit/eval/test_question_answering_evaluator.py
@@ -148,6 +148,40 @@ class TestPreparePipeline:
         ):
             make_evaluator(io_config={"input_shapes": [[1, 384]]}, tokenizer=None)
 
+    def test_document_mode_scopes_extractive_pipeline_to_evaluator(self):
+        from winml.modelkit.eval import DatasetConfig, WinMLEvaluationConfig
+
+        evaluator = object.__new__(WinMLQuestionAnsweringEvaluator)
+        evaluator.model = MagicMock()
+        evaluator.model.io_config = {
+            "input_names": ["input_ids", "bbox", "attention_mask"],
+            "input_shapes": [[1, 512], [1, 512, 4], [1, 512]],
+        }
+        evaluator.config = WinMLEvaluationConfig(
+            model_id="test/document-model",
+            task="document-question-answering",
+            dataset=DatasetConfig(
+                path="test/document-dataset",
+                columns_mapping={"document_mode": "true"},
+            ),
+        )
+        pipe = MagicMock()
+
+        with patch(
+            "winml.modelkit.inference.pipeline.create_pipeline",
+            return_value=pipe,
+        ) as create_pipeline:
+            result = evaluator.prepare_pipeline()
+
+        assert result is pipe
+        create_pipeline.assert_called_once_with(
+            "question-answering",
+            evaluator.model,
+            "test/document-model",
+            device="cpu",
+            trust_remote_code=False,
+        )
+
     def test_no_padding_without_shapes(self):
         ev = make_evaluator()
 
@@ -388,6 +422,11 @@ class TestDocumentCompute:
     def test_declared_image_input_is_rejected_before_document_inference(self):
         evaluator, _, model = self._make_document_evaluator({})
         model.io_config["input_names"].append("pixel_values")
+        evaluator.pipe.tokenizer.model_input_names = (
+            "input_ids",
+            "attention_mask",
+            "pixel_values",
+        )
 
         with pytest.raises(
             ValueError,

--- a/tests/unit/eval/test_question_answering_evaluator.py
+++ b/tests/unit/eval/test_question_answering_evaluator.py
@@ -7,7 +7,10 @@
 
 from __future__ import annotations
 
+import builtins
 import logging
+import sys
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -16,6 +19,11 @@ import torch
 from transformers.modeling_outputs import QuestionAnsweringModelOutput
 
 from winml.modelkit.eval import WinMLQuestionAnsweringEvaluator
+from winml.modelkit.eval.question_answering_evaluator import (
+    _align_token_boxes,
+    _decode_document_span,
+    _normalize_boxes,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -30,6 +38,37 @@ class _TokenizerStub:
 
 
 _DEFAULT_TOKENIZER = object()
+
+
+class _DocumentEncoding(dict):
+    def __init__(self):
+        super().__init__(
+            input_ids=torch.tensor([[0, 10, 2, 2, 20, 21, 22, 2, 1]]),
+            attention_mask=torch.tensor([[1, 1, 1, 1, 1, 1, 1, 1, 0]]),
+            token_type_ids=torch.zeros((1, 9), dtype=torch.long),
+        )
+        self._sequence_ids = [None, 0, None, None, 1, 1, 1, None, None]
+        self._word_ids = [None, 0, None, None, 0, 1, 1, None, None]
+
+    def sequence_ids(self, feature_index):
+        assert feature_index == 0
+        return self._sequence_ids
+
+    def word_ids(self, feature_index):
+        assert feature_index == 0
+        return self._word_ids
+
+
+class _DocumentTokenizer:
+    model_max_length = 512
+    sep_token_id = 2
+
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        return _DocumentEncoding()
 
 
 def make_evaluator(
@@ -143,6 +182,243 @@ class TestCompute:
         assert call_kwargs["squad_v2_format"] is False
         assert result["exact_match"] == 80.0
         assert result["f1"] == 85.0
+
+
+class TestDocumentHelpers:
+    def test_normalizes_absolute_boxes_and_clamps(self):
+        boxes = _normalize_boxes(
+            [[-10, 20, 110, 220], [80, 180, 20, 40]],
+            image_size=(100, 200),
+            coordinate_system="absolute",
+        )
+
+        assert boxes == [[0, 100, 1000, 1000], [200, 200, 800, 900]]
+
+    def test_preserves_normalized_boxes(self):
+        assert _normalize_boxes(
+            [[10, 20, 30, 40]],
+            image_size=None,
+            coordinate_system="normalized",
+        ) == [[10, 20, 30, 40]]
+
+    def test_aligns_document_subwords_and_special_tokens(self):
+        aligned = _align_token_boxes(
+            _DocumentEncoding(),
+            0,
+            [[10, 20, 30, 40], [50, 60, 70, 80]],
+            sep_token_id=2,
+        )
+
+        assert aligned[1] == [0, 0, 0, 0]
+        assert aligned[2] == [1000, 1000, 1000, 1000]
+        assert aligned[4] == [10, 20, 30, 40]
+        assert aligned[5:7] == [[50, 60, 70, 80], [50, 60, 70, 80]]
+
+    def test_decodes_highest_scoring_contiguous_word_span(self):
+        encoding = _DocumentEncoding()
+        starts = np.zeros(9)
+        ends = np.zeros(9)
+        starts[4] = 8
+        ends[6] = 9
+
+        _, answer = _decode_document_span(
+            starts,
+            ends,
+            encoding.sequence_ids(0),
+            encoding.word_ids(0),
+            ["ITC", "Limited"],
+            max_answer_words=2,
+        )
+
+        assert answer == "ITC Limited"
+
+    def test_answer_word_limit_excludes_longer_span(self):
+        encoding = _DocumentEncoding()
+        starts = np.zeros(9)
+        ends = np.zeros(9)
+        starts[4] = 8
+        ends[6] = 9
+        starts[5] = 7
+
+        _, answer = _decode_document_span(
+            starts,
+            ends,
+            encoding.sequence_ids(0),
+            encoding.word_ids(0),
+            ["ITC", "Limited"],
+            max_answer_words=1,
+        )
+
+        assert answer == "Limited"
+
+
+class TestDocumentCompute:
+    @staticmethod
+    def _make_document_evaluator(row):
+        from winml.modelkit.eval import DatasetConfig, WinMLEvaluationConfig
+
+        tokenizer = _DocumentTokenizer()
+        model = MagicMock()
+        model.io_config = {
+            "input_names": ["input_ids", "bbox", "attention_mask", "token_type_ids"],
+            "input_shapes": [[1, 512], [1, 512, 4], [1, 512], [1, 512]],
+        }
+        starts = torch.zeros((1, 9))
+        ends = torch.zeros((1, 9))
+        starts[0, 4] = 8
+        ends[0, 6] = 9
+        model.return_value = QuestionAnsweringModelOutput(start_logits=starts, end_logits=ends)
+
+        evaluator = object.__new__(WinMLQuestionAnsweringEvaluator)
+        evaluator.model = model
+        evaluator.data = [row]
+        evaluator.pipe = SimpleNamespace(tokenizer=tokenizer, device="cpu")
+        evaluator.config = WinMLEvaluationConfig(
+            model_id="test/document-model",
+            task="question-answering",
+            dataset=DatasetConfig(
+                path="test/document-dataset",
+                columns_mapping={
+                    "document_mode": "true",
+                    "max_windows": "1",
+                    "doc_stride": "128",
+                    "max_answer_words": "64",
+                    "top_k": "1",
+                },
+            ),
+        )
+        return evaluator, tokenizer, model
+
+    def test_precomputed_document_path_forwards_exact_named_inputs(self):
+        evaluator, tokenizer, model = self._make_document_evaluator(
+            {
+                "question": "What is the company?",
+                "words": ["ITC", "Limited"],
+                "boxes": [[10, 20, 30, 40], [50, 60, 70, 80]],
+                "answers": ["ITC Limited"],
+            }
+        )
+
+        result = evaluator.compute()
+
+        assert result == {
+            "anls": 1.0,
+            "n_samples": 1,
+            "skipped_samples": 0,
+            "windows_processed": 1,
+            "ocr_samples": 0,
+            "precomputed_samples": 1,
+        }
+        assert set(model.call_args.kwargs) == {
+            "input_ids",
+            "bbox",
+            "attention_mask",
+            "token_type_ids",
+        }
+        assert model.call_args.kwargs["bbox"].shape == (1, 9, 4)
+        _, tokenizer_kwargs = tokenizer.calls[0]
+        assert tokenizer_kwargs["max_length"] == 512
+        assert tokenizer_kwargs["stride"] == 128
+        assert tokenizer_kwargs["return_overflowing_tokens"] is True
+
+    def test_missing_token_type_ids_are_forwarded_as_zeros_when_declared(self):
+        evaluator, tokenizer, model = self._make_document_evaluator(
+            {
+                "question": "What is the company?",
+                "words": ["ITC", "Limited"],
+                "boxes": [[10, 20, 30, 40], [50, 60, 70, 80]],
+                "answers": ["ITC Limited"],
+            }
+        )
+        encoding = _DocumentEncoding()
+        del encoding["token_type_ids"]
+        tokenizer.__call__ = MagicMock(return_value=encoding)
+
+        with patch.object(_DocumentTokenizer, "__call__", return_value=encoding):
+            evaluator.compute()
+
+        torch.testing.assert_close(
+            model.call_args.kwargs["token_type_ids"],
+            torch.zeros((1, 9), dtype=torch.long),
+        )
+
+    def test_sample_index_selects_pinned_document_row(self):
+        evaluator, _, _ = self._make_document_evaluator({})
+        evaluator.config.dataset.columns_mapping["sample_index"] = "2"
+        dataset = MagicMock()
+        dataset.__len__.return_value = 3
+        selected = MagicMock()
+        dataset.select.return_value = selected
+
+        with patch(
+            "winml.modelkit.eval.base_evaluator.WinMLEvaluator.prepare_data",
+            return_value=dataset,
+        ):
+            result = evaluator.prepare_data()
+
+        assert result is selected
+        dataset.select.assert_called_once_with([2])
+        assert evaluator.config.dataset.samples == 100
+        assert evaluator.config.dataset.shuffle is True
+
+    def test_image_path_uses_one_ocr_pass_and_normalizes_boxes(self):
+        evaluator, _, _ = self._make_document_evaluator({})
+        evaluator.config.dataset.columns_mapping = {"document_mode": "true"}
+        image = SimpleNamespace(size=(200, 100))
+        image_to_data = MagicMock(
+            return_value={
+                "text": ["", "ITC", "Limited"],
+                "left": [0, 20, 60],
+                "top": [0, 10, 10],
+                "width": [0, 30, 40],
+                "height": [0, 20, 20],
+            }
+        )
+        pytesseract = SimpleNamespace(
+            image_to_data=image_to_data,
+            Output=SimpleNamespace(DICT="dict"),
+            TesseractNotFoundError=RuntimeError,
+        )
+
+        with patch.dict(sys.modules, {"pytesseract": pytesseract}):
+            words, boxes, source = evaluator._document_words_and_boxes({"image": image})
+
+        assert image_to_data.call_count == 1
+        assert words == ["ITC", "Limited"]
+        assert boxes == [[100, 100, 250, 300], [300, 100, 500, 300]]
+        assert source == "tesseract"
+
+    def test_missing_native_tesseract_has_actionable_error(self):
+        evaluator, _, _ = self._make_document_evaluator({})
+        evaluator.config.dataset.columns_mapping = {"document_mode": "true"}
+        not_found = type("TesseractNotFoundError", (Exception,), {})
+        pytesseract = SimpleNamespace(
+            image_to_data=MagicMock(side_effect=not_found()),
+            Output=SimpleNamespace(DICT="dict"),
+            TesseractNotFoundError=not_found,
+        )
+
+        with (
+            patch.dict(sys.modules, {"pytesseract": pytesseract}),
+            pytest.raises(RuntimeError, match="Native Tesseract was not found"),
+        ):
+            evaluator._document_words_and_boxes({"image": SimpleNamespace(size=(10, 10))})
+
+    def test_missing_python_ocr_extra_has_actionable_error(self):
+        evaluator, _, _ = self._make_document_evaluator({})
+        evaluator.config.dataset.columns_mapping = {"document_mode": "true"}
+        original_import = builtins.__import__
+
+        def import_without_pytesseract(name, *args, **kwargs):
+            if name == "pytesseract":
+                raise ImportError(name)
+            return original_import(name, *args, **kwargs)
+
+        with (
+            patch("builtins.__import__", side_effect=import_without_pytesseract),
+            pytest.raises(RuntimeError, match=r"Install winml-cli\[document\]"),
+        ):
+            evaluator._document_words_and_boxes({"image": SimpleNamespace(size=(10, 10))})
 
     def test_squad_v2_uses_squad_v2_metric(self):
         ev = make_evaluator()
@@ -320,6 +596,28 @@ class TestModelForward:
 
         call_kwargs = model._format_inputs.call_args[1]
         assert "token_type_ids" not in call_kwargs
+
+    def test_includes_bbox_when_model_accepts(self):
+        model = self._make_model(input_names=["input_ids", "attention_mask", "bbox"])
+        ids = np.array([[1, 2, 3]])
+        boxes = np.array([[[0, 0, 0, 0], [10, 20, 30, 40], [1000, 1000, 1000, 1000]]])
+
+        model.forward(input_ids=ids, bbox=boxes)
+
+        call_kwargs = model._format_inputs.call_args[1]
+        np.testing.assert_array_equal(call_kwargs["bbox"], boxes)
+
+    def test_excludes_bbox_when_model_lacks_input(self):
+        model = self._make_model(
+            input_names=["input_ids", "attention_mask"],
+            has_token_type_ids=False,
+        )
+        ids = np.array([[1, 2, 3]])
+        boxes = np.zeros((1, 3, 4), dtype=np.int64)
+
+        model.forward(input_ids=ids, bbox=boxes)
+
+        assert "bbox" not in model._format_inputs.call_args[1]
 
     def test_raises_when_input_ids_is_none(self):
         model = self._make_model()

--- a/tests/unit/eval/test_question_answering_evaluator.py
+++ b/tests/unit/eval/test_question_answering_evaluator.py
@@ -385,6 +385,18 @@ class TestDocumentCompute:
             torch.zeros((1, 9), dtype=torch.long),
         )
 
+    def test_declared_image_input_is_rejected_before_document_inference(self):
+        evaluator, _, model = self._make_document_evaluator({})
+        model.io_config["input_names"].append("pixel_values")
+
+        with pytest.raises(
+            ValueError,
+            match=r"text-and-layout model inputs.*cannot produce.*pixel_values",
+        ):
+            evaluator.compute()
+
+        model.assert_not_called()
+
     def test_sample_index_selects_pinned_document_row(self):
         evaluator, _, _ = self._make_document_evaluator({})
         evaluator.config.dataset.columns_mapping["sample_index"] = "2"

--- a/tests/unit/eval/test_question_answering_evaluator.py
+++ b/tests/unit/eval/test_question_answering_evaluator.py
@@ -232,6 +232,13 @@ class TestDocumentHelpers:
             coordinate_system="normalized",
         ) == [[10, 20, 30, 40]]
 
+    def test_auto_scales_sub_1000_pixel_boxes_when_image_size_is_available(self):
+        assert _normalize_boxes(
+            [[80, 60, 160, 120]],
+            image_size=(800, 600),
+            coordinate_system="auto",
+        ) == [[100, 100, 200, 200]]
+
     def test_aligns_document_subwords_and_special_tokens(self):
         aligned = _align_token_boxes(
             _DocumentEncoding(),

--- a/tests/unit/eval/test_question_answering_evaluator.py
+++ b/tests/unit/eval/test_question_answering_evaluator.py
@@ -58,6 +58,19 @@ class _DocumentEncoding(dict):
         assert feature_index == 0
         return self._word_ids
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, _DocumentEncoding):
+            return False
+        return (
+            self.keys() == other.keys()
+            and all(torch.equal(value, other[key]) for key, value in self.items())
+            and self._sequence_ids == other._sequence_ids
+            and self._word_ids == other._word_ids
+        )
+
+    def __ne__(self, other: object) -> bool:
+        return not self == other
+
 
 class _DocumentTokenizer:
     model_max_length = 512
@@ -185,6 +198,24 @@ class TestCompute:
 
 
 class TestDocumentHelpers:
+    def test_document_encoding_equality_includes_alignment_metadata(self):
+        encoding = _DocumentEncoding()
+        same = _DocumentEncoding()
+        different = _DocumentEncoding()
+        different._word_ids[4] = 7
+
+        assert encoding == same
+        assert same == encoding
+        assert encoding != different
+        assert different != encoding
+
+    def test_document_encoding_is_not_equal_to_plain_dict(self):
+        encoding = _DocumentEncoding()
+        plain = dict(encoding)
+
+        assert encoding != plain
+        assert plain != encoding
+
     def test_normalizes_absolute_boxes_and_clamps(self):
         boxes = _normalize_boxes(
             [[-10, 20, 110, 220], [80, 180, 20, 40]],

--- a/tests/unit/export/test_onnx_config_overrides.py
+++ b/tests/unit/export/test_onnx_config_overrides.py
@@ -138,20 +138,25 @@ class TestBertSequenceLengthOverride:
 class TestLayoutLMQuestionAnsweringOverride:
     """LayoutLM QA export must include bbox and safe token_type_ids."""
 
-    def test_layoutlm_qa_dummy_inputs_include_bbox_and_zero_token_types(self) -> None:
-        """Dummy inputs must keep bbox while forcing token_type_ids to zero."""
+    @staticmethod
+    def _config(*, max_position_embeddings: int = 32, pad_token_id: int = 0):
         from transformers import LayoutLMConfig
 
-        layoutlm_config = LayoutLMConfig(
+        return LayoutLMConfig(
             vocab_size=100,
             hidden_size=64,
             num_hidden_layers=2,
             num_attention_heads=2,
             intermediate_size=128,
-            max_position_embeddings=32,
+            max_position_embeddings=max_position_embeddings,
             max_2d_position_embeddings=1024,
+            pad_token_id=pad_token_id,
             type_vocab_size=1,
         )
+
+    def test_layoutlm_qa_dummy_inputs_include_bbox_and_zero_token_types(self) -> None:
+        """Dummy inputs must keep bbox while forcing token_type_ids to zero."""
+        layoutlm_config = self._config()
 
         inputs = generate_dummy_inputs("layoutlm", "question-answering", layoutlm_config)
 
@@ -163,18 +168,7 @@ class TestLayoutLMQuestionAnsweringOverride:
 
     def test_layoutlm_qa_io_specs_include_span_outputs(self) -> None:
         """LayoutLM QA specs expose document bbox input and span logits outputs."""
-        from transformers import LayoutLMConfig
-
-        layoutlm_config = LayoutLMConfig(
-            vocab_size=100,
-            hidden_size=64,
-            num_hidden_layers=2,
-            num_attention_heads=2,
-            intermediate_size=128,
-            max_position_embeddings=32,
-            max_2d_position_embeddings=1024,
-            type_vocab_size=1,
-        )
+        layoutlm_config = self._config()
 
         specs = resolve_io_specs("layoutlm", "question-answering", layoutlm_config)
 
@@ -186,6 +180,36 @@ class TestLayoutLMQuestionAnsweringOverride:
         ]
         assert specs["input_shapes"] == [(1, 32), (1, 32, 4), (1, 32), (1, 32)]
         assert specs["output_names"] == ["start_logits", "end_logits"]
+        assert specs["value_ranges"]["token_type_ids"] == (0, 1)
+
+    def test_layoutlm_qa_uses_usable_roberta_style_sequence_length(self) -> None:
+        """A 514-position, pad-offset config has capacity for 512 input tokens."""
+        layoutlm_config = self._config(max_position_embeddings=514, pad_token_id=1)
+
+        specs = resolve_io_specs("layoutlm", "question-answering", layoutlm_config)
+
+        assert specs["input_shapes"] == [(1, 512), (1, 512, 4), (1, 512), (1, 512)]
+
+    def test_layoutlm_qa_keeps_bert_style_sequence_length(self) -> None:
+        """A zero-offset LayoutLM config keeps its full position capacity."""
+        layoutlm_config = self._config(max_position_embeddings=512, pad_token_id=0)
+
+        specs = resolve_io_specs("layoutlm", "question-answering", layoutlm_config)
+
+        assert specs["input_shapes"] == [(1, 512), (1, 512, 4), (1, 512), (1, 512)]
+
+    def test_layoutlm_qa_preserves_explicit_sequence_length(self) -> None:
+        """An explicit content budget remains authoritative for every coupled input."""
+        layoutlm_config = self._config(max_position_embeddings=514, pad_token_id=1)
+
+        specs = resolve_io_specs(
+            "layoutlm",
+            "question-answering",
+            layoutlm_config,
+            sequence_length=128,
+        )
+
+        assert specs["input_shapes"] == [(1, 128), (1, 128, 4), (1, 128), (1, 128)]
 
 
 class TestLayoutLMv3QuestionAnsweringOverride:

--- a/tests/unit/inference/test_pipeline.py
+++ b/tests/unit/inference/test_pipeline.py
@@ -157,13 +157,18 @@ def _create_qa_compat_pipe(tokenizer, model, task="question-answering"):
         return create_pipeline(task, model, "test-model")
 
 
-def test_document_question_answering_uses_extractive_compat_pipeline() -> None:
-    tokenizer = _make_fast_qa_tokenizer()
-    model, _ = _make_qa_model(tokenizer)
+def test_document_question_answering_uses_native_transformers_pipeline() -> None:
+    model = MagicMock()
+    pipe = MagicMock(tokenizer=None, image_processor=None)
 
-    pipe = _create_qa_compat_pipe(tokenizer, model, "document-question-answering")
+    with (
+        patch("winml.modelkit.inference.pipeline._pipeline_component_kwargs", return_value={}),
+        patch("transformers.pipeline", return_value=pipe) as pipeline,
+    ):
+        result = create_pipeline("document-question-answering", model, "test-model")
 
-    assert isinstance(pipe, _ExtractiveQuestionAnsweringPipeline)
+    assert result is pipe
+    pipeline.assert_called_once_with("document-question-answering", model=model, device="cpu")
 
 
 class TestHFPipelineTaskMap:

--- a/tests/unit/inference/test_pipeline.py
+++ b/tests/unit/inference/test_pipeline.py
@@ -146,7 +146,7 @@ def _make_qa_model(tokenizer, *, batch_size: int = 1) -> tuple[MagicMock, str]:
     return model, input_name
 
 
-def _create_qa_compat_pipe(tokenizer, model):
+def _create_qa_compat_pipe(tokenizer, model, task="question-answering"):
     with (
         patch("transformers.__version__", "5.0.0"),
         patch(
@@ -154,7 +154,16 @@ def _create_qa_compat_pipe(tokenizer, model):
             return_value=tokenizer,
         ),
     ):
-        return create_pipeline("question-answering", model, "test-model")
+        return create_pipeline(task, model, "test-model")
+
+
+def test_document_question_answering_uses_extractive_compat_pipeline() -> None:
+    tokenizer = _make_fast_qa_tokenizer()
+    model, _ = _make_qa_model(tokenizer)
+
+    pipe = _create_qa_compat_pipe(tokenizer, model, "document-question-answering")
+
+    assert isinstance(pipe, _ExtractiveQuestionAnsweringPipeline)
 
 
 class TestHFPipelineTaskMap:

--- a/tests/unit/inspect/test_resolve_exporter_task_synonyms.py
+++ b/tests/unit/inspect/test_resolve_exporter_task_synonyms.py
@@ -50,3 +50,10 @@ class TestResolveExporterTaskSynonyms:
         assert info.support_level != SupportLevel.UNSUPPORTED
         assert info.onnx_config_source == "TasksManager"
         assert info.onnx_config_class is not None
+
+    def test_document_question_answering_resolves_layoutlm_qa_exporter(self) -> None:
+        info = resolve_exporter("layoutlm", "document-question-answering", hf_config=None)
+
+        assert info.support_level != SupportLevel.UNSUPPORTED
+        assert info.onnx_config_source == "TasksManager"
+        assert info.onnx_config_class == "LayoutLMQAIOConfig"

--- a/tests/unit/loader/test_detect_task.py
+++ b/tests/unit/loader/test_detect_task.py
@@ -104,7 +104,10 @@ def test_resolve_task_upgrades_pixel_values_feature_extraction_to_image() -> Non
     architecture takes pixel_values surfaces as image-feature-extraction."""
     cfg = _FakeConfig("faketype")
     with (
-        patch(_INFER, return_value="feature-extraction") as m,
+        patch(
+            _INFER,
+            return_value=("feature-extraction", TaskSource.TASKS_MANAGER),
+        ) as m,
         patch(_RESOLVE_CLASS, return_value=_fake_arch_class("pixel_values")),
     ):
         r = resolve_task(cfg)
@@ -160,7 +163,10 @@ def test_resolve_task_does_not_short_circuit_for_ambiguous_model_type() -> None:
     model_type alone, so resolve_task must fall through to architecture-aware
     detection instead of short-circuiting to the first key (feature-extraction)."""
     cfg = _FakeConfig("bart", architectures=["BartForSequenceClassification"])
-    with patch(_INFER, return_value="text-classification") as m:
+    with patch(
+        _INFER,
+        return_value=("text-classification", TaskSource.TASKS_MANAGER),
+    ) as m:
         r = resolve_task(cfg)
     assert r.task == "text-classification"
     assert r.source == TaskSource.TASKS_MANAGER
@@ -209,7 +215,10 @@ def test_resolve_task_no_override_for_single_entry_without_sentinel() -> None:
     fine-tuned classification checkpoint therefore keeps image-classification rather than
     being forced to image-segmentation."""
     cfg = _FakeConfig("segformer")
-    with patch(_INFER, return_value="image-classification") as m:
+    with patch(
+        _INFER,
+        return_value=("image-classification", TaskSource.TASKS_MANAGER),
+    ) as m:
         r = resolve_task(cfg)
     assert (r.task, r.source) == ("image-classification", TaskSource.TASKS_MANAGER)
     m.assert_called_once()
@@ -222,7 +231,10 @@ def test_resolve_task_case1_surfaces_modality_aware_task() -> None:
     (config.architectures), not the resolved/Auto class."""
     cfg = _FakeConfig("faketype")
     with (
-        patch(_INFER, return_value="feature-extraction"),
+        patch(
+            _INFER,
+            return_value=("feature-extraction", TaskSource.TASKS_MANAGER),
+        ),
         patch(_RESOLVE_CLASS, return_value=_fake_arch_class("pixel_values")),
     ):
         r = resolve_task(cfg)

--- a/tests/unit/loader/test_resolve_task.py
+++ b/tests/unit/loader/test_resolve_task.py
@@ -48,6 +48,14 @@ def test_seq2seq_fill_mask_is_upgraded_and_source_is_tasks_manager():
     assert r.composite == {"encoder": "feature-extraction", "decoder": "text2text-generation"}
 
 
+def test_architecture_suffix_fallback_resolves_layoutlm_question_answering():
+    r = resolve_task(_cfg("layoutlm", ["LayoutLMForQuestionAnswering"]))
+    assert r.task == "question-answering"
+    assert r.optimum_task == "question-answering"
+    assert r.model_class.__name__ == "AutoModelForQuestionAnswering"
+    assert r.source == TaskSource.TASKS_MANAGER
+
+
 def test_user_task_preserved_verbatim_no_modality_upgrade():
     r = resolve_task(_cfg("vit", ["ViTModel"]), task="feature-extraction")
     assert r.task == "feature-extraction"

--- a/tests/unit/loader/test_resolve_task.py
+++ b/tests/unit/loader/test_resolve_task.py
@@ -52,12 +52,22 @@ def test_seq2seq_fill_mask_is_upgraded_and_source_is_tasks_manager():
     assert r.composite == {"encoder": "feature-extraction", "decoder": "text2text-generation"}
 
 
-def test_architecture_suffix_fallback_resolves_layoutlm_question_answering():
-    r = resolve_task(_cfg("layoutlm", ["LayoutLMForQuestionAnswering"]))
-    assert r.task == "question-answering"
+def test_architecture_suffix_fallback_resolves_layoutlm_document_question_answering():
+    config = _cfg("layoutlm", ["LayoutLMForQuestionAnswering"])
+
+    r = resolve_task(config)
+
+    assert r.task == "document-question-answering"
     assert r.optimum_task == "question-answering"
-    assert r.model_class.__name__ == "AutoModelForQuestionAnswering"
+    assert r.model_class.__name__ == "LayoutLMForQuestionAnswering"
+    assert r.model_class.config_class is type(config)
     assert r.source == TaskSource.ARCHITECTURE_SUFFIX
+
+
+def test_architecture_suffix_fallback_keeps_ordinary_question_answering():
+    config = _cfg("bert", ["BertForQuestionAnswering"])
+
+    assert _infer_task_from_architecture_suffix(config) == "question-answering"
 
 
 def test_architecture_suffix_fallback_only_uses_primary_architecture():

--- a/tests/unit/loader/test_resolve_task.py
+++ b/tests/unit/loader/test_resolve_task.py
@@ -11,7 +11,11 @@ Offline / config-only: every case builds its config with
 import pytest
 from transformers import AutoConfig
 
-from winml.modelkit.loader.resolution import TaskSource, resolve_task
+from winml.modelkit.loader.resolution import (
+    TaskSource,
+    _infer_task_from_architecture_suffix,
+    resolve_task,
+)
 from winml.modelkit.loader.task import to_optimum_task
 
 
@@ -54,6 +58,14 @@ def test_architecture_suffix_fallback_resolves_layoutlm_question_answering():
     assert r.optimum_task == "question-answering"
     assert r.model_class.__name__ == "AutoModelForQuestionAnswering"
     assert r.source == TaskSource.TASKS_MANAGER
+
+
+def test_architecture_suffix_fallback_only_uses_primary_architecture():
+    config = _cfg(
+        "layoutlm",
+        ["LayoutLMForSequenceClassification", "LayoutLMForQuestionAnswering"],
+    )
+    assert _infer_task_from_architecture_suffix(config) is None
 
 
 def test_user_task_preserved_verbatim_no_modality_upgrade():
@@ -181,9 +193,7 @@ def test_user_class_explicit_feature_extraction_is_modality_aware():
     surface image-feature-extraction (-> ImageDataset), not the modality-blind
     feature-extraction (-> TextDataset). optimum_task still collapses for the Optimum
     class lookup."""
-    r = resolve_task(
-        _cfg("vit", ["ViTModel"]), model_class="ViTModel", task="feature-extraction"
-    )
+    r = resolve_task(_cfg("vit", ["ViTModel"]), model_class="ViTModel", task="feature-extraction")
     assert r.source == TaskSource.USER_CLASS
     assert r.task == "image-feature-extraction"
     assert r.optimum_task == "feature-extraction"

--- a/tests/unit/loader/test_resolve_task.py
+++ b/tests/unit/loader/test_resolve_task.py
@@ -57,7 +57,7 @@ def test_architecture_suffix_fallback_resolves_layoutlm_question_answering():
     assert r.task == "question-answering"
     assert r.optimum_task == "question-answering"
     assert r.model_class.__name__ == "AutoModelForQuestionAnswering"
-    assert r.source == TaskSource.TASKS_MANAGER
+    assert r.source == TaskSource.ARCHITECTURE_SUFFIX
 
 
 def test_architecture_suffix_fallback_only_uses_primary_architecture():

--- a/tests/unit/loader/test_resolve_task.py
+++ b/tests/unit/loader/test_resolve_task.py
@@ -64,6 +64,16 @@ def test_architecture_suffix_fallback_resolves_layoutlm_document_question_answer
     assert r.source == TaskSource.ARCHITECTURE_SUFFIX
 
 
+def test_layoutlmv3_question_answering_keeps_tasks_manager_resolution():
+    config = _cfg("layoutlmv3", ["LayoutLMv3ForQuestionAnswering"])
+
+    r = resolve_task(config)
+
+    assert r.task == "question-answering"
+    assert r.optimum_task == "question-answering"
+    assert r.source == TaskSource.TASKS_MANAGER
+
+
 def test_architecture_suffix_fallback_keeps_ordinary_question_answering():
     config = _cfg("bert", ["BertForQuestionAnswering"])
 

--- a/tests/unit/loader/test_task_boundary.py
+++ b/tests/unit/loader/test_task_boundary.py
@@ -24,6 +24,8 @@ from winml.modelkit.loader import to_optimum_task
         ("image-feature-extraction", "feature-extraction"),
         # WinML extension: routed to its Optimum-canonical target.
         ("next-sentence-prediction", "text-classification"),
+        # Document QA retains its surfaced task while sharing the extractive-QA exporter.
+        ("document-question-answering", "question-answering"),
         # WinML extension preserved as-is (Optimum would mis-map it otherwise).
         ("mask-generation", "mask-generation"),
         # Already-canonical task passes through unchanged.

--- a/tests/unit/models/auto/test_auto_model.py
+++ b/tests/unit/models/auto/test_auto_model.py
@@ -131,6 +131,15 @@ class TestTaskDetection:
         cls = get_winml_class("segformer", "image-segmentation")
         assert cls == WinMLModelForImageSegmentation
 
+    def test_get_winml_class_document_question_answering(self):
+        from winml.modelkit.models import get_winml_class
+        from winml.modelkit.models.winml.question_answering import (
+            WinMLModelForQuestionAnswering,
+        )
+
+        cls = get_winml_class("layoutlm", "document-question-answering")
+        assert cls == WinMLModelForQuestionAnswering
+
     def test_get_winml_class_unknown_task_fallback(self):
         """AC-4: Unknown task falls back to generic class."""
         from winml.modelkit.models import WinMLModelForGenericTask, get_winml_class


### PR DESCRIPTION
## Summary

This PR adds `DmitrySpartak/layoutlm-invoices` support for invoice and document question answering with CPU FP32 and FP16 recipes, metadata-driven automatic loader selection, and reusable bbox-aware document evaluation. It ships Effort L2 / Outcome L2 and reaches Goal L3 PASS through one bounded real-data FP32 CPU functional smoke; ANLS `0.0` is operability evidence only, not an accuracy claim. The checkpoint is licensed CC-BY-NC-SA-4.0 for noncommercial use.

## Current acceptance (authoritative)

This section supersedes older candidate-SHA acceptance statements below. Those measurements remain historical or path-invariant context only.

- Base: `8d631f6f1e5db26a04e8c13045280408c6f984dc` (`main`).
- Accepted head: `ef2852f6692cfae54a7e82f4c8bfb217a4fc0629`.
- Fresh GitHub validation on the accepted head: all 9 checks passed, with 0 failed, cancelled, skipped, or pending.
- Exact-head local gates: license, Ruff, and mypy passed; focused document-QA coverage passed with 120 tests.
- Exact-head CI partitions: Analyze 1,529 passed / 45 skipped; models/loader/datasets/export 1,550 passed / 7 skipped / 1 xfailed; optim 876 passed / 16 skipped / 1 xfailed; commands/config/build/compiler/session/eval 3,716 passed / 9 skipped; remaining core/regression/CLI 965 passed / 2 skipped / 1 deselected.
- Exact-head real DocVQA smoke: one sample processed and none skipped; prediction `DORAL`; ANLS `1.0`; the ONNX graph received `input_ids`, `attention_mask`, `bbox`, and `token_type_ids`. The resolved public task was `document-question-answering`, while the evaluator intentionally requested the compatible extractive `question-answering` pipeline internally.
- Public API boundary: run/serve `document-question-answering` keeps the native Transformers image/question pipeline. Compatibility routing is scoped to the document evaluator's bbox-aware extractive path and is not a global document-QA override.
- Resolver boundary: LayoutLM v1 retains the document-QA architecture-suffix fallback required by this checkpoint; LayoutLMv3 continues through TasksManager as standard `question-answering`, with explicit regression coverage.
- Environment note: public PyPI TLS validation failed on the local machine, so the detached tester was provisioned from `https://packagefeedproxy.microsoft.io/pypi/simple/` and validation invoked the installed `.venv` executables directly. This is an environment constraint, not a test failure; the normal online GitHub workflows passed on the accepted head.

The sealed local evidence manifest contains 49 entries totaling 6,112,327 bytes and independently rewalked with 0 missing, unexpected, or hash-mismatched files (manifest SHA-256 `3763a3d6832879dd52952509fe3912ef25ab3294e8c85a00303cfa195317a3d7`).

## Model metadata

### What the model does

`LayoutLMForQuestionAnswering` consumes tokenized document text together with normalized 2D token bounding boxes and predicts start and end logits for extracting an answer span; this checkpoint is fine-tuned for questions about invoices and other documents.

- Evidence/confidence: pinned [model card](https://huggingface.co/DmitrySpartak/layoutlm-invoices/blob/ce2422049c250384731eccef90bf6d92e846b09c/README.md) and [config](https://huggingface.co/DmitrySpartak/layoutlm-invoices/blob/ce2422049c250384731eccef90bf6d92e846b09c/config.json) (`verified`).

### Primary user stories

A user supplies an invoice or document question plus OCR-aligned words and boxes to obtain the document text span answering fields such as invoice number or purchase amount.

- Evidence/confidence: pinned [model card](https://huggingface.co/DmitrySpartak/layoutlm-invoices/blob/ce2422049c250384731eccef90bf6d92e846b09c/README.md) (`verified`).

### Supported tasks

- `question-answering` across the Transformers, Optimum ONNX, and WinML support surfaces (`verified` from the pinned checkpoint architecture, checked-in recipes, and Reproduce commands).
- `document-question-answering` as the checkpoint's document-domain task (`verified` from the pinned [model card](https://huggingface.co/DmitrySpartak/layoutlm-invoices/blob/ce2422049c250384731eccef90bf6d92e846b09c/README.md)).

### Model architecture

```text
LayoutLMForQuestionAnswering
|-- LayoutLMModel
|   |-- Embeddings (token + 1D position + token type + 2D layout)
|   `-- Encoder layer x 12
`-- QA span head (start_logits + end_logits)
```

- Source/confidence: pinned checkpoint config and `LayoutLMForQuestionAnswering` source (`verified`).

## Validation and support evidence

### Baseline

WinML `0.2.0` baseline evidence was executed at commit `48bfd0f91478a8e281b205b0449222024729f3ea`; pinned main is `2b9ec0e9e57bba8003d25eaff85f8c7c9e30d75a`. Baseline automatic config selected `next-sentence-prediction` / `AutoModelForNextSentencePrediction`; build exited 2 because that class does not recognize `LayoutLMConfig`, so perf and Eval were not reached. The Optimum probe exposed feature extraction, fill mask, text classification, and token classification; WinML's override additionally exposed question answering.

The planner recorded `REUSE` because pinned main is unchanged from the prior current-main assessment. This retains baseline execution provenance and does not relabel it as newly executed on candidate head `61ffb5f5651573b22f47fed47571e163a1013335`.

### Goal

- **Effort:** L2, because the missing capability crosses task/loader resolution, evaluator schema, document preprocessing, bbox forwarding, span decoding, metric handling, optional OCR support, and metadata-derived export input constraints.
- **Goal ceiling:** L3, defined as CPU FP32/FP16 L0-L2 plus one bounded, document-aware FP32 CPU functional smoke on a licensed compatible dataset.
- **Outcome:** L2, shipping recipes and generalized code support with regression coverage and task-family findings.
- **Canonicalization:** automatic inspection surfaces `document-question-answering`; the concrete model is `LayoutLMForQuestionAnswering`, and the exporter boundary uses `LayoutLMQAIOConfig`. Checked-in recipes retain `question-answering` as the export/runtime identity while document-aware evaluation is selected from the declared `bbox` input and document columns.

### Outcome

Overall verdict is PASS; highest reached Goal is **L3 PASS** and shipped Outcome is **L2**. Coverage is full for the declared `CPUExecutionProvider / cpu` FP32 and FP16 tuples, with no deferred tuples. The PR ships both CPU recipes, generalized architecture/config-driven resolution, LayoutLM export input derivation, bbox-aware QA evaluation and forwarding, ANLS, document schema support, an explicit native OCR contract, and regression tests. Model findings retain the contiguous start/end span limitation; no non-consecutive answer-decoding claim is made. No methodology finding was triggered.

Execution provenance is split without upgrading reused measurements:

- Exact-head evidence at `61ffb5f5651573b22f47fed47571e163a1013335`: source/lock identity; exact checkpoint snapshot materialization; pinned-snapshot inspect/config/Eval; native Tesseract contract and runtime capture; fresh DocVQA L3 smoke; affected Eval/commands tests; OCR-focused tests; Ruff, mypy, license, lock, and docs validation.
- L0 FP32/FP16 artifact validation was executed at `2007e13ab59532f1a20a099babc432da9c1aa47d` against artifacts originating at `5274a714997a8d03cc3b3048590aac2389419805`. The final OCR-validation/docs-only repair does not change recipes, export, optimization, precision, graphs, or runtime forwarding, so their byte-identity evidence is retained.
- L1 perf, L2 parity, and Analyze were executed at `5274a714997a8d03cc3b3048590aac2389419805` and validated on `2007e13ab59532f1a20a099babc432da9c1aa47d` through byte-identical explicit artifacts. They remain reused on `61ffb5f5651573b22f47fed47571e163a1013335` for the same path-invariance reason.
- Models and remaining test partitions were executed at `2007e13ab59532f1a20a099babc432da9c1aa47d` and retained as path-invariant. All nine GitHub checks independently completed successfully on exact head `61ffb5f5651573b22f47fed47571e163a1013335`.

The Lane A `layoutlm-003` knowledge entry now names the two shipped recipe files exactly: `examples/recipes/DmitrySpartak_layoutlm-invoices/cpu/cpu/question-answering_fp32_config.json` and `examples/recipes/DmitrySpartak_layoutlm-invoices/cpu/cpu/question-answering_fp16_config.json`. That correction is preserved in a dedicated local Lane A commit and is intentionally unpushed; it is not mixed into this model-support PR.

### Per-EP/device/precision results and Functional smoke Eval

#### Automatic recipe-free acceptance

At execution head `2007e13ab59532f1a20a099babc432da9c1aa47d`, automatic inspection selected task `document-question-answering`, model class `LayoutLMForQuestionAnswering`, and exporter `LayoutLMQAIOConfig` without a recipe or task/model-class override. Metadata produced a usable sequence capacity of 512 from `model_max_length=512`, `max_position_embeddings=514`, and `pad_token_id=1`; paired question/document tokenization reserves four special tokens, leaving a 508-token content budget. FP32 and FP16 automatic configs consistently use `[1, 512]` for `input_ids`, `attention_mask`, and `token_type_ids`, `[1, 512, 4]` for `bbox`, and `[0, 1)` for `token_type_ids` from `type_vocab_size=1`.

The recipe-free CPU FP32 build passed. CPU ORT inference used all four int32 inputs, zero-only `token_type_ids`, bbox values within `[0, 1000]`, and produced finite `start_logits` and `end_logits`, each shaped `[1, 512]`. Exact head `61ffb5f5651573b22f47fed47571e163a1013335` freshly materialized checkpoint revision `ce2422049c250384731eccef90bf6d92e846b09c`; inspect and config passed against that local snapshot with the same task, model class, exporter, and four-input schema.

#### Explicit tuple builds and L1 perf

Recipe-authoritative FP32 and FP16 builds passed at `2007e13ab59532f1a20a099babc432da9c1aa47d`; the explicit artifacts were byte-identical to those measured at `5274a714997a8d03cc3b3048590aac2389419805`. L1 used a synthetic invoice-like OCR fixture with named `input_ids`, `bbox`, `attention_mask`, and `token_type_ids`, 5 warmups, and 20 timed iterations. It is not presented as real-data performance.

| Tier | EP / Device | Precision | Verdict | Mean | p50 | Throughput | RAM delta |
|---|---|---|---|---:|---:|---:|---:|
| L0/L1 | CPUExecutionProvider / cpu | fp32 | PASS | 233.261 ms | 231.604 ms | 4.29 samples/s | +132.88 MB |
| L0/L1 | CPUExecutionProvider / cpu | fp16 | PASS | 301.999 ms | 298.991 ms | 3.31 samples/s | +153.05 MB |

FP32 produced an IR 8, opset 17 graph with 394 nodes and FLOAT initializers. FP16 produced an IR 8, opset 17 graph with 396 nodes and 206 FLOAT16 initializers. Both expose `input_ids`, `bbox`, `attention_mask`, and `token_type_ids` and produce `start_logits` / `end_logits`.

#### L2 PyTorch/ONNX parity

Parity used the same synthetic invoice-like OCR inputs, with 65 non-padding tokens and exact named input shapes: `input_ids`, `attention_mask`, and `token_type_ids` are `[1, 512]` int32; `bbox` is `[1, 512, 4]` int32.

| Precision | Output | Cosine | Max abs | L2 | Reference / ONNX argmax |
|---|---|---:|---:|---:|---|
| fp32 | start logits | 0.9999999999999309 | 0.000034809112548828125 | 0.0001277129801970843 | 50 / 50 |
| fp32 | end logits | 0.9999999999999252 | 0.000041961669921875 | 0.00014027023337799058 | 55 / 55 |
| fp16 | start logits | 0.999999823476883 | 0.11089324951171875 | 0.20976535244230682 | 50 / 50 |
| fp16 | end logits | 0.9999996397368223 | 0.11360549926757812 | 0.30969060293798095 | 55 / 55 |

#### Functional smoke Eval

**L3 PASS: the FP32 CPU DocVQA smoke was freshly executed on exact head `61ffb5f5651573b22f47fed47571e163a1013335` against the locally materialized checkpoint revision. ANLS `0.0` proves end-to-end operability only; it is not representative accuracy or benchmark quality.**

- Runtime: Python `3.11.16`, ModelKit `0.3.0`, Transformers `5.14.1`, datasets `5.0.0`, pytesseract `0.3.13`, Pillow `12.3.0`, JPEG decoder `8.0`, zlib `1.3.1.zlib-ng`, and native Tesseract `5.5.3`.
- Dataset: public, ungated `lmms-lab-encoder/DocVQA`, config `DocVQA`, revision `539088ef8a8ada01ac8e2e6d4e372586748a265e`, validation row index 2, questionId `57349`; dataset card license `Apache-2.0`.
- Scope: 1 sample requested, 1 processed, 0 skipped. Question: "What is the name of the company?" References: `itc limited`, `ITC Limited`; prediction: `ITC's`.
- Input semantics: one real 1701x2386 grayscale PNG document decoded through Pillow; one native Tesseract `5.5.3` OCR pass produced 141 words and 141 normalized boxes in range `[0, 997]`; bbox forwarding was verified as `[1, 512, 4]` int64 alongside all four declared inputs.
- Bounds/accounting: 1 question/document, 1 OCR pass, 1 selected 512-token window, stride 128, top-k 1, maximum 64 answer words, 1 beam, 1 frame/crop, and 1 candidate label/prompt. Metrics: ANLS `0.0`, `n_samples=1`, `skipped_samples=0`, `windows_processed=1`, `ocr_samples=1`, `precomputed_samples=0`, `ocr_engine_version=5.5.3`.
- The image-only path now validates native Tesseract 5.x before execution and records only its sanitized version. A separately verified precomputed `words`/`boxes` path forwards the same four named inputs without importing or probing pytesseract or native Tesseract; it reported `ocr_samples=0` and `precomputed_samples=1`.
- Schema, answer-label semantics, contiguous document-word prediction semantics, OCR word/box normalization, bbox forwarding, and metric accounting were verified. The former blockers were missing document preprocessing/bbox-aware decoding and an undeclared native OCR runtime; this PR adds both contracts while preserving text-only QA behavior.

### Delta

Baseline had no usable automatic recipe: it selected next-sentence prediction and failed before generating an authoritative starting recipe. The checked-in CPU recipes explicitly select `question-answering` / `LayoutLMForQuestionAnswering`, use 512-position inputs with normalized bbox and zero-only token types, enable constant clamping, and select FP32 or FP16 realization. The final OCR repair does not modify either recipe; retained explicit artifacts remain byte-identical. The production recipe README remains untouched.

The automatic-path repair replaces the prior raw position-table interpretation with metadata-derived usable capacity and exposes the valid token-type range at config generation. The prior automatic path's 514-position configuration and build failure are fixed-delta context only; accepted automatic shapes are 512 and recipe-free build/ORT pass.

#### Bug fix explanation: architecture/config-driven task and loader selection

1. **Symptom and trigger:** automatic resolution for the primary `LayoutLMForQuestionAnswering` architecture selected loader behavior that Transformers could not instantiate for `LayoutLMConfig`; the concrete recipe masked the automatic-path defect.
2. **Root cause:** the architecture-suffix fallback did not consult Transformers' per-config plain-QA and document-QA mappings, and surfacing document QA directly initially bypassed the existing Optimum QA exporter boundary.
3. **Symbols and mechanism:** loader resolution/task helpers consult `MODEL_FOR_DOCUMENT_QUESTION_ANSWERING_MAPPING_NAMES` and `MODEL_FOR_QUESTION_ANSWERING_MAPPING_NAMES`, choose document QA only for configurations supported exclusively there, and canonicalize the exporter boundary so `LayoutLMQAIOConfig` remains available.
4. **General rule:** selection is derived from `config.architectures` and Transformers config mappings, with no checkpoint ID or repository-name branch.
5. **Compatibility/blast radius:** TasksManager and explicit task/class choices remain authoritative; ordinary `BertForQuestionAnswering` stays plain `question-answering`, and only document-only configurations take the document path.
6. **Regression evidence:** automatic inspect/config/build/ORT pass; resolver, task-boundary, exporter, build-preflight, equality, evaluator, models/loader/export, commands, and remaining partitions pass.

#### Bug fix explanation: metadata-derived LayoutLM export inputs

1. **Symptom and trigger:** the prior recipe-free config used the raw LayoutLM position-table size and exposed an invalid token-type range, causing automatic CPU FP32 build to fail during hierarchy tracing.
2. **Root cause:** `max_position_embeddings` includes the RoBERTa-style offset, while post-processing generated token types to zero happened too late for serialized config reconstruction.
3. **Symbols and mechanism:** `LayoutLMQAIOConfig` applies the existing position-embedding adjustment before shape resolution; the LayoutLM input generator derives `token_type_ids` directly from `type_vocab_size`.
4. **General rule:** sequence capacity and token-type bounds come from checkpoint metadata, not checkpoint identity; explicit `sequence_length` remains authoritative.
5. **Compatibility/blast radius:** zero-offset LayoutLM remains at its full declared length, a requested 128-token budget applies consistently to all sequence-coupled inputs, and ordinary QA plus LayoutLMv3/RoBERTa behavior remains covered.
6. **Regression evidence:** automatic FP32/FP16 configs use length 512 and `[0, 1)` token types; recipe-free build and CPU ORT pass; explicit FP32/FP16 artifacts remain byte-identical; models/loader/datasets/export coverage reports 1,538 passed, 6 skipped, and 2 xfailed.

#### Bug fix explanation: bbox-aware document evaluation and native OCR validation

1. **Symptom and trigger:** the existing text-QA path could not construct or forward the graph's required `bbox` input, decode OCR-aligned document spans, or emit a document metric; the initial image-only implementation also depended on an undeclared native Tesseract executable.
2. **Root cause:** the evaluator had no document row schema, OCR/precomputed word-box preprocessing, subword box alignment, bbox-aware forwarding, ANLS path, or native executable/version validation.
3. **Symbols and mechanism:** the question-answering evaluator adds bounded document preprocessing and contiguous span decoding; the WinML QA model conditionally forwards declared bbox inputs; image-only validation requires native Tesseract 5.x and emits its sanitized version, while precomputed words/boxes bypass OCR entirely.
4. **General rule:** document mode is selected from a declared `bbox` model input plus document columns or an explicit request, not a checkpoint identifier. Precomputed words/boxes are preferred; image rows use one optional, version-validated OCR pass.
5. **Compatibility/blast radius:** models without a bbox input retain the existing SQuAD/SQuAD-v2 text-QA path and metrics; incidental bbox values are dropped; missing/unsupported OCR runtimes fail with actionable installation/version guidance; precomputed words/boxes require no native OCR.
6. **Regression evidence:** exact-head OCR contract tests report 5 passed/29 deselected; Eval reports 648 passed; accepted command shards report 1,427 passed/1 skipped; Ruff, mypy across 437 source files, license, lock, docs, and all nine exact-head GitHub checks pass. Models and remaining retained partitions report 1,538 passed/6 skipped/2 xfailed and 872 passed/2 skipped/1 deselected, respectively.

### Analyze summary - component level and op level

Analyze completed with `ANALYZE-PARTIAL-SUCCESS` (exit 1) and seven parseable rows per artifact at execution SHA `5274a714997a8d03cc3b3048590aac2389419805`; byte-identical artifact validation at `2007e13ab59532f1a20a099babc432da9c1aa47d` remains reusable on exact head `61ffb5f5651573b22f47fed47571e163a1013335`. This is static rule compatibility analysis, not runtime execution. There were no actionable partial or unsupported findings, and `runtime_support=false` is not runtime EP evidence.

#### Component-level summary

| Artifact | Architecture coverage | Mapping | Actionable EP findings |
|---|---|---|---|
| fp32 | embeddings; 12x encoder attention; 12x encoder feed-forward; model plumbing; QA span head | 394 mapped, 0 unmapped; mapped confidence | none |
| fp16 | embeddings; 12x encoder attention; 12x encoder feed-forward; model plumbing; QA span head | 396 mapped, 0 unmapped; mapped confidence | none |

#### Op-level summary

| Artifact | Graph | Dominant ops | EP roll-up |
|---|---|---|---|
| fp32 | 394 operators / 15 types | Reshape 122; Gemm 73; Transpose 48; Add 44 | QNN/GPU: all 15 types statically supported; OpenVINO/GPU: 7 supported and 8 unknown; no actionable partial/unsupported types |
| fp16 | 396 operators / 15 types | Reshape 122; Gemm 73; Transpose 48; Add 44 | QNN/GPU: all 15 types statically supported; OpenVINO/GPU: 7 supported and 8 unknown; no actionable partial/unsupported types |

NvTensorRTRTX/GPU reports all 15 types unknown. CUDA/GPU, MIGraphX/GPU, TensorRT/GPU, and DML/GPU have no shipped classifications; unknown is not unsupported. There are no component mapping gaps.

### Reproduce commands

```powershell
$OUT = 'temp/layoutlm-invoices-repro'
$MODEL = Join-Path $OUT 'model_snapshot'
$REVISION = 'ce2422049c250384731eccef90bf6d92e846b09c'
$DATASET_REVISION = '539088ef8a8ada01ac8e2e6d4e372586748a265e'
$RECIPE = 'examples/recipes/DmitrySpartak_layoutlm-invoices/cpu/cpu/question-answering_fp32_config.json'
$ARTIFACT = Join-Path $OUT 'fp32/model.onnx'

# Materialize the reviewed checkpoint revision and use only this local snapshot.
python -c "from huggingface_hub import snapshot_download; snapshot_download(repo_id='DmitrySpartak/layoutlm-invoices', revision='$REVISION', local_dir=r'$MODEL')"

# Image-only document QA requires supported native Tesseract 5.x on Windows.
winget install --id UB-Mannheim.TesseractOCR --version 5.4.0.20240606 --exact
tesseract --version
Get-Command tesseract | Select-Object Name, CommandType

# Record the relevant Python/runtime versions without machine-specific paths.
python --version
python -c "from importlib.metadata import version; from PIL import features; print('winml-cli='+version('winml-cli')); print('transformers='+version('transformers')); print('datasets='+version('datasets')); print('pytesseract='+version('pytesseract')); print('Pillow='+version('Pillow')); print('jpeg='+str(features.version('jpg')))"

# Automatic metadata-driven path and recipe-authoritative FP32 build use the snapshot.
winml inspect -m $MODEL --format json
winml config -m $MODEL --device cpu --ep cpu --precision fp32 --no-quant --no-compile -o (Join-Path $OUT 'fp32_config.json')
winml build -c $RECIPE -m $MODEL -o (Join-Path $OUT 'fp32')

# Pinned real-media FP32 CPU functional smoke; one sample/OCR pass/window, operability only.
winml eval -m $ARTIFACT --model-id $MODEL --task question-answering --dataset lmms-lab-encoder/DocVQA --dataset-name DocVQA --dataset-revision $DATASET_REVISION --split validation --samples 1 --no-shuffle --streaming --column question_column=question --column image_column=image --column label_column=answers --column document_mode=true --column ocr_engine=tesseract --column sample_index=2 --column max_windows=1 --column doc_stride=128 --column max_answer_words=64 --column top_k=1 --device cpu --ep cpu

# Precomputed words/boxes exercise document inputs without pytesseract or native OCR.
python -m pytest tests/unit/eval/test_question_answering_evaluator.py::TestDocumentCompute::test_precomputed_document_path_forwards_exact_named_inputs -q --no-cov
```