### PR TITLE
recipe(multilingual-e5-large): add CPU fp32 and fp16 recipes

### DIFF
--- a/examples/recipes/intfloat_multilingual-e5-large/cpu/cpu/feature-extraction_fp16_config.json
+++ b/examples/recipes/intfloat_multilingual-e5-large/cpu/cpu/feature-extraction_fp16_config.json
@@ -1,0 +1,76 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          250002
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "feature-extraction",
+    "model_id": "intfloat/multilingual-e5-large",
+    "model_type": "xlm-roberta",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "feature-extraction",
+    "model_class": "AutoModel",
+    "model_type": "xlm-roberta"
+  }
+}

--- a/examples/recipes/intfloat_multilingual-e5-large/cpu/cpu/feature-extraction_fp32_config.json
+++ b/examples/recipes/intfloat_multilingual-e5-large/cpu/cpu/feature-extraction_fp32_config.json
@@ -1,0 +1,54 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          250002
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "feature-extraction",
+    "model_class": "AutoModel",
+    "model_type": "xlm-roberta"
+  }
+}


### PR DESCRIPTION
## Summary

Add verified CPU execution provider coverage recipes for `intfloat/multilingual-e5-large` (feature-extraction, XLM-RoBERTa) with fp32 and fp16 precision. No source changes — current `main` already builds and runs this model recipe-free; these recipes record exact verified `(cpu, cpu, fp32)` and `(cpu, cpu, fp16)` coverage.

## Model metadata

- **What the model does**: Multilingual text embedding model producing dense 1024-dim vectors for semantic similarity, retrieval, and clustering across 100+ languages (confidence: verified — HuggingFace model card + architecture inspection)
- **Primary user stories**: User supplies multilingual text queries/passages to obtain normalized embeddings for cross-lingual semantic search and sentence similarity
- **Supported tasks**: feature-extraction (sentence-similarity via cosine; Optimum vendor-registered for xlm-roberta)
- **Model architecture**:
  XLMRobertaModel (560M params)
  ├── XLMRobertaEmbeddings (word + position + type + LayerNorm)
  └── XLMRobertaEncoder
      └── XLMRobertaLayer ×24 (self-attention + intermediate + output)

## Validation and support evidence

**Baseline** (origin/main `67169d45`, winml 0.2.0):
- `winml build -m intfloat/multilingual-e5-large` → ✅ PASS (82.7s)
- `winml perf` → ✅ avg 411.65ms, 2.43 samples/s, +1309.1 MB RSS
- `winml eval --task feature-extraction` → ✅ cosine_spearman 84.0374 (mteb/stsbenchmark-sts, 100 samples)
- **Goal floor**: L3 (baseline already reaches task metric)

**Committed tiers**: Effort L0 / Goal L3 / Outcome L0

**Per-tuple results**:

| EP | Device | Precision | L0 (build) | L1 (perf) | L3 (eval) |
|---|---|---|---|---|---|
| cpu | cpu | fp32 | ✅ 94.9s | ✅ avg 506.25ms, 2.14 samples/s, +1308.7 MB RSS | ✅ cosine_spearman 84.0374 (mteb/stsbenchmark-sts, 100 samples) |
| cpu | cpu | fp16 | ✅ 94.3s | ✅ avg 445.69ms, 2.01 samples/s, +1308.3 MB RSS | ✅ cosine_spearman 84.0374 (mteb/stsbenchmark-sts, 100 samples) |

**Delta** (recipe vs `winml config --ep cpu --device cpu`):
- fp32: identical to auto-config (filed for verified cpu/cpu coverage)
- fp16: adds `quant` block (`mode: fp16`, `fp16_keep_io_types: true`)

**Analyze**: CLI-BLOCKED — runtime rule parquet files not found on this host.

**Reproduce commands**:
```bash
# fp32
winml build -m intfloat/multilingual-e5-large \
-c examples/recipes/intfloat_multilingual-e5-large/cpu/cpu/feature-extraction_fp32_config.json \
-o out_fp32 --ep cpu --device cpu --rebuild
winml perf -m out_fp32/model.onnx --ep cpu --device cpu
winml eval -m out_fp32/model.onnx --model-id intfloat/multilingual-e5-large --task feature-extraction --ep cpu --device cpu

# fp16
winml build -m intfloat/multilingual-e5-large \
-c examples/recipes/intfloat_multilingual-e5-large/cpu/cpu/feature-extraction_fp16_config.json \
-o out_fp16 --ep cpu --device cpu --rebuild
winml perf -m out_fp16/model.onnx --ep cpu --device cpu
winml eval -m out_fp16/model.onnx --model-id intfloat/multilingual-e5-large --task feature-extraction --ep cpu --device cpu