### PR TITLE
recipe(BiRefNet_lite-ONNX): image segmentation recipes

### DIFF
--- a/examples/recipes/onnx-community_BiRefNet_lite-ONNX/cpu/cpu/image-segmentation_fp16_config.json
+++ b/examples/recipes/onnx-community_BiRefNet_lite-ONNX/cpu/cpu/image-segmentation_fp16_config.json
@@ -1,0 +1,10 @@
+{
+  "skip_optimize": true,
+  "export": null,
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "image-segmentation"
+  }
+}

--- a/examples/recipes/onnx-community_BiRefNet_lite-ONNX/cpu/cpu/image-segmentation_fp32_config.json
+++ b/examples/recipes/onnx-community_BiRefNet_lite-ONNX/cpu/cpu/image-segmentation_fp32_config.json
@@ -1,0 +1,9 @@
+{
+  "export": null,
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "image-segmentation"
+  }
+}


### PR DESCRIPTION
## Summary

Adds CPU recipe coverage for `onnx-community/BiRefNet_lite-ONNX` as a direct Hub ONNX image-segmentation/background-removal model. This is an L0 recipe-only contribution: no WinML exporter code is changed, and the checked-in recipes document verified CPU fp32/fp16 direct-ONNX builds for the published `onnx/model.onnx` and `onnx/model_fp16.onnx` artifacts.

The highest completed goal is L0 PASS. CPU perf was attempted but did not complete within the host time budget for either precision, and task eval is blocked on dataset/mask provenance rather than reported as a fabricated metric.

## Model metadata

**What the model does:** `onnx-community/BiRefNet_lite-ONNX` produces a single-channel foreground/background mask from an RGB image. The checkpoint is published as a direct ONNX artifact for background removal, mask generation, and image segmentation.

**Primary user stories:**

| Story | Confidence |
|---|---|
| A user supplies an RGB image and receives a foreground mask suitable for background removal or cutout workflows. | verified from the model card tags, ONNX graph I/O, and preprocessor metadata |

**Supported tasks:**

| Task | Surface | Confidence |
|---|---|---|
| `image-segmentation` | Direct ONNX model refs `onnx/model.onnx` and `onnx/model_fp16.onnx` | verified for build/graph structure |

**Model architecture:**

```text
BiRefNet_lite direct ONNX image segmentation graph
|-- Image preprocessing contract (external)
|   |-- RGB image resized to 1024 x 1024
|   `-- Rescale and normalize with ImageNet mean/std
|-- Swin-style hierarchical vision backbone / feature encoder
|-- Multi-scale decoder with attention-like ASPP/deformable-convolution regions
`-- Binary mask head producing output_image [1, 1, 1024, 1024]
```

Source/confidence: graph I/O, task, dtype, and preprocessor contract are verified from the pinned direct ONNX artifacts and repository metadata. The high-level architecture tree is inferred from the published `model_type: swin`, base-model tag, and ONNX node scopes; no source-code architecture change is made in this PR.

## Validation and support evidence

### Baseline

Baseline was refreshed on current `origin/main` at `e405dc6638dff6cac96b1539ee0cea678cc6d183` with `winml, version 0.2.0`. The PR branch merge-base is the same commit.

| Probe | Result |
|---|---|
| Root HF model inspect | `winml inspect -m onnx-community/BiRefNet_lite-ONNX --format json` resolves the repository root as `model_type: swin`, task `feature-extraction`, loader `AutoModel`, exporter `SwinOnnxConfig`, and input `pixel_values [1,3,224,224]`. That is not the published BiRefNet segmentation ONNX graph shipped by this PR. |
| Root HF recipe-free build | FAIL: `uv run winml build -m onnx-community/BiRefNet_lite-ONNX ...` attempts HuggingFace export and fails because the repo has no PyTorch/safetensors/TF/Flax weights. |
| Optimum probe | `swin` has vendor ONNX tasks `feature-extraction`, `image-classification`, and `masked-im`; WinML adds no override tasks. |
| Direct ONNX source refs | PASS: `onnx/model.onnx` has 16400 nodes, opset 17, input `input_image [1,3,1024,1024]` FLOAT, output `output_image [1,1,1024,1024]` FLOAT, and 437 FLOAT initializers. `onnx/model_fp16.onnx` has 16446 nodes with the same I/O and 437 FLOAT16 initializers. |
| Direct ONNX auto-config | PASS: `winml config -m .../onnx/model.onnx` and `.../model_fp16.onnx` emit `export: null`, `optim: {}`, `quant: null`, `compile: null`; they do not infer `loader.task`. |
| Direct ONNX recipe-free build | PASS: fp32 direct build completes in 25.7s. fp16 direct build also completes, but without `skip_optimize` it produces a mixed/fp32-sized optimized artifact: 4654 nodes with 450 FLOAT, 256 INT64, and only 40 FLOAT16 initializers plus a 243 MB external-data file. |
| L3 task metric | DATA-PROVENANCE-BLOCKED: `winml eval --schema --task image-segmentation` is available, but no authoritative dataset revision, split, binary mask semantics, and label mapping were established for this background-removal artifact. |

### Goal

Effort: L0. Goal ceiling: L1 attempted on CPU. Outcome: L0 recipe-only.

Success means the checked-in CPU fp32/fp16 recipes build structurally valid direct ONNX artifacts with the expected image-segmentation I/O. L1 CPU perf was attempted and recorded as timeout on this host; L2 numeric comparison is not claimed because this PR consumes published ONNX artifacts directly rather than exporting a matched PyTorch checkpoint; L3 is blocked by dataset and semantic provenance.

### Outcome

Highest verified goal: L0 PASS on CPU for both fp32 and fp16. Coverage is full for the targeted direct-ONNX build tuples (`cpu/cpu/fp32`, `cpu/cpu/fp16`); no accelerator tuples are claimed.

Shipped recipes:

| Recipe |
|---|
| `examples/recipes/onnx-community_BiRefNet_lite-ONNX/cpu/cpu/image-segmentation_fp32_config.json` |
| `examples/recipes/onnx-community_BiRefNet_lite-ONNX/cpu/cpu/image-segmentation_fp16_config.json` |

No methodology friction observed. The fp16 `skip_optimize: true` field is a model-specific direct-ONNX recipe delta, not a skill or CLI methodology change. No source, skill, or `examples/recipes/README.md` files are included in this model PR.

### Per-EP/device/precision results

| Tier | EP / Device | Precision | Verdict | Evidence |
|---|---|---:|---|---|
| L0 build | CPUExecutionProvider / cpu | fp32 | PASS | Recipe build complete in 23.0s from `onnx/model.onnx`; optimized final graph has input `input_image [1,3,1024,1024]` FLOAT, output `output_image [1,1,1024,1024]` FLOAT, 4099 nodes, FLOAT/INT64 initializers, and colocated external data. |
| L0 build | CPUExecutionProvider / cpu | fp16 | PASS | Recipe build complete in 0.9s from `onnx/model_fp16.onnx` with `--precision fp16` and `skip_optimize: true`; final graph keeps 16446 nodes and 437 FLOAT16 initializers, with the same FLOAT input/output mask contract. |
| L1 perf | CPUExecutionProvider / cpu | fp32 | TIMEOUT | `winml perf` with 3 iterations and 1 warmup did not complete within about 904s on this host; no latency/throughput/memory JSON was produced. |
| L1 perf | CPUExecutionProvider / cpu | fp16 | TIMEOUT | `winml perf` with 1 iteration and 0 warmup did not complete within about 304s on this host; no latency/throughput/memory JSON was produced. |
| L3 eval | CPUExecutionProvider / cpu | fp32 | DATA-PROVENANCE-BLOCKED | CLI schema exists for `image-segmentation`, but no authoritative dataset/revision/split and foreground-mask semantic mapping were established for this checkpoint. |
| L3 eval | CPUExecutionProvider / cpu | fp16 | DATA-PROVENANCE-BLOCKED | Same dataset and mask-semantics provenance blocker as fp32. |

Available runtime providers on this host: `['AzureExecutionProvider', 'CPUExecutionProvider']`.

### Delta

The fp32 recipe adds the missing loader task to the direct-ONNX CPU auto-config shape. The fp16 recipe also preserves the published fp16 ONNX graph by disabling the optimization path that otherwise expands the artifact back toward fp32.

| Recipe | JSON pointer | Baseline value | Shipped value | Reason |
|---|---|---|---|---|
| fp32 | `/loader/task` | absent | `image-segmentation` | Direct ONNX auto-config cannot infer task intent from the artifact alone; this recipe records the checkpoint-specific segmentation task. |
| fp16 | `/loader/task` | absent | `image-segmentation` | Same task declaration as fp32. |
| fp16 | `/skip_optimize` | absent | `true` | Preserve the published `onnx/model_fp16.onnx` graph and its 437 FLOAT16 initializers. Recipe-free direct build re-optimizes into a mixed/fp32-sized artifact. |

No source code or tests are changed, and `examples/recipes/README.md` is untouched.

Reducibility: recipe-only is appropriate because the deltas are direct-artifact task intent and checkpoint-specific fp16 preservation. A class-wide Swin exporter or task-resolution change would not correctly describe the repository-root `swin` feature-extraction config versus the shipped segmentation ONNX graph.

### Analyze summary

Static rule analysis produced parseable JSON but exited nonzero because rule derivation lacks required shape information for some `GatherND`/`Conv` checks and reports `Sum` unsupported during QNN/OpenVINO rule evaluation. This is compatibility analysis, not runtime execution.

**Component-level summary**

| Artifact | Architecture coverage | Mapping | Actionable EP findings |
|---|---|---|---|
| fp32 | external preprocessing contract; Swin-style feature encoder; multi-scale decoder; binary mask head | 4099 optimized ONNX ops analyzed; architecture-region mapping is partial because this is a direct ONNX artifact without HTP export module tags | QNN/OpenVINO have partial outcomes for high-rank reshape/transpose and shape-dependent arithmetic. Unknown rule outcomes include `GatherND`, `Sum`, `Conv`, and related decoder ops. VitisAI has no useful op-level support rules for this graph on this host. |

**Op-level summary**

| Artifact | Graph | Dominant ops | EP roll-up |
|---|---|---|---|
| fp32 | 4099 ops / 27 types | Unsqueeze 1361; Reshape 568; Add 287; Mul 275; Slice 260; Transpose 240; Concat 159; MatMul 150; Conv 102; Clip 80 | QNN: 19 supported, 11 partial, 0 unsupported, 9 unknown op entries. OpenVINO: 21 supported, 9 partial, 0 unsupported, 9 unknown. VitisAI: 27 unknown. |

### Reproduce commands

```powershell
$OUT = "temp/birefnet-repro"

uv run winml --version
git rev-parse origin/main
uv run winml inspect -m onnx-community/BiRefNet_lite-ONNX --format json
uv run winml config -m onnx-community/BiRefNet_lite-ONNX/onnx/model.onnx --ep cpu --device cpu -o "$OUT/config_cpu_fp32.json" --overwrite
uv run winml config -m onnx-community/BiRefNet_lite-ONNX/onnx/model_fp16.onnx --ep cpu --device cpu -o "$OUT/config_cpu_fp16.json" --overwrite

uv run winml build -m onnx-community/BiRefNet_lite-ONNX -o "$OUT/root_baseline" --device cpu --ep cpu --no-analyze --no-optimize --no-compile --rebuild
uv run winml build -m onnx-community/BiRefNet_lite-ONNX/onnx/model.onnx -o "$OUT/baseline_fp32" --device cpu --ep cpu --no-analyze --no-compile --rebuild
uv run winml build -m onnx-community/BiRefNet_lite-ONNX/onnx/model_fp16.onnx -o "$OUT/baseline_fp16" --device cpu --ep cpu --no-analyze --no-compile --rebuild

uv run winml build -c examples/recipes/onnx-community_BiRefNet_lite-ONNX/cpu/cpu/image-segmentation_fp32_config.json -m onnx-community/BiRefNet_lite-ONNX/onnx/model.onnx -o "$OUT/fp32" --device cpu --ep cpu --precision fp32 --no-analyze --no-compile --rebuild
uv run winml build -c examples/recipes/onnx-community_BiRefNet_lite-ONNX/cpu/cpu/image-segmentation_fp16_config.json -m onnx-community/BiRefNet_lite-ONNX/onnx/model_fp16.onnx -o "$OUT/fp16" --device cpu --ep cpu --precision fp16 --no-analyze --no-compile --rebuild

uv run python -c "import onnx, collections; from onnx import TensorProto; paths=['$OUT/fp32/model.onnx','$OUT/fp16/model.onnx'];\nfor p in paths:\n    m=onnx.load(p, load_external_data=False)\n    dims=lambda v:[d.dim_value or d.dim_param for d in v.type.tensor_type.shape.dim]\n    init=collections.Counter(TensorProto.DataType.Name(i.data_type) for i in m.graph.initializer)\n    ops=collections.Counter(n.op_type for n in m.graph.node)\n    print(p, len(m.graph.node), [(i.name, dims(i), TensorProto.DataType.Name(i.type.tensor_type.elem_type)) for i in m.graph.input], [(o.name, dims(o), TensorProto.DataType.Name(o.type.tensor_type.elem_type)) for o in m.graph.output], init.most_common(), ops.most_common(10))"
uv run winml perf -m "$OUT/fp32/model.onnx" --device cpu --ep cpu --iterations 3 --warmup 1 --memory --format json -o "$OUT/fp32/perf_cpu.json" --overwrite
uv run winml perf -m "$OUT/fp16/model.onnx" --device cpu --ep cpu --iterations 1 --warmup 0 --memory --format json -o "$OUT/fp16/perf_cpu.json" --overwrite
uv run winml eval --schema --task image-segmentation
uv run winml analyze --model "$OUT/fp32/model.onnx" --ep all --output "$OUT/fp32/analyze_all.json"
```
