### PR TITLE
recipe(google/owlv2-base-patch16-finetuned): add verified CPU fp32/fp16 recipes

### DIFF
--- a/examples/recipes/google_owlv2-base-patch16-finetuned/cpu/cpu/zero-shot-object-detection_fp16_config.json
+++ b/examples/recipes/google_owlv2-base-patch16-finetuned/cpu/cpu/zero-shot-object-detection_fp16_config.json
@@ -1,0 +1,74 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [1, 3, 960, 960],
+        "value_range": [0, 1]
+      },
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [1, 16],
+        "value_range": [0, 49408]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [1, 16],
+        "value_range": [0, 2]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      },
+      {
+        "name": "pred_boxes"
+      },
+      {
+        "name": "text_embeds"
+      },
+      {
+        "name": "image_embeds"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "zero-shot-object-detection",
+    "model_class": "AutoModelForZeroShotObjectDetection",
+    "model_type": "owlv2"
+  }
+}

--- a/examples/recipes/google_owlv2-base-patch16-finetuned/cpu/cpu/zero-shot-object-detection_fp32_config.json
+++ b/examples/recipes/google_owlv2-base-patch16-finetuned/cpu/cpu/zero-shot-object-detection_fp32_config.json
@@ -1,0 +1,55 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [1, 3, 960, 960],
+        "value_range": [0, 1]
+      },
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [1, 16],
+        "value_range": [0, 49408]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [1, 16],
+        "value_range": [0, 2]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      },
+      {
+        "name": "pred_boxes"
+      },
+      {
+        "name": "text_embeds"
+      },
+      {
+        "name": "image_embeds"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "zero-shot-object-detection",
+    "model_class": "AutoModelForZeroShotObjectDetection",
+    "model_type": "owlv2"
+  }
+}


### PR DESCRIPTION
## Summary

Add verified CPU fp32 and fp16 zero-shot-object-detection recipes for `google/owlv2-base-patch16-finetuned`, an OWLv2 open-vocabulary object detector fine-tuned for zero-shot detection. This is an Effort L0 / Outcome L0 recipe-only contribution because current `main` already exports the model without a recipe; the recipes record verified precision coverage for CPUExecutionProvider. Highest Goal verdict: **L1 PASS** (L3 CLI-BLOCKED: `zero-shot-object-detection` is not supported by `winml eval`).

## Model metadata

1. **What the model does** — OWLv2 (Open-World Localization v2) is an open-vocabulary object detector that localizes objects in images given free-form text queries. It combines a CLIP-style text encoder with a large ViT vision encoder fused by class and box prediction heads. Evidence: [checkpoint config](https://huggingface.co/google/owlv2-base-patch16-finetuned), `Owlv2ForObjectDetection` architecture, and ONNX outputs `logits`, `pred_boxes`, `text_embeds`, `image_embeds`. Confidence: **verified**.
2. **Primary user stories** — A user supplies an image and text queries describing target objects to obtain bounding boxes, confidence scores, and embeddings for zero-shot object detection. Evidence: checkpoint model card and task registration. Confidence: **verified**.
3. **Supported tasks** — `zero-shot-object-detection` across checkpoint, Transformers, Optimum ONNX (`OwlV2OnnxConfig`), and WinML surfaces. Evidence: Optimum vendor probe (`VENDOR-ONLY`), `winml inspect` on current `main`. Confidence: **verified**.
4. **Model architecture** — OWLv2 zero-shot object detector: CLIP text encoder (12-layer transformer, hidden=512, 8 heads, seq_len=16, vocab=49408) + ViT vision encoder (patch16, 960x960 input, 60x60 patches) + detection head.

```text
Owlv2ForObjectDetection
├── CLIP Text Encoder
│   ├── Token + position embeddings (vocab 49408, seq 16, hidden 512)
│   ├── Transformer layer × 12 (8-head self-attention, GELU MLP)
│   └── Final LayerNorm → text_embeds [1, 1, 512]
├── ViT Vision Encoder
│   ├── Patch projection (Conv2d 3→hidden, kernel/stride 16, 960×960 → 60×60)
│   ├── CLS token + position embeddings
│   ├── Transformer layer × 12 (self-attention + GELU MLP)
│   └── Final LayerNorm → image_embeds [1, 60, 60, 768]
├── Class prediction head → logits [1, 3600, 1]
└── Box prediction head → pred_boxes [1, 3600, 4]
```

- Source/confidence: Transformers `Owlv2ForObjectDetection` source, `winml inspect` I/O shapes, and built ONNX outputs (**mapped**).

## Validation and support evidence

### Baseline

- Current `main` at `eca56bbbc1bd512570d83213d15abb8b2e2fd0f1`; WinML CLI version from that commit.
- Starting auto-config (`winml config`): **PASS** with task `zero-shot-object-detection`, `AutoModelForZeroShotObjectDetection`, inputs `pixel_values [1,3,960,960]`, `input_ids [1,16]`, `attention_mask [1,16]`, outputs `logits`, `pred_boxes`, `text_embeds`, `image_embeds`, opset 17.
- Recipe-free build: **PASS** in 59.0s; final artifact 585.6 MB.
- Baseline CPU fp32 perf: **PASS**; mean 1983 ms, P50 1788 ms, throughput 0.50 samples/s, RAM model load +510 MB, inference +922 MB.
- Baseline eval: **CLI-BLOCKED** — `winml eval` does not support task `zero-shot-object-detection` (supported tasks list does not include it).
- Optimum probe: `zero-shot-object-detection` and `feature-extraction` in vendor registration; WinML adds nothing (**VENDOR-ONLY**).

### Goal

- Committed axes: **Effort L0 / Goal ceiling L1 / Outcome L0**.
- L0 is inherited from baseline (build passes on `main`). Ceiling is L1 (perf) because L3 is CLI-BLOCKED (`zero-shot-object-detection` not in `winml eval` supported tasks). L2 (numeric parity) was not attempted in this run.

### Outcome

- Shipped tier: **L0**; highest Goal verdict: **L1 PASS**; coverage: **full** (all required CPU tuples passed); deferred tuples: **none**.
- Shipped recipes:
  - `examples/recipes/google_owlv2-base-patch16-finetuned/cpu/cpu/zero-shot-object-detection_fp32_config.json`
  - `examples/recipes/google_owlv2-base-patch16-finetuned/cpu/cpu/zero-shot-object-detection_fp16_config.json`
- No source code, test, skill, or recipe README files changed.

### Per-EP/device/precision results

#### Goal ladder

| Tier | CPUExecutionProvider / cpu / fp32 | CPUExecutionProvider / cpu / fp16 |
|---|---|---|
| L0 — build | PASS — 126.6s, 585.6 MB | PASS — 55.6s, 293.0 MB (genuine fp16) |
| L1 — perf | PASS — P50 1737 ms | PASS — P50 2942 ms |
| L3 — eval | CLI-BLOCKED | CLI-BLOCKED |

#### Perf

| EP / Device | Precision | Verdict | Mean | P50 | Throughput | RAM model load Δ | RAM inference Δ |
|---|---|---|---:|---:|---:|---:|---:|
| CPUExecutionProvider / cpu | fp32 | PASS | 1838 ms | 1737 ms | 0.54 samples/s | +509 MB | +922 MB |
| CPUExecutionProvider / cpu | fp16 | PASS | 3092 ms | 2942 ms | 0.32 samples/s | +629 MB | +3018 MB |

#### Eval

| EP / Device | Precision | Verdict | Evidence |
|---|---|---|---|
| CPUExecutionProvider / cpu | fp32 | CLI-BLOCKED | `winml eval --task zero-shot-object-detection` → "Task 'zero-shot-object-detection' is not supported by `winml eval`" |
| CPUExecutionProvider / cpu | fp16 | CLI-BLOCKED | Same as above |

### Delta

- Both shipped recipes are identical to the `winml config` auto-config output for their respective precisions, filed for verified `cpu/cpu` coverage that the out-of-the-box auto-build does not establish as a checked-in claim.
- fp32 recipe: no delta from auto-config.
- fp16 recipe: changes `/quant` from `null` to `{mode: "fp16", samples: 10, calibration_method: "minmax", weight_type: "uint8", activation_type: "uint8", per_channel: false, symmetric: false, fp16_keep_io_types: true, ...}`.
- No code paths, symbols, or class-wide behavior changes. `examples/recipes/README.md` remains untouched.

### Analyze

- **CLI-BLOCKED** — `winml analyze` failed with "No runtime rule parquet files were found" in the development environment. Static EP compatibility analysis was not available.

### Reproduce commands

```bash
# fp32 build + perf
winml build -m google/owlv2-base-patch16-finetuned \
  -c examples/recipes/google_owlv2-base-patch16-finetuned/cpu/cpu/zero-shot-object-detection_fp32_config.json \
  --ep cpu --device cpu -o out_fp32
winml perf -m out_fp32/model.onnx --ep cpu --device cpu

# fp16 build + perf
winml build -m google/owlv2-base-patch16-finetuned \
  -c examples/recipes/google_owlv2-base-patch16-finetuned/cpu/cpu/zero-shot-object-detection_fp16_config.json \
  -p fp16 --ep cpu --device cpu -o out_fp16
winml perf -m out_fp16/model.onnx --ep cpu --device cpu
```
