### PR TITLE
recipe(nli-MiniLM2-L6-H768): add CPU text classification configs

### DIFF
--- a/examples/recipes/cross-encoder_nli-MiniLM2-L6-H768/cpu/cpu/text-classification_fp16_config.json
+++ b/examples/recipes/cross-encoder_nli-MiniLM2-L6-H768/cpu/cpu/text-classification_fp16_config.json
@@ -1,0 +1,76 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          50265
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "text-classification",
+    "model_id": "cross-encoder/nli-MiniLM2-L6-H768",
+    "model_type": "roberta",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "text-classification",
+    "model_class": "AutoModelForSequenceClassification",
+    "model_type": "roberta"
+  }
+}

--- a/examples/recipes/cross-encoder_nli-MiniLM2-L6-H768/cpu/cpu/text-classification_fp32_config.json
+++ b/examples/recipes/cross-encoder_nli-MiniLM2-L6-H768/cpu/cpu/text-classification_fp32_config.json
@@ -1,0 +1,54 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          50265
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "text-classification",
+    "model_class": "AutoModelForSequenceClassification",
+    "model_type": "roberta"
+  }
+}


### PR DESCRIPTION
## Summary

Adds CPU recipe coverage for `cross-encoder/nli-MiniLM2-L6-H768`, an NLI cross-encoder exported through WinML's existing RoBERTa sequence-classification path. This is an L0 recipe-only contribution: current `main` already builds and runs the model, and this PR records verified CPU fp32/fp16 coverage with checked-in recipes.

## Model metadata

**What the model does:** `cross-encoder/nli-MiniLM2-L6-H768` classifies sentence pairs into NLI labels (`contradiction`, `entailment`, `neutral`). WinML resolves it as `text-classification` with `RobertaForSequenceClassification`.

**Primary user stories:**

| Story | Confidence |
|---|---|
| A user supplies a premise/hypothesis pair to obtain NLI logits for entailment-style classification. | verified from checkpoint config labels and architecture |

**Supported tasks:**

| Task | Surface | Confidence |
|---|---|---|
| `text-classification` | Transformers / Optimum ONNX / WinML export surface | verified |
| NLI / sentence-pair classification | checkpoint label semantics | verified |

**Model architecture:**

```text
RobertaForSequenceClassification
├── RobertaModel
│   ├── Embeddings (vocab 50265, hidden 768)
│   └── Encoder stack x6
│       ├── Self-attention (12 heads)
│       └── Feed-forward + GELU + residual/layernorm
└── RobertaClassificationHead -> logits [B, 3]
```

Source/confidence: pinned checkpoint config resolves `model_type: roberta`, `architectures: [RobertaForSequenceClassification]`, hidden size 768, 6 layers, 12 attention heads, and 3 NLI labels.

## Validation and support evidence

### Baseline

Baseline was run from current `origin/main` at `2c378c7dc213e0a69afec87d3d7c5015eb4e570d` with `winml, version 0.2.0`.

| Probe | Result |
|---|---|
| `winml inspect` | PASS: loader `AutoModelForSequenceClassification`, exporter `RobertaIOConfig`, WinML class `WinMLModelForSequenceClassification`; inputs `input_ids` and `attention_mask` int32 `[1, 512]`; output `logits`. |
| Optimum coverage | VENDOR-ONLY for `roberta`: vendor tasks include `text-classification`; WinML adds no extra task override. |
| Recipe-free build | PASS: build complete in 27.9s; final artifact emitted; 368 exported ONNX nodes. |
| Recipe-free perf | PASS on CPU fp32: avg 167.59 ms, p50 189.91 ms, throughput 5.97 samples/sec, RAM total +282.3 MB. |
| L2 compare | PASS on CPU fp32: cosine mean `0.9999999999995716`, max absolute diff max `2.2649765014648438e-06`. |
| L3 task metric | BLOCKED: default `text-classification` eval uses GLUE/MRPC labels and fails label alignment for label `equivalent`; this checkpoint's labels are `contradiction`, `entailment`, and `neutral`. |

Baseline `winml config -p fp32 --ep cpu --device cpu` and `winml config -p fp16 --ep cpu --device cpu` are the sources for the checked-in recipes.

### Goal

Effort: L0. Goal ceiling: L2. Outcome: L0 recipe-only.

Success means the checked-in CPU fp32/fp16 recipes build structurally valid ONNX artifacts, run `winml perf` on CPU, and match the PyTorch reference numerically through WinML compare mode. L3 is explicitly blocked by default dataset label semantics for this NLI checkpoint.

### Outcome

Highest verified goal: L2 PASS on CPU for both fp32 and fp16. Coverage is full for the targeted EP set (`cpu/cpu/fp32`, `cpu/cpu/fp16`); no accelerator tuples are claimed.

Shipped recipes:

| Recipe |
|---|
| `examples/recipes/cross-encoder_nli-MiniLM2-L6-H768/cpu/cpu/text-classification_fp32_config.json` |
| `examples/recipes/cross-encoder_nli-MiniLM2-L6-H768/cpu/cpu/text-classification_fp16_config.json` |

Methodology friction observed: none. Model finding: RoBERTa NLI cross-encoders export cleanly through `text-classification`; default MRPC eval is not semantically compatible without an NLI-specific dataset/label mapping.

### Per-EP/device/precision results

| Tier | EP / Device | Precision | Verdict | Evidence |
|---|---|---:|---|---|
| L0 build | CPUExecutionProvider / cpu | fp32 | PASS | Recipe build complete in 22.0s; optimized model is loadable with inputs `input_ids`, `attention_mask` int32 `[1, 512]`, output `logits [1, 3]`, 210 nodes, external data colocated with `model.onnx`. |
| L0 build | CPUExecutionProvider / cpu | fp16 | PASS | Recipe build complete in 25.3s with `--precision fp16`; final artifact is about 165.1 MB and reports fp16 at perf time, with 211 nodes. |
| L1 perf | CPUExecutionProvider / cpu | fp32 | PASS | Avg 538.38 ms, p50 528.47 ms, throughput 1.86 samples/sec, RAM total +277.7 MB. |
| L1 perf | CPUExecutionProvider / cpu | fp16 | PASS | Avg 587.20 ms, p50 669.09 ms, throughput 1.70 samples/sec, RAM total +296.9 MB. |
| L2 compare | CPUExecutionProvider / cpu | fp32 | PASS | `winml eval --mode compare`: cosine mean `0.9999999999995716`, max absolute diff max `2.2649765014648438e-06`, SQNR mean 117.705 dB. |
| L2 compare | CPUExecutionProvider / cpu | fp16 | PASS | `winml eval --mode compare`: cosine mean `0.9999997277161565`, max absolute diff max `0.0017644912004470825`, SQNR mean 63.299 dB. |
| L3 eval | CPUExecutionProvider / cpu | fp32 | CLI-BLOCKED | Default `text-classification` eval dataset `nyu-mll/glue`/`mrpc` fails label alignment for label `equivalent`; checkpoint labels are NLI labels. |
| L3 eval | CPUExecutionProvider / cpu | fp16 | CLI-BLOCKED | Same label-alignment blocker as fp32; no task-metric value is reported. |

### Delta

Both recipes are generated from current `winml config` output with explicit CPU targeting. The fp32 recipe preserves `quant: null`; the fp16 recipe preserves the generated fp16 quantization block and model metadata. No source code or tests are changed, and `examples/recipes/README.md` is untouched.

Reducibility: recipe-only is appropriate because auto-config already resolves task, loader, exporter, and WinML inference class correctly; this PR is a per-checkpoint verified CPU coverage declaration rather than a class-wide code fix.

### Analyze summary

Static rule analysis completed with partial-success exit semantics: QNN/OpenVINO rows were complete, while VitisAI has no rule data and is all-unknown. This is compatibility analysis, not runtime execution.

**Component-level summary**

| Artifact | Architecture coverage | Mapping | Actionable EP findings |
|---|---|---|---|
| fp32 | embeddings; 6x encoder attention/FFN; sequence-classification head | 368 exported nodes tagged during HTP export; 210 optimized ONNX ops analyzed | QNN/OpenVINO NPU: all analyzed op types supported; VitisAI: no rule data. |
| fp16 | embeddings; 6x encoder attention/FFN; sequence-classification head | 368 exported nodes tagged during HTP export; 211 optimized ONNX ops analyzed | QNN/OpenVINO NPU: all analyzed op types supported; VitisAI: no rule data. |

**Op-level summary**

| Artifact | Graph | Dominant ops | EP roll-up |
|---|---|---|---|
| fp32 | 210 ops / 19 types | Reshape 60; Gemm 38; Transpose 24; Add 21; LayerNormalization 13; Mul 13; MatMul 12 | QNN/OpenVINO: 210 supported, 0 partial, 0 unsupported, 0 unknown; VitisAI: 210 unknown. |
| fp16 | 211 ops / 19 types | Reshape 60; Gemm 38; Transpose 24; Add 21; LayerNormalization 13; Mul 13; MatMul 12 | QNN/OpenVINO: 211 supported, 0 partial, 0 unsupported, 0 unknown; VitisAI: 211 unknown. |

### Reproduce commands

```powershell
$MODEL = "cross-encoder/nli-MiniLM2-L6-H768"
$OUT = "temp/repro_cross_encoder_nli_MiniLM2_L6_H768"

uv run winml inspect -m $MODEL --format json
uv run winml build -c examples/recipes/cross-encoder_nli-MiniLM2-L6-H768/cpu/cpu/text-classification_fp32_config.json -m $MODEL -o "$OUT/fp32" --ep cpu --device cpu --no-compile --rebuild
uv run winml build -c examples/recipes/cross-encoder_nli-MiniLM2-L6-H768/cpu/cpu/text-classification_fp16_config.json -m $MODEL -o "$OUT/fp16" --ep cpu --device cpu --precision fp16 --no-compile --rebuild
uv run winml perf -m "$OUT/fp32/model.onnx" --ep cpu --device cpu
uv run winml perf -m "$OUT/fp16/model.onnx" --ep cpu --device cpu
uv run winml eval -m "$OUT/fp32/model.onnx" --model-id $MODEL --task text-classification --mode compare --ep cpu --device cpu --samples 20
uv run winml eval -m "$OUT/fp16/model.onnx" --model-id $MODEL --task text-classification --mode compare --ep cpu --device cpu --samples 20
uv run winml analyze --model "$OUT/fp32/model.onnx" --ep all --output "$OUT/fp32/analyze_all.json"
uv run winml analyze --model "$OUT/fp16/model.onnx" --ep all --output "$OUT/fp16/analyze_all.json"
```
