### PR TITLE
recipe(Common-Voice-Gender-Detection): audio-classification cpu recipes

### DIFF
--- a/examples/recipes/prithivMLmods_Common-Voice-Gender-Detection/cpu/cpu/audio-classification_fp16_config.json
+++ b/examples/recipes/prithivMLmods_Common-Voice-Gender-Detection/cpu/cpu/audio-classification_fp16_config.json
@@ -1,0 +1,59 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          16000
+        ],
+        "value_range": [
+          -1,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "audio-classification",
+    "model_class": "AutoModelForAudioClassification",
+    "model_type": "wav2vec2"
+  }
+}

--- a/examples/recipes/prithivMLmods_Common-Voice-Gender-Detection/cpu/cpu/audio-classification_fp32_config.json
+++ b/examples/recipes/prithivMLmods_Common-Voice-Gender-Detection/cpu/cpu/audio-classification_fp32_config.json
@@ -1,0 +1,40 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          16000
+        ],
+        "value_range": [
+          -1,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "audio-classification",
+    "model_class": "AutoModelForAudioClassification",
+    "model_type": "wav2vec2"
+  }
+}


### PR DESCRIPTION
## Summary

Adds verified CPU recipes (fp32 and fp16) for [prithivMLmods/Common-Voice-Gender-Detection](https://huggingface.co/prithivMLmods/Common-Voice-Gender-Detection), a Wav2Vec2ForSequenceClassification model for binary gender classification (female/male) from audio. Effort L0, Goal ceiling L2, Outcome L0. Both precisions pass build and perf; eval (L3) is CLI-BLOCKED due to audio-classification task not being supported for eval.

## Model metadata

**What the model does:** Binary gender classification (female/male) from raw audio waveforms using a fine-tuned Wav2Vec2 encoder.

**Primary user stories:** Classify speaker gender from audio clips for analytics, content tagging, and demographic analysis.

**Supported tasks:** audio-classification

**Model architecture:**

```text
Wav2Vec2ForSequenceClassification
├── Feature extractor (CNN: 7 conv layers, 512 channels)
├── Feature projection (512 → 1024)
├── Encoder stack x 24
│   ├── Self-attention (16 heads, 1024 dim)
│   ├── Feed-forward (1024 → 4096 → 1024, GELU)
│   └── Residual + LayerNorm
└── Classification head (1024 → 256 → 2: female/male)
```

- Source/confidence: pinned checkpoint config and `Wav2Vec2ForSequenceClassification` source (`verified`).

## Validation and support evidence

### Baseline

- Pinned main commit: `57dc6b20`
- Build PASS, Perf PASS on main
- Auto-config produces identical fp32 recipe; fp16 adds quant block with `mode: "fp16"`

### Goal

- Effort: L0 (recipe-only)
- Goal ceiling: L2
- Outcome: L0
- Success definition: Build PASS + Perf PASS for cpu/cpu fp32 and fp16

### Outcome

L0 PASS for both tuples. L2 reached (cosine similarity 1.0 for both precisions). L3 CLI-BLOCKED: audio-classification task not supported for eval.

Shipped recipes:
- `examples/recipes/prithivMLmods_Common-Voice-Gender-Detection/cpu/cpu/audio-classification_fp32_config.json`
- `examples/recipes/prithivMLmods_Common-Voice-Gender-Detection/cpu/cpu/audio-classification_fp16_config.json`

Appended finding: wav2vec2-005 to `model_knowledge/wav2vec2.json`.

### Per-EP/device/precision results

| Tier | EP / Device | Precision | Verdict | Mean | Throughput | RAM Δ | Eval metric |
|---|---|---|---|---|---|---|---|
| L0 | CPUExecutionProvider / cpu | fp32 | PASS (26.6s, 360.9MB) | — | — | — | — |
| L1 | CPUExecutionProvider / cpu | fp32 | PASS | 49.08 ms | 20.38 sps | +401.5 MB | — |
| L2 | CPUExecutionProvider / cpu | fp32 | PASS | — | — | — | cosine=1.0, max_abs=1.05e-5 |
| L3 | CPUExecutionProvider / cpu | fp32 | CLI-BLOCKED | — | — | — | — |
| L0 | CPUExecutionProvider / cpu | fp16 | PASS (32.6s, 180.5MB) | — | — | — | — |
| L1 | CPUExecutionProvider / cpu | fp16 | PASS | 63.25 ms | 15.81 sps | +422.6 MB | — |
| L2 | CPUExecutionProvider / cpu | fp16 | PASS | — | — | — | cosine=1.0, max_abs=3.10e-3 |
| L3 | CPUExecutionProvider / cpu | fp16 | CLI-BLOCKED | — | — | — | — |

L3 CLI-BLOCKED: audio-classification task not supported for eval. Rules parquet unavailable on host.

### Delta

- fp32 recipe: identical to baseline auto-config output
- fp16 recipe: adds `quant` block with `mode: "fp16"` and default calibration settings
- `examples/recipes/README.md` untouched

### Analyze summary — component level and op level

Static rule analysis: rules parquet unavailable on host. Analyze data could not be produced.

#### Component-level summary
| Artifact | Status | Notes |
|---|---|---|
| fp32 | ANALYZE-UNAVAILABLE | Rules parquet not available on host |
| fp16 | ANALYZE-UNAVAILABLE | Rules parquet not available on host |

#### Op-level summary

Not available — rules parquet unavailable on host.

### Reproduce commands

```powershell
# Build fp32
winml build --model prithivMLmods/Common-Voice-Gender-Detection --config examples/recipes/prithivMLmods_Common-Voice-Gender-Detection/cpu/cpu/audio-classification_fp32_config.json --output $OUT/fp32

# Build fp16
winml build --model prithivMLmods/Common-Voice-Gender-Detection --config examples/recipes/prithivMLmods_Common-Voice-Gender-Detection/cpu/cpu/audio-classification_fp16_config.json --output $OUT/fp16

# Perf fp32
winml perf --model $OUT/fp32 --runs 20

# Perf fp16
winml perf --model $OUT/fp16 --runs 20
```