### PR TITLE
Disable Dynamo by default for export

### DIFF
--- a/docs/commands/export.md
+++ b/docs/commands/export.md
@@ -22,7 +22,7 @@ $ winml export [options]
 | `--output` | `-o` | path | *(required)* | Output ONNX file path (e.g., `model.onnx`). |
 | `--with-report/--no-with-report` | | flag | `false` | Generate full export reports: Markdown, JSON, and a console tree. |
 | `--hierarchy/--no-hierarchy` | | flag | `true` | Preserve `hierarchy_tag` metadata in ONNX nodes (use `--no-hierarchy` for a clean ONNX file). |
-| `--dynamo/--no-dynamo` | | flag | `true` | Use PyTorch's TorchDynamo ONNX exporter (default) for richer per-node module metadata. Pass `--no-dynamo` for the legacy TorchScript exporter, whose opset-17 op decomposition is the validated path for QNN/NPU compilation today. |
+| `--dynamo/--no-dynamo` | | flag | `false` | Use the legacy TorchScript exporter by default, whose opset-17 op decomposition is the validated path for QNN/NPU compilation today. Pass `--dynamo` to use PyTorch's TorchDynamo ONNX exporter for richer per-node module metadata. |
 | `--torch-module` | | string | `None` | Comma-separated list of `torch.nn` module types to include in hierarchy (e.g., `LayerNorm,Embedding`). (Experimental — currently logs a warning.) |
 | `--input-specs` | | path | `None` | JSON file with explicit input tensor specifications. Auto-generated when omitted. |
 | `--task` | `-t` | string | `None` | Override auto-detected Hugging Face task (e.g., `image-feature-extraction`). |
@@ -39,10 +39,10 @@ $ winml export [options]
 eight-step Hierarchy-preserving Tags Protocol (HTP): model preparation, input
 generation, module-hierarchy recovery, ONNX export, node-tagger
 creation, per-node tagging, tag injection into ONNX `metadata_props`, and
-optional report generation. By default the hierarchy is reconstructed from the
-TorchDynamo exporter's per-node module metadata; with `--no-dynamo` it is
-captured by tracing the model's forward pass under the legacy TorchScript
-exporter instead. The hierarchy metadata allows downstream tools to
+optional report generation. By default the hierarchy is captured by tracing the
+model's forward pass under the legacy TorchScript exporter; with `--dynamo` it
+is reconstructed from the TorchDynamo exporter's per-node module metadata.
+The hierarchy metadata allows downstream tools to
 reason about operators grouped by their originating module rather than flat
 graph position. When `--no-hierarchy` is specified, hierarchy steps are bypassed
 and a bare ONNX file is written, useful for third-party tools that do not
@@ -126,9 +126,10 @@ winml export -m microsoft/resnet-50 -o resnet50_clean.onnx --no-hierarchy
 - **Dynamic dimensions can reduce QNN optimization coverage.** Static batch and
   static shapes remain the default because some QNN fusions require them. Use
   `--dynamic-axes` only when downstream runtime scenarios need variable sizes.
-- **Dynamo is the default exporter.** `winml export` uses PyTorch's TorchDynamo
-  ONNX exporter, which records rich per-node module metadata that drives the
-  hierarchy tags. Pass `--no-dynamo` to select the legacy TorchScript exporter.
+- **Dynamo is opt-in.** `winml export` uses the legacy TorchScript exporter by
+  default, whose opset-17 graph is the validated path for QNN/NPU compilation.
+  Pass `--dynamo` to use PyTorch's TorchDynamo ONNX exporter, which records rich
+  per-node module metadata that drives the hierarchy tags.
   Shape staticness is independent of the exporter: both default to static shapes
   and only emit dynamic axes when you ask for them. The QNN-relevant
   difference is opset and op decomposition: torch's dynamo op library is built
@@ -136,14 +137,14 @@ winml export -m microsoft/resnet-50 -o resnet50_clean.onnx --no-hierarchy
   dynamo attempts to down-convert the graph to it; this can succeed (the graph is
   saved at the requested opset) or fail (the graph stays at opset 18). `winml
   export` reports the opset actually produced and warns when it differs from the
-  one you requested, so pass `--no-dynamo` if you need a graph natively at opset
-  17. The TorchScript path always exports at the configured opset (17 by
-  default). Dynamo also
+  one you requested, so keep the default TorchScript path if you need a graph
+  natively at opset 17. The TorchScript path always exports at the configured
+  opset (17 by default). Dynamo also
   lowers some ops differently -- for example ResNet's classification head becomes
   `ReduceMean` + `Reshape` under dynamo but `GlobalAveragePool` + `Flatten` under
-  TorchScript -- which can change or reduce QNN fusion coverage. Prefer
-  `--no-dynamo` for hand exports targeting QNN/NPU compilation until the dynamo
-  graph is validated for your model.
+  TorchScript -- which can change or reduce QNN fusion coverage. Keep the
+  TorchScript default for hand exports targeting QNN/NPU compilation until the
+  Dynamo graph is validated for your model.
 - **`--torch-module` is experimental.** The flag emits a warning and has no
   effect in the current release. Do not rely on it in automated pipelines yet.
 - **Output directory must be writable.** The command creates parent directories

--- a/docs/concepts/load-and-export.md
+++ b/docs/concepts/load-and-export.md
@@ -16,7 +16,7 @@ Some community models host custom Python code in their repositories. The loader 
 
 ## Exporting to ONNX
 
-`winml export` converts the loaded model to ONNX. By default it uses PyTorch's TorchDynamo ONNX exporter (`torch.onnx.export(dynamo=True)`), which records rich per-node module metadata that is used to derive the `winml.hierarchy.*` node tags. Pass `--no-dynamo` to fall back to the legacy TorchScript exporter, which follows actual execution paths and tends to produce compact inference-oriented graphs. Both exporters default to static shapes; the QNN-relevant difference is opset and op decomposition: torch's dynamo op library is built against a minimum opset of 18. When a lower opset is requested (17 by default), dynamo attempts to down-convert to it, which may succeed (the graph is saved at the requested opset) or fail (it stays at opset 18); `winml export` reports the opset actually produced and warns when it differs from the requested value. The TorchScript path always exports at the configured opset (17 by default) and lowers some ops differently (e.g. ResNet's head becomes `ReduceMean` + `Reshape` under dynamo but `GlobalAveragePool` + `Flatten` under TorchScript). Because the opset-17 TorchScript graph is what the QNN/NPU toolchain has been validated against, `--no-dynamo` remains the validated choice for QNN/NPU hand exports today.
+`winml export` converts the loaded model to ONNX. By default it uses the legacy TorchScript exporter (`torch.onnx.export(dynamo=False)`), which follows actual execution paths and tends to produce compact inference-oriented graphs. Pass `--dynamo` to use PyTorch's TorchDynamo ONNX exporter, which records rich per-node module metadata that is used to derive the `winml.hierarchy.*` node tags. Both exporters default to static shapes; the QNN-relevant difference is opset and op decomposition: torch's dynamo op library is built against a minimum opset of 18. When a lower opset is requested (17 by default), dynamo attempts to down-convert to it, which may succeed (the graph is saved at the requested opset) or fail (it stays at opset 18); `winml export` reports the opset actually produced and warns when it differs from the requested value. The TorchScript path always exports at the configured opset (17 by default) and lowers some ops differently (e.g. ResNet's head becomes `ReduceMean` + `Reshape` under dynamo but `GlobalAveragePool` + `Flatten` under TorchScript). The default opset-17 TorchScript graph is the path validated for QNN/NPU hand exports today.
 
 By default the exporter runs an eight-step process that includes hierarchy recovery and tag injection. The result is an ONNX file enriched with structural metadata that powers downstream features such as per-module benchmarking, inspector views, and optimizer scoping.
 
@@ -31,9 +31,9 @@ During export the HTP (Hierarchy-preserving Tags Protocol) exporter attaches two
 
 #### How tags are built
 
-The module path attached to each node is obtained differently depending on the exporter. Under the default TorchDynamo exporter, dynamo records originating-module information as ONNX metadata, and the exporter reconstructs the hierarchy directly from that metadata after export — no forward hooks are involved. Under `--no-dynamo`, the TorchScript path instead registers PyTorch forward hooks on each module: when a module executes, a pre-hook pushes its class name onto a tag stack and the post-hook pops it. Either way the result is hierarchical paths that mirror the PyTorch module tree.
+The module path attached to each node is obtained differently depending on the exporter. Under the default TorchScript exporter, the exporter registers PyTorch forward hooks on each module: when a module executes, a pre-hook pushes its class name onto a tag stack and the post-hook pops it. Under `--dynamo`, Dynamo instead records originating-module information as ONNX metadata, and the exporter reconstructs the hierarchy directly from that metadata after export — no forward hooks are involved. Either way the result is hierarchical paths that mirror the PyTorch module tree.
 
-The hook flow below applies only to the `--no-dynamo` TorchScript path:
+The hook flow below applies to the default TorchScript path:
 
 ```mermaid
 flowchart LR
@@ -44,11 +44,11 @@ flowchart LR
     E --> F[Tag stack → path]
 ```
 
-Under `--no-dynamo`, only modules that are actually executed during tracing receive tags — unused modules are excluded. For example, `prajjwal1/bert-tiny` has 48 registered modules but only 18 are reached during a forward pass. (Under the default dynamo path the hierarchy instead reflects the modules present in the exported graph's metadata.)
+Under the default TorchScript path, only modules that are actually executed during tracing receive tags — unused modules are excluded. For example, `prajjwal1/bert-tiny` has 48 registered modules but only 18 are reached during a forward pass. (Under `--dynamo`, the hierarchy instead reflects the modules present in the exported graph's metadata.)
 
 #### Concrete example: BERT-tiny
 
-Running `winml export -m prajjwal1/bert-tiny -o model.onnx -v --no-dynamo` produces the following hierarchy tree (18 traced modules, 132 ONNX nodes, 100 % coverage) — the numbers below are from the TorchScript trace path:
+Running `winml export -m prajjwal1/bert-tiny -o model.onnx -v` produces the following hierarchy tree (18 traced modules, 132 ONNX nodes, 100 % coverage) — the numbers below are from the default TorchScript trace path:
 
 ```
 BertModel (132 nodes)
@@ -77,7 +77,7 @@ Each ONNX node gets its tag from the module it belongs to. Here are a few exampl
 
 #### Node-to-module mapping
 
-Under the default dynamo path, each node is assigned directly from its `pkg.torch.onnx.name_scopes` and `pkg.torch.onnx.class_hierarchy` metadata; nodes without usable metadata receive the model-root fallback. Under `--no-dynamo`, after the ONNX graph is produced by `torch.onnx.export`, the legacy tagger instead uses a 4-priority system to assign each ONNX node to the closest traced module:
+Under `--dynamo`, each node is assigned directly from its `pkg.torch.onnx.name_scopes` and `pkg.torch.onnx.class_hierarchy` metadata; nodes without usable metadata receive the model-root fallback. Under the default TorchScript path, after the ONNX graph is produced by `torch.onnx.export`, the legacy tagger instead uses a 4-priority system to assign each ONNX node to the closest traced module:
 
 1. **Direct match** (61 %) — the node's scope name maps exactly to a traced module.
 2. **Parent match** (24 %) — walk up the scope hierarchy until a traced module is found.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -54,7 +54,7 @@ stages based on the target device and precision.
 | `export_params` | `bool` | `true` | Include model parameters in ONNX. |
 | `do_constant_folding` | `bool` | `true` | Fold constants during export. |
 | `verbose` | `bool` | `false` | Verbose export logging. |
-| `dynamo` | `bool` | `true` | Use PyTorch's TorchDynamo ONNX exporter (default); set `false` for the legacy TorchScript exporter. |
+| `dynamo` | `bool` | `false` | Use PyTorch's TorchDynamo ONNX exporter; the default `false` selects the legacy TorchScript exporter. |
 | `enable_hierarchy_tags` | `bool` | `true` | Add module hierarchy tags to ONNX nodes. |
 | `clean_onnx` | `bool` | `false` | Strip hierarchy tags after export. |
 | `hierarchy_tag_format` | `"full" \| "module_only"` | `"full"` | Tag detail level. |

--- a/src/winml/modelkit/commands/export.py
+++ b/src/winml/modelkit/commands/export.py
@@ -116,11 +116,11 @@ def _warn_partial_composite(completed: list[Path]) -> None:
 @click.option(
     "--dynamo/--no-dynamo",
     "dynamo",
-    default=True,
+    default=False,
     show_default=True,
-    help="Use PyTorch's TorchDynamo ONNX exporter (default). "
-    "Pass --no-dynamo for the legacy TorchScript exporter, the validated "
-    "path for QNN/NPU compilation today.",
+    help="Use PyTorch's TorchDynamo ONNX exporter. "
+    "Pass --dynamo to opt in; the default TorchScript exporter is the "
+    "validated path for QNN/NPU compilation today.",
 )
 @click.option(
     "--torch-module",
@@ -187,10 +187,10 @@ def export(
     The export process (8 steps):
     1. Model Preparation - Load and configure model
     2. Input Generation - Generate example inputs
-    3. Hierarchy Building - Recover the module hierarchy (from the ONNX metadata
-       under dynamo, or a forward-execution trace with --no-dynamo)
-    4. ONNX Export - Convert to ONNX format (TorchDynamo by default; TorchScript
-       with --no-dynamo)
+    3. Hierarchy Building - Recover the module hierarchy (from a forward-execution
+       trace by default, or from ONNX metadata under --dynamo)
+    4. ONNX Export - Convert to ONNX format (TorchScript by default; TorchDynamo
+       with --dynamo)
     5. Node Tagger Creation - Create tagger from hierarchy
     6. Node Tagging - Apply hierarchy tags to nodes
     7. Tag Injection - Embed tags in ONNX node metadata_props
@@ -210,8 +210,8 @@ def export(
         # Clean ONNX output (no hierarchy metadata, for optimization)
         winml export -m prajjwal1/bert-tiny -o model.onnx --clean-onnx
 
-        # Use the legacy TorchScript exporter (dynamo is the default)
-        winml export -m prajjwal1/bert-tiny -o model.onnx --no-dynamo
+        # Use the TorchDynamo exporter (TorchScript is the default)
+        winml export -m prajjwal1/bert-tiny -o model.onnx --dynamo
 
         # Include torch.nn modules in hierarchy
         winml export -m prajjwal1/bert-tiny -o model.onnx --torch-module LayerNorm,Embedding

--- a/src/winml/modelkit/export/config.py
+++ b/src/winml/modelkit/export/config.py
@@ -177,7 +177,7 @@ class WinMLExportConfig:
     export_params: bool = True
     do_constant_folding: bool = True
     verbose: bool = False
-    dynamo: bool = True  # TorchDynamo exporter by default; False = legacy TorchScript path
+    dynamo: bool = False  # TorchScript exporter by default; True enables TorchDynamo
 
     # Phase 2: Hierarchy Preservation Options
     enable_hierarchy_tags: bool = True  # Enable HTP hierarchy tagging by default
@@ -403,7 +403,7 @@ class WinMLExportConfig:
             export_params=data.get("export_params", True),
             do_constant_folding=data.get("do_constant_folding", True),
             verbose=data.get("verbose", False),
-            dynamo=data.get("dynamo", True),
+            dynamo=data.get("dynamo", False),
             enable_hierarchy_tags=data.get("enable_hierarchy_tags", True),
             clean_onnx=data.get("clean_onnx", False),
             hierarchy_tag_format=data.get("hierarchy_tag_format", "full"),

--- a/tests/e2e/test_export_e2e.py
+++ b/tests/e2e/test_export_e2e.py
@@ -247,21 +247,9 @@ class TestExportHappyPath:
         _assert_all_nodes_have(model, "winml.hierarchy.tag")
         _assert_all_nodes_have(model, "winml.hierarchy.depth")
 
-        # Dynamo is the default exporter, so nodes carry torch's native module
-        # metadata and the hierarchy tags are derived from it — not collapsed to
-        # the model root (the pre-fix regression). Assert both facts generically,
-        # without referencing any architecture-specific names.
-        _assert_some_node_has(model, "pkg.torch.onnx.class_hierarchy")
-        depths = [
-            int(prop.value)
-            for node in model.graph.node
-            for prop in node.metadata_props
-            if prop.key == "winml.hierarchy.depth"
-        ]
-        assert depths and max(depths) >= 2, (
-            "expected dynamo-derived hierarchy tags deeper than the model root; "
-            f"got max depth {max(depths) if depths else 0}"
-        )
+        # TorchScript is the default exporter, so torch's Dynamo-native module
+        # metadata must be absent.
+        _assert_no_node_has(model, "pkg.torch.onnx.class_hierarchy")
 
 
 class TestExportDinoV2:
@@ -351,10 +339,9 @@ class TestExportFlagVariants:
         _assert_some_node_has(model, "pkg.onnxscript.rewriter.rule_name")
 
     def test_no_dynamo_uses_torchscript_hierarchy(self, tmp_path: Path):
-        # Dynamo is the default, so --no-dynamo selects the legacy TorchScript
-        # exporter. It must still populate hierarchy tags (derived from node
-        # names via the module trace) and, unlike dynamo, emit no torch-native
-        # class_hierarchy metadata — proving the two paths stay distinct.
+        # --no-dynamo explicitly selects the default TorchScript path. It must
+        # still populate hierarchy tags (derived from node names via the module
+        # trace) and emit no torch-native class_hierarchy metadata.
         onnx_path = tmp_path / "model.onnx"
         model = _assert_succeeds(_happy_args(onnx_path, "--no-dynamo"), onnx_path)
         _assert_all_nodes_have(model, "winml.hierarchy.tag")

--- a/tests/unit/commands/test_boolean_flag_pairs.py
+++ b/tests/unit/commands/test_boolean_flag_pairs.py
@@ -150,6 +150,7 @@ class TestDefaultValues:
             (compile, "embed", False),
             (eval_cmd, "streaming", False),
             (export, "with_report", False),
+            (export, "dynamo", False),
             (inspect, "hierarchy", False),
             (perf, "rebuild", False),
             (perf, "ignore_cache", False),
@@ -171,7 +172,6 @@ class TestDefaultValues:
             (eval_cmd, "optimize", True),
             (eval_cmd, "analyze", True),
             (export, "hierarchy", True),
-            (export, "dynamo", True),
         ],
     )
     def test_default_value(self, command, param_name: str, expected_default) -> None:

--- a/tests/unit/commands/test_config_value_priority.py
+++ b/tests/unit/commands/test_config_value_priority.py
@@ -855,7 +855,7 @@ class TestExportPriority:
         Guards the same fix as ``enable_hierarchy_tags`` above.
         """
         eff = _run_export([], {"export": {}}, tmp_path)
-        assert eff["dynamo"] is True  # CLI default (dynamo is the default exporter)
+        assert eff["dynamo"] is False  # CLI and shared config default
 
 
 class TestQuantizePriority:

--- a/tests/unit/commands/test_export.py
+++ b/tests/unit/commands/test_export.py
@@ -612,14 +612,14 @@ class TestExportWarnings:
 
         assert "not yet supported" in result.output or "Warning" in result.output
 
-    def test_export_dynamo_enabled_by_default(
+    def test_export_dynamo_disabled_by_default(
         self,
         runner: CliRunner,
         mock_export_onnx: MagicMock,
         mock_load_hf_model: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """Dynamo is the default exporter when neither flag is passed."""
+        """TorchScript is the default exporter when neither flag is passed."""
         from winml.modelkit.commands.export import export
 
         output_path = tmp_path / "model.onnx"
@@ -630,7 +630,7 @@ class TestExportWarnings:
         )
 
         config = mock_export_onnx.call_args.kwargs["export_config"]
-        assert config.dynamo is True
+        assert config.dynamo is False
         assert "not yet supported" not in result.output
 
     def test_export_dynamo_flag_enables_dynamo(

--- a/tests/unit/export/test_config_validation.py
+++ b/tests/unit/export/test_config_validation.py
@@ -331,6 +331,12 @@ class TestOutputTensorSpecRoundtrip:
 class TestWinMLExportConfigRoundtrip:
     """WinMLExportConfig serialization roundtrip."""
 
+    def test_default_disables_dynamo(self):
+        assert WinMLExportConfig().dynamo is False
+
+    def test_empty_dict_disables_dynamo(self):
+        assert WinMLExportConfig.from_dict({}).dynamo is False
+
     def test_defaults_roundtrip(self):
         original = WinMLExportConfig()
         restored = WinMLExportConfig.from_dict(original.to_dict())


### PR DESCRIPTION
## Summary
- default WinML export configuration and CLI behavior to TorchScript (dynamo=False)
- preserve explicit Dynamo opt-in through CLI flags, JSON configuration, and model recipes
- update focused unit/E2E coverage and exporter documentation