### PR TITLE
recipe(rubentito/layoutlmv3-base-mpdocvqa): add verified CPU fp32/fp16 recipes

### DIFF
--- a/examples/recipes/rubentito_layoutlmv3-base-mpdocvqa/cpu/cpu/question-answering_fp16_config.json
+++ b/examples/recipes/rubentito_layoutlmv3-base-mpdocvqa/cpu/cpu/question-answering_fp16_config.json
@@ -1,0 +1,106 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          50265
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      },
+      {
+        "name": "bbox",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512,
+          4
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          224,
+          224
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "start_logits"
+      },
+      {
+        "name": "end_logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "question-answering",
+    "model_id": "rubentito/layoutlmv3-base-mpdocvqa",
+    "model_type": "layoutlmv3",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "question-answering",
+    "model_class": "AutoModelForQuestionAnswering",
+    "model_type": "layoutlmv3"
+  }
+}

--- a/examples/recipes/rubentito_layoutlmv3-base-mpdocvqa/cpu/cpu/question-answering_fp32_config.json
+++ b/examples/recipes/rubentito_layoutlmv3-base-mpdocvqa/cpu/cpu/question-answering_fp32_config.json
@@ -1,0 +1,84 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          50265
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      },
+      {
+        "name": "bbox",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512,
+          4
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          224,
+          224
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "start_logits"
+      },
+      {
+        "name": "end_logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "question-answering",
+    "model_class": "AutoModelForQuestionAnswering",
+    "model_type": "layoutlmv3"
+  }
+}


### PR DESCRIPTION
## Summary

Add verified CPU fp32 and fp16 recipes for `rubentito/layoutlmv3-base-mpdocvqa`, a LayoutLMv3 model fine-tuned on MP-DocVQA for document question answering. Architecture support already exists on `main` (PR #1174); this contribution ships checkpoint-specific recipe configs with L1 (perf) verification on both precisions.

## Model metadata

**What the model does:** LayoutLMv3 is a multimodal document understanding Transformer that jointly encodes text tokens (with bounding-box position embeddings) and document image patches to perform extractive question answering over visually-rich documents.

**Primary user stories:**
- Extract answers from scanned/digital documents given a natural-language question
- Automate document VQA pipelines for forms, invoices, and multi-page documents

**Supported tasks:** question-answering (extractive span prediction — start_logits / end_logits)

**Model architecture:**

```text
LayoutLMv3ForQuestionAnswering
├── Embeddings
│   ├── Word embeddings (vocab 50265 × 768)
│   ├── Position embeddings (512 × 768)
│   ├── Spatial (bbox) embeddings (2D: x/y/w/h)
│   └── Patch embeddings (3×224×224 → 196 patches × 768)
├── Encoder stack × 12
│   ├── Self-attention (12 heads, 768 dim)
│   ├── Feed-forward (768 → 3072 → 768, GELU)
│   └── Residual + LayerNorm
└── QA span head (768 → 2: start/end logits)
```

- Source/confidence: pinned checkpoint config.json and `LayoutLMv3ForQuestionAnswering` class (`verified`).

## Validation and support evidence

### Baseline

On `main` (commit `67169d45`, WinML CLI latest), `rubentito/layoutlmv3-base-mpdocvqa` builds successfully out-of-the-box for both fp32 (512.7 MB) and fp16 (260.3 MB) via auto-config. PR #1174 (merged 2026-07-23) registered `LayoutLMv3IOConfig` with full multi-modal input support. Optimum coverage: layoutlmv3 is a supported architecture in optimum exporters.

### Goal

| Axis | Level | Definition |
|---|---|---|
| Effort | L0 (recipe only) | No code changes; architecture infra already on main |
| Goal | L1 (perf) | Build + benchmark latency/throughput/memory |
| Outcome | L0 (recipe + report) | Verified recipes shipped |

### Outcome

Goal L1 reached on all required tuples. Coverage: **full** (all planned tuples PASS). No deferred tuples.

### Per-EP/device/precision results

| Tier | EP / Device | Precision | Verdict | Avg | P50 | Throughput | RAM Δ |
|---|---|---|---|---|---|---|---|
| L0 | CPUExecutionProvider / cpu | fp32 | PASS | — | — | — | — |
| L1 | CPUExecutionProvider / cpu | fp32 | PASS | 353.03 ms | 352.95 ms | 2.83 samples/s | +550.4 MB |
| L0 | CPUExecutionProvider / cpu | fp16 | PASS | — | — | — | — |
| L1 | CPUExecutionProvider / cpu | fp16 | PASS | 354.06 ms | 354.27 ms | 2.82 samples/s | +550.0 MB |

Eval: CLI-BLOCKED — no `winml eval` command available for task-metric verification.

### Delta

Shipped recipes relative to auto-config baseline:
- `examples/recipes/rubentito_layoutlmv3-base-mpdocvqa/cpu/cpu/question-answering_fp32_config.json` — identical to auto-generated config (explicit checkpoint pin)
- `examples/recipes/rubentito_layoutlmv3-base-mpdocvqa/cpu/cpu/question-answering_fp16_config.json` — adds `quant.mode: "fp16"` with uint8 weight/activation quantization

`examples/recipes/README.md` untouched.

### Analyze summary — component level and op level

CLI-BLOCKED — `winml analyze` requires runtime rule parquet files not present in this installation. This is an infrastructure gap, not a model issue. Static rule analysis was not executed.

### Reproduce commands

```powershell
# Build fp32
winml build -m rubentito/layoutlmv3-base-mpdocvqa -c examples/recipes/rubentito_layoutlmv3-base-mpdocvqa/cpu/cpu/question-answering_fp32_config.json --use-cache

# Build fp16
winml build -m rubentito/layoutlmv3-base-mpdocvqa -c examples/recipes/rubentito_layoutlmv3-base-mpdocvqa/cpu/cpu/question-answering_fp16_config.json --use-cache

# Perf fp32
winml perf -m rubentito/layoutlmv3-base-mpdocvqa -c examples/recipes/rubentito_layoutlmv3-base-mpdocvqa/cpu/cpu/question-answering_fp32_config.json

# Perf fp16
winml perf -m rubentito/layoutlmv3-base-mpdocvqa -c examples/recipes/rubentito_layoutlmv3-base-mpdocvqa/cpu/cpu/question-answering_fp16_config.json
```
