### PR TITLE
recipe(multilingual-e5-small): add CPU fp32/fp16 feature-extraction and sentence-similarity recipes

### DIFF
--- a/examples/recipes/intfloat_multilingual-e5-small/cpu/cpu/feature-extraction_fp16_config.json
+++ b/examples/recipes/intfloat_multilingual-e5-small/cpu/cpu/feature-extraction_fp16_config.json
@@ -1,0 +1,66 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          250037
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      },
+      {
+        "name": "token_type_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "feature-extraction",
+    "model_class": "AutoModel",
+    "model_type": "bert"
+  }
+}

--- a/examples/recipes/intfloat_multilingual-e5-small/cpu/cpu/feature-extraction_fp16_config.json
+++ b/examples/recipes/intfloat_multilingual-e5-small/cpu/cpu/feature-extraction_fp16_config.json
@@ -51,12 +51,37 @@
       {
         "name": "last_hidden_state"
       }
-    ]
+    ],
+    "compatibility": {
+      "transformers_attention": "eager"
+    }
   },
   "optim": {
     "clamp_constant_values": true
   },
-  "quant": null,
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "feature-extraction",
+    "model_id": "intfloat/multilingual-e5-small",
+    "model_type": "bert",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
   "compile": null,
   "loader": {
     "task": "feature-extraction",

--- a/examples/recipes/intfloat_multilingual-e5-small/cpu/cpu/feature-extraction_fp32_config.json
+++ b/examples/recipes/intfloat_multilingual-e5-small/cpu/cpu/feature-extraction_fp32_config.json
@@ -1,0 +1,66 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          250037
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      },
+      {
+        "name": "token_type_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "feature-extraction",
+    "model_class": "AutoModel",
+    "model_type": "bert"
+  }
+}

--- a/examples/recipes/intfloat_multilingual-e5-small/cpu/cpu/feature-extraction_fp32_config.json
+++ b/examples/recipes/intfloat_multilingual-e5-small/cpu/cpu/feature-extraction_fp32_config.json
@@ -51,7 +51,10 @@
       {
         "name": "last_hidden_state"
       }
-    ]
+    ],
+    "compatibility": {
+      "transformers_attention": "eager"
+    }
   },
   "optim": {
     "clamp_constant_values": true

--- a/examples/recipes/intfloat_multilingual-e5-small/cpu/cpu/sentence-similarity_fp16_config.json
+++ b/examples/recipes/intfloat_multilingual-e5-small/cpu/cpu/sentence-similarity_fp16_config.json
@@ -1,0 +1,66 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          250037
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      },
+      {
+        "name": "token_type_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "sentence-similarity",
+    "model_class": "AutoModel",
+    "model_type": "bert"
+  }
+}

--- a/examples/recipes/intfloat_multilingual-e5-small/cpu/cpu/sentence-similarity_fp16_config.json
+++ b/examples/recipes/intfloat_multilingual-e5-small/cpu/cpu/sentence-similarity_fp16_config.json
@@ -51,12 +51,37 @@
       {
         "name": "last_hidden_state"
       }
-    ]
+    ],
+    "compatibility": {
+      "transformers_attention": "eager"
+    }
   },
   "optim": {
     "clamp_constant_values": true
   },
-  "quant": null,
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "sentence-similarity",
+    "model_id": "intfloat/multilingual-e5-small",
+    "model_type": "bert",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
   "compile": null,
   "loader": {
     "task": "sentence-similarity",

--- a/examples/recipes/intfloat_multilingual-e5-small/cpu/cpu/sentence-similarity_fp32_config.json
+++ b/examples/recipes/intfloat_multilingual-e5-small/cpu/cpu/sentence-similarity_fp32_config.json
@@ -1,0 +1,66 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          250037
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      },
+      {
+        "name": "token_type_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "sentence-similarity",
+    "model_class": "AutoModel",
+    "model_type": "bert"
+  }
+}

--- a/examples/recipes/intfloat_multilingual-e5-small/cpu/cpu/sentence-similarity_fp32_config.json
+++ b/examples/recipes/intfloat_multilingual-e5-small/cpu/cpu/sentence-similarity_fp32_config.json
@@ -51,7 +51,10 @@
       {
         "name": "last_hidden_state"
       }
-    ]
+    ],
+    "compatibility": {
+      "transformers_attention": "eager"
+    }
   },
   "optim": {
     "clamp_constant_values": true

--- a/src/winml/modelkit/models/winml/feature_extraction.py
+++ b/src/winml/modelkit/models/winml/feature_extraction.py
@@ -15,6 +15,7 @@ import logging
 from collections import OrderedDict
 from typing import Any
 
+import numpy as np
 from transformers.utils.generic import ModelOutput
 
 from .base import WinMLPreTrainedModel
@@ -58,7 +59,31 @@ class WinMLModelForFeatureExtraction(WinMLPreTrainedModel):
         order. Tensors keep their native rank (no unsqueeze); downstream
         pooling handles 1-D and 2-D after raw[0].
         """
-        outputs = self._run_inference(self._format_inputs(**kwargs))
+        inputs = self._format_inputs(**kwargs)
+        if "token_type_ids" not in inputs and "input_ids" in inputs:
+            input_names = self.io_config.get("input_names", [])
+            if "token_type_ids" in input_names:
+                input_index = input_names.index("token_type_ids")
+                input_types = self.io_config.get("input_types", [])
+                input_shapes = self.io_config.get("input_shapes", [])
+                if input_index < len(input_types) and input_index < len(input_shapes):
+                    required_shape = input_shapes[input_index]
+                    actual_shape = inputs["input_ids"].shape
+                    shape_matches = len(required_shape) == len(actual_shape) and all(
+                        not isinstance(dimension, int)
+                        or dimension <= 0
+                        or dimension == actual_dimension
+                        for dimension, actual_dimension in zip(
+                            required_shape, actual_shape, strict=True
+                        )
+                    )
+                    if shape_matches:
+                        inputs["token_type_ids"] = np.zeros(
+                            actual_shape,
+                            dtype=np.dtype(input_types[input_index]),
+                        )
+
+        outputs = self._run_inference(inputs)
         # WinMLEncoderDecoderModel expects its encoder sub-component to expose
         # hidden states as "last_hidden_state". Alias the primary output when an
         # encoder ONNX graph named it otherwise (e.g. "encoder_hidden_states").

--- a/tests/unit/models/auto/test_feature_extraction.py
+++ b/tests/unit/models/auto/test_feature_extraction.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import numpy as np
+import pytest
 import torch
 from transformers.utils import ModelOutput
 
@@ -27,6 +28,8 @@ def create_mock_model():
     mock_session = MagicMock()
     mock_session.io_config = {
         "input_names": ["input_ids", "attention_mask", "token_type_ids"],
+        "input_types": [np.dtype("int32"), np.dtype("int32"), np.dtype("int32")],
+        "input_shapes": [[1, 8], [1, 8], [1, 8]],
         "output_names": ["last_hidden_state"],
     }
     mock_session.run.return_value = {
@@ -89,13 +92,69 @@ class TestForwardLastHiddenState:
         assert "attention_mask" in call_kwargs
         assert "token_type_ids" in call_kwargs
 
-    def test_none_inputs_excluded(self):
+    def test_missing_token_type_ids_synthesized_with_required_shape_and_dtype(self):
         model = create_mock_model()
-        model.forward(input_ids=torch.ones(1, 8, dtype=torch.long))
+        model.forward(
+            input_ids=torch.ones(1, 8, dtype=torch.long),
+            attention_mask=torch.ones(1, 8, dtype=torch.long),
+        )
 
         call_kwargs = model._session.run.call_args[0][0]
-        assert "attention_mask" not in call_kwargs
-        assert "token_type_ids" not in call_kwargs
+        np.testing.assert_array_equal(call_kwargs["token_type_ids"], np.zeros((1, 8)))
+        assert call_kwargs["token_type_ids"].dtype == np.int32
+
+    def test_provided_token_type_ids_preserved(self):
+        model = create_mock_model()
+        provided = torch.tensor([[0, 0, 0, 0, 1, 1, 1, 1]], dtype=torch.int64)
+
+        model.forward(
+            input_ids=torch.ones(1, 8, dtype=torch.long),
+            attention_mask=torch.ones(1, 8, dtype=torch.long),
+            token_type_ids=provided,
+        )
+
+        call_kwargs = model._session.run.call_args[0][0]
+        np.testing.assert_array_equal(call_kwargs["token_type_ids"], provided.numpy())
+        assert call_kwargs["token_type_ids"].dtype == provided.numpy().dtype
+
+    def test_unrelated_missing_required_input_still_fails(self):
+        from winml.modelkit.session.session import WinMLSession
+
+        model = create_mock_model()
+        model._session.run.side_effect = lambda inputs: (
+            WinMLSession._validate_inputs(model._session, inputs)
+        )
+
+        with pytest.raises(ValueError, match="attention_mask"):
+            model.forward(input_ids=torch.ones(1, 8, dtype=torch.long))
+
+    def test_incompatible_static_token_type_shape_is_not_hidden(self):
+        from winml.modelkit.session.session import WinMLSession
+
+        model = create_mock_model()
+        model._session.io_config["input_shapes"][2] = [1, 16]
+        model._session.run.side_effect = lambda inputs: (
+            WinMLSession._validate_inputs(model._session, inputs)
+        )
+
+        with pytest.raises(ValueError, match="token_type_ids"):
+            model.forward(
+                input_ids=torch.ones(1, 8, dtype=torch.long),
+                attention_mask=torch.ones(1, 8, dtype=torch.long),
+            )
+
+    def test_sentence_similarity_feature_path_synthesizes_each_single_segment(self):
+        model = create_mock_model()
+
+        for token_id in (1, 2):
+            model.forward(
+                input_ids=torch.full((1, 8), token_id, dtype=torch.long),
+                attention_mask=torch.ones(1, 8, dtype=torch.long),
+            )
+
+        assert model._session.run.call_count == 2
+        for call in model._session.run.call_args_list:
+            np.testing.assert_array_equal(call.args[0]["token_type_ids"], np.zeros((1, 8)))
 
 
 class TestForwardPreservesOnnxOutputNames:


### PR DESCRIPTION
## Summary

Adds complete CPU fp32/fp16 support for `intfloat/multilingual-e5-small` across feature extraction and sentence similarity. The Effort L2 contribution ships four task/precision recipes plus a metadata-driven shared input fix and regression coverage; Outcome L2 reached the committed Goal L3 with full coverage on candidate `8e7c621a2312a3ef45b08c43e7347301e992f842`. The bounded L3 result is functional-smoke evidence only, not representative benchmark accuracy.

## Model metadata

### What the model does

`intfloat/multilingual-e5-small` is a multilingual text-embedding checkpoint. It encodes prefixed text with a 12-layer `BertModel` into token-level hidden states; the published SentenceTransformers pipeline applies attention-mask-aware mean pooling and L2 normalization to obtain 384-dimensional embeddings for retrieval, semantic similarity, clustering, and related feature use.

- Evidence: [Hugging Face model card and metadata](https://huggingface.co/intfloat/multilingual-e5-small/tree/614241f622f53c4eeff9890bdc4f31cfecc418b3), including pinned `modules.json`, `1_Pooling/config.json`, and model config; current-main `winml inspect` for feature extraction and sentence similarity.
- Confidence: `verified`.

### Primary user stories

- A user supplies a prefixed query and candidate passages to obtain normalized embeddings for multilingual semantic retrieval. Evidence: pinned model-card usage and FAQ for `query:`/`passage:` asymmetric retrieval prefixes. Confidence: `verified`.
- A user supplies two query-prefixed sentences to obtain cosine-comparable embeddings for semantic similarity or paraphrase matching. Evidence: pinned model-card FAQ for the `query:` prefix on symmetric semantic-similarity tasks. Confidence: `verified`.
- A user supplies query-prefixed text to obtain reusable dense features for clustering or linear-probe classification. Evidence: pinned model-card FAQ for the `query:` prefix on embedding-as-feature use. Confidence: `verified`.

### Supported tasks

- **Feature extraction:** supported through Transformers, Optimum ONNX, and WinML. The Optimum BERT vendor registry contains `feature-extraction`, and current-main `winml inspect` resolves `AutoModel` and `BertIOConfig`. Confidence: `verified`.
- **Sentence similarity:** declared by the pinned checkpoint (`pipeline_tag=sentence-similarity`, `library_name=sentence-transformers`) and supported by WinML while using the feature-extraction export contract. Confidence: `verified`.

### Model architecture

```text
BertModel
├── Embeddings (vocab 250037 × 384; positions 512 × 384; token types 2 × 384)
│   └── LayerNorm + dropout
├── Encoder stack × 12
│   ├── Multi-head self-attention (12 heads; head width 32)
│   ├── Feed-forward (384 → 1536 → 384, GELU)
│   └── Residual + LayerNorm
└── Raw export output: last_hidden_state [batch, sequence, 384]
SentenceTransformers postprocessing (outside BertModel/ONNX)
├── Attention-mask-aware mean pooling
└── L2 normalization → sentence embedding [batch, 384]
```

- Source/confidence: pinned model config (`architectures=[BertModel]`), Transformers 5.14.1 `BertModel` source, and pinned SentenceTransformers module/pooling configs (`verified`).

## Validation and support evidence

### Baseline

Baseline was fully rerun at current `main` `e564a6375d6cd2b596fb3d21d918f07824b349e0` with WinML `0.2.0`.

- **Auto-config and export classification:** current-main config resolves both tasks to `AutoModel`/`BertIOConfig`; sentence similarity deliberately uses the feature-extraction ONNX graph contract. `winml config` produced task-specific anchors and has no precision selector. The repaired final recipes are structurally identical to the corresponding frozen current-main fp32/fp16 auto-config anchors. This is not a new task-family registry.
- **Optimum classification:** `VENDOR-ONLY`. Optimum's BERT registry already supplies `feature-extraction`; WinML adds no vendor task, and sentence similarity reuses the feature-extraction export contract.
- **Build:** PASS in `67.6s` (`31.0s` export, `31.1s` optimize), `quant=null`, 448.4 MB float model. ONNX checker passed: IR 8, opset 17, 372 nodes, three int32 `[1,512]` inputs, and float32 `[1,512,384]` `last_hidden_state`. The historical default-quant failure is not current.
- **Perf:** mean `96.87 ms`, p50 `94.99 ms`, p90 `108.50 ms`, p95 `111.20 ms`, p99 `115.63 ms`, `10.32 samples/s`, total RSS delta `+81.4 MB`.
- **Numeric parity:** raw `last_hidden_state` max absolute error `1.996755599975586e-06` (1.997e-6), mean absolute error `2.1955554529995425e-07`, cosine `0.9999999403953552`; pooled normalized embedding cosine minimum `0.9999999403953552`. PyTorch and ONNX retrieval rankings were identical for the pinned bilingual examples.
- **Former Eval blocker:** the bounded 2-source-row/4-pair sentence-similarity Eval loaded its data but failed before emitting a metric because the tokenizer omitted `token_type_ids` while the ONNX graph required it.

### Goal

- **Effort:** L2.
- **Goal ceiling:** L3.
- **Outcome:** L2.
- **Success definition:** L0 four clean builds; L1 four CPU perf rows; L2 per-artifact PyTorch parity; one bounded final-SHA fp32 CPU functional Eval.

The final Goal ladder passed at every tier: L0 `4/4`, L1 `4/4`, L2 `4/4`, and L3 `PASS`. The ceiling was not downgraded.

### Outcome

Outcome L2 shipped at final candidate `8e7c621a2312a3ef45b08c43e7347301e992f842`; highest Goal verdict is **L3 PASS**, coverage is **full**, and there are no deferred tuples or blockers.

Shipped paths:

- `examples/recipes/intfloat_multilingual-e5-small/cpu/cpu/feature-extraction_fp32_config.json`
- `examples/recipes/intfloat_multilingual-e5-small/cpu/cpu/feature-extraction_fp16_config.json`
- `examples/recipes/intfloat_multilingual-e5-small/cpu/cpu/sentence-similarity_fp32_config.json`
- `examples/recipes/intfloat_multilingual-e5-small/cpu/cpu/sentence-similarity_fp16_config.json`
- `src/winml/modelkit/models/winml/feature_extraction.py`
- `tests/unit/models/auto/test_feature_extraction.py`

Model findings `bert-011` through `bert-016` were appended on the separate Lane A Draft [ModelKitArtifacts PR #216](https://github.com/gim-home/ModelKitArtifacts/pull/216), final head `8c67d9cb69ac1ca464beabe82bac1771c4edd912`, labeled `model-scale-by-skill`. **Methodology declaration:** `no_friction:false; reviewer-discovered doc-code drift captured as _meta-108 with paired tester/reviewer contract edits in pushed Lane A PR #216`. `_meta-108` records only that schema-v2 perf precision supersedes the stale literal console gate.

### Per-EP/device/precision results and Functional smoke Eval

#### Goal ladder and CPU perf

| Task | EP / device | Precision | L0 build | Build time | L1 | Mean | p50 | Throughput | RAM delta |
|---|---|---:|---|---:|---|---:|---:|---:|---:|
| feature-extraction | CPUExecutionProvider / cpu | fp32 | PASS | 70.2s | PASS | 116.4 ms | 115.92 ms | 8.59 samples/s | +81.4 MB |
| feature-extraction | CPUExecutionProvider / cpu | fp16 | PASS | 72.8s | PASS | 179.643 ms | 178.686 ms | 5.57 samples/s | +88.73 MB |
| sentence-similarity | CPUExecutionProvider / cpu | fp32 | PASS | 65.7s | PASS | 118.74 ms | 118.04 ms | 8.42 samples/s | +81.3 MB |
| sentence-similarity | CPUExecutionProvider / cpu | fp16 | PASS | 70.7s | PASS | 180.017 ms | 179.447 ms | 5.56 samples/s | +88.71 MB |

Both fp16 builds used `--precision fp16` without `--no-quant`. Current `winml perf --format json` emitted schema-v2 authoritative resolved `model_info.precision="fp16"` and corroborating requested-policy `benchmark_info.precision="fp16"` for both fp16 artifacts. Each contains 200 `FLOAT16` initializers and `234,931,456` external-data bytes, versus 200 `FLOAT` initializers and `470,027,776` bytes for fp32, a ratio of `0.4998246231`; float I/O is preserved.

#### L2 numeric and retrieval parity

Pinned PyTorch checkpoint revision: `614241f622f53c4eeff9890bdc4f31cfecc418b3`.

| Artifact | Max abs error | Mean abs error | Minimum embedding cosine | Retrieval ranking |
|---|---:|---:|---:|---|
| feature-extraction fp32 | 1.7583370208740234e-06 | 2.223688824187775e-07 | 0.9999999403953552 | identical |
| feature-extraction fp16 | 0.003210783004760742 | 0.0002058723330264911 | 0.9999998211860657 | identical |
| sentence-similarity fp32 | 1.7583370208740234e-06 | 2.223688824187775e-07 | 0.9999999403953552 | identical |
| sentence-similarity fp16 | 0.003210783004760742 | 0.0002058723330264911 | 0.9999998211860657 | identical |

#### Functional smoke Eval

**Functional smoke only; this is not representative benchmark accuracy or model-quality evidence.** One final-SHA FP32 CPU sentence-similarity run passed on candidate `8e7c621a2312a3ef45b08c43e7347301e992f842`.

- Dataset: tester-owned, E5 model-card-derived multilingual smoke at source checkpoint revision `614241f622f53c4eeff9890bdc4f31cfecc418b3`; split `train`; deterministic no-shuffle selection with seed `0`.
- Scope: 2 bilingual source rows × 2 passages = 4 requested and 4 processed pairs; 8 wrapper inference calls.
- Fan-out caps: 2 source rows; 2 candidate passages per query; 4 expanded pairs; 2 inferences per pair; sequence length 512; beams 1; frames/crops not applicable.
- Schema fields `sentence1`, `sentence2`, `score`, `source_query_row`, `source_passage_row`, and `relation` were verified. Labels were `1.0` for same-source matches and `0.0` for cross-source negatives; predictions were attention-mask-aware mean-pooled embedding cosine similarities. Schema, label semantics, and prediction semantics all passed.
- The tokenizer omitted `token_type_ids`; all 8 wrapper feeds synthesized all-zero int32 `[1,512]` values. The former missing-input blocker was therefore removed through the shared metadata-driven input capability.
- Metric: `cosine_spearman=89.4427` on the MTEB `[-100, 100]` scale.

### Delta

All four recipe paths listed under Outcome were repaired and are structurally identical to their current-main auto-config anchors. Relative to the pre-repair recipes, all four changed `/export/compatibility/transformers_attention` from absent to `"eager"`. The fp32 recipes retain `/quant = null`. Both fp16 recipes changed `/quant` from `null` to the full current auto-config block, including `/quant/mode = "fp16"`, `/quant/model_id = "intfloat/multilingual-e5-small"`, `/quant/model_type = "bert"`, `/quant/fp16_keep_io_types = true`, and task-specific `/quant/task` values of `"feature-extraction"` or `"sentence-similarity"`. These deltas are reducibility-consistent: eager attention is already class-wide current-source behavior, while precision and task are tuple intent rather than checkpoint hardcoding. `examples/recipes/README.md` is unchanged.

Shared source and regression paths are `src/winml/modelkit/models/winml/feature_extraction.py` and `tests/unit/models/auto/test_feature_extraction.py`. No-recipe acceptance passed for final-SHA FP32 feature extraction and sentence similarity; the change does not add or modify a task-family registry.

#### Bug fix explanation

1. **Symptom and trigger:** single-segment feature-extraction/sentence-similarity inference failed with `Missing required inputs: {'token_type_ids'}` when the tokenizer emitted `input_ids` and `attention_mask` but the exported ONNX graph also declared `token_type_ids`.
2. **Root cause:** strict session input validation correctly rejected the incomplete feed before inference. The single-text wrapper had no safe defaulting path for a graph-declared segment-ID input omitted by a tokenizer.
3. **Symbols and mechanism:** `WinMLModelForFeatureExtraction.forward` now synthesizes an all-zero `token_type_ids` tensor only when ONNX input metadata declares that input, the tokenizer omitted it, `input_ids` supplies the realized batch/sequence shape, declared dtype/shape metadata exists, and every static required dimension matches. The tensor uses the realized `input_ids` shape and exact declared ONNX dtype before normal strict validation.
4. **Class-wide rationale:** the rule is driven entirely by ONNX input metadata and tokenizer-produced `input_ids`; it contains no model ID or `model_type` branch and applies to the single-text feature-extraction abstraction.
5. **Compatibility and blast radius:** tokenizer-provided segment IDs are preserved; only `token_type_ids` receives the safe zero default; unrelated missing inputs and incompatible static shapes still fail; synthesized dtype/shape follows graph metadata; output names/shapes, attention-mask pooling, sentence-similarity postprocessing, and recipe-owned semantics are unchanged. The intentional change is that single-segment paths can now feed graphs requiring omitted segment IDs.
6. **Regression and partition evidence:** focused tests `13 passed in 16.92s`; models/loader/datasets/export `1527 passed, 6 skipped, 2 xfailed`; optim `711 passed, 16 skipped, 1 xfailed`; commands/config/build/compiler/session/eval `3563 passed, 9 skipped, 1 warning`; remaining core/ONNX/cache/utils/helpers/sysinfo/inspect/optracing/regression/CLI `869 passed, 2 skipped, 1 deselected, 1 warning`; analyze `1526 passed, 45 skipped`. Total non-overlapping completed tests: `8196`. Ruff reported `All checks passed!`; mypy reported no issues in 435 source files.

### Analyze summary — component level and op level

Static rule analysis **PASS** completed for all four artifacts. These classifications are static compatibility evidence, not runtime execution or a claim that accelerator inference was run.

#### Component-level summary

| Artifact | Architecture regions | Mapping | Actionable EP findings |
|---|---|---|---|
| feature-extraction fp32 | embeddings; 12× encoder attention/feed-forward; runtime mean pooling/normalize | 372 mapped, 0 partial, 0 unmapped; runtime-only postprocessing explicitly excluded | QNN GPU/NPU: `Gather` partial |
| feature-extraction fp16 | embeddings; 12× encoder attention/feed-forward; runtime mean pooling/normalize | 373 mapped, 0 partial, 0 unmapped; runtime-only postprocessing explicitly excluded | QNN GPU/NPU: `Gather` partial |
| sentence-similarity fp32 | embeddings; 12× encoder attention/feed-forward; runtime mean pooling/normalize | 372 mapped, 0 partial, 0 unmapped; runtime-only postprocessing explicitly excluded | QNN GPU/NPU: `Gather` partial |
| sentence-similarity fp16 | embeddings; 12× encoder attention/feed-forward; runtime mean pooling/normalize | 373 mapped, 0 partial, 0 unmapped; runtime-only postprocessing explicitly excluded | QNN GPU/NPU: `Gather` partial |

There are no mapping gaps.

#### Op-level summary

| Artifact | Graph | Dominant operator counts | Rule-backed EP roll-up |
|---|---|---|---|
| feature-extraction fp32 | 372 operators / 15 types | Reshape 121; Gemm 72; Transpose 48; Add 38; LayerNormalization 25 | NVIDIA TensorRT RTX GPU and OpenVINO CPU/GPU/NPU: 14 supported types, `Where` unknown; QNN GPU/NPU: same plus `Gather` partial |
| feature-extraction fp16 | 373 operators / 15 types | Reshape 121; Gemm 72; Transpose 48; Add 38; LayerNormalization 25 | NVIDIA TensorRT RTX GPU and OpenVINO CPU/GPU/NPU: 14 supported types, `Where` unknown; QNN GPU/NPU: same plus `Gather` partial |
| sentence-similarity fp32 | 372 operators / 15 types | Reshape 121; Gemm 72; Transpose 48; Add 38; LayerNormalization 25 | NVIDIA TensorRT RTX GPU and OpenVINO CPU/GPU/NPU: 14 supported types, `Where` unknown; QNN GPU/NPU: same plus `Gather` partial |
| sentence-similarity fp16 | 373 operators / 15 types | Reshape 121; Gemm 72; Transpose 48; Add 38; LayerNormalization 25 | NVIDIA TensorRT RTX GPU and OpenVINO CPU/GPU/NPU: 14 supported types, `Where` unknown; QNN GPU/NPU: same plus `Gather` partial |

The six rule-backed targets are `NvTensorRTRTXExecutionProvider/GPU`, `OpenVINOExecutionProvider/{CPU,GPU,NPU}`, and `QNNExecutionProvider/{GPU,NPU}`. No rule-backed target reports an unsupported type. Rule-less CPU, CUDA, MIGraphX, and DML groups classify all 15 operator types as unknown.

### Reproduce commands

```powershell
$OUT='temp/multilingual-e5-small-repro'
winml build -c examples/recipes/intfloat_multilingual-e5-small/cpu/cpu/sentence-similarity_fp32_config.json -m intfloat/multilingual-e5-small -o $OUT
winml perf -m $OUT/model.onnx --device cpu --ep cpu
winml eval -m $OUT/model.onnx --model-id intfloat/multilingual-e5-small --task sentence-similarity --dataset <fresh-e5-smoke-dataset> --split train --samples 4 --no-shuffle --ep cpu --device cpu --skip-build
winml analyze --model $OUT/model.onnx --ep QNNExecutionProvider --device npu --no-information --output $OUT/analyze-qnn-npu.json
```