### PR TITLE
recipe(wav2vec2-deepfake-audio): add CPU audio classification configs

### DIFF
--- a/examples/recipes/Gustking_wav2vec2-large-xlsr-deepfake-audio-classification/cpu/cpu/audio-classification_fp16_config.json
+++ b/examples/recipes/Gustking_wav2vec2-large-xlsr-deepfake-audio-classification/cpu/cpu/audio-classification_fp16_config.json
@@ -1,0 +1,62 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          16000
+        ],
+        "value_range": [
+          -1,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "audio-classification",
+    "model_id": "Gustking/wav2vec2-large-xlsr-deepfake-audio-classification",
+    "model_type": "wav2vec2",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "audio-classification",
+    "model_class": "AutoModelForAudioClassification",
+    "model_type": "wav2vec2"
+  }
+}

--- a/examples/recipes/Gustking_wav2vec2-large-xlsr-deepfake-audio-classification/cpu/cpu/audio-classification_fp32_config.json
+++ b/examples/recipes/Gustking_wav2vec2-large-xlsr-deepfake-audio-classification/cpu/cpu/audio-classification_fp32_config.json
@@ -1,0 +1,40 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          16000
+        ],
+        "value_range": [
+          -1,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "audio-classification",
+    "model_class": "AutoModelForAudioClassification",
+    "model_type": "wav2vec2"
+  }
+}


### PR DESCRIPTION
## Summary

Adds CPU recipe coverage for `Gustking/wav2vec2-large-xlsr-deepfake-audio-classification`, a Wav2Vec2 audio classifier for real/fake speech detection. This is an L0 recipe-only contribution: current `main` already resolves the model through Optimum's Wav2Vec2 audio-classification path, and this PR records verified CPU fp32/fp16 coverage with checked-in recipes.

## Model metadata

**What the model does:** `Gustking/wav2vec2-large-xlsr-deepfake-audio-classification` classifies audio waveforms into `real` and `fake` labels. WinML exports it as `audio-classification` with `Wav2Vec2ForSequenceClassification`.

**Primary user stories:**

| Story | Confidence |
|---|---|
| A user supplies a 16 kHz audio waveform to obtain real/fake logits for deepfake-audio detection. | verified from checkpoint config labels, feature extractor metadata, and architecture |

**Supported tasks:**

| Task | Surface | Confidence |
|---|---|---|
| `audio-classification` | Transformers / Optimum ONNX / WinML export surface | verified |

**Model architecture:**

```text
Wav2Vec2ForSequenceClassification
├── Wav2Vec2Model
│   ├── convolutional feature encoder over waveform samples
│   ├── feature projection (hidden 1024)
│   └── encoder stack x24
│       ├── self-attention (16 heads)
│       └── feed-forward + GELU + residual/layernorm
└── sequence-classification head -> logits [B, 2] (`real`, `fake`)
```

Source/confidence: pinned checkpoint config resolves `model_type: wav2vec2`, `architectures: [Wav2Vec2ForSequenceClassification]`, hidden size 1024, 24 layers, 16 attention heads, 2 labels, and `Wav2Vec2FeatureExtractor`.

## Validation and support evidence

### Baseline

Baseline was run from current `origin/main` at `ace130f20e36df44ebf7de6cf0356235c8ee79fd` with `winml, version 0.2.0`.

| Probe | Result |
|---|---|
| `winml inspect` | PASS: loader `AutoModelForAudioClassification`, exporter `Wav2Vec2OnnxConfig`, WinML class `WinMLModelForGenericTask`; input `input_values [1,16000] float32`; output `logits`. |
| Optimum coverage | VENDOR-ONLY for `wav2vec2`: vendor ONNX tasks include `audio-classification`; WinML adds no extra task override. |
| Recipe-free build | PASS: build complete in 81.2s; model loaded as `Wav2Vec2ForSequenceClassification` with 409 modules and 315.7M parameters; export tagged 1144/1144 nodes; final artifact emitted. |
| Recipe-free perf | PASS on CPU fp32: avg 53.87 ms, p50 53.97 ms, throughput 18.56 samples/sec, RAM total +1267.2 MB. |
| L3 task metric | CLI-BLOCKED: `winml eval --schema --task audio-classification` reports the task is not supported by the eval registry, so no task metric is available through the CLI today. |

Baseline `winml config -p fp32 --ep cpu --device cpu` and `winml config -p fp16 --ep cpu --device cpu` are the sources for the checked-in recipes.

### Goal

Effort: L0. Goal ceiling: L2. Outcome: L0 recipe-only.

Success means the checked-in CPU fp32/fp16 recipes build structurally valid ONNX artifacts, run `winml perf` on CPU, and match the PyTorch reference numerically with the same waveform input. L3 is explicitly blocked by the missing `audio-classification` eval task.

### Outcome

Highest verified goal: L2 PASS on CPU for both fp32 and fp16. Coverage is full for the targeted EP set (`cpu/cpu/fp32`, `cpu/cpu/fp16`); no accelerator tuples are claimed.

Shipped recipes:

| Recipe |
|---|
| `examples/recipes/Gustking_wav2vec2-large-xlsr-deepfake-audio-classification/cpu/cpu/audio-classification_fp32_config.json` |
| `examples/recipes/Gustking_wav2vec2-large-xlsr-deepfake-audio-classification/cpu/cpu/audio-classification_fp16_config.json` |

Methodology friction observed: none. Model finding: large Wav2Vec2 sequence classifiers export cleanly through existing `audio-classification`; task-metric eval remains CLI-blocked until WinML adds audio-classification evaluation support.

### Per-EP/device/precision results

| Tier | EP / Device | Precision | Verdict | Evidence |
|---|---|---:|---|---|
| L0 build | CPUExecutionProvider / cpu | fp32 | PASS | Recipe build complete in 64.1s; optimized model is loadable with input `input_values [1,16000] float32`, output `logits [1,2]`, 897 nodes, FLOAT initializers, and 1204.3 MB external data colocated with `model.onnx`. |
| L0 build | CPUExecutionProvider / cpu | fp16 | PASS | Recipe build complete in 77.8s with `--precision fp16`; fp16 stage complete in 13.1s; optimized model is loadable with 899 nodes, FLOAT16 initializers, and 602.2 MB external data. |
| L1 perf | CPUExecutionProvider / cpu | fp32 | PASS | Avg 55.87 ms, p50 56.70 ms, throughput 17.90 samples/sec, RAM total +1267.4 MB. |
| L1 perf | CPUExecutionProvider / cpu | fp16 | PASS | Avg 75.01 ms, p50 73.46 ms, throughput 13.33 samples/sec, RAM total +1276.0 MB; perf reports model precision fp16. |
| L2 compare | CPUExecutionProvider / cpu | fp32 | PASS | PyTorch vs ONNX logits on the same deterministic waveform: cosine 1.0, max absolute diff `1.6391277313232422e-06`. |
| L2 compare | CPUExecutionProvider / cpu | fp16 | PASS | PyTorch vs ONNX logits on the same deterministic waveform: cosine 1.0, max absolute diff `0.0008488893508911133`. |
| L3 eval | CPUExecutionProvider / cpu | fp32 | CLI-BLOCKED | `winml eval --schema --task audio-classification` reports unsupported task; supported task list does not include `audio-classification`. |
| L3 eval | CPUExecutionProvider / cpu | fp16 | CLI-BLOCKED | Same unsupported-task blocker as fp32; no task-metric value is reported. |

### Delta

Both recipes are generated from current `winml config` output with explicit CPU targeting. The fp32 recipe preserves `quant: null`; the fp16 recipe preserves the generated fp16 quantization block and model metadata. No source code or tests are changed, and `examples/recipes/README.md` is untouched.

Reducibility: recipe-only is appropriate because auto-config already resolves task, loader, exporter, and WinML inference class correctly; this PR is a per-checkpoint verified CPU coverage declaration rather than a class-wide code fix.

### Analyze summary

Static rule analysis completed with partial-success exit semantics: QNN/OpenVINO rows were complete, while VitisAI has no rule data and is all-unknown. This is compatibility analysis, not runtime execution.

**Component-level summary**

| Artifact | Architecture coverage | Mapping | Actionable EP findings |
|---|---|---|---|
| fp32 | convolutional feature encoder; 24x Wav2Vec2 encoder attention/FFN; sequence-classification head | 1144 exported nodes tagged during HTP export; 897 optimized ONNX ops analyzed | QNN NPU partial: GELU-related `Div`, `Erf`, `Add`, `Mul`; OpenVINO NPU fully supported; VitisAI: no rule data. |
| fp16 | convolutional feature encoder; 24x Wav2Vec2 encoder attention/FFN; sequence-classification head | 1144 exported nodes tagged during HTP export; 899 optimized ONNX ops analyzed | QNN NPU partial: GELU-related `Div`, `Erf`, `Add`, `Mul`; OpenVINO NPU fully supported; VitisAI: no rule data. |

**Op-level summary**

| Artifact | Graph | Dominant ops | EP roll-up |
|---|---|---|---|
| fp32 | 897 ops / 14 types | Add 227; MatMul 194; Mul 112; Transpose 111; Reshape 96; LayerNormalization 57; Div 32; Erf 32 | QNN: 865 supported, 32 partial, 0 unsupported, 0 unknown. OpenVINO: 897 supported. VitisAI: 897 unknown. |
| fp16 | 899 ops / 15 types | Add 227; MatMul 194; Mul 112; Transpose 111; Reshape 96; LayerNormalization 57; Div 32; Erf 32 | QNN: 867 supported, 32 partial, 0 unsupported, 0 unknown. OpenVINO: 899 supported. VitisAI: 899 unknown. |

### Reproduce commands

```powershell
$MODEL = "Gustking/wav2vec2-large-xlsr-deepfake-audio-classification"
$OUT = "temp/repro_Gustking_wav2vec2_large_xlsr_deepfake_audio_classification"

uv run winml inspect -m $MODEL --format json
uv run winml config -m $MODEL -p fp32 --ep cpu --device cpu -o "$OUT/config_fp32.json"
uv run winml config -m $MODEL -p fp16 --ep cpu --device cpu -o "$OUT/config_fp16.json"
uv run winml build -c examples/recipes/Gustking_wav2vec2-large-xlsr-deepfake-audio-classification/cpu/cpu/audio-classification_fp32_config.json -m $MODEL -o "$OUT/fp32" --ep cpu --device cpu --no-analyze --no-compile --rebuild
uv run winml build -c examples/recipes/Gustking_wav2vec2-large-xlsr-deepfake-audio-classification/cpu/cpu/audio-classification_fp16_config.json -m $MODEL -o "$OUT/fp16" --ep cpu --device cpu --precision fp16 --no-analyze --no-compile --rebuild
uv run winml perf -m "$OUT/fp32/model.onnx" --ep cpu --device cpu --iterations 3 --warmup 1
uv run winml perf -m "$OUT/fp16/model.onnx" --ep cpu --device cpu --iterations 3 --warmup 1
uv run winml eval --schema --task audio-classification
uv run winml analyze --model "$OUT/fp32/model.onnx" --ep all --output "$OUT/fp32/analyze_all.json"
uv run winml analyze --model "$OUT/fp16/model.onnx" --ep all --output "$OUT/fp16/analyze_all.json"
```
