### PR TITLE
Add keypoint detection inference support

### DIFF
--- a/src/winml/modelkit/inference/pipeline.py
+++ b/src/winml/modelkit/inference/pipeline.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import inspect
 import logging
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
 
@@ -36,6 +37,114 @@ logger = logging.getLogger(__name__)
 _HF_PIPELINE_TASK_MAP: dict[str, str] = {
     "sentence-similarity": "feature-extraction",
 }
+
+
+class KeypointDetectionPipeline:
+    """Minimal ViTPose inference adapter.
+
+    Transformers does not expose a ``keypoint-detection`` pipeline. ViTPose is
+    top-down, so callers provide person boxes and this adapter runs
+    image_processor.preprocess -> WinML model -> post_process_pose_estimation.
+    """
+
+    def __init__(self, model: Any, model_id: str | None = None) -> None:
+        from transformers import AutoImageProcessor
+
+        self.model = model
+        self.image_processor = AutoImageProcessor.from_pretrained(model_id) if model_id else None
+        if self.image_processor is None:
+            raise ValueError("keypoint-detection requires model_id to load the image processor")
+        self._adapt_processor_size()
+
+    def __call__(
+        self,
+        image: Any,
+        *,
+        boxes: list[list[float]],
+        box_format: str = "xywh",
+        dataset_index: int | float = 0,
+    ) -> list[dict[str, Any]]:
+        import torch
+
+        if not isinstance(boxes, list) or not boxes:
+            raise ValueError("boxes must be a non-empty list of [x, y, w, h] boxes")
+        xywh_boxes = [self._to_xywh(box, box_format) for box in boxes]
+        inputs = self.image_processor.preprocess(
+            images=image,
+            boxes=[xywh_boxes],
+            return_tensors="pt",
+        )
+        pixel_values = inputs["pixel_values"]
+
+        extra_inputs: dict[str, Any] = {}
+        if self._declares_input("dataset_index"):
+            extra_inputs["dataset_index"] = torch.tensor([int(dataset_index)], dtype=torch.long)
+
+        heatmaps = []
+        with torch.no_grad():
+            for i in range(pixel_values.shape[0]):
+                outputs = self.model(pixel_values=pixel_values[i : i + 1], **extra_inputs)
+                heatmaps.append(self._extract_heatmaps(outputs))
+
+        wrapped = SimpleNamespace(heatmaps=torch.cat(heatmaps, dim=0))
+        poses = self.image_processor.post_process_pose_estimation(wrapped, boxes=[xywh_boxes])[0]
+        return [self._serialize_pose(pose) for pose in poses]
+
+    def _sanitize_parameters(
+        self,
+        boxes: tuple[Any, ...] = (),
+        box_format: str = "xywh",
+        dataset_index: int = 0,
+    ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+        """Expose accepted kwargs for InferenceEngine parameter filtering."""
+        forward_kwargs = {
+            "boxes": boxes,
+            "box_format": box_format,
+            "dataset_index": dataset_index,
+        }
+        return {}, forward_kwargs, {}
+
+    def _adapt_processor_size(self) -> None:
+        io_config = getattr(self.model, "io_config", None) or {}
+        for shape in io_config.get("input_shapes", []):
+            if len(shape) == 4:
+                _, _, h, w = shape
+                self.image_processor.size = {"height": h, "width": w}
+                break
+
+    def _declares_input(self, name: str) -> bool:
+        io_config = getattr(self.model, "io_config", None) or {}
+        return name in (io_config.get("input_names") or [])
+
+    @staticmethod
+    def _extract_heatmaps(outputs: Any) -> Any:
+        if not isinstance(outputs, dict):
+            return outputs.heatmaps
+        heatmaps = outputs.get("heatmaps")
+        if heatmaps is None:
+            heatmaps = next(iter(outputs.values()))
+        return heatmaps
+
+    @staticmethod
+    def _serialize_pose(pose: dict[str, Any]) -> dict[str, Any]:
+        keypoints = pose["keypoints"].detach().cpu().numpy().tolist()
+        scores = pose["scores"].detach().cpu().numpy().tolist()
+        return {
+            "keypoints": keypoints,
+            "scores": scores,
+            "score": float(sum(scores) / len(scores)) if scores else 0.0,
+        }
+
+    @staticmethod
+    def _to_xywh(box: list[float], box_format: str) -> list[float]:
+        if len(box) != 4:
+            raise ValueError("each box must contain exactly four coordinates")
+        x0, y0, a, b = (float(v) for v in box)
+        if box_format == "xyxy":
+            return [x0, y0, a - x0, b - y0]
+        if box_format != "xywh":
+            raise ValueError("box_format must be 'xywh' or 'xyxy'")
+        return [x0, y0, a, b]
 
 
 def create_pipeline(
@@ -57,6 +166,9 @@ def create_pipeline(
     Returns:
         A configured ``transformers.Pipeline`` ready for inference.
     """
+    if task == "keypoint-detection":
+        return KeypointDetectionPipeline(model, model_id)
+
     from transformers import pipeline
 
     kwargs: dict[str, Any] = {

--- a/src/winml/modelkit/inference/tasks.py
+++ b/src/winml/modelkit/inference/tasks.py
@@ -252,6 +252,35 @@ TASK_REGISTRY: dict[str, TaskInputSpec] = {
         ],
         mapping=PipelineMapping(pipe_input="image"),
     ),
+    "keypoint-detection": TaskInputSpec(
+        user_inputs=[
+            InputField(name="image", type="image", required=True, description="Image to analyze"),
+            InputField(
+                name="boxes",
+                type="json",
+                required=True,
+                description="Person boxes [[x,y,w,h],...] or [[x1,y1,x2,y2],...]",
+            ),
+            InputField(
+                name="box_format",
+                type="text",
+                required=False,
+                description="Box coordinate format: xywh or xyxy",
+                default="xywh",
+            ),
+            InputField(
+                name="dataset_index",
+                type="number",
+                required=False,
+                description="ViTPose+ dataset expert index",
+                default=0,
+            ),
+        ],
+        mapping=PipelineMapping(
+            pipe_input="image",
+            pipe_kwargs=["boxes", "box_format", "dataset_index"],
+        ),
+    ),
     "image-segmentation": TaskInputSpec(
         user_inputs=[
             InputField(name="image", type="image", required=True, description="Image to segment"),

--- a/src/winml/modelkit/models/winml/__init__.py
+++ b/src/winml/modelkit/models/winml/__init__.py
@@ -40,6 +40,7 @@ TASK_TO_WINML_CLASS: dict[str, str] = {
     "image-segmentation": "WinMLModelForImageSegmentation",
     "semantic-segmentation": "WinMLModelForSemanticSegmentation",
     "object-detection": "WinMLModelForObjectDetection",
+    "keypoint-detection": "WinMLModelForKeypointDetection",
     "depth-estimation": "WinMLModelForDepthEstimation",
     # Not yet implemented — falls back to WinMLModelForGenericTask at runtime
     "token-classification": "WinMLModelForTokenClassification",
@@ -82,6 +83,7 @@ def _import_winml_class(class_name: str) -> type[WinMLPreTrainedModel]:
         WinMLModelForImageSegmentation,
         WinMLModelForSemanticSegmentation,
     )
+    from .keypoint_detection import WinMLModelForKeypointDetection
     from .object_detection import WinMLModelForObjectDetection
     from .question_answering import WinMLModelForQuestionAnswering
     from .sequence_classification import WinMLModelForSequenceClassification
@@ -92,6 +94,7 @@ def _import_winml_class(class_name: str) -> type[WinMLPreTrainedModel]:
         "WinMLModelForFeatureExtraction": WinMLModelForFeatureExtraction,
         "WinMLModelForImageClassification": WinMLModelForImageClassification,
         "WinMLModelForImageSegmentation": WinMLModelForImageSegmentation,
+        "WinMLModelForKeypointDetection": WinMLModelForKeypointDetection,
         "WinMLModelForObjectDetection": WinMLModelForObjectDetection,
         "WinMLModelForQuestionAnswering": WinMLModelForQuestionAnswering,
         "WinMLModelForSemanticSegmentation": WinMLModelForSemanticSegmentation,
@@ -204,6 +207,7 @@ from .image_segmentation import (
     WinMLModelForImageSegmentation,
     WinMLModelForSemanticSegmentation,
 )
+from .keypoint_detection import KeypointDetectionOutput, WinMLModelForKeypointDetection
 from .kv_cache import (
     WinMLCache,
     WinMLSlidingWindowCache,
@@ -224,6 +228,7 @@ __all__ = [
     "GenaiTarget",
     "GenaiTransformerSpec",
     "ImageSegmentationOutput",
+    "KeypointDetectionOutput",
     "WinMLCache",
     "WinMLCompositeModel",
     "WinMLDecoderOnlyModel",
@@ -233,6 +238,7 @@ __all__ = [
     "WinMLModelForGenericTask",
     "WinMLModelForImageClassification",
     "WinMLModelForImageSegmentation",
+    "WinMLModelForKeypointDetection",
     "WinMLModelForObjectDetection",
     "WinMLModelForSemanticSegmentation",
     "WinMLModelForSequenceClassification",

--- a/src/winml/modelkit/models/winml/keypoint_detection.py
+++ b/src/winml/modelkit/models/winml/keypoint_detection.py
@@ -1,0 +1,58 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+"""WinML keypoint-detection model wrapper."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import torch
+from transformers.utils.generic import ModelOutput
+
+from .base import WinMLPreTrainedModel
+
+
+if TYPE_CHECKING:
+    import numpy as np
+
+
+@dataclass
+class KeypointDetectionOutput(ModelOutput):
+    """Output for ViTPose-style keypoint detection models."""
+
+    loss: torch.Tensor | None = None
+    heatmaps: torch.Tensor | None = None
+
+
+class WinMLModelForKeypointDetection(WinMLPreTrainedModel):
+    """WinML model for top-down pose estimation.
+
+    Returns ``KeypointDetectionOutput`` with ``heatmaps`` so ViTPose image
+    processors can run ``post_process_pose_estimation``.
+    """
+
+    def forward(  # type: ignore[override]
+        self,
+        pixel_values: torch.Tensor | np.ndarray,
+        dataset_index: torch.Tensor | np.ndarray | None = None,
+        **kwargs: Any,
+    ) -> KeypointDetectionOutput:
+        inputs: dict[str, Any] = {"pixel_values": pixel_values}
+        accepted_inputs = set(self.io_config.get("input_names", []))
+        if dataset_index is not None and "dataset_index" in accepted_inputs:
+            inputs["dataset_index"] = dataset_index
+        for name, value in kwargs.items():
+            if value is not None and name in accepted_inputs:
+                inputs[name] = value
+
+        formatted = self._format_inputs(**inputs)
+        outputs = self._run_inference(formatted)
+
+        heatmaps = outputs.get("heatmaps")
+        if heatmaps is None:
+            heatmaps = next(iter(outputs.values()))
+        return KeypointDetectionOutput(heatmaps=heatmaps)

--- a/tests/unit/inference/test_keypoint_detection_pipeline.py
+++ b/tests/unit/inference/test_keypoint_detection_pipeline.py
@@ -1,0 +1,127 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+"""Unit tests for the keypoint-detection inference adapter."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from winml.modelkit.inference.pipeline import KeypointDetectionPipeline
+
+
+class _Processor:
+    def __init__(self) -> None:
+        self.size = {"height": 256, "width": 192}
+        self.boxes_seen = None
+
+    def preprocess(self, images, boxes, return_tensors="pt"):
+        self.boxes_seen = boxes
+        return {"pixel_values": torch.zeros(len(boxes[0]), 3, 256, 192)}
+
+    def post_process_pose_estimation(self, outputs, boxes):
+        num_persons = outputs.heatmaps.shape[0]
+        poses = [
+            {
+                "keypoints": torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
+                "scores": torch.tensor([0.5, 0.75]),
+            }
+            for _ in range(num_persons)
+        ]
+        return [poses]
+
+
+class _Model:
+    io_config = {"input_shapes": [[1, 3, 384, 288]], "input_names": ["pixel_values"]}
+
+    def __call__(self, pixel_values, **kwargs):
+        return {"heatmaps": torch.zeros(pixel_values.shape[0], 2, 64, 48)}
+
+
+def test_adapter_runs_preprocess_model_and_postprocess() -> None:
+    processor = _Processor()
+    with patch(
+        "transformers.AutoImageProcessor.from_pretrained",
+        return_value=processor,
+    ):
+        pipe = KeypointDetectionPipeline(_Model(), "test/model")
+
+    result = pipe(object(), boxes=[[10, 20, 30, 40]])
+
+    assert processor.size == {"height": 384, "width": 288}
+    assert processor.boxes_seen == [[[10.0, 20.0, 30.0, 40.0]]]
+    assert result == [
+        {
+            "keypoints": [[1.0, 2.0], [3.0, 4.0]],
+            "scores": [0.5, 0.75],
+            "score": 0.625,
+        }
+    ]
+
+
+def test_xyxy_boxes_are_converted_to_xywh() -> None:
+    processor = _Processor()
+    with patch(
+        "transformers.AutoImageProcessor.from_pretrained",
+        return_value=processor,
+    ):
+        pipe = KeypointDetectionPipeline(_Model(), "test/model")
+
+    pipe(object(), boxes=[[10, 20, 40, 70]], box_format="xyxy")
+
+    assert processor.boxes_seen == [[[10.0, 20.0, 30.0, 50.0]]]
+
+
+def test_dataset_index_is_forwarded_when_model_declares_it() -> None:
+    class ModelWithDatasetIndex(_Model):
+        io_config = {
+            "input_shapes": [[1, 3, 256, 192]],
+            "input_names": ["pixel_values", "dataset_index"],
+        }
+
+        def __init__(self) -> None:
+            self.dataset_index = None
+
+        def __call__(self, pixel_values, **kwargs):
+            self.dataset_index = kwargs.get("dataset_index")
+            return super().__call__(pixel_values, **kwargs)
+
+    model = ModelWithDatasetIndex()
+    with patch(
+        "transformers.AutoImageProcessor.from_pretrained",
+        return_value=_Processor(),
+    ):
+        pipe = KeypointDetectionPipeline(model, "test/model")
+
+    pipe(object(), boxes=[[0, 0, 10, 10]], dataset_index=3)
+
+    assert model.dataset_index.tolist() == [3]
+
+
+def test_sanitize_parameters_exposes_kwargs_for_engine_filtering() -> None:
+    processor = _Processor()
+    with patch(
+        "transformers.AutoImageProcessor.from_pretrained",
+        return_value=processor,
+    ):
+        pipe = KeypointDetectionPipeline(_Model(), "test/model")
+
+    _, forward_kwargs, _ = pipe._sanitize_parameters()
+
+    assert set(forward_kwargs) == {"boxes", "box_format", "dataset_index"}
+
+
+def test_empty_boxes_raise_clear_error() -> None:
+    with patch(
+        "transformers.AutoImageProcessor.from_pretrained",
+        return_value=_Processor(),
+    ):
+        pipe = KeypointDetectionPipeline(_Model(), "test/model")
+
+    with pytest.raises(ValueError, match="boxes must be a non-empty list"):
+        pipe(object(), boxes=[])

--- a/tests/unit/inference/test_tasks.py
+++ b/tests/unit/inference/test_tasks.py
@@ -177,3 +177,25 @@ class TestSegmentationRegistry:
 
     def test_semantic_alias(self) -> None:
         assert TASK_REGISTRY["semantic-segmentation"].postprocess is _postprocess_segmentation
+
+
+# ---------------------------------------------------------------------------
+# keypoint-detection registry entry
+# ---------------------------------------------------------------------------
+
+
+class TestKeypointDetectionRegistry:
+    def test_registered_with_image_boxes_and_options(self) -> None:
+        spec = TASK_REGISTRY["keypoint-detection"]
+        names = [f.name for f in spec.user_inputs]
+        assert names == ["image", "boxes", "box_format", "dataset_index"]
+
+    def test_boxes_are_pipeline_kwargs(self) -> None:
+        spec = TASK_REGISTRY["keypoint-detection"]
+        assert spec.mapping.pipe_input == "image"
+        assert spec.mapping.pipe_kwargs == ["boxes", "box_format", "dataset_index"]
+
+    def test_option_defaults(self) -> None:
+        fields = {f.name: f for f in TASK_REGISTRY["keypoint-detection"].user_inputs}
+        assert fields["box_format"].default == "xywh"
+        assert fields["dataset_index"].default == 0

--- a/tests/unit/models/winml/test_keypoint_detection.py
+++ b/tests/unit/models/winml/test_keypoint_detection.py
@@ -1,0 +1,85 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+"""Unit tests for ``WinMLModelForKeypointDetection``."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+
+from winml.modelkit.models.winml import (
+    TASK_TO_WINML_CLASS,
+    KeypointDetectionOutput,
+    WinMLModelForKeypointDetection,
+    get_winml_class,
+)
+
+
+class TestRegistry:
+    def test_task_mapped(self) -> None:
+        assert (
+            TASK_TO_WINML_CLASS["keypoint-detection"]
+            == "WinMLModelForKeypointDetection"
+        )
+
+    def test_get_winml_class_returns_keypoint_detection(self) -> None:
+        cls = get_winml_class(model_type="vitpose", task="keypoint-detection")
+        assert cls is WinMLModelForKeypointDetection
+
+
+def _make_model(
+    onnx_outputs: dict[str, torch.Tensor],
+    input_names: list[str] | None = None,
+) -> WinMLModelForKeypointDetection:
+    model = object.__new__(WinMLModelForKeypointDetection)
+    model._session = SimpleNamespace(io_config={"input_names": input_names or ["pixel_values"]})
+    model._run_inference = lambda formatted: onnx_outputs
+    model.formatted = None
+
+    def _format_inputs(**kw):
+        model.formatted = kw
+        return kw
+
+    model._format_inputs = _format_inputs
+    return model
+
+
+class TestForward:
+    def test_returns_keypoint_detection_output(self) -> None:
+        heatmaps = torch.zeros((1, 17, 64, 48))
+        model = _make_model({"heatmaps": heatmaps})
+
+        out = model.forward(pixel_values=torch.zeros((1, 3, 256, 192)))
+
+        assert isinstance(out, KeypointDetectionOutput)
+        assert out.heatmaps is heatmaps
+        assert out["heatmaps"] is heatmaps
+
+    def test_falls_back_to_first_output_when_name_differs(self) -> None:
+        heatmaps = torch.ones((1, 17, 64, 48))
+        model = _make_model({"unusual_output": heatmaps})
+
+        out = model.forward(pixel_values=torch.zeros((1, 3, 256, 192)))
+
+        assert out.heatmaps is heatmaps
+
+    def test_dataset_index_only_passed_when_declared(self) -> None:
+        heatmaps = torch.zeros((1, 17, 64, 48))
+        dataset_index = torch.tensor([2])
+        model = _make_model({"heatmaps": heatmaps}, ["pixel_values", "dataset_index"])
+
+        model.forward(pixel_values=torch.zeros((1, 3, 256, 192)), dataset_index=dataset_index)
+
+        assert model.formatted["dataset_index"] is dataset_index
+
+    def test_dataset_index_ignored_when_not_declared(self) -> None:
+        heatmaps = torch.zeros((1, 17, 64, 48))
+        model = _make_model({"heatmaps": heatmaps}, ["pixel_values"])
+
+        model.forward(pixel_values=torch.zeros((1, 3, 256, 192)), dataset_index=torch.tensor([2]))
+
+        assert "dataset_index" not in model.formatted


### PR DESCRIPTION
## Summary
- Adds a WinML keypoint-detection inference wrapper for ViTPose-style heatmap outputs.
- Adds a lightweight keypoint-detection pipeline adapter because Transformers does not expose a native keypoint-detection pipeline.
- Registers the task input schema for run/serve with image, person boxes, box format, and ViTPose+ dataset index support.

## Validation and support evidence
- Baseline: current main already contains ViTPose model resolution, recipes, and keypoint evaluation support, but run/serve lacks a keypoint-detection inference path because HF pipeline() has no keypoint-detection task.
- Goal: prove the inference dispatch path is wired without regressing existing keypoint build/eval support.
- Outcome: task-family inference support for keypoint-detection; no recipe index changes.

## Tests
- ..\\..\\.venv\\Scripts\\pytest.exe tests\\unit\\inference\\test_tasks.py tests\\unit\\inference\\test_keypoint_detection_pipeline.py tests\\unit\\models\\winml\\test_keypoint_detection.py tests\\unit\\models\\test_vitpose_mapping.py tests\\unit\\eval\\test_keypoint_detection_evaluator.py -q
- Result: 44 passed, 1 pytest cache warning due local .pytest_cache write permissions.