### PR TITLE
Add recipe for dima806/music_genres_classification

### DIFF
--- a/examples/recipes/dima806_music_genres_classification/cpu/cpu/audio-classification_fp16_config.json
+++ b/examples/recipes/dima806_music_genres_classification/cpu/cpu/audio-classification_fp16_config.json
@@ -1,0 +1,53 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_values",
+        "dtype": "float32",
+        "shape": [1, 16000],
+        "value_range": [-1, 1]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "audio-classification",
+    "model_class": "AutoModelForAudioClassification",
+    "model_type": "wav2vec2"
+  }
+}

--- a/examples/recipes/dima806_music_genres_classification/cpu/cpu/audio-classification_fp32_config.json
+++ b/examples/recipes/dima806_music_genres_classification/cpu/cpu/audio-classification_fp32_config.json
@@ -1,0 +1,34 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_values",
+        "dtype": "float32",
+        "shape": [1, 16000],
+        "value_range": [-1, 1]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "audio-classification",
+    "model_class": "AutoModelForAudioClassification",
+    "model_type": "wav2vec2"
+  }
+}

--- a/src/winml/modelkit/export/htp/exporter.py
+++ b/src/winml/modelkit/export/htp/exporter.py
@@ -546,12 +546,15 @@ class HTPExporter:
         output_path = str(Path(output_path).resolve())
         Path(output_path).parent.mkdir(parents=True, exist_ok=True)
 
-        # Input names from config, fallback to inputs dict keys. Keyword inputs
-        # invoke forward() by name, but the TorchScript exporter assigns these
-        # ONNX names positionally to the traced graph inputs. Align names with
-        # forward() order so a config's tensor order cannot swap graph bindings.
+        # Input names from config, fallback to inputs dict keys.
+        # The TorchScript exporter assigns input_names positionally to graph
+        # inputs emitted in forward() signature order, so we must reorder to
+        # match. The dynamo exporter, however, preserves dict iteration order
+        # (the order inputs were generated), so reordering would mismatch
+        # names with tensors and swap dtype/shape bindings.
         input_names = export_config.get_input_names() or list(inputs.keys())
-        input_names = self._resolve_keyword_input_names(model, inputs, input_names)
+        if not export_config.dynamo:
+            input_names = self._resolve_keyword_input_names(model, inputs, input_names)
 
         # Output names: infer from traced hierarchy, validate against config
         traced_outputs = self._hierarchy_builder.get_outputs() if self._hierarchy_builder else None

--- a/src/winml/modelkit/export/htp/exporter.py
+++ b/src/winml/modelkit/export/htp/exporter.py
@@ -546,15 +546,12 @@ class HTPExporter:
         output_path = str(Path(output_path).resolve())
         Path(output_path).parent.mkdir(parents=True, exist_ok=True)
 
-        # Input names from config, fallback to inputs dict keys.
-        # The TorchScript exporter assigns input_names positionally to graph
-        # inputs emitted in forward() signature order, so we must reorder to
-        # match. The dynamo exporter, however, preserves dict iteration order
-        # (the order inputs were generated), so reordering would mismatch
-        # names with tensors and swap dtype/shape bindings.
+        # Input names from config, fallback to inputs dict keys. Keyword inputs
+        # invoke forward() by name, but the TorchScript exporter assigns these
+        # ONNX names positionally to the traced graph inputs. Align names with
+        # forward() order so a config's tensor order cannot swap graph bindings.
         input_names = export_config.get_input_names() or list(inputs.keys())
-        if not export_config.dynamo:
-            input_names = self._resolve_keyword_input_names(model, inputs, input_names)
+        input_names = self._resolve_keyword_input_names(model, inputs, input_names)
 
         # Output names: infer from traced hierarchy, validate against config
         traced_outputs = self._hierarchy_builder.get_outputs() if self._hierarchy_builder else None


### PR DESCRIPTION
## Summary

Add verified CPU recipe for `dima806/music_genres_classification` (Wav2Vec2 audio classification).

**Highest verified outcome**: L2 numeric parity (cosine similarity ≈ 1.0 for fp32, 0.999983 for fp16).

## Model metadata

| Field | Value |
|-------|-------|
| **What** | Wav2Vec2-base fine-tuned on GTZAN for 10-genre music classification |
| **User stories** | Classify audio waveforms into music genres for content tagging/recommendation |
| **Tasks** | audio-classification |
| **Architecture** | Wav2Vec2ForSequenceClassification (feature extractor + 12-layer encoder + classification head 768→10) |

## Validation and support evidence

**Baseline** (current `main`): Build PASS, Perf PASS (~57ms avg CPU)

**Goal ceiling**: L2 (numeric parity vs PyTorch)

| EP | Device | Precision | L0 (Build) | L1 (Perf) | L2 (Numeric) |
|----|--------|-----------|-----------|-----------|---------------|
| CPU | cpu | fp32 | ✅ 360.9MB | ✅ 57ms avg, 17.5 sps | ✅ cosine=1.000000, max_abs=6e-05 |
| CPU | cpu | fp16 | ✅ 180.5MB | ✅ 69ms avg, 14.6 sps | ✅ cosine=0.999983, max_abs=2.7e-02 |

**L3 (Eval)**: CLI-BLOCKED — `audio-classification` task not in eval registry.

**Delta from auto-config**: `dynamo: false` (matches all peer wav2vec2 recipes; auto-config generates `true`).

### Reproduce

```powershell
$OUT = 'temp/music-genres-repro'

# fp32
uv run winml build -m dima806/music_genres_classification --config examples/recipes/dima806_music_genres_classification/cpu/cpu/audio-classification_fp32_config.json -o $OUT/fp32 --ep cpu --device cpu
uv run winml perf -m $OUT/fp32/model.onnx --ep cpu --device cpu

# fp16
uv run winml build -m dima806/music_genres_classification --config examples/recipes/dima806_music_genres_classification/cpu/cpu/audio-classification_fp16_config.json -o $OUT/fp16 --ep cpu --device cpu --precision fp16
uv run winml perf -m $OUT/fp16/model.onnx --ep cpu --device cpu
```