### PR TITLE
recipe(stanfordmimi/synthpose-vitpose-base-hf): add verified CPU fp32/fp16 recipes

### DIFF
--- a/examples/recipes/stanfordmimi_synthpose-vitpose-base-hf/cpu/cpu/keypoint-detection_fp16_config.json
+++ b/examples/recipes/stanfordmimi_synthpose-vitpose-base-hf/cpu/cpu/keypoint-detection_fp16_config.json
@@ -1,0 +1,64 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          256,
+          192
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "heatmaps"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "keypoint-detection",
+    "model_id": "stanfordmimi/synthpose-vitpose-base-hf",
+    "model_type": "vitpose",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "keypoint-detection",
+    "model_class": "VitPoseForPoseEstimation",
+    "model_type": "vitpose"
+  }
+}

--- a/examples/recipes/stanfordmimi_synthpose-vitpose-base-hf/cpu/cpu/keypoint-detection_fp32_config.json
+++ b/examples/recipes/stanfordmimi_synthpose-vitpose-base-hf/cpu/cpu/keypoint-detection_fp32_config.json
@@ -1,0 +1,42 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          256,
+          192
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "heatmaps"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "keypoint-detection",
+    "model_class": "VitPoseForPoseEstimation",
+    "model_type": "vitpose"
+  }
+}


### PR DESCRIPTION
## Summary

Add verified CPU fp32 and fp16 keypoint-detection recipes for `stanfordmimi/synthpose-vitpose-base-hf`, a ViTPose base model trained on synthetic pose data for human keypoint estimation. This is an Effort L0 / Outcome L0 recipe-only contribution because current `main` already exports the model without a recipe; the recipes record verified precision coverage for CPUExecutionProvider. Highest Goal verdict: **L1 PASS** (L3 CLI-BLOCKED: `winml eval` metrics computation failed for `keypoint-detection`).

## Model metadata

1. **What the model does** — ViTPose is a vision-transformer-based model for human pose estimation that predicts body keypoint heatmaps from cropped person images. This checkpoint is trained on synthetic pose data (SynthPose). Evidence: HF checkpoint config, `VitPoseForPoseEstimation` architecture. Confidence: **verified**.
2. **Primary user stories** — A user supplies a cropped person image to obtain keypoint heatmaps for human pose estimation. Evidence: checkpoint model card, task registration. Confidence: **verified**.
3. **Supported tasks** — `keypoint-detection` across checkpoint, Transformers, and WinML surfaces. Evidence: `winml inspect` on current `main`, Optimum probe (`WINML-ONLY`). Confidence: **verified**.
4. **Model architecture** — ViTPose base model for pose estimation.

```text
VitPoseForPoseEstimation
├── ViT Backbone
│   ├── Patch embedding (Conv2d 3→768, patch 16×16, input 256×192)
│   ├── Position embeddings
│   └── Transformer layer × 12 (self-attention + MLP)
└── Keypoint head → heatmaps [B, num_keypoints, H, W]
```

- Source/confidence: Transformers `VitPoseForPoseEstimation` source, `winml inspect` I/O shapes (**mapped**).

## Validation and support evidence

### Baseline

- Current `main` at `3ea6df73d5438040d21167b502c251d3e451fb2b`.
- Starting auto-config (`winml config`): **PASS** with task `keypoint-detection`, `VitPoseForPoseEstimation`, input `pixel_values [1,3,256,192]`, output `heatmaps`, opset 17.
- Recipe-free build: **PASS** in 24.2s; final artifact 343.5 MB.
- Baseline CPU fp32 perf: **PASS**; mean 57.44 ms, P50 57.07 ms, throughput 17.41 samples/s, RAM model load +360 MB, inference +27 MB.
- Baseline eval: **CLI-BLOCKED** — `winml eval` ran inference but failed at metrics computation for task `keypoint-detection`.
- Optimum probe: `keypoint-detection` in `added_by_winml` only (**WINML-ONLY**).

### Goal

- Committed axes: **Effort L0 / Goal ceiling L1 / Outcome L0**.
- L0 is inherited from baseline (build passes on `main`). Ceiling is L1 (perf) because L3 is CLI-BLOCKED (metrics computation failure) and L2 is CLI-pending.

### Outcome

- Shipped tier: **L0**; highest Goal verdict: **L1 PASS**; coverage: **full** (all required CPU tuples passed); deferred tuples: **none**.
- Shipped recipes:
  - `examples/recipes/stanfordmimi_synthpose-vitpose-base-hf/cpu/cpu/keypoint-detection_fp32_config.json`
  - `examples/recipes/stanfordmimi_synthpose-vitpose-base-hf/cpu/cpu/keypoint-detection_fp16_config.json`
- No source code changes.

### Per-EP/device/precision results

#### Goal ladder

| Tier | CPUExecutionProvider / cpu / fp32 | CPUExecutionProvider / cpu / fp16 |
|---|---|---|
| L0 — build | PASS — 22.5s, 343.5 MB | PASS — 21.6s, 171.8 MB |
| L1 — perf | PASS — P50 58.39 ms | PASS — P50 70.35 ms |
| L3 — eval | CLI-BLOCKED | CLI-BLOCKED |

#### Perf

| EP / Device | Precision | Verdict | Mean | P50 | Throughput | RAM model load Δ | RAM inference Δ |
|---|---|---|---:|---:|---:|---:|---:|
| CPUExecutionProvider / cpu | fp32 | PASS | 56.46 ms | 58.39 ms | 17.71 samples/s | +359 MB | +27 MB |
| CPUExecutionProvider / cpu | fp16 | PASS | 70.38 ms | 70.35 ms | 14.21 samples/s | +368 MB | +33 MB |

#### Eval

| EP / Device | Precision | Verdict | Evidence |
|---|---|---|---|
| CPUExecutionProvider / cpu | fp32 | CLI-BLOCKED | `winml eval` inference completed but metrics computation failed for `keypoint-detection` |
| CPUExecutionProvider / cpu | fp16 | CLI-BLOCKED | Same as above |

### Delta

- fp32 recipe: identical to `winml config` auto-config output — filed for verified `cpu/cpu` coverage.
- fp16 recipe: identical to `winml config -p fp16` auto-config output — filed for verified `cpu/cpu` coverage.

### Reproduce

```bash
# fp32
winml build -m stanfordmimi/synthpose-vitpose-base-hf \
  -c examples/recipes/stanfordmimi_synthpose-vitpose-base-hf/cpu/cpu/keypoint-detection_fp32_config.json \
  --ep cpu --device cpu -o out/fp32
winml perf -m out/fp32/model.onnx --ep cpu --device cpu

# fp16
winml build -m stanfordmimi/synthpose-vitpose-base-hf \
  -c examples/recipes/stanfordmimi_synthpose-vitpose-base-hf/cpu/cpu/keypoint-detection_fp16_config.json \
  -p fp16 --ep cpu --device cpu -o out/fp16
winml perf -m out/fp16/model.onnx --ep cpu --device cpu
```
