### PR TITLE
support(transformer): add DigitalEdu tabular recipe

### DIFF
--- a/examples/recipes/SnowFlash383935_DigitalEduTransformers/cpu/cpu/tabular-classification_fp16_config.json
+++ b/examples/recipes/SnowFlash383935_DigitalEduTransformers/cpu/cpu/tabular-classification_fp16_config.json
@@ -1,0 +1,30 @@
+{
+  "loader": {
+    "model_type": "transformer",
+    "model_class": "TabularTransformerWrapper",
+    "task": "tabular-classification",
+    "trust_remote_code": true
+  },
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "input_tensors": [
+      {
+        "name": "features",
+        "dtype": "float32",
+        "shape": [1, 7],
+        "value_range": [0, 1000]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "fp16"
+  },
+  "compile": null
+}

--- a/examples/recipes/SnowFlash383935_DigitalEduTransformers/cpu/cpu/tabular-classification_fp32_config.json
+++ b/examples/recipes/SnowFlash383935_DigitalEduTransformers/cpu/cpu/tabular-classification_fp32_config.json
@@ -1,0 +1,28 @@
+{
+  "loader": {
+    "model_type": "transformer",
+    "model_class": "TabularTransformerWrapper",
+    "task": "tabular-classification",
+    "trust_remote_code": true
+  },
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "input_tensors": [
+      {
+        "name": "features",
+        "dtype": "float32",
+        "shape": [1, 7],
+        "value_range": [0, 1000]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null
+}

--- a/src/winml/modelkit/eval/__init__.py
+++ b/src/winml/modelkit/eval/__init__.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
     from .metrics.top_k_accuracy import TopKAccuracyMetric
     from .object_detection_evaluator import WinMLObjectDetectionEvaluator
     from .question_answering_evaluator import WinMLQuestionAnsweringEvaluator
+    from .tabular_classification_evaluator import WinMLTabularClassificationEvaluator
     from .tensor_similarity_evaluator import TensorSimilarityEvaluator
     from .text_classification_evaluator import WinMLTextClassificationEvaluator
     from .text_generation_evaluator import WinMLTextGenerationEvaluator
@@ -80,6 +81,9 @@ _LAZY_ATTRS: dict[str, str] = {
         ".zero_shot_image_classification_evaluator:WinMLZeroShotImageClassificationEvaluator"
     ),
     "TensorSimilarityEvaluator": ".tensor_similarity_evaluator:TensorSimilarityEvaluator",
+    "WinMLTabularClassificationEvaluator": (
+        ".tabular_classification_evaluator:WinMLTabularClassificationEvaluator"
+    ),
     # Metrics (defer numpy / scipy / torch / torchmetrics until first use)
     "ClassificationMetric": ".metrics.classification:ClassificationMetric",
     "DepthMetric": ".metrics.depth:DepthMetric",
@@ -137,6 +141,7 @@ __all__ = [
     "WinMLKeypointDetectionEvaluator",
     "WinMLObjectDetectionEvaluator",
     "WinMLQuestionAnsweringEvaluator",
+    "WinMLTabularClassificationEvaluator",
     "WinMLTextClassificationEvaluator",
     "WinMLTextGenerationEvaluator",
     "WinMLTokenClassificationEvaluator",

--- a/src/winml/modelkit/eval/evaluate.py
+++ b/src/winml/modelkit/eval/evaluate.py
@@ -450,6 +450,7 @@ def _load_model(
             device=config.device,
             ep=config.ep,
             precision=config.precision,
+            trust_remote_code=config.trust_remote_code,
             allow_unsupported_nodes=config.allow_unsupported_nodes,
             config=build_override,
             shape_config=config.shape_config,

--- a/src/winml/modelkit/eval/evaluate.py
+++ b/src/winml/modelkit/eval/evaluate.py
@@ -71,6 +71,8 @@ _EVALUATOR_REGISTRY: dict[str, str] = {
         "winml.modelkit.eval.text_classification_evaluator:WinMLTextClassificationEvaluator",
     "next-sentence-prediction":
         "winml.modelkit.eval.text_classification_evaluator:WinMLTextClassificationEvaluator",
+    "tabular-classification":
+        "winml.modelkit.eval.tabular_classification_evaluator:WinMLTabularClassificationEvaluator",
     "token-classification":
         "winml.modelkit.eval.token_classification_evaluator:WinMLTokenClassificationEvaluator",
     "object-detection":

--- a/src/winml/modelkit/eval/tabular_classification_evaluator.py
+++ b/src/winml/modelkit/eval/tabular_classification_evaluator.py
@@ -57,11 +57,16 @@ class WinMLTabularClassificationEvaluator(WinMLEvaluator):
             if logits is None:
                 raise ValueError("Tabular model output does not contain logits.")
             values = np.asarray(logits.detach().cpu(), dtype=np.float32).reshape(-1)
-            if values.size != 1:
+            if values.size == 1:
+                prediction = int(values[0] >= 0.0)
+            elif values.size == 2:
+                prediction = int(np.argmax(values))
+            else:
                 raise ValueError(
-                    f"Binary tabular classifier must emit one logit per sample, got {values.size}."
+                    "Binary tabular classifier must emit one logit or two class logits per "
+                    f"sample, got {values.size}."
                 )
-            predictions.append(str(int(values[0] >= 0.0)))
+            predictions.append(str(prediction))
             references.append(str(label))
 
         metric = ClassificationMetric()

--- a/src/winml/modelkit/eval/tabular_classification_evaluator.py
+++ b/src/winml/modelkit/eval/tabular_classification_evaluator.py
@@ -1,0 +1,70 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Binary tabular classification evaluator."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from .base_evaluator import WinMLEvaluator
+
+
+if TYPE_CHECKING:
+    from .config import WinMLEvaluationConfig
+
+
+class WinMLTabularClassificationEvaluator(WinMLEvaluator):
+    """Evaluate numeric feature vectors against binary labels."""
+
+    def __init__(self, config: WinMLEvaluationConfig, model: Any) -> None:
+        from ..utils.eval_utils import get_default
+
+        mapping = config.dataset.columns_mapping
+        task = "tabular-classification"
+        self._input_col = mapping.get("input_column", get_default(task, "input_column"))
+        self._label_col = mapping.get("label_column", get_default(task, "label_column"))
+        super().__init__(config, model)
+
+    def prepare_pipeline(self) -> Any:
+        """Use the tensor-native model directly; no HF processor is required."""
+        return self.model
+
+    def compute(self) -> dict[str, Any]:
+        """Compute accuracy and macro-F1 using a zero-logit binary threshold."""
+        import numpy as np
+        import torch
+
+        from .metrics import ClassificationMetric
+
+        predictions: list[str] = []
+        references: list[str] = []
+        for sample in self.data:
+            features = np.asarray(sample[self._input_col], dtype=np.float32)
+            if features.ndim != 1:
+                raise ValueError(
+                    f"Tabular features must be a 1D numeric vector, got shape {features.shape}."
+                )
+            label = int(sample[self._label_col])
+            if label not in (0, 1):
+                raise ValueError(f"Binary tabular label must be 0 or 1, got {label}.")
+
+            output = self.model(features=torch.from_numpy(features).unsqueeze(0))
+            logits = getattr(output, "logits", None)
+            if logits is None and isinstance(output, dict):
+                logits = output.get("logits")
+            if logits is None:
+                raise ValueError("Tabular model output does not contain logits.")
+            values = np.asarray(logits.detach().cpu(), dtype=np.float32).reshape(-1)
+            if values.size != 1:
+                raise ValueError(
+                    f"Binary tabular classifier must emit one logit per sample, got {values.size}."
+                )
+            predictions.append(str(int(values[0] >= 0.0)))
+            references.append(str(label))
+
+        metric = ClassificationMetric()
+        result = metric.compute(predictions, references, labels=["0", "1"])
+        result["num_samples"] = len(references)
+        return result

--- a/src/winml/modelkit/eval/tensor_similarity_evaluator.py
+++ b/src/winml/modelkit/eval/tensor_similarity_evaluator.py
@@ -129,12 +129,18 @@ class TensorSimilarityEvaluator:
         if self.config.model_id is None:
             raise ValueError("model_id is required to load the HF reference model.")
 
-        hf_config = load_hf_config(AutoConfig, self.config.model_id)
+        hf_config = load_hf_config(
+            AutoConfig,
+            self.config.model_id,
+            trust_remote_code=self.config.trust_remote_code,
+        )
         cls = resolve_task(hf_config, task=self.config.task).model_class
         logger.info("Loading HF reference %s on CPU/fp32", cls.__name__)
         # cls is a HF model class which exposes from_pretrained; not in `type`.
         return cls.from_pretrained(  # type: ignore[attr-defined]
-            self.config.model_id, dtype=torch.float32
+            self.config.model_id,
+            dtype=torch.float32,
+            trust_remote_code=self.config.trust_remote_code,
         ).eval()
 
     def prepare_data(self) -> Any:
@@ -238,6 +244,9 @@ class TensorSimilarityEvaluator:
             for k, v in sample.items()
         }
         output = model(**inputs)
+        if isinstance(output, torch.Tensor):
+            output_name = getattr(model, "main_output_name", "output")
+            return {output_name: output.detach().cpu().numpy()}
         return {
             name: tensor.detach().cpu().numpy()
             for name, tensor in output.items()

--- a/src/winml/modelkit/inference/pipeline.py
+++ b/src/winml/modelkit/inference/pipeline.py
@@ -505,8 +505,61 @@ def _create_extractive_question_answering_pipeline(
     return _ExtractiveQuestionAnsweringPipeline(model, tokenizer, device=device)
 
 
+class _TabularClassificationPipeline:
+    """Tensor-native pipeline for numeric tabular classifiers."""
+
+    task = "tabular-classification"
+    tokenizer = None
+    image_processor = None
+
+    def __init__(self, model: Any) -> None:
+        self.model = model
+        self._preprocess_params: dict[str, Any] = {}
+
+    def _sanitize_parameters(self) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+        return {}, {}, {}
+
+    def __call__(self, features: Any) -> list[dict[str, Any]]:
+        import numpy as np
+        import torch
+
+        values = np.asarray(features, dtype=np.float32)
+        if values.ndim != 1:
+            raise ValueError(
+                f"Tabular features must be a 1D numeric vector, got shape {values.shape}."
+            )
+        output = self.model(features=torch.from_numpy(values).unsqueeze(0))
+        logits = getattr(output, "logits", output)
+        logits = torch.as_tensor(logits).detach().cpu().reshape(-1)
+        if logits.numel() == 1:
+            probability = torch.sigmoid(logits[0])
+            label_id = int(logits[0] >= 0)
+            score = probability if label_id == 1 else 1 - probability
+        elif logits.numel() == 2:
+            probabilities = torch.softmax(logits, dim=0)
+            label_id = int(torch.argmax(probabilities))
+            score = probabilities[label_id]
+        else:
+            raise ValueError(
+                "Tabular classification expects one binary logit or two class logits, "
+                f"got {logits.numel()}."
+            )
+        return [{"label": str(label_id), "score": float(score)}]
+
+
+def _create_tabular_classification_pipeline(
+    model: Any,
+    _model_id: str | None,
+    device: str = "cpu",
+    trust_remote_code: bool = False,
+) -> _TabularClassificationPipeline:
+    del device, trust_remote_code
+    return _TabularClassificationPipeline(model)
+
+
 _COMPAT_PIPELINE_FACTORIES = {
     "question-answering": _create_extractive_question_answering_pipeline,
+    "tabular-classification": _create_tabular_classification_pipeline,
 }
 
 

--- a/src/winml/modelkit/inference/tasks.py
+++ b/src/winml/modelkit/inference/tasks.py
@@ -301,6 +301,17 @@ TASK_REGISTRY: dict[str, TaskInputSpec] = {
         ],
         mapping=PipelineMapping(pipe_input="text"),
     ),
+    "tabular-classification": TaskInputSpec(
+        user_inputs=[
+            InputField(
+                name="features",
+                type="json",
+                required=True,
+                description="Numeric feature vector",
+            ),
+        ],
+        mapping=PipelineMapping(pipe_input="features"),
+    ),
     "token-classification": TaskInputSpec(
         user_inputs=[
             InputField(

--- a/src/winml/modelkit/loader/task.py
+++ b/src/winml/modelkit/loader/task.py
@@ -76,6 +76,7 @@ _TASK_REGISTRY: dict[str, str | None] = {
     "next-sentence-prediction": "nsp",
     "table-question-answering": "tabqa",
     "document-question-answering": "docqa",
+    "tabular-classification": "tabcls",
     "sentence-similarity": None,
     # Audio
     "audio-classification": "audiocls",
@@ -250,6 +251,9 @@ TASK_SYNONYM_EXTENSIONS: dict[str, str] = {
     # collapse to feature-extraction is guarded by tests/unit/loader/test_task_boundary.py.
     # next-sentence-prediction has the same I/O as text-classification: input_ids -> logits
     "next-sentence-prediction": "text-classification",
+    # tabular-classification uses a custom WinML task name but reuses Optimum's
+    # classification exporter boundary once the model exposes tensor features.
+    "tabular-classification": "text-classification",
     # mask-generation is registered via register_onnx_overwrite for SAM2.
     # Optimum incorrectly maps it to "feature-extraction"; preserve as-is.
     "mask-generation": "mask-generation",

--- a/src/winml/modelkit/models/hf/__init__.py
+++ b/src/winml/modelkit/models/hf/__init__.py
@@ -95,6 +95,8 @@ from .t5 import MODEL_CLASS_MAPPING as _T5_CLASS_MAPPING
 from .t5 import T5_CONFIG
 from .t5 import T5DecoderIOConfig as _T5DecoderIOConfig  # triggers registration
 from .t5 import T5EncoderIOConfig as _T5EncoderIOConfig  # triggers registration
+from .transformer import MODEL_CLASS_MAPPING as _TRANSFORMER_CLASS_MAPPING
+from .transformer import TabularTransformerIOConfig as _TabularTransformerIOConfig
 from .unlimited_ocr import MODEL_CLASS_MAPPING as _UNLIMITED_OCR_CLASS_MAPPING
 from .unlimited_ocr import (
     UnlimitedOCRVisionIOConfig as _UnlimitedOCRVisionIOConfig,  # triggers registration
@@ -142,6 +144,7 @@ MODEL_CLASS_MAPPING: dict[tuple[str, str | None], type] = {
         _SEGFORMER_CLASS_MAPPING,
         _SIGLIP_CLASS_MAPPING,
         _T5_CLASS_MAPPING,
+        _TRANSFORMER_CLASS_MAPPING,
         _UNLIMITED_OCR_CLASS_MAPPING,
         _VED_CLASS_MAPPING,
         _VITPOSE_CLASS_MAPPING,

--- a/src/winml/modelkit/models/hf/transformer.py
+++ b/src/winml/modelkit/models/hf/transformer.py
@@ -1,0 +1,132 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Custom tabular Transformer export support.
+
+The SnowFlash383935/DigitalEduTransformers checkpoint publishes a custom
+``model_type='transformer'`` architecture whose public ``forward`` accepts a
+Python list, performs NumPy normalization, and returns Python booleans. That is
+useful for the model card example but is not an ONNX export contract. The
+wrapper below exposes the tensor path directly: normalized tabular features in,
+logits out.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import torch
+import torch.nn as nn
+from optimum.exporters.onnx import OnnxConfig
+from optimum.utils import NormalizedConfig
+from optimum.utils.input_generators import DummyInputGenerator
+
+from ...export import register_onnx_overwrite
+
+
+class TabularInputGenerator(DummyInputGenerator):  # type: ignore[misc]
+    """Generate floating tabular feature tensors."""
+
+    SUPPORTED_INPUT_NAMES = ("features",)
+
+    def __init__(
+        self,
+        task: str,
+        normalized_config: NormalizedConfig,
+        batch_size: int = 1,
+        **_: Any,
+    ) -> None:
+        """Initialize the generator from Optimum's OnnxConfig factory args."""
+        self.task = task
+        self.normalized_config = normalized_config
+        self.batch_size = batch_size
+
+    def generate(
+        self,
+        input_name: str,
+        framework: str = "pt",
+        int_dtype: str = "int64",
+        float_dtype: str = "fp32",
+    ) -> Any:
+        """Generate a zero-valued tabular feature tensor."""
+        import torch
+
+        if input_name != "features":
+            raise ValueError(f"Unsupported input for tabular transformer: {input_name}")
+        input_dim = int(getattr(self.normalized_config, "input_dim", 7))
+        return torch.zeros((self.batch_size, input_dim), dtype=torch.float32)
+
+
+class TabularTransformerWrapper(nn.Module):
+    """Tensor-in/tensor-out wrapper around the remote tabular model."""
+
+    def __init__(self, model: nn.Module) -> None:
+        super().__init__()
+        self.config = model.config
+        self.input_proj = cast("nn.Module", model.input_proj)
+        self.transformer = cast("nn.Module", model.transformer)
+        self.head = cast("nn.Module", model.head)
+        mean = torch.tensor(self.config.mean, dtype=torch.float32)
+        std = torch.tensor(self.config.std, dtype=torch.float32)
+        self.register_buffer("mean", mean)
+        self.register_buffer("std", std)
+
+    @classmethod
+    def from_pretrained(cls, model_name_or_path: str, **kwargs: Any) -> TabularTransformerWrapper:
+        """Load the remote model and wrap its tensorizable submodules."""
+        from transformers import AutoModel
+
+        model = AutoModel.from_pretrained(model_name_or_path, **kwargs)
+        wrapper = cls(model)
+        wrapper.eval()
+        return wrapper
+
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        """Run normalized tabular features through the Transformer classifier."""
+        mean = cast("torch.Tensor", self.mean)
+        std = cast("torch.Tensor", self.std)
+        x = (features - mean.to(features.device, features.dtype)) / (
+            std.to(features.device, features.dtype) + 1e-8
+        )
+        x = self.input_proj(x)
+        x = x.unsqueeze(1)
+        x = self.transformer(x)
+        x = x.squeeze(1)
+        return cast("torch.Tensor", self.head(x))
+
+
+@register_onnx_overwrite("transformer", "text-classification", library_name="transformers")
+class TabularTransformerIOConfig(OnnxConfig):  # type: ignore[misc]
+    """ONNX config for tensorized tabular classification."""
+
+    NORMALIZED_CONFIG_CLASS = NormalizedConfig.with_args(
+        input_dim="input_dim",
+        allow_new=True,
+    )
+    DUMMY_INPUT_GENERATOR_CLASSES = (TabularInputGenerator,)
+
+    @property
+    def inputs(self) -> dict[str, dict[int, str]]:
+        """ONNX input names and dynamic axes."""
+        return {"features": {0: "batch_size"}}
+
+    @property
+    def outputs(self) -> dict[str, dict[int, str]]:
+        """ONNX output names and dynamic axes."""
+        return {"logits": {0: "batch_size"}}
+
+
+MODEL_CLASS_MAPPING: dict[tuple[str, str | None], type] = {
+    ("transformer", "tabular-classification"): TabularTransformerWrapper,
+    ("transformer", "text-classification"): TabularTransformerWrapper,
+    ("transformer", None): TabularTransformerWrapper,
+}
+
+
+__all__ = [
+    "MODEL_CLASS_MAPPING",
+    "TabularInputGenerator",
+    "TabularTransformerIOConfig",
+    "TabularTransformerWrapper",
+]

--- a/src/winml/modelkit/models/hf/transformer.py
+++ b/src/winml/modelkit/models/hf/transformer.py
@@ -95,9 +95,12 @@ class TabularTransformerWrapper(nn.Module):
         """Load the remote model and wrap its tensorizable submodules."""
         from transformers import AutoConfig, AutoModel
 
+        from ...loader import load_hf_config
+
         config = kwargs.pop("config", None)
         if config is None:
-            config = AutoConfig.from_pretrained(
+            config = load_hf_config(
+                AutoConfig,
                 model_name_or_path,
                 trust_remote_code=kwargs.get("trust_remote_code", False),
                 revision=kwargs.get("revision"),

--- a/src/winml/modelkit/models/hf/transformer.py
+++ b/src/winml/modelkit/models/hf/transformer.py
@@ -25,6 +25,22 @@ from optimum.utils.input_generators import DummyInputGenerator
 from ...export import register_onnx_overwrite
 
 
+def _ensure_legacy_remote_model_compat(
+    auto_model: Any,
+    config: Any,
+    *,
+    trust_remote_code: bool,
+) -> None:
+    model_class = type(
+        auto_model.from_config(
+            config,
+            trust_remote_code=trust_remote_code,
+        )
+    )
+    if not hasattr(model_class, "all_tied_weights_keys"):
+        model_class.all_tied_weights_keys = {}
+
+
 class TabularInputGenerator(DummyInputGenerator):  # type: ignore[misc]
     """Generate floating tabular feature tensors."""
 
@@ -61,6 +77,8 @@ class TabularInputGenerator(DummyInputGenerator):  # type: ignore[misc]
 class TabularTransformerWrapper(nn.Module):
     """Tensor-in/tensor-out wrapper around the remote tabular model."""
 
+    main_output_name = "logits"
+
     def __init__(self, model: nn.Module) -> None:
         super().__init__()
         self.config = model.config
@@ -75,9 +93,23 @@ class TabularTransformerWrapper(nn.Module):
     @classmethod
     def from_pretrained(cls, model_name_or_path: str, **kwargs: Any) -> TabularTransformerWrapper:
         """Load the remote model and wrap its tensorizable submodules."""
-        from transformers import AutoModel
+        from transformers import AutoConfig, AutoModel
 
-        model = AutoModel.from_pretrained(model_name_or_path, **kwargs)
+        config = kwargs.pop("config", None)
+        if config is None:
+            config = AutoConfig.from_pretrained(
+                model_name_or_path,
+                trust_remote_code=kwargs.get("trust_remote_code", False),
+                revision=kwargs.get("revision"),
+            )
+
+        _ensure_legacy_remote_model_compat(
+            AutoModel,
+            config,
+            trust_remote_code=kwargs.get("trust_remote_code", False),
+        )
+
+        model = AutoModel.from_pretrained(model_name_or_path, config=config, **kwargs)
         wrapper = cls(model)
         wrapper.eval()
         return wrapper
@@ -91,7 +123,15 @@ class TabularTransformerWrapper(nn.Module):
         )
         x = self.input_proj(x)
         x = x.unsqueeze(1)
-        x = self.transformer(x)
+        if torch.onnx.is_in_onnx_export():
+            fastpath_enabled = torch.backends.mha.get_fastpath_enabled()
+            torch.backends.mha.set_fastpath_enabled(False)
+            try:
+                x = self.transformer(x)
+            finally:
+                torch.backends.mha.set_fastpath_enabled(fastpath_enabled)
+        else:
+            x = self.transformer(x)
         x = x.squeeze(1)
         return cast("torch.Tensor", self.head(x))
 

--- a/src/winml/modelkit/models/winml/__init__.py
+++ b/src/winml/modelkit/models/winml/__init__.py
@@ -37,6 +37,7 @@ TASK_TO_WINML_CLASS: dict[str, str] = {
     "text-classification": "WinMLModelForSequenceClassification",
     "sequence-classification": "WinMLModelForSequenceClassification",
     "next-sentence-prediction": "WinMLModelForSequenceClassification",
+    "tabular-classification": "WinMLModelForSequenceClassification",
     "image-segmentation": "WinMLModelForImageSegmentation",
     "semantic-segmentation": "WinMLModelForSemanticSegmentation",
     "object-detection": "WinMLModelForObjectDetection",

--- a/src/winml/modelkit/models/winml/__init__.py
+++ b/src/winml/modelkit/models/winml/__init__.py
@@ -37,7 +37,7 @@ TASK_TO_WINML_CLASS: dict[str, str] = {
     "text-classification": "WinMLModelForSequenceClassification",
     "sequence-classification": "WinMLModelForSequenceClassification",
     "next-sentence-prediction": "WinMLModelForSequenceClassification",
-    "tabular-classification": "WinMLModelForSequenceClassification",
+    "tabular-classification": "WinMLModelForTabularClassification",
     "image-segmentation": "WinMLModelForImageSegmentation",
     "semantic-segmentation": "WinMLModelForSemanticSegmentation",
     "object-detection": "WinMLModelForObjectDetection",
@@ -86,6 +86,7 @@ def _import_winml_class(class_name: str) -> type[WinMLPreTrainedModel]:
     from .object_detection import WinMLModelForObjectDetection
     from .question_answering import WinMLModelForQuestionAnswering
     from .sequence_classification import WinMLModelForSequenceClassification
+    from .tabular_classification import WinMLModelForTabularClassification
 
     # Map class names to modules
     class_map: dict[str, type] = {
@@ -97,6 +98,7 @@ def _import_winml_class(class_name: str) -> type[WinMLPreTrainedModel]:
         "WinMLModelForQuestionAnswering": WinMLModelForQuestionAnswering,
         "WinMLModelForSemanticSegmentation": WinMLModelForSemanticSegmentation,
         "WinMLModelForSequenceClassification": WinMLModelForSequenceClassification,
+        "WinMLModelForTabularClassification": WinMLModelForTabularClassification,
         "WinMLModelForGenericTask": WinMLModelForGenericTask,
     }
 
@@ -213,6 +215,7 @@ from .kv_cache import (
 )
 from .object_detection import WinMLModelForObjectDetection
 from .sequence_classification import WinMLModelForSequenceClassification
+from .tabular_classification import WinMLModelForTabularClassification
 from .zero_shot_image_classification import WinMLModelForZeroShotImageClassification
 
 
@@ -240,6 +243,7 @@ __all__ = [
     "WinMLModelForObjectDetection",
     "WinMLModelForSemanticSegmentation",
     "WinMLModelForSequenceClassification",
+    "WinMLModelForTabularClassification",
     "WinMLModelForZeroShotImageClassification",
     "WinMLPreTrainedModel",
     "WinMLSlidingWindowCache",

--- a/src/winml/modelkit/models/winml/tabular_classification.py
+++ b/src/winml/modelkit/models/winml/tabular_classification.py
@@ -1,0 +1,31 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""WinML runtime wrapper for tensor-based tabular classification."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+from transformers.modeling_outputs import SequenceClassifierOutput
+
+from .base import WinMLPreTrainedModel
+
+
+if TYPE_CHECKING:
+    import numpy as np
+    import torch
+
+
+class WinMLModelForTabularClassification(WinMLPreTrainedModel):
+    """Run a tabular classifier whose ONNX input is named ``features``."""
+
+    def forward(  # type: ignore[override]
+        self,
+        features: torch.Tensor | np.ndarray,
+    ) -> SequenceClassifierOutput:
+        """Run inference and expose the classifier logits."""
+        outputs = self._run_inference(self._format_inputs(features=features))
+        logits = outputs.get("logits", next(iter(outputs.values())))
+        return SequenceClassifierOutput(logits=cast("torch.FloatTensor", logits))

--- a/src/winml/modelkit/models/winml/tabular_classification.py
+++ b/src/winml/modelkit/models/winml/tabular_classification.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from transformers.modeling_outputs import SequenceClassifierOutput
 
@@ -14,18 +14,14 @@ from .base import WinMLPreTrainedModel
 
 
 if TYPE_CHECKING:
-    import numpy as np
     import torch
 
 
 class WinMLModelForTabularClassification(WinMLPreTrainedModel):
     """Run a tabular classifier whose ONNX input is named ``features``."""
 
-    def forward(  # type: ignore[override]
-        self,
-        features: torch.Tensor | np.ndarray,
-    ) -> SequenceClassifierOutput:
+    def forward(self, **kwargs: Any) -> SequenceClassifierOutput:
         """Run inference and expose the classifier logits."""
-        outputs = self._run_inference(self._format_inputs(features=features))
+        outputs = self._run_inference(self._format_inputs(**kwargs))
         logits = outputs.get("logits", next(iter(outputs.values())))
         return SequenceClassifierOutput(logits=cast("torch.FloatTensor", logits))

--- a/src/winml/modelkit/models/winml/tabular_classification.py
+++ b/src/winml/modelkit/models/winml/tabular_classification.py
@@ -6,15 +6,11 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
 
 from transformers.modeling_outputs import SequenceClassifierOutput
 
 from .base import WinMLPreTrainedModel
-
-
-if TYPE_CHECKING:
-    import torch
 
 
 class WinMLModelForTabularClassification(WinMLPreTrainedModel):
@@ -24,4 +20,4 @@ class WinMLModelForTabularClassification(WinMLPreTrainedModel):
         """Run inference and expose the classifier logits."""
         outputs = self._run_inference(self._format_inputs(**kwargs))
         logits = outputs.get("logits", next(iter(outputs.values())))
-        return SequenceClassifierOutput(logits=cast("torch.FloatTensor", logits))
+        return SequenceClassifierOutput(logits=cast("Any", logits))

--- a/src/winml/modelkit/utils/eval_utils.py
+++ b/src/winml/modelkit/utils/eval_utils.py
@@ -79,6 +79,23 @@ _TEXT_CLASSIFICATION_SCHEMA = TaskSchema(
     ),
 )
 
+_TABULAR_CLASSIFICATION_SCHEMA = TaskSchema(
+    columns=(
+        SchemaItem(
+            "input_column",
+            "numeric feature vector",
+            default="features",
+            remap_hint="<your_features_column>",
+        ),
+        SchemaItem(
+            "label_column",
+            "binary class label (0 or 1)",
+            default="label",
+            remap_hint="<your_label_column>",
+        ),
+    ),
+)
+
 _TOKEN_CLASSIFICATION_SCHEMA = TaskSchema(
     columns=(
         SchemaItem(
@@ -453,6 +470,7 @@ TASK_SCHEMAS: dict[str, TaskSchema] = {
     "text-classification": _TEXT_CLASSIFICATION_SCHEMA,
     "sequence-classification": _TEXT_CLASSIFICATION_SCHEMA,
     "next-sentence-prediction": _TEXT_CLASSIFICATION_SCHEMA,
+    "tabular-classification": _TABULAR_CLASSIFICATION_SCHEMA,
     "token-classification": _TOKEN_CLASSIFICATION_SCHEMA,
     "object-detection": _OBJECT_DETECTION_SCHEMA,
     "image-segmentation": _IMAGE_SEGMENTATION_SCHEMA,

--- a/tests/unit/eval/test_eval.py
+++ b/tests/unit/eval/test_eval.py
@@ -1552,7 +1552,32 @@ class TestLoadModel:
         assert call_args.kwargs["config"] is None
         assert call_args.kwargs["use_cache"] is True
         assert call_args.kwargs["force_rebuild"] is False
+        assert call_args.kwargs["trust_remote_code"] is False
         assert result is mock_model
+
+    def test_load_model_forwards_trust_remote_code(self):
+        import importlib
+        import sys
+
+        eval_mod = sys.modules.get(
+            "winml.modelkit.eval.evaluate",
+        ) or importlib.import_module("winml.modelkit.eval.evaluate")
+        mock_auto = MagicMock()
+        mock_auto.from_pretrained.return_value = MagicMock()
+        config = WinMLEvaluationConfig(
+            model_id="test/remote-model",
+            task="tabular-classification",
+            device="cpu",
+            trust_remote_code=True,
+        )
+
+        with patch.dict(
+            "sys.modules",
+            {"winml.modelkit.models": MagicMock(WinMLAutoModel=mock_auto)},
+        ):
+            eval_mod._load_model(config)
+
+        assert mock_auto.from_pretrained.call_args.kwargs["trust_remote_code"] is True
 
     def test_auto_target_retries_cpu_after_ort_runtime_failure(self, caplog):
         """An unusable auto-selected accelerator retries with the CPU EP."""

--- a/tests/unit/eval/test_tabular_classification_evaluator.py
+++ b/tests/unit/eval/test_tabular_classification_evaluator.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+import pytest
+
+from winml.modelkit.eval import WinMLEvaluationConfig, get_evaluator_class
+from winml.modelkit.eval.tabular_classification_evaluator import (
+    WinMLTabularClassificationEvaluator,
+)
+from winml.modelkit.utils.eval_utils import TASK_SCHEMAS
+
+
+if TYPE_CHECKING:
+    import torch
+
+
+class _FakeModel:
+    config = SimpleNamespace()
+
+    def __call__(self, *, features: torch.Tensor) -> SimpleNamespace:
+        return SimpleNamespace(logits=features[:, :1] - 0.5)
+
+
+def _make_evaluator() -> WinMLTabularClassificationEvaluator:
+    evaluator = object.__new__(WinMLTabularClassificationEvaluator)
+    evaluator.model = _FakeModel()
+    evaluator.pipe = evaluator.model
+    evaluator._input_col = "features"
+    evaluator._label_col = "label"
+    return evaluator
+
+
+def test_tabular_evaluator_registered_with_schema() -> None:
+    assert (
+        get_evaluator_class(WinMLEvaluationConfig(task="tabular-classification"))
+        is WinMLTabularClassificationEvaluator
+    )
+    schema = TASK_SCHEMAS["tabular-classification"]
+    assert [column.default for column in schema.columns] == ["features", "label"]
+
+
+def test_compute_uses_binary_logit_semantics() -> None:
+    evaluator = _make_evaluator()
+    evaluator.data = [
+        {"features": [0.25, 2.0], "label": 0},
+        {"features": [0.75, 3.0], "label": 1},
+    ]
+
+    assert evaluator.compute() == {"accuracy": 1.0, "f1": 1.0, "num_samples": 2}
+
+
+def test_compute_rejects_non_binary_labels() -> None:
+    evaluator = _make_evaluator()
+    evaluator.data = [{"features": [0.25, 2.0], "label": 2}]
+
+    with pytest.raises(ValueError, match="0 or 1"):
+        evaluator.compute()

--- a/tests/unit/eval/test_tabular_classification_evaluator.py
+++ b/tests/unit/eval/test_tabular_classification_evaluator.py
@@ -1,3 +1,7 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
 from __future__ import annotations
 
 from types import SimpleNamespace

--- a/tests/unit/eval/test_tabular_classification_evaluator.py
+++ b/tests/unit/eval/test_tabular_classification_evaluator.py
@@ -1,19 +1,15 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
 
 import pytest
+import torch
 
 from winml.modelkit.eval import WinMLEvaluationConfig, get_evaluator_class
 from winml.modelkit.eval.tabular_classification_evaluator import (
     WinMLTabularClassificationEvaluator,
 )
 from winml.modelkit.utils.eval_utils import TASK_SCHEMAS
-
-
-if TYPE_CHECKING:
-    import torch
 
 
 class _FakeModel:
@@ -57,3 +53,13 @@ def test_compute_rejects_non_binary_labels() -> None:
 
     with pytest.raises(ValueError, match="0 or 1"):
         evaluator.compute()
+
+
+def test_compute_accepts_two_class_logits() -> None:
+    evaluator = _make_evaluator()
+    evaluator.model = lambda **_kwargs: SimpleNamespace(logits=torch.tensor([[0.1, 0.9]]))
+    evaluator.data = [{"features": [0.25, 2.0], "label": 1}]
+
+    result = evaluator.compute()
+
+    assert result["accuracy"] == 1.0

--- a/tests/unit/eval/test_tensor_similarity_evaluator.py
+++ b/tests/unit/eval/test_tensor_similarity_evaluator.py
@@ -13,6 +13,7 @@ and end-to-end ``compute()`` is covered by ``tests/e2e/test_eval_e2e.py``.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import ClassVar
 
 import numpy as np
@@ -75,6 +76,21 @@ class TestInferenceModel:
         assert set(out) == {"last_hidden_state"}
         assert isinstance(out["last_hidden_state"], np.ndarray)
         assert out["last_hidden_state"].shape == (1, 2, 3)
+
+    def test_names_raw_tensor_from_model_contract(self):
+        class RawTensorModel:
+            main_output_name = "logits"
+
+            def __call__(self, **_inputs):
+                return torch.ones((1, 1))
+
+        out = TensorSimilarityEvaluator._inference_model(
+            RawTensorModel(),
+            {"features": torch.zeros((1, 7))},
+        )
+
+        assert set(out) == {"logits"}
+        assert out["logits"].shape == (1, 1)
 
 
 # ---------------------------------------------------------------------------
@@ -150,6 +166,44 @@ class TestInputDataCompare:
         # prepare_data must NOT mutate the config -- the real sample count is
         # surfaced via EvalResult.num_samples, not written back here.
         assert evaluator.config.dataset.samples == 100
+
+
+def test_reference_loader_propagates_trust_remote_code(monkeypatch) -> None:
+    import winml.modelkit.loader as loader_module
+    import winml.modelkit.loader.resolution as resolution_module
+
+    calls: dict[str, object] = {}
+
+    class FakeReferenceModel:
+        @classmethod
+        def from_pretrained(cls, model_id, **kwargs):
+            calls["model_id"] = model_id
+            calls["model_kwargs"] = kwargs
+            return SimpleNamespace(eval=lambda: "reference")
+
+    def fake_load_hf_config(_auto_config, model_id, **kwargs):
+        calls["config_model_id"] = model_id
+        calls["config_kwargs"] = kwargs
+        return SimpleNamespace()
+
+    monkeypatch.setattr(loader_module, "load_hf_config", fake_load_hf_config)
+    monkeypatch.setattr(
+        resolution_module,
+        "resolve_task",
+        lambda *_args, **_kwargs: SimpleNamespace(model_class=FakeReferenceModel),
+    )
+
+    evaluator = object.__new__(TensorSimilarityEvaluator)
+    evaluator.config = WinMLEvaluationConfig(
+        model_id="test/remote-model",
+        task="tabular-classification",
+        mode="compare",
+        trust_remote_code=True,
+    )
+
+    assert evaluator._load_reference_model() == "reference"
+    assert calls["config_kwargs"] == {"trust_remote_code": True}
+    assert calls["model_kwargs"]["trust_remote_code"] is True  # type: ignore[index]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/inference/test_pipeline.py
+++ b/tests/unit/inference/test_pipeline.py
@@ -262,6 +262,24 @@ class TestCreatePipeline:
 
         assert isinstance(result, ImageClassificationPipeline)
 
+    @pytest.mark.parametrize(
+        ("logits", "expected_label"),
+        [([-2.0], "0"), ([2.0], "1"), ([2.0, -1.0], "0")],
+    )
+    def test_constructs_tensor_native_tabular_pipeline(
+        self,
+        logits: list[float],
+        expected_label: str,
+    ) -> None:
+        model = MagicMock(return_value=SimpleNamespace(logits=torch.tensor([logits])))
+
+        pipe = create_pipeline("tabular-classification", model, "test-model")
+        result = pipe([1, 1, 1, 150, 2, 0, 0])
+
+        assert result[0]["label"] == expected_label
+        assert 0.5 < result[0]["score"] <= 1.0
+        assert model.call_args.kwargs["features"].shape == (1, 7)
+
     def test_constructs_removed_question_answering_pipeline(self) -> None:
         model = _make_model_with_shapes([[1, 16]])
         tokenizer = MagicMock()

--- a/tests/unit/models/test_tabular_transformer.py
+++ b/tests/unit/models/test_tabular_transformer.py
@@ -1,0 +1,55 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+from __future__ import annotations
+
+from typing import ClassVar
+
+import torch
+
+from winml.modelkit.loader.task import TASK_SYNONYM_EXTENSIONS, to_optimum_task
+from winml.modelkit.models.hf import MODEL_CLASS_MAPPING
+from winml.modelkit.models.hf.transformer import TabularTransformerWrapper
+
+
+class _Config:
+    mean: ClassVar[list[float]] = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
+    std: ClassVar[list[float]] = [1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0]
+
+
+class _RemoteTabularModel(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.config = _Config()
+        self.input_proj = torch.nn.Linear(7, 3, bias=False)
+        self.transformer = torch.nn.Identity()
+        self.head = torch.nn.Linear(3, 1, bias=False)
+
+
+def test_tabular_task_maps_to_optimum_text_classification() -> None:
+    assert TASK_SYNONYM_EXTENSIONS["tabular-classification"] == "text-classification"
+    assert to_optimum_task("tabular-classification") == "text-classification"
+
+
+def test_transformer_model_class_mapping_registers_tabular_wrapper() -> None:
+    assert (
+        MODEL_CLASS_MAPPING[("transformer", "tabular-classification")]
+        is TabularTransformerWrapper
+    )
+    assert MODEL_CLASS_MAPPING[("transformer", "text-classification")] is TabularTransformerWrapper
+    assert MODEL_CLASS_MAPPING[("transformer", None)] is TabularTransformerWrapper
+
+
+def test_tabular_wrapper_exposes_tensor_logits() -> None:
+    remote = _RemoteTabularModel()
+    wrapper = TabularTransformerWrapper(remote)
+
+    features = torch.tensor([[1.0, 4.0, 7.0, 12.0, 21.0, 38.0, 71.0]])
+    logits = wrapper(features)
+
+    normalized = (features - torch.tensor(_Config.mean)) / (torch.tensor(_Config.std) + 1e-8)
+    hidden = remote.input_proj(normalized).unsqueeze(1)
+    expected = remote.head(remote.transformer(hidden).squeeze(1))
+    torch.testing.assert_close(logits, expected)
+    assert logits.shape == (1, 1)

--- a/tests/unit/models/test_tabular_transformer.py
+++ b/tests/unit/models/test_tabular_transformer.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------
 from __future__ import annotations
 
+import inspect
 from typing import ClassVar
 
 import torch
@@ -13,6 +14,9 @@ from winml.modelkit.models.hf import MODEL_CLASS_MAPPING
 from winml.modelkit.models.hf.transformer import (
     TabularTransformerWrapper,
     _ensure_legacy_remote_model_compat,
+)
+from winml.modelkit.models.winml.tabular_classification import (
+    WinMLModelForTabularClassification,
 )
 
 
@@ -42,6 +46,17 @@ def test_transformer_model_class_mapping_registers_tabular_wrapper() -> None:
     )
     assert MODEL_CLASS_MAPPING[("transformer", "text-classification")] is TabularTransformerWrapper
     assert MODEL_CLASS_MAPPING[("transformer", None)] is TabularTransformerWrapper
+
+
+def test_runtime_wrapper_forward_matches_generic_base_signature() -> None:
+    parameters = list(
+        inspect.signature(WinMLModelForTabularClassification.forward).parameters.values()
+    )
+
+    assert [parameter.kind for parameter in parameters] == [
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        inspect.Parameter.VAR_KEYWORD,
+    ]
 
 
 def test_tabular_wrapper_exposes_tensor_logits() -> None:

--- a/tests/unit/models/test_tabular_transformer.py
+++ b/tests/unit/models/test_tabular_transformer.py
@@ -10,7 +10,10 @@ import torch
 
 from winml.modelkit.loader.task import TASK_SYNONYM_EXTENSIONS, to_optimum_task
 from winml.modelkit.models.hf import MODEL_CLASS_MAPPING
-from winml.modelkit.models.hf.transformer import TabularTransformerWrapper
+from winml.modelkit.models.hf.transformer import (
+    TabularTransformerWrapper,
+    _ensure_legacy_remote_model_compat,
+)
 
 
 class _Config:
@@ -53,3 +56,33 @@ def test_tabular_wrapper_exposes_tensor_logits() -> None:
     expected = remote.head(remote.transformer(hidden).squeeze(1))
     torch.testing.assert_close(logits, expected)
     assert logits.shape == (1, 1)
+
+
+def test_tabular_wrapper_restores_mha_fastpath_after_export(monkeypatch) -> None:
+    wrapper = TabularTransformerWrapper(_RemoteTabularModel())
+    monkeypatch.setattr(torch.onnx, "is_in_onnx_export", lambda: True)
+    torch.backends.mha.set_fastpath_enabled(True)
+
+    wrapper(torch.zeros((1, 7)))
+
+    assert torch.backends.mha.get_fastpath_enabled() is True
+
+
+def test_loader_shims_legacy_remote_model_class() -> None:
+    class LegacyRemoteModel(_RemoteTabularModel):
+        pass
+
+    probe = LegacyRemoteModel()
+
+    class FakeAutoModel:
+        @staticmethod
+        def from_config(*_args, **_kwargs):
+            return probe
+
+    _ensure_legacy_remote_model_compat(
+        FakeAutoModel,
+        _Config(),
+        trust_remote_code=True,
+    )
+
+    assert LegacyRemoteModel.all_tied_weights_keys == {}


### PR DESCRIPTION
### Summary

Adds WinML 0.3.0 support for `SnowFlash383935/DigitalEduTransformers`, a remote-code binary tabular Transformer over seven numeric features. This Outcome-L2 change adds the shared `tabular-classification` task path, model/export wrapper, runtime pipeline, evaluator, tensor-comparison compatibility, and verified CPU fp32/fp16 recipes. Highest verified goal is L3 PASS: build, CPU perf, PyTorch parity, and a bounded two-sample functional Eval all pass on candidate `56f09d1d94290370387ce2cbdeeaa6a2e49524c5`.

### Model metadata

**What the model does:** Binary classification over seven numeric educational features. The checkpoint config declares `model_type="transformer"`, `architectures=["FleshkaTabularTransformer"]`, `input_dim=7`, and `pipeline_tag="tabular-classification"`.

**Primary user stories:** Convert and run the trained classifier through WinML/ONNX with a stable tensor contract, and evaluate it with the same zero-threshold boolean semantics used by the checkpoint's remote code.

**Supported tasks:** `tabular-classification`, with tensor input `features` and output `logits`.

**Model architecture:**

```text
FleshkaTabularTransformer
├── feature normalization (mean/std, 7 features)
├── input projection (7 -> 512)
├── Transformer encoder layer x 32
│   ├── multi-head self-attention (16 heads)
│   ├── feed-forward block
│   └── residual + LayerNorm
└── binary classification head (512 -> 1 logit)
```

- Source/confidence: checkpoint config, model card, and remote `model.py` for `SnowFlash383935/DigitalEduTransformers`; verified against the loaded `TabularTransformerWrapper` (100,881,921 parameters).

### Validation and support evidence

#### Baseline

The rerun started from WinML 0.3.0 at `origin/main@48bfd0f9`. Baseline config with `--task tabular-classification --trust-remote-code` could not resolve a supported task/export boundary, normal pipeline construction had no Transformers task for tabular classification, and `winml eval` had no task evaluator. The historical PR head was 96 commits behind and conflicted, so this was a FULL-RERUN rather than a mechanical rebase. Before shipment, `origin/main` moved to `2b9ec0e9`; its complete delta only changed `docs/commands/sys.md`, `src/winml/modelkit/commands/sys.py`, and corresponding sys tests. The candidate was rebased without conflict, the patch remained equivalent on owned paths, and final-head focused tests were rerun.

Starting auto-config behavior: no usable recipe could be emitted because the task and model wrapper were unregistered. Optimum exposes a text-classification exporter boundary, but not this remote tabular model/task contract; WinML now maps the new task to that boundary only inside the per-architecture wrapper.

#### Goal

- **Effort:** L2, because support requires a model wrapper plus a new shared task family.
- **Goal ceiling:** L3, defined as L0 build/structure, L1 CPU perf, L2 PyTorch-vs-ONNX numeric comparison, and one semantically valid FP32 CPU functional smoke Eval.
- **Outcome:** L2 task-family support with CPU fp32/fp16 recipes and regression coverage.

#### Outcome

L0-L3 all PASS on final candidate `56f09d1d94290370387ce2cbdeeaa6a2e49524c5`. Coverage is full for the declared CPU target: both required precision tuples are freshly built and measured. No accelerator runtime support is claimed; `--ep all` below is static rule analysis only.

Shipped recipes:

- `examples/recipes/SnowFlash383935_DigitalEduTransformers/cpu/cpu/tabular-classification_fp32_config.json`
- `examples/recipes/SnowFlash383935_DigitalEduTransformers/cpu/cpu/tabular-classification_fp16_config.json`

Shipped capability includes the tabular task registry, remote-code-aware model loading, tensor-native serving pipeline, binary evaluator, raw-tensor comparison mapping, and localized Transformer export compatibility. No new methodology friction was observed beyond cases already covered by the current skill.

#### Per-EP/device/precision results and Functional smoke Eval

| Tier | EP / Device | Precision | Verdict | Mean | p50 | Throughput | RAM delta |
|---|---|---|---|---:|---:|---:|---:|
| L0 | CPUExecutionProvider / cpu | fp32 | PASS; build 93.7 s; 385.2 MB weights | - | - | - | - |
| L0 | CPUExecutionProvider / cpu | fp16 | PASS; build 102.7 s; 192.8 MB weights | - | - | - | - |
| L1 | CPUExecutionProvider / cpu | fp32 | PASS | 17.74 ms | 17.31 ms | 56.36 samples/s | +2.5 MB total |
| L1 | CPUExecutionProvider / cpu | fp16 | PASS | 18.86 ms | 18.88 ms | 53.03 samples/s | +1.3 MB total |
| L2 | CPUExecutionProvider / cpu | fp32 | PASS | - | - | - | cosine 1.0000; max-abs 0.0000 |
| L2 | CPUExecutionProvider / cpu | fp16 | PASS | - | - | - | cosine 1.0000; max-abs mean 0.0004, max 0.0008 |

Both artifacts load as ONNX IR 8/opset 17 with `features [1,7] float32 -> logits [1,1] float32`. FP32 has 393 FLOAT initializers and a 384.83 MB sidecar; FP16 has 393 FLOAT16 initializers and a 192.42 MB sidecar.

**Functional smoke Eval:** L3 PASS on final candidate SHA, FP32 CPU, using the two real examples published in the model card: `[1,1,1,150,2,0,0] -> False` and `[0,1,1,294,0,0,0] -> True`. The local Dataset contained exactly two selected and two processed rows, `--samples 2`, `--no-shuffle`, no label/prompt/beam/frame/crop/generation expansion, labels encoded as `[0,1]`, and predictions interpreted with the remote model's `logit > 0` binary rule. Raw metrics: accuracy `1.0`, F1 `1.0`, `num_samples=2`. This proves end-to-end evaluator operability only; it is not representative accuracy or a benchmark-quality claim. The former blocker was the missing tabular evaluator/pipeline and trust propagation, which this PR implements and regression-tests.

Quality gates on the candidate:

- `uv run ruff check src/ tests/`: PASS.
- `uv run mypy -p winml.modelkit`: PASS, 439 source files.
- `uv run pytest tests/unit/eval --tb=short --no-cov -m "not e2e and not npu and not gpu"`: 630 passed.
- Final-head focused Eval/pipeline regression set: 127 passed.
- Final-head models CI partition: 1537 passed, 6 skipped, 2 xfailed.
- `uv run pre-commit run insert-license --all-files`: PASS.

#### Delta

The baseline had no generated tabular recipe to diff. The shipped recipes therefore make the previously unresolved contract explicit: `loader.model_type=transformer`, `loader.model_class=TabularTransformerWrapper`, `loader.task=tabular-classification`, `loader.trust_remote_code=true`, opset 17, `features` float32 shape `[1,7]`, and output `logits`; the fp16 recipe additionally sets `quant.mode=fp16`. The production `examples/recipes/README.md` is unchanged.

**Bug fix explanation:** (a) Minimal triggers were config/build on the remote checkpoint, normal `create_pipeline("tabular-classification", ...)`, and `winml eval`; these respectively lacked a model/task boundary, a native Transformers pipeline, and an evaluator. (b) The root causes were missing shared task registration, missing trust propagation, an old remote class incompatible with Transformers 5 tied-weight metadata, PyTorch's fused MHA export path at opset 17, tensor comparison assuming a `ModelOutput` mapping, and a task wrapper override that added a required positional parameter relative to the generic base signature. (c) The fix adds `TabularTransformerWrapper`, `WinMLModelForTabularClassification`, `WinMLTabularClassificationEvaluator`, `_TabularClassificationPipeline`, task/schema registrations, trust forwarding, raw-tensor output naming, compatible config loading, and a generic `forward(**kwargs)` runtime signature; export temporarily disables the MHA fastpath only while ONNX export is active and restores it in `finally`. The runtime output uses an `Any` cast boundary because Transformers' legacy `FloatTensor` annotation is narrower than the real tensor returned by the ONNX session, avoiding a type-only runtime import. (d) Dispatch is based on registered task/model class and output shape, never the checkpoint ID; one-logit and two-logit binary outputs are both supported. (e) Existing tasks retain their mappings and defaults, remote code remains opt-in, the base runtime call contract is preserved, and the fastpath global is restored after successful or failed export. (f) Regression evidence includes the 630-test Eval partition, 1537-test models partition, 69-test runtime-focused set, full Ruff/mypy, both exact recipe builds, both CPU perf runs, both parity runs, and the two-row functional Eval above.

#### Analyze summary — component level and op level

Static rule analysis completed for both artifacts with `WINMLCLI_RULES_DIR` and `--ep all`; this is compatibility classification, not runtime execution.

**Component-level summary**

| Artifact | Architecture coverage | Mapping | Actionable EP findings |
|---|---|---|---|
| fp32 | normalization; projection; 32x attention/FFN; binary head | export tagged 2668/2668 nodes, all model-root fallback; final optimized graph 1287 nodes | TensorRT RTX, QNN GPU, OpenVINO GPU rules classify most types supported; conditional `Reshape` and `Softmax` remain unknown |
| fp16 | same regions plus FP16 boundary casts | export tagged 2668/2668 nodes, all model-root fallback; final graph 1289 nodes | same unknowns plus conditional `Cast`; no partial or unsupported type reported |

Mapping confidence is fallback-only because remote-module tracing captured 1/327 modules; node scope names still expose `input_proj`, `transformer/layers.0..31`, normalizations, and the head. This limitation is retained rather than presented as high-confidence per-module mapping.

**Op-level summary**

| Artifact | Graph | Dominant ops | EP roll-up |
|---|---|---|---|
| fp32 | 1287 ops / 14 types | Reshape 448; Transpose 256; Gemm 130; Gather 96; LayerNormalization 65 | TensorRT RTX/QNN GPU/OpenVINO GPU: supported types with conditional Reshape/Softmax unknown; CUDA/MIGraphX/TensorRT/DML have no rule classifications |
| fp16 | 1289 ops / 15 types | Reshape 448; Transpose 256; Gemm 130; Gather 96; LayerNormalization 65; Cast 2 | same, with conditional Cast also unknown |

No Analyze row reported an unsupported operator type. Rule-less rows are not runtime claims.

#### Reproduce commands

```powershell
$OUT = 'temp/digitaledu-repro'
uv run winml build -c examples\recipes\SnowFlash383935_DigitalEduTransformers\cpu\cpu\tabular-classification_fp32_config.json -m SnowFlash383935/DigitalEduTransformers -o $OUT\fp32 --trust-remote-code --rebuild
uv run winml build -c examples\recipes\SnowFlash383935_DigitalEduTransformers\cpu\cpu\tabular-classification_fp16_config.json -m SnowFlash383935/DigitalEduTransformers -o $OUT\fp16 --trust-remote-code --precision fp16 --rebuild
uv run winml perf -m $OUT\fp32\model.onnx --ep cpu --device cpu
uv run winml perf -m $OUT\fp16\model.onnx --ep cpu --device cpu
uv run python -c "from datasets import Dataset; Dataset.from_dict({'features':[[1,1,1,150,2,0,0],[0,1,1,294,0,0,0]],'label':[0,1]}).save_to_disk(r'$OUT\model-card-dataset')"
uv run winml eval -m $OUT\fp32\model.onnx --model-id SnowFlash383935/DigitalEduTransformers --task tabular-classification --dataset $OUT\model-card-dataset --samples 2 --no-shuffle --ep cpu --device cpu --trust-remote-code --output $OUT\fp32\eval_model_card.json
$env:WINMLCLI_RULES_DIR = '<populated-rules-directory>'
uv run winml analyze --model $OUT\fp32\model.onnx --ep all --output $OUT\fp32\analyze_all.json
uv run winml analyze --model $OUT\fp16\model.onnx --ep all --output $OUT\fp16\analyze_all.json
Remove-Item Env:WINMLCLI_RULES_DIR
```

`--trust-remote-code` is required because this checkpoint loads custom `auto_map` Python from its model repository.