### PR TITLE
feat(modelkit): add document question answering task support

### DIFF
--- a/src/winml/modelkit/loader/resolution.py
+++ b/src/winml/modelkit/loader/resolution.py
@@ -545,6 +545,7 @@ def resolve_task(
     if task is not None:
         original = task
         normalized = normalize_task(task)
+        optimum_task = to_optimum_task(original)
         # Exact-key composite lookup on the ORIGINAL user string: registration keys are
         # `summarization` / `table-question-answering`, never the normalized
         # `text2text-generation`. So `--task summarization` tags the composite while
@@ -552,12 +553,14 @@ def resolve_task(
         composite = resolve_composite(model_type_norm, original) if model_type_norm else None
         resolved = None
         if model_type_norm:
-            resolved = _get_custom_model_class(
-                model_type_norm, original
-            ) or _get_custom_model_class(model_type_norm, normalized)
+            resolved = (
+                _get_custom_model_class(model_type_norm, original)
+                or _get_custom_model_class(model_type_norm, normalized)
+                or _get_custom_model_class(model_type_norm, optimum_task)
+            )
         if resolved is None:
             try:
-                resolved = TasksManager.get_model_class_for_task(normalized, framework="pt")
+                resolved = TasksManager.get_model_class_for_task(optimum_task, framework="pt")
             except KeyError as e:
                 if composite is not None:
                     # Pure composite (e.g. table-question-answering): no single model class

--- a/src/winml/modelkit/loader/task.py
+++ b/src/winml/modelkit/loader/task.py
@@ -253,6 +253,10 @@ TASK_SYNONYM_EXTENSIONS: dict[str, str] = {
     # mask-generation is registered via register_onnx_overwrite for SAM2.
     # Optimum incorrectly maps it to "feature-extraction"; preserve as-is.
     "mask-generation": "mask-generation",
+    # Document QA is a user-facing multimodal pipeline label. The exported
+    # model is still an extractive QA head with text/bbox tensors, so Optimum
+    # should resolve it through its question-answering support.
+    "document-question-answering": "question-answering",
 }
 
 

--- a/src/winml/modelkit/models/winml/__init__.py
+++ b/src/winml/modelkit/models/winml/__init__.py
@@ -44,6 +44,7 @@ TASK_TO_WINML_CLASS: dict[str, str] = {
     # Not yet implemented — falls back to WinMLModelForGenericTask at runtime
     "token-classification": "WinMLModelForTokenClassification",
     "question-answering": "WinMLModelForQuestionAnswering",
+    "document-question-answering": "WinMLModelForQuestionAnswering",
     "text-generation": "WinMLModelForCausalLM",
     "text2text-generation": "WinMLModelForSeq2SeqLM",
     "fill-mask": "WinMLModelForMaskedLM",

--- a/src/winml/modelkit/models/winml/question_answering.py
+++ b/src/winml/modelkit/models/winml/question_answering.py
@@ -45,6 +45,7 @@ class WinMLModelForQuestionAnswering(WinMLPreTrainedModel):
         input_ids: torch.Tensor | np.ndarray | None = None,
         attention_mask: torch.Tensor | np.ndarray | None = None,
         token_type_ids: torch.Tensor | np.ndarray | None = None,
+        bbox: torch.Tensor | np.ndarray | None = None,
         **kwargs: Any,
     ) -> QuestionAnsweringModelOutput:
         """Run question answering inference.
@@ -56,6 +57,8 @@ class WinMLModelForQuestionAnswering(WinMLPreTrainedModel):
                 if the model actually has this input.  Models like
                 DeBERTa-v3 omit this input; it is silently dropped when
                 not in the ONNX graph's input list.
+            bbox: Layout-aware token bounding boxes (B, seq_len, 4). Only
+                passed to ONNX when the exported graph declares a ``bbox`` input.
             **kwargs: Ignored. Accepted for HF pipeline compatibility —
                 the pipeline may forward extra keys (e.g. ``offset_mapping``,
                 ``overflow_to_sample_mapping``) that are not needed for
@@ -68,8 +71,11 @@ class WinMLModelForQuestionAnswering(WinMLPreTrainedModel):
             raise ValueError("input_ids must be provided for question answering inference.")
 
         inputs: dict[str, Any] = {"input_ids": input_ids, "attention_mask": attention_mask}
-        if token_type_ids is not None and "token_type_ids" in self.io_config.get("input_names", []):
+        input_names = self.io_config.get("input_names", [])
+        if token_type_ids is not None and "token_type_ids" in input_names:
             inputs["token_type_ids"] = token_type_ids
+        if bbox is not None and "bbox" in input_names:
+            inputs["bbox"] = bbox
 
         formatted = self._format_inputs(**inputs)
         outputs = self._run_inference(formatted)

--- a/tests/unit/commands/test_run_task_combos.py
+++ b/tests/unit/commands/test_run_task_combos.py
@@ -331,6 +331,55 @@ class TestVisualQuestionAnswering:
         assert inputs["question"] == "What is this?"
 
 
+class TestDocumentQuestionAnswering:
+    """document-question-answering: document image plus question text."""
+
+    TASK = "document-question-answering"
+
+    def test_file_and_text_shortcuts(self, runner: CliRunner, tmp_path: Path) -> None:
+        """--file + --text map to image and question fields."""
+        img = tmp_path / "document.png"
+        img.write_bytes(b"doc-image")
+        engine = _make_engine(self.TASK)
+        with patch(_ENGINE_PATH, return_value=engine):
+            result = runner.invoke(
+                run,
+                [
+                    "--model",
+                    "layoutlm-docqa",
+                    "--file",
+                    str(img),
+                    "--text",
+                    "What is the invoice total?",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        inputs = engine.predict.call_args.kwargs["inputs"]
+        assert inputs["image"] == b"doc-image"
+        assert inputs["question"] == "What is the invoice total?"
+
+    def test_all_named_inputs(self, runner: CliRunner, tmp_path: Path) -> None:
+        """Both inputs also work through -I."""
+        img = tmp_path / "document.jpg"
+        img.write_bytes(b"doc-jpeg")
+        engine = _make_engine(self.TASK)
+        with patch(_ENGINE_PATH, return_value=engine):
+            result = runner.invoke(
+                run,
+                [
+                    "--model",
+                    "layoutlm-docqa",
+                    "-I",
+                    f"image=@{img}",
+                    "-I",
+                    "question=Who signed the form?",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        inputs = engine.predict.call_args.kwargs["inputs"]
+        assert inputs["image"] == b"doc-jpeg"
+        assert inputs["question"] == "Who signed the form?"
+
 # =====================================================================
 # 6. Image pair task: keypoint-matching
 # =====================================================================

--- a/tests/unit/config/test_build.py
+++ b/tests/unit/config/test_build.py
@@ -28,6 +28,7 @@ from winml.modelkit.config import (
     SubmoduleClassNotFoundError,
     WinMLBuildConfig,
     generate_build_config,
+    generate_hf_build_config,
     generate_onnx_build_config,
 )
 from winml.modelkit.config.build import (
@@ -62,6 +63,30 @@ TEXT_MAX_POSITION_EMBEDDINGS = 32
 TEXT_INTERMEDIATE_SIZE = TEXT_HIDDEN_SIZE * 4
 
 
+def test_generate_hf_build_config_document_question_answering_layoutlm() -> None:
+    """document-question-answering keeps its task while exporting via LayoutLM QA."""
+    cfg = generate_hf_build_config(
+        model_type="layoutlm",
+        task="document-question-answering",
+        device="cpu",
+        precision="fp32",
+    )
+
+    assert isinstance(cfg, WinMLBuildConfig)
+    assert cfg.loader.task == "document-question-answering"
+    assert cfg.loader.model_class == "AutoModelForQuestionAnswering"
+    assert cfg.loader.model_type == "layoutlm"
+    assert cfg.export is not None
+    assert [t.name for t in cfg.export.input_tensors or []] == [
+        "input_ids",
+        "bbox",
+        "attention_mask",
+        "token_type_ids",
+    ]
+    assert [t.name for t in cfg.export.output_tensors or []] == [
+        "start_logits",
+        "end_logits",
+    ]
 # =============================================================================
 # Fixtures
 # =============================================================================

--- a/tests/unit/eval/test_question_answering_evaluator.py
+++ b/tests/unit/eval/test_question_answering_evaluator.py
@@ -346,6 +346,32 @@ class TestModelForward:
         call_kwargs = model._format_inputs.call_args[1]
         np.testing.assert_array_equal(call_kwargs["token_type_ids"], tids)
 
+    def test_includes_bbox_when_model_accepts(self):
+        model = self._make_model(
+            input_names=["input_ids", "bbox", "attention_mask", "token_type_ids"],
+        )
+        ids = np.array([[1, 2, 3]])
+        mask = np.array([[1, 1, 1]])
+        bbox = np.array([[[0, 0, 10, 10], [10, 10, 20, 20], [0, 0, 0, 0]]])
+
+        model.forward(input_ids=ids, attention_mask=mask, bbox=bbox)
+
+        call_kwargs = model._format_inputs.call_args[1]
+        np.testing.assert_array_equal(call_kwargs["bbox"], bbox)
+
+    def test_excludes_bbox_when_model_lacks_input(self):
+        model = self._make_model(
+            input_names=["input_ids", "attention_mask"],
+            has_token_type_ids=False,
+        )
+        ids = np.array([[1, 2, 3]])
+        bbox = np.array([[[0, 0, 10, 10], [10, 10, 20, 20], [0, 0, 0, 0]]])
+
+        model.forward(input_ids=ids, bbox=bbox)
+
+        call_kwargs = model._format_inputs.call_args[1]
+        assert "bbox" not in call_kwargs
+
     def test_excludes_token_type_ids_when_model_lacks_input(self):
         model = self._make_model(
             input_names=["input_ids", "attention_mask"],

--- a/tests/unit/export/test_onnx_config_overrides.py
+++ b/tests/unit/export/test_onnx_config_overrides.py
@@ -152,8 +152,12 @@ class TestLayoutLMQuestionAnsweringOverride:
         )
 
         inputs = generate_dummy_inputs("layoutlm", "question-answering", layoutlm_config)
+        doc_inputs = generate_dummy_inputs(
+            "layoutlm", "document-question-answering", layoutlm_config
+        )
 
         assert set(inputs) == {"input_ids", "bbox", "attention_mask", "token_type_ids"}
+        assert set(doc_inputs) == set(inputs)
         assert inputs["input_ids"].shape == (1, layoutlm_config.max_position_embeddings)
         assert inputs["bbox"].shape == (1, layoutlm_config.max_position_embeddings, 4)
         assert inputs["token_type_ids"].shape == (1, layoutlm_config.max_position_embeddings)
@@ -175,7 +179,11 @@ class TestLayoutLMQuestionAnsweringOverride:
         )
 
         specs = resolve_io_specs("layoutlm", "question-answering", layoutlm_config)
+        doc_specs = resolve_io_specs("layoutlm", "document-question-answering", layoutlm_config)
 
+        assert doc_specs["input_names"] == specs["input_names"]
+        assert doc_specs["input_shapes"] == specs["input_shapes"]
+        assert doc_specs["output_names"] == specs["output_names"]
         assert specs["input_names"] == [
             "input_ids",
             "bbox",

--- a/tests/unit/loader/test_resolve_task.py
+++ b/tests/unit/loader/test_resolve_task.py
@@ -84,6 +84,18 @@ def test_pure_composite_task_resolves_without_crashing():
     assert r.model_class.__name__ == "BartDecoderWrapper"
 
 
+def test_user_task_document_question_answering_uses_qa_model_class():
+    """document-question-answering stays user-facing but uses Optimum QA lookup."""
+    r = resolve_task(
+        _cfg("layoutlm", ["LayoutLMForQuestionAnswering"]),
+        task="document-question-answering",
+    )
+    assert r.task == "document-question-answering"
+    assert r.optimum_task == "question-answering"
+    assert r.source == TaskSource.USER_TASK
+    assert r.model_class.__name__ == "AutoModelForQuestionAnswering"
+    assert r.composite is None
+
 def test_no_architectures_uses_first_supported_task():
     cfg = AutoConfig.for_model("bert")
     assert not getattr(cfg, "architectures", None)

--- a/tests/unit/loader/test_task_boundary.py
+++ b/tests/unit/loader/test_task_boundary.py
@@ -26,6 +26,8 @@ from winml.modelkit.loader import to_optimum_task
         ("next-sentence-prediction", "text-classification"),
         # WinML extension preserved as-is (Optimum would mis-map it otherwise).
         ("mask-generation", "mask-generation"),
+        # User-facing document QA exports through Optimum's extractive QA path.
+        ("document-question-answering", "question-answering"),
         # Already-canonical task passes through unchanged.
         ("text-classification", "text-classification"),
     ],


### PR DESCRIPTION
﻿## Summary
Adds WinML task-boundary support for `document-question-answering` so user-facing document QA can resolve through Optimum's extractive `question-answering` exporter while preserving the WinML task name. Also routes LayoutLM-style `bbox` inputs through the WinML QA wrapper so document-layout models can execute with their exported ONNX input contract.

## Model metadata
This is task-family support rather than a checkpoint-specific recipe. The concrete validated export surface is LayoutLM-style document QA: `AutoModelForQuestionAnswering` with `input_ids`, `bbox`, `attention_mask`, `token_type_ids` inputs and `start_logits` / `end_logits` outputs.

## Validation and support evidence
### Baseline
Current branch base: `5deebd422e95f28fe8fd912ee50ce874710187b3`.

### Goal
Outcome-L2 task-family support: map `document-question-answering` to the Optimum QA export task, register it to the existing WinML QA runtime class, and preserve the user-facing task name in generated configs.

### Outcome
Implemented source and test coverage only; no recipe files and `examples/recipes/README.md` is unchanged.

### Per-EP/device/precision results
No model artifact recipe was added in this change. Config-generation validation confirms CPU fp32 config generation for LayoutLM document QA.

### Delta
- `src/winml/modelkit/loader/task.py`: maps `document-question-answering` to Optimum `question-answering`.
- `src/winml/modelkit/loader/resolution.py`: explicit user tasks now consult the Optimum task alias for model-class lookup.
- `src/winml/modelkit/models/winml/__init__.py`: maps document QA to `WinMLModelForQuestionAnswering`.
- `src/winml/modelkit/models/winml/question_answering.py`: forwards optional `bbox` when the ONNX graph declares it.
- Tests cover task boundary, resolver behavior, LayoutLM I/O specs, build config generation, QA wrapper bbox forwarding, and CLI run input mapping.

### Analyze summary
Not applicable: this task-family source change does not add a built ONNX artifact or recipe.

### Reproduce commands
```powershell
$env:PYTHONPATH='D:\WPDProjects\winml-cli\.worktrees\document-qa\src'
& 'D:\WPDProjects\winml-cli\.venv\Scripts\python.exe' -m pytest tests\unit\loader\test_task_boundary.py tests\unit\loader\test_resolve_task.py tests\unit\export\test_onnx_config_overrides.py::TestLayoutLMQuestionAnsweringOverride tests\unit\config\test_build.py::test_generate_hf_build_config_document_question_answering_layoutlm tests\unit\eval\test_question_answering_evaluator.py::TestModelForward -q -p no:cacheprovider --tb=short
& 'D:\WPDProjects\winml-cli\.venv\Scripts\python.exe' -m winml.modelkit config --model-type layoutlm --task document-question-answering --device cpu --precision fp32 --no-compile --no-quant --output temp\docqa_config.json --overwrite
```

Validation observed locally:
- `38 passed in 0.82s` for targeted unit coverage.
- `manual document-question-answering run tests passed` for the two CLI file/text mapping paths that pytest could not complete here because pytest tmpdir cleanup hits WinError 5.
- Config generation produced `AutoModelForQuestionAnswering`, task `document-question-answering`, inputs `input_ids`, `bbox`, `attention_mask`, `token_type_ids`, and outputs `start_logits`, `end_logits`.

Blocked local checks:
- `uv run ruff ...` is blocked by local `uv` cache/interpreter metadata permission errors (`Access is denied`).
- Some pytest invocations using `tmp_path` fail during pytest session temp cleanup with `PermissionError: [WinError 5]`, so the equivalent CLI path was validated by a direct script.
