### PR TITLE
recipe(mmarco-mMiniLMv2-L12-H384-v1): add CPU text classification configs

### DIFF
--- a/examples/recipes/cross-encoder_mmarco-mMiniLMv2-L12-H384-v1/cpu/cpu/text-classification_fp16_config.json
+++ b/examples/recipes/cross-encoder_mmarco-mMiniLMv2-L12-H384-v1/cpu/cpu/text-classification_fp16_config.json
@@ -1,0 +1,76 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          250002
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "text-classification",
+    "model_id": "cross-encoder/mmarco-mMiniLMv2-L12-H384-v1",
+    "model_type": "xlm-roberta",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "text-classification",
+    "model_class": "AutoModelForSequenceClassification",
+    "model_type": "xlm-roberta"
+  }
+}

--- a/examples/recipes/cross-encoder_mmarco-mMiniLMv2-L12-H384-v1/cpu/cpu/text-classification_fp32_config.json
+++ b/examples/recipes/cross-encoder_mmarco-mMiniLMv2-L12-H384-v1/cpu/cpu/text-classification_fp32_config.json
@@ -1,0 +1,54 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          250002
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "text-classification",
+    "model_class": "AutoModelForSequenceClassification",
+    "model_type": "xlm-roberta"
+  }
+}


### PR DESCRIPTION
## Summary

Adds CPU recipe coverage for `cross-encoder/mmarco-mMiniLMv2-L12-H384-v1`, a multilingual MMARCO cross-encoder reranker exported through WinML's existing XLM-RoBERTa sequence-classification path. This is an L0 recipe-only contribution: current `main` already builds and runs the model, and this PR records verified CPU fp32/fp16 coverage with checked-in recipes.

## Model metadata

**What the model does:** `cross-encoder/mmarco-mMiniLMv2-L12-H384-v1` scores query/passage text pairs for multilingual retrieval reranking. The checkpoint exposes a single-logit `XLMRobertaForSequenceClassification` head, so WinML exports it through `text-classification` even though its semantic use is text ranking.

**Primary user stories:**

| Story | Confidence |
|---|---|
| A user supplies a query and candidate passages to obtain ranking scores for retrieve-and-rerank search. | verified from checkpoint task/model card metadata and config |

**Supported tasks:**

| Task | Surface | Confidence |
|---|---|---|
| `text-ranking` | checkpoint/model-card semantic task | verified |
| `text-classification` | Transformers / Optimum ONNX / WinML export surface | verified |

**Model architecture:**

```text
XLMRobertaForSequenceClassification
├── XLMRobertaModel
│   ├── Embeddings (vocab 250002, hidden 384)
│   └── Encoder stack x12
│       ├── Self-attention (12 heads)
│       └── Feed-forward + GELU + residual/layernorm
└── XLMRobertaClassificationHead -> logits [B, 1]
```

Source/confidence: pinned checkpoint config resolves `model_type: xlm-roberta`, `architectures: [XLMRobertaForSequenceClassification]`, hidden size 384, 12 layers, 12 attention heads, and one output label.

## Validation and support evidence

### Baseline

Baseline was run from current `origin/main` at `2c378c7dc213e0a69afec87d3d7c5015eb4e570d` with `winml, version 0.2.0`.

| Probe | Result |
|---|---|
| `winml inspect` | PASS: loader `AutoModelForSequenceClassification`, exporter `XLMRobertaIOConfig`, WinML class `WinMLModelForSequenceClassification`; inputs `input_ids` and `attention_mask` int32 `[1, 512]`; output `logits`. |
| Optimum coverage | VENDOR-ONLY for `xlm-roberta`: vendor tasks include `text-classification`; WinML adds no extra task override. |
| Recipe-free build | PASS: build complete in 49.1s; final artifact emitted; 686 exported ONNX nodes, optimized to 444 nodes in the no-analyze baseline build. |
| Recipe-free perf | PASS on CPU fp32: avg 43.06 ms, p50 40.80 ms, throughput 23.22 samples/sec, RAM total +177.4 MB. |
| L2 compare | PASS on CPU fp32: cosine mean 1.0, max absolute diff max `1.71661376953125e-05`. |
| L3 task metric | BLOCKED: default `text-classification` eval uses GLUE/MRPC label alignment and fails on label `equivalent`; this checkpoint is a single-score reranker, not a MRPC class-label model. |

Baseline `winml config` is the source for the checked-in recipe shape, task, loader, and optimization defaults.

### Goal

Effort: L0. Goal ceiling: L2. Outcome: L0 recipe-only.

Success means the checked-in CPU fp32/fp16 recipes build structurally valid ONNX artifacts, run `winml perf` on CPU, and match the PyTorch reference numerically through WinML compare mode. L3 is explicitly blocked by dataset/task semantics for this reranking checkpoint.

### Outcome

Highest verified goal: L2 PASS on CPU for both fp32 and fp16. Coverage is full for the targeted EP set (`cpu/cpu/fp32`, `cpu/cpu/fp16`); no accelerator tuples are claimed.

Shipped recipes:

| Recipe |
|---|
| `examples/recipes/cross-encoder_mmarco-mMiniLMv2-L12-H384-v1/cpu/cpu/text-classification_fp32_config.json` |
| `examples/recipes/cross-encoder_mmarco-mMiniLMv2-L12-H384-v1/cpu/cpu/text-classification_fp16_config.json` |

Methodology friction observed: none. Model finding: XLM-RoBERTa single-logit cross-encoder rerankers export cleanly through `text-classification`; task-metric eval needs a text-ranking dataset/metric rather than the default GLUE/MRPC text-classification path.

### Per-EP/device/precision results

| Tier | EP / Device | Precision | Verdict | Evidence |
|---|---|---:|---|---|
| L0 build | CPUExecutionProvider / cpu | fp32 | PASS | Recipe build complete in 61.9s; optimized model is loadable with inputs `input_ids`, `attention_mask` int32 `[1, 512]`, output `logits [1, 1]`, 396 nodes, external data colocated with `model.onnx`. |
| L0 build | CPUExecutionProvider / cpu | fp16 | PASS | Recipe build complete in 55.1s with `--precision fp16`; final artifact is about 235.8 MB and reports fp16 at perf time, with 397 nodes. |
| L1 perf | CPUExecutionProvider / cpu | fp32 | PASS | Avg 540.46 ms, p50 553.04 ms, throughput 1.85 samples/sec, RAM total +173.6 MB. |
| L1 perf | CPUExecutionProvider / cpu | fp16 | PASS | Avg 667.73 ms, p50 730.24 ms, throughput 1.50 samples/sec, RAM total +193.9 MB. |
| L2 compare | CPUExecutionProvider / cpu | fp32 | PASS | `winml eval --mode compare`: cosine mean 1.0, max absolute diff max `1.71661376953125e-05`, SQNR mean 114.598 dB. |
| L2 compare | CPUExecutionProvider / cpu | fp16 | PASS | `winml eval --mode compare`: cosine mean 1.0, max absolute diff max `0.013412952423095703`, SQNR mean 58.651 dB. |
| L3 eval | CPUExecutionProvider / cpu | fp32 | CLI-BLOCKED | Default `text-classification` eval dataset `nyu-mll/glue`/`mrpc` fails label alignment for label `equivalent`; checkpoint emits a single reranking score. |
| L3 eval | CPUExecutionProvider / cpu | fp16 | CLI-BLOCKED | Same label-alignment blocker as fp32; no task-metric value is reported. |

### Delta

Both recipes are generated from current `winml config` output for this checkpoint. The fp32 recipe is identical to auto-config for loader/export/optim fields. The fp16 recipe is identical to `winml config -p fp16`, preserving the generated fp16 quantization block and model metadata. No source code or tests are changed, and `examples/recipes/README.md` is untouched.

Reducibility: recipe-only is appropriate because auto-config already resolves task, loader, exporter, and WinML inference class correctly; this PR is a per-checkpoint verified CPU coverage declaration rather than a class-wide code fix.

### Analyze summary

Static rule analysis completed with partial-success exit semantics: QNN/OpenVINO rows were complete, while VitisAI has no rule data and is all-unknown. This is compatibility analysis, not runtime execution.

**Component-level summary**

| Artifact | Architecture coverage | Mapping | Actionable EP findings |
|---|---|---|---|
| fp32 | embeddings; 12x encoder attention/FFN; sequence-classification head | 686 exported nodes tagged during HTP export; 396 optimized ONNX ops analyzed | QNN/OpenVINO NPU: all analyzed op types supported; VitisAI: no rule data. |
| fp16 | embeddings; 12x encoder attention/FFN; sequence-classification head | 686 exported nodes tagged during HTP export; 397 optimized ONNX ops analyzed | QNN/OpenVINO NPU: one fp16 `Cast` op unknown, no unsupported ops; VitisAI: no rule data. |

**Op-level summary**

| Artifact | Graph | Dominant ops | EP roll-up |
|---|---|---|---|
| fp32 | 396 ops / 19 types | Reshape 120; Gemm 74; Transpose 48; Add 39; LayerNormalization 25; Mul 25; MatMul 24 | QNN/OpenVINO: 396 supported, 0 partial, 0 unsupported, 0 unknown; VitisAI: 396 unknown. |
| fp16 | 397 ops / 19 types | Reshape 120; Gemm 74; Transpose 48; Add 39; LayerNormalization 25; Mul 25; MatMul 24 | QNN/OpenVINO: 396 supported, 0 partial, 0 unsupported, 1 unknown (`Cast`); VitisAI: 397 unknown. |

### Reproduce commands

```powershell
$MODEL = "cross-encoder/mmarco-mMiniLMv2-L12-H384-v1"
$OUT = "temp/repro_cross_encoder_mmarco_mMiniLMv2_L12_H384_v1"

uv run winml inspect -m $MODEL --format json
uv run winml build -c examples/recipes/cross-encoder_mmarco-mMiniLMv2-L12-H384-v1/cpu/cpu/text-classification_fp32_config.json -m $MODEL -o "$OUT/fp32" --ep cpu --device cpu --no-compile --rebuild
uv run winml build -c examples/recipes/cross-encoder_mmarco-mMiniLMv2-L12-H384-v1/cpu/cpu/text-classification_fp16_config.json -m $MODEL -o "$OUT/fp16" --ep cpu --device cpu --precision fp16 --no-compile --rebuild
uv run winml perf -m "$OUT/fp32/model.onnx" --ep cpu --device cpu
uv run winml perf -m "$OUT/fp16/model.onnx" --ep cpu --device cpu
uv run winml eval -m "$OUT/fp32/model.onnx" --model-id $MODEL --task text-classification --mode compare --ep cpu --device cpu --samples 20
uv run winml eval -m "$OUT/fp16/model.onnx" --model-id $MODEL --task text-classification --mode compare --ep cpu --device cpu --samples 20
uv run winml analyze --model "$OUT/fp32/model.onnx" --ep all --output "$OUT/fp32/analyze_all.json"
uv run winml analyze --model "$OUT/fp16/model.onnx" --ep all --output "$OUT/fp16/analyze_all.json"
```
