### PR TITLE
feat(eval): add translation quality evaluation

### DIFF
--- a/src/winml/modelkit/eval/__init__.py
+++ b/src/winml/modelkit/eval/__init__.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
     from .tensor_similarity_evaluator import TensorSimilarityEvaluator
     from .text_classification_evaluator import WinMLTextClassificationEvaluator
     from .token_classification_evaluator import WinMLTokenClassificationEvaluator
+    from .translation_evaluator import WinMLTranslationEvaluator
     from .zero_shot_classification_evaluator import WinMLZeroShotClassificationEvaluator
     from .zero_shot_image_classification_evaluator import WinMLZeroShotImageClassificationEvaluator
 
@@ -68,6 +69,8 @@ _LAZY_ATTRS: dict[str, str] = {
         ".text_classification_evaluator:WinMLTextClassificationEvaluator",
     "WinMLTokenClassificationEvaluator":
         ".token_classification_evaluator:WinMLTokenClassificationEvaluator",
+    "WinMLTranslationEvaluator":
+        ".translation_evaluator:WinMLTranslationEvaluator",
     "WinMLZeroShotClassificationEvaluator":
         ".zero_shot_classification_evaluator:WinMLZeroShotClassificationEvaluator",
     "WinMLZeroShotImageClassificationEvaluator":
@@ -142,6 +145,7 @@ __all__ = [
     "WinMLQuestionAnsweringEvaluator",
     "WinMLTextClassificationEvaluator",
     "WinMLTokenClassificationEvaluator",
+    "WinMLTranslationEvaluator",
     "WinMLZeroShotClassificationEvaluator",
     "WinMLZeroShotImageClassificationEvaluator",
     "evaluate",

--- a/src/winml/modelkit/eval/evaluate.py
+++ b/src/winml/modelkit/eval/evaluate.py
@@ -55,6 +55,8 @@ _EVALUATOR_REGISTRY: dict[str, str] = {
         "winml.modelkit.eval.image_feature_extraction_evaluator:WinMLImageFeatureExtractionEvaluator",
     "image-to-text":
         "winml.modelkit.eval.image_to_text_evaluator:WinMLImageToTextEvaluator",
+    "translation":
+        "winml.modelkit.eval.translation_evaluator:WinMLTranslationEvaluator",
     "fill-mask":
         "winml.modelkit.eval.fill_mask_evaluator:WinMLFillMaskEvaluator",
     "zero-shot-classification":

--- a/src/winml/modelkit/eval/metrics/translation.py
+++ b/src/winml/modelkit/eval/metrics/translation.py
@@ -1,0 +1,48 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+"""Corpus-level machine-translation metrics."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class TranslationMetric:
+    """Aggregate corpus SacreBLEU and chrF over translated sentences."""
+
+    def __init__(self) -> None:
+        self._predictions: list[str] = []
+        self._references: list[list[str]] = []
+
+    def update(self, prediction: str, references: str | list[str]) -> None:
+        """Record one prediction and one or more non-empty references."""
+        refs = [references] if isinstance(references, str) else references
+        cleaned = [reference.strip() for reference in refs if reference and reference.strip()]
+        if not cleaned:
+            raise ValueError("at least one non-empty translation reference is required")
+        self._predictions.append((prediction or "").strip())
+        self._references.append(cleaned)
+
+    def compute(self) -> dict[str, Any]:
+        """Return corpus SacreBLEU and chrF scores on the conventional 0-100 scale."""
+        if not self._predictions:
+            return {"sacrebleu": None, "chrf": None, "n_samples": 0}
+
+        from torchmetrics.text import CHRFScore, SacreBLEUScore
+
+        sacrebleu = SacreBLEUScore(tokenize="13a")(
+            self._predictions,
+            self._references,
+        )
+        # Standard chrF2: character n-grams only (word_order=0), beta=2.
+        # TorchMetrics otherwise defaults to word_order=2, which is chrF++.
+        chrf = CHRFScore(n_word_order=0, beta=2.0)(self._predictions, self._references)
+
+        return {
+            "sacrebleu": round(float(sacrebleu) * 100, 4),
+            "chrf": round(float(chrf) * 100, 4),
+            "n_samples": len(self._predictions),
+        }

--- a/src/winml/modelkit/eval/translation_evaluator.py
+++ b/src/winml/modelkit/eval/translation_evaluator.py
@@ -65,7 +65,11 @@ class WinMLTranslationEvaluator(WinMLEvaluator):
             self._pipeline_kwargs["tgt_lang"] = self._tokenizer_target_lang
 
         max_encoder_length = getattr(model, "max_encoder_length", None)
-        if isinstance(max_encoder_length, int) and max_encoder_length > 0:
+        if (
+            isinstance(max_encoder_length, int)
+            and max_encoder_length > 0
+            and self.pipe.tokenizer is not None
+        ):
             self.pipe.tokenizer.model_max_length = max_encoder_length
 
         max_decode_length = getattr(model, "max_decode_length", None)

--- a/src/winml/modelkit/eval/translation_evaluator.py
+++ b/src/winml/modelkit/eval/translation_evaluator.py
@@ -1,0 +1,191 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+"""Evaluator for text-to-text machine translation models."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
+
+from .base_evaluator import WinMLEvaluator
+
+
+if TYPE_CHECKING:
+    from datasets import Dataset
+
+    from ..models.winml.composite_model import WinMLCompositeModel
+    from .config import DatasetConfig, WinMLEvaluationConfig
+
+
+logger = logging.getLogger(__name__)
+
+
+class WinMLTranslationEvaluator(WinMLEvaluator):
+    """Evaluate translations with corpus SacreBLEU and chrF.
+
+    Flat datasets can map separate ``source_column`` and
+    ``reference_column`` values. WMT-style datasets can leave both columns
+    mapped to ``translation`` and provide explicit ``source_lang`` and
+    ``target_lang`` keys. Language direction is never guessed from a model ID.
+    """
+
+    def __init__(
+        self,
+        config: WinMLEvaluationConfig,
+        model: WinMLCompositeModel,
+    ) -> None:
+        from ..utils.eval_utils import get_default
+
+        mapping = config.dataset.columns_mapping
+        self._source_col = mapping.get(
+            "source_column",
+            get_default("translation", "source_column") or "translation",
+        )
+        self._reference_col = mapping.get(
+            "reference_column",
+            get_default("translation", "reference_column") or "translation",
+        )
+        self._source_lang = mapping.get("source_lang")
+        self._target_lang = mapping.get("target_lang")
+        self._tokenizer_source_lang = mapping.get("tokenizer_source_lang", self._source_lang)
+        self._tokenizer_target_lang = mapping.get("tokenizer_target_lang", self._target_lang)
+        self._source_prefix = mapping.get("source_prefix", "")
+        super().__init__(config, model)
+        self._pipeline_kwargs: dict[str, Any] = {
+            "num_beams": 1,
+            "truncation": True,
+        }
+        if self._tokenizer_source_lang:
+            self._pipeline_kwargs["src_lang"] = self._tokenizer_source_lang
+        if self._tokenizer_target_lang:
+            self._pipeline_kwargs["tgt_lang"] = self._tokenizer_target_lang
+
+        max_encoder_length = getattr(model, "max_encoder_length", None)
+        if isinstance(max_encoder_length, int) and max_encoder_length > 0:
+            self.pipe.tokenizer.model_max_length = max_encoder_length
+
+        max_decode_length = getattr(model, "max_decode_length", None)
+        if isinstance(max_decode_length, int) and max_decode_length > 1:
+            self._pipeline_kwargs["max_new_tokens"] = max_decode_length - 1
+            # TranslationPipeline.check_inputs() only reads max_length, while
+            # generate() should use the explicit max_new_tokens capacity.
+            # Align the check and remove checkpoint-specific beam/token caps.
+            self.pipe.generation_config.max_length = max_decode_length
+            self.pipe.generation_config.max_new_tokens = None
+            self.pipe.generation_config.num_beams = 1
+
+    def align_labels(self, dataset: Dataset, ds_config: DatasetConfig) -> Dataset:
+        """Return free-text references unchanged."""
+        return dataset
+
+    @staticmethod
+    def _extract_text(value: Any, language: str | None, field: str) -> str:
+        """Extract one text value from a flat string or language-keyed mapping."""
+        from ..utils.eval_utils import DatasetValidationError
+
+        if isinstance(value, Mapping):
+            if not language:
+                raise DatasetValidationError(
+                    f"{field} contains a translation dict; provide --column "
+                    f"{'source_lang' if field == 'source' else 'target_lang'}=<language key>",
+                )
+            if language not in value:
+                raise DatasetValidationError(
+                    f"{field} translation dict has no language key '{language}'; "
+                    f"available keys: {sorted(str(key) for key in value)}",
+                )
+            value = value[language]
+        if not isinstance(value, str) or not value.strip():
+            raise DatasetValidationError(f"{field} must resolve to a non-empty string")
+        return value.strip()
+
+    def _extract_references(self, value: Any) -> str | list[str]:
+        """Extract one or more reference translations."""
+        if isinstance(value, list):
+            if not value:
+                from ..utils.eval_utils import DatasetValidationError
+
+                raise DatasetValidationError("reference must contain at least one translation")
+            return [self._extract_text(item, self._target_lang, "reference") for item in value]
+        return self._extract_text(value, self._target_lang, "reference")
+
+    @staticmethod
+    def _prediction_text(output: Any) -> str:
+        """Normalize Hugging Face translation pipeline output shapes."""
+        from ..utils.eval_utils import DatasetValidationError
+
+        if isinstance(output, list):
+            if not output:
+                raise DatasetValidationError("pipeline returned no translations")
+            output = output[0]
+        if isinstance(output, Mapping):
+            prediction = output.get("translation_text", output.get("generated_text", ""))
+            if isinstance(prediction, str) and prediction.strip():
+                return prediction.strip()
+            raise DatasetValidationError("pipeline returned an empty translation")
+        if isinstance(output, str) and output.strip():
+            return output.strip()
+        raise DatasetValidationError("pipeline returned an unsupported translation result")
+
+    def _extract_sample(self, sample: Any) -> tuple[str, str | list[str]]:
+        """Extract and validate source/reference values from one dataset row."""
+        from ..utils.eval_utils import DatasetValidationError
+
+        if not isinstance(sample, Mapping):
+            raise DatasetValidationError(
+                f"dataset row must be a mapping, got {type(sample).__name__}"
+            )
+        source = self._extract_text(
+            sample.get(self._source_col),
+            self._source_lang,
+            "source",
+        )
+        return f"{self._source_prefix}{source}", self._extract_references(
+            sample.get(self._reference_col)
+        )
+
+    def compute(self) -> dict[str, Any]:
+        """Translate each valid row and compute corpus-level metrics."""
+        from tqdm.auto import tqdm
+
+        from ..utils.eval_utils import DatasetValidationError
+        from .metrics.translation import TranslationMetric
+
+        metric = TranslationMetric()
+        skipped = 0
+        first_error: str | None = None
+        attempted = 0
+
+        for sample in tqdm(self.data, desc="Evaluating", unit="sample"):
+            attempted += 1
+            try:
+                source, references = self._extract_sample(sample)
+            except DatasetValidationError as error:
+                logger.warning("Translation sample rejected: %s", error)
+                first_error = first_error or str(error)
+                skipped += 1
+                continue
+
+            # Do not catch inference/tokenizer/runtime failures: a broken model
+            # must fail the evaluation rather than produce partial metrics.
+            output = self.pipe(source, **self._pipeline_kwargs)
+            try:
+                prediction = self._prediction_text(output)
+                metric.update(prediction, references)
+            except (DatasetValidationError, ValueError) as error:
+                logger.warning("Translation output rejected: %s", error)
+                first_error = first_error or str(error)
+                skipped += 1
+
+        result = metric.compute()
+        if result["n_samples"] == 0:
+            detail = f": {first_error}" if first_error else ""
+            raise DatasetValidationError(f"No valid translation samples were evaluated{detail}")
+        result["attempted"] = attempted
+        result["evaluated"] = result["n_samples"]
+        result["skipped"] = skipped
+        return result

--- a/src/winml/modelkit/models/winml/encoder_decoder.py
+++ b/src/winml/modelkit/models/winml/encoder_decoder.py
@@ -206,7 +206,12 @@ class WinMLEncoderDecoderModel(WinMLCompositeModel, GenerationMixin):
         )
 
         # Max decode length and KV dtype from decoder ONNX metadata
-        self._max_dec = self._dec_expected["past_0_key"][2]
+        max_decode_length = self._dec_expected["past_0_key"][2]
+        if not isinstance(max_decode_length, int) or max_decode_length <= 0:
+            raise ValueError(
+                "Decoder input 'past_0_key' must have a positive static cache length"
+            )
+        self._max_dec = max_decode_length
         self._num_kv_layers = sum(
             1 for n in self._dec_expected if n.startswith("past_") and n.endswith("_key")
         )

--- a/src/winml/modelkit/models/winml/encoder_decoder.py
+++ b/src/winml/modelkit/models/winml/encoder_decoder.py
@@ -191,6 +191,12 @@ class WinMLEncoderDecoderModel(WinMLCompositeModel, GenerationMixin):
         enc_expected = dict(
             zip(enc_io.get("input_names", []), enc_io.get("input_shapes", []), strict=False)
         )
+        input_ids_shape = enc_expected.get("input_ids", [])
+        self._max_enc = (
+            input_ids_shape[1]
+            if len(input_ids_shape) > 1 and isinstance(input_ids_shape[1], int)
+            else None
+        )
         # Wrap encoder with auto-padding so all callsites just use self._encoder(...)
         self._encoder = self._EncoderWithInputPadding(raw_encoder, enc_expected)
 
@@ -218,6 +224,16 @@ class WinMLEncoderDecoderModel(WinMLCompositeModel, GenerationMixin):
             )
         _np_dtype = dec_type_map["past_0_key"]
         self._kv_dtype = torch.from_numpy(np.zeros(1, dtype=_np_dtype)).dtype
+
+    @property
+    def max_encoder_length(self) -> int | None:
+        """Return the encoder's static token capacity, or ``None`` when dynamic."""
+        return self._max_enc
+
+    @property
+    def max_decode_length(self) -> int:
+        """Return the decoder's static output/cache capacity."""
+        return self._max_dec
 
     # ----- Encoder -----
 

--- a/src/winml/modelkit/utils/eval_utils.py
+++ b/src/winml/modelkit/utils/eval_utils.py
@@ -243,6 +243,51 @@ _IMAGE_TO_TEXT_SCHEMA = TaskSchema(
     roles=("encoder", "decoder"),
 )
 
+_TRANSLATION_SCHEMA = TaskSchema(
+    columns=(
+        SchemaItem(
+            "source_column",
+            "source text, or a translation dict containing the source language key",
+            default="translation",
+            remap_hint="<your_source_column>",
+        ),
+        SchemaItem(
+            "reference_column",
+            "reference text(s), or a translation dict containing the target language key",
+            default="translation",
+            remap_hint="<your_reference_column>",
+        ),
+    ),
+    params=(
+        SchemaItem(
+            "source_lang",
+            "source-language key when source_column contains translation dicts",
+            remap_hint="<source_language_key>",
+        ),
+        SchemaItem(
+            "target_lang",
+            "target-language key when reference_column contains translation dicts",
+            remap_hint="<target_language_key>",
+        ),
+        SchemaItem(
+            "tokenizer_source_lang",
+            "source-language identifier for multilingual tokenizers; defaults to source_lang",
+            remap_hint="<tokenizer_source_language>",
+        ),
+        SchemaItem(
+            "tokenizer_target_lang",
+            "target-language identifier for multilingual tokenizers; defaults to target_lang",
+            remap_hint="<tokenizer_target_language>",
+        ),
+        SchemaItem(
+            "source_prefix",
+            "optional task prefix prepended before tokenization (for example, a T5 prompt)",
+            remap_hint="<translation_prefix>",
+        ),
+    ),
+    roles=("encoder", "decoder"),
+)
+
 _FILL_MASK_SCHEMA = TaskSchema(
     columns=(
         SchemaItem(
@@ -436,6 +481,7 @@ TASK_SCHEMAS: dict[str, TaskSchema] = {
     "sentence-similarity": _FEATURE_EXTRACTION_SCHEMA,
     "image-feature-extraction": _IMAGE_FEATURE_EXTRACTION_SCHEMA,
     "image-to-text": _IMAGE_TO_TEXT_SCHEMA,
+    "translation": _TRANSLATION_SCHEMA,
     "fill-mask": _FILL_MASK_SCHEMA,
     "zero-shot-classification": _ZERO_SHOT_CLASSIFICATION_SCHEMA,
     "zero-shot-image-classification": _ZERO_SHOT_IMAGE_CLASSIFICATION_SCHEMA,

--- a/tests/unit/eval/test_translation_evaluator.py
+++ b/tests/unit/eval/test_translation_evaluator.py
@@ -1,0 +1,259 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+"""Unit tests for translation evaluation."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from datasets import Dataset
+
+from winml.modelkit.eval.translation_evaluator import WinMLTranslationEvaluator
+from winml.modelkit.utils.eval_utils import DatasetValidationError
+
+
+def make_evaluator(rows, columns_mapping=None):
+    from winml.modelkit.eval import DatasetConfig, WinMLEvaluationConfig
+
+    dataset = Dataset.from_list(rows)
+    model = MagicMock()
+    model.config.label2id = None
+    model.max_encoder_length = 512
+    model.max_decode_length = 512
+    config = WinMLEvaluationConfig(
+        model_id="Helsinki-NLP/opus-mt-fr-en",
+        task="translation",
+        dataset=DatasetConfig(
+            path="wmt14",
+            samples=len(rows),
+            shuffle=False,
+            columns_mapping=columns_mapping or {},
+        ),
+    )
+    with (
+        patch("datasets.load_dataset", return_value=dataset),
+        patch(
+            "winml.modelkit.eval.base_evaluator.WinMLEvaluator.prepare_pipeline",
+            return_value=MagicMock(),
+        ),
+    ):
+        return WinMLTranslationEvaluator(config, model)
+
+
+class TestTranslationMetric:
+    def test_perfect_corpus_scores_100(self):
+        from winml.modelkit.eval.metrics.translation import TranslationMetric
+
+        metric = TranslationMetric()
+        metric.update("This is a complete test sentence.", "This is a complete test sentence.")
+        result = metric.compute()
+
+        assert result == {"sacrebleu": 100.0, "chrf": 100.0, "n_samples": 1}
+
+    def test_empty_corpus_has_no_scores(self):
+        from winml.modelkit.eval.metrics.translation import TranslationMetric
+
+        assert TranslationMetric().compute() == {
+            "sacrebleu": None,
+            "chrf": None,
+            "n_samples": 0,
+        }
+
+    def test_multiple_references_are_supported(self):
+        from winml.modelkit.eval.metrics.translation import TranslationMetric
+
+        metric = TranslationMetric()
+        metric.update(
+            "A sufficiently long reference sentence is here.",
+            [
+                "Another reference sentence is also supplied.",
+                "A sufficiently long reference sentence is here.",
+            ],
+        )
+        assert metric.compute()["sacrebleu"] == 100.0
+
+    def test_multiple_perfect_samples_have_perfect_corpus_scores(self):
+        from winml.modelkit.eval.metrics.translation import TranslationMetric
+
+        metric = TranslationMetric()
+        first = "The first complete sentence is correct."
+        second = "The second complete sentence is correct."
+        metric.update(first, first)
+        metric.update(second, second)
+        result = metric.compute()
+
+        assert result["sacrebleu"] == 100.0
+        assert result["chrf"] == 100.0
+
+    def test_empty_references_are_rejected(self):
+        from winml.modelkit.eval.metrics.translation import TranslationMetric
+
+        with pytest.raises(ValueError, match="at least one non-empty"):
+            TranslationMetric().update("prediction", [])
+
+
+class TestTranslationEvaluator:
+    def test_nested_translation_dict_uses_explicit_language_keys(self):
+        evaluator = make_evaluator(
+            [{"translation": {"fr": "Bonjour le monde", "en": "Hello world"}}],
+            {"source_lang": "fr", "target_lang": "en"},
+        )
+        assert evaluator.pipe.tokenizer.model_max_length == 512
+        assert evaluator.pipe.generation_config.max_new_tokens is None
+        assert evaluator.pipe.generation_config.num_beams == 1
+        evaluator.pipe = MagicMock(return_value=[{"translation_text": "Hello world"}])
+
+        result = evaluator.compute()
+
+        evaluator.pipe.assert_called_once_with(
+            "Bonjour le monde",
+            num_beams=1,
+            truncation=True,
+            src_lang="fr",
+            tgt_lang="en",
+            max_new_tokens=511,
+        )
+        assert result["n_samples"] == 1
+        assert result["chrf"] == 100.0
+        assert result["attempted"] == 1
+        assert result["evaluated"] == 1
+        assert result["skipped"] == 0
+
+    def test_flat_custom_columns_need_no_language_keys(self):
+        evaluator = make_evaluator(
+            [{"french": "Une phrase source", "english": "A source sentence"}],
+            {"source_column": "french", "reference_column": "english"},
+        )
+        evaluator.pipe = MagicMock(return_value={"generated_text": "A source sentence"})
+
+        result = evaluator.compute()
+
+        assert result["n_samples"] == 1
+        assert result["chrf"] == 100.0
+
+    def test_missing_language_key_rejects_row_with_accounting(self):
+        evaluator = make_evaluator(
+            [
+                {"translation": {"fr": "Valide", "en": "Valid"}},
+                {"translation": {"fr": "Invalide", "de": "Ungültig"}},
+            ],
+            {"source_lang": "fr", "target_lang": "en"},
+        )
+        evaluator.pipe = MagicMock(return_value=[{"translation_text": "Valid"}])
+
+        result = evaluator.compute()
+
+        assert result["n_samples"] == 1
+        assert result["attempted"] == 2
+        assert result["evaluated"] == 1
+        assert result["skipped"] == 1
+        evaluator.pipe.assert_called_once()
+
+    def test_nested_translation_requires_explicit_direction(self):
+        evaluator = make_evaluator(
+            [{"translation": {"fr": "Bonjour", "en": "Hello"}}],
+        )
+
+        with pytest.raises(DatasetValidationError, match="provide --column source_lang"):
+            evaluator.compute()
+
+    def test_pipeline_runtime_failure_propagates(self):
+        evaluator = make_evaluator(
+            [
+                {"source": "un", "reference": "one"},
+                {"source": "deux", "reference": "two"},
+            ],
+            {"source_column": "source", "reference_column": "reference"},
+        )
+        evaluator.pipe = MagicMock(
+            side_effect=[
+                [{"translation_text": "one"}],
+                RuntimeError("decoder failed"),
+            ]
+        )
+
+        with pytest.raises(RuntimeError, match="decoder failed"):
+            evaluator.compute()
+
+    def test_all_rejected_fails_closed(self):
+        evaluator = make_evaluator(
+            [{"source": "texte", "reference": "text"}],
+            {"source_column": "source", "reference_column": "reference"},
+        )
+        evaluator.pipe = MagicMock(return_value=[{"translation_text": ""}])
+
+        with pytest.raises(DatasetValidationError, match="No valid translation samples"):
+            evaluator.compute()
+
+    @pytest.mark.parametrize("output", [[], [{}], [{"translation_text": ""}]])
+    def test_empty_pipeline_output_is_rejected(self, output):
+        evaluator = make_evaluator(
+            [{"source": "texte", "reference": "text"}],
+            {"source_column": "source", "reference_column": "reference"},
+        )
+        evaluator.pipe = MagicMock(return_value=output)
+
+        with pytest.raises(DatasetValidationError, match="No valid translation samples"):
+            evaluator.compute()
+
+    def test_empty_reference_list_is_rejected(self):
+        evaluator = make_evaluator(
+            [{"source": "texte", "references": []}],
+            {"source_column": "source", "reference_column": "references"},
+        )
+
+        with pytest.raises(DatasetValidationError, match="No valid translation samples"):
+            evaluator.compute()
+
+    def test_non_mapping_row_is_rejected_with_accounting(self):
+        evaluator = make_evaluator(
+            [{"source": "valide", "reference": "valid"}],
+            {"source_column": "source", "reference_column": "reference"},
+        )
+        evaluator.data = [None, {"source": "valide", "reference": "valid"}]
+        evaluator.pipe = MagicMock(return_value=[{"translation_text": "valid"}])
+
+        result = evaluator.compute()
+
+        assert result["attempted"] == 2
+        assert result["evaluated"] == 1
+        assert result["skipped"] == 1
+
+    def test_tokenizer_language_ids_and_source_prefix_are_independent_of_dataset_keys(self):
+        evaluator = make_evaluator(
+            [{"translation": {"fra_Latn": "Bonjour", "eng_Latn": "Hello"}}],
+            {
+                "source_lang": "fra_Latn",
+                "target_lang": "eng_Latn",
+                "tokenizer_source_lang": "fra_Latn",
+                "tokenizer_target_lang": "eng_Latn",
+                "source_prefix": "translate French to English: ",
+            },
+        )
+        evaluator.pipe = MagicMock(return_value=[{"translation_text": "Hello"}])
+
+        evaluator.compute()
+
+        evaluator.pipe.assert_called_once_with(
+            "translate French to English: Bonjour",
+            num_beams=1,
+            truncation=True,
+            src_lang="fra_Latn",
+            tgt_lang="eng_Latn",
+            max_new_tokens=511,
+        )
+
+
+class TestTranslationRegistration:
+    def test_registry_and_schema_are_present(self):
+        from winml.modelkit.eval import WinMLEvaluationConfig, get_evaluator_class
+        from winml.modelkit.utils.eval_utils import TASK_SCHEMAS
+
+        assert get_evaluator_class(WinMLEvaluationConfig(task="translation")) is (
+            WinMLTranslationEvaluator
+        )
+        assert TASK_SCHEMAS["translation"].roles == ("encoder", "decoder")

--- a/tests/unit/eval/test_translation_evaluator.py
+++ b/tests/unit/eval/test_translation_evaluator.py
@@ -16,7 +16,7 @@ from winml.modelkit.eval.translation_evaluator import WinMLTranslationEvaluator
 from winml.modelkit.utils.eval_utils import DatasetValidationError
 
 
-def make_evaluator(rows, columns_mapping=None):
+def make_evaluator(rows, columns_mapping=None, pipeline=None):
     from winml.modelkit.eval import DatasetConfig, WinMLEvaluationConfig
 
     dataset = Dataset.from_list(rows)
@@ -38,7 +38,7 @@ def make_evaluator(rows, columns_mapping=None):
         patch("datasets.load_dataset", return_value=dataset),
         patch(
             "winml.modelkit.eval.base_evaluator.WinMLEvaluator.prepare_pipeline",
-            return_value=MagicMock(),
+            return_value=pipeline or MagicMock(),
         ),
     ):
         return WinMLTranslationEvaluator(config, model)
@@ -97,6 +97,18 @@ class TestTranslationMetric:
 
 
 class TestTranslationEvaluator:
+    def test_static_encoder_capacity_allows_pipeline_without_tokenizer(self):
+        pipeline = MagicMock()
+        pipeline.tokenizer = None
+
+        evaluator = make_evaluator(
+            [{"source": "texte", "reference": "text"}],
+            {"source_column": "source", "reference_column": "reference"},
+            pipeline,
+        )
+
+        assert evaluator.pipe.tokenizer is None
+
     def test_nested_translation_dict_uses_explicit_language_keys(self):
         evaluator = make_evaluator(
             [{"translation": {"fr": "Bonjour le monde", "en": "Hello world"}}],


### PR DESCRIPTION
## Summary

This follow-up to merged PR #1115 turns `translation` evaluation from an explicit CLI blocker into a supported, task-meaningful path for WinML encoder-decoder models. It adds a generalized translation dataset adapter, deterministic static-shape generation, corpus SacreBLEU/chrF2 metrics, precise sample accounting, and regression coverage without branching on a checkpoint name. CPU fp32 and fp16 both complete a pinned, shuffled 100-row WMT14 French-to-English evaluation with identical quality scores.

## Model metadata

### What the model does

`Helsinki-NLP/opus-mt-fr-en` is a text-to-text Marian encoder-decoder checkpoint that translates French input text into English output text. The encoder produces contextual hidden states; the autoregressive decoder produces vocabulary logits and updated key/value-cache tensors. Evidence: pinned checkpoint revision `c4aed37b318c763fd177aa449b44e3b783cc6c02`, checkpoint configuration, and exported encoder/decoder interfaces. Confidence: **verified**.

### Primary user stories

- Supply French text and obtain English translation for cross-language communication or downstream processing. Evidence: checkpoint identity and declared translation pipeline task. Confidence: **verified**.

### Supported tasks

- `translation`: checkpoint, Transformers, and WinML composite inference. Confidence: **verified**.
- `text2text-generation`: Transformers, Optimum ONNX, and the decoder component. Confidence: **verified**.
- `feature-extraction`: Optimum ONNX and the encoder component. Confidence: **verified**.

### Model architecture

```text
MarianMTModel (hidden width 512, 8 attention heads)
Γö£ΓöÇΓöÇ Encoder graph (static batch 1, sequence length 512)
Γöé   Γö£ΓöÇΓöÇ Token + sinusoidal position embeddings
Γöé   ΓööΓöÇΓöÇ Encoder layer ├ù 6
Γöé       Γö£ΓöÇΓöÇ Self-attention
Γöé       Γö£ΓöÇΓöÇ Feed-forward network
Γöé       ΓööΓöÇΓöÇ Residual + LayerNorm
ΓööΓöÇΓöÇ Cached autoregressive decoder graph (capacity 512)
    Γö£ΓöÇΓöÇ Token + sinusoidal position embeddings
    Γö£ΓöÇΓöÇ Decoder layer ├ù 6
    Γöé   Γö£ΓöÇΓöÇ Self-attention
    Γöé   Γö£ΓöÇΓöÇ Encoder cross-attention
    Γöé   Γö£ΓöÇΓöÇ Feed-forward network
    Γöé   ΓööΓöÇΓöÇ Residual + LayerNorm
    Γö£ΓöÇΓöÇ Key/value cache (6 key/value pairs, 8 heads ├ù 512 ├ù 64)
    ΓööΓöÇΓöÇ LM head (512 ΓåÆ 59,514 vocabulary logits)
```

- Source/confidence: pinned checkpoint configuration, `MarianMTModel`/WinML wrapper source, traced module hierarchy, and ONNX graph interfaces (**mapped**).

## Validation and support evidence

### Baseline

- Base: current `origin/main` commit `67169d45c40ed8326065e87ed29d19623b79cbb4`.
- The merged #1115 recipes already build fp32/fp16 encoder and decoder artifacts and support component perf/parity, but `winml eval --schema --task translation` exits 2 because `translation` is absent from the evaluator registry.
- Existing recipe evidence was produced from semantically identical build configurations: all four `winml_build_config.json` payloads equal the current checked-in recipes after removing the build-generated `auto: false` field.
- Baseline model build: PASS; encoder and decoder artifacts emitted. Baseline component perf was approximately 71.773 ms encoder and 21.897 ms decoder on CPU fp32.
- Optimum/WinML already resolve Marian component export and composite inference; the unsupported surface was task evaluation, not model export.

### Goal

- **Effort:** shared task-family evaluator support.
- **Goal:** meaningful L3 translation quality evaluation while retaining existing L0 build, L1 perf, and L2 encoder parity evidence.
- **Outcome:** add generalized `translation` registry/schema/adapter/generation/metric support, not checkpoint-specific behavior.
- Success requires the real dataset ΓåÆ preprocessing ΓåÆ static ONNX encoder ΓåÆ cached decoder generation ΓåÆ corpus metric path to complete for both fp32 and fp16, with inference errors propagated rather than hidden as skipped samples.

### Outcome

- `translation` changed from CLI-unsupported to supported.
- Flat source/reference columns and WMT-style nested translation dictionaries are supported.
- Dataset language keys, multilingual-tokenizer language identifiers, and prompt prefixes are independently configurable.
- Static encoder inputs truncate to ONNX capacity. Decoder generation is greedy (`num_beams=1`) and bounded by the graph's static KV-cache capacity.
- Metrics are computed once at corpus level: SacreBLEU with `13a` tokenization and standard character-only chrF2 (`n_word_order=0`, `beta=2`), both reported on the conventional 0ΓÇô100 scale.
- Runtime, tokenizer, and inference failures propagate. Only malformed dataset rows or malformed generated outputs are skipped and counted; an all-rejected run fails closed.
- CPU coverage is complete for the existing fp32/fp16 composite recipes. No accelerator runtime claim is made by this CPU evaluation.

### Per-EP/device/precision results ΓÇö including perf and eval data

#### Goal ladder

| Tier | Scope | Verdict | Evidence |
|---|---|---|---|
| L0 | CPU fp32/fp16 encoder + decoder | PASS | Four ONNX graphs load with named static interfaces; fp16 artifacts contain FLOAT16 initializers. |
| L1 | CPU component perf | PASS | Concrete latency, throughput, and RSS deltas below. |
| L2 | Encoder ONNX vs PyTorch | PASS | fp32 cosine `0.9999999999995187`, max abs `3.337860107421875e-06`; fp16 cosine `0.999999184734255`, max abs `0.004638791084289551`. Decoder parity is not claimed because the harness does not reconstruct identical dynamic-cache state. |
| L3 | CPU composite translation | PASS | Pinned WMT14 `fr-en/test`, deterministic shuffled 100-row subset, 100/100 evaluated for both precisions. |

#### Perf

These are per-component CPU measurements from the semantically identical #1115 recipe artifacts (10 measured iterations after 3 warmups). Composite autoregressive wall time depends on generated sequence length, so component figures are retained rather than combined into a misleading constant latency.

| EP / device | Precision | Component | Mean | p50 | Throughput | RSS ╬ö | VRAM ╬ö |
|---|---|---|---:|---:|---:|---:|---:|
| CPUExecutionProvider / cpu | fp32 | encoder | 70.032 ms | 70.415 ms | 14.28 samples/s | 140.57 MB | 0 MB |
| CPUExecutionProvider / cpu | fp32 | decoder step | 23.607 ms | 23.677 ms | 42.36 samples/s | 243.33 MB | 0 MB |
| CPUExecutionProvider / cpu | fp16 | encoder | 92.095 ms | 92.482 ms | 10.86 samples/s | 291.08 MB | 0 MB |
| CPUExecutionProvider / cpu | fp16 | decoder step | 26.441 ms | 26.450 ms | 37.82 samples/s | 252.65 MB | 0 MB |

#### Eval

Dataset: `wmt/wmt14`, config `fr-en`, split `test`, revision `b199e406369ec1b7634206d3ded5ba45de2fe696`. The row schema is a nested `translation` mapping; `source_lang=fr` and `target_lang=en` match the checkpoint direction. The 3,003-row test split is document-grouped, so this evidence uses streaming seeded shuffle (`seed=42`) before taking 100 rows rather than biased first-N sampling. It is a reproducible engineering subset, not a claim of full-test benchmark equivalence. Hugging Face reports the dataset license as unknown; this PR makes no permissive-license claim.

| EP / device | Precision | Selection | Accounting | SacreBLEU 13a | chrF2 |
|---|---|---|---|---:|---:|
| CPUExecutionProvider / cpu | fp32 | shuffled seed 42, 100 rows | attempted 100, evaluated 100, skipped 0 | 39.0807 | 63.2021 |
| CPUExecutionProvider / cpu | fp16 | shuffled seed 42, 100 rows | attempted 100, evaluated 100, skipped 0 | 39.0807 | 63.2021 |

Precision deltas are `0.0000` SacreBLEU and `0.0000` chrF2. The scale is consistent with the checkpoint card's full WMT14 report (BLEU 37.8 and chrF approximately 63.3), while preserving the subset qualification above.

On this Windows host the native process can terminate during provider teardown after the complete result JSON is written and is parseable. Both final runs were accepted only after validating JSON, exact 100/100/0 accounting, and zero `INVALID_ARGUMENT`, `Inference failed`, or `Evaluation failed` log matches; this is not represented as an inference failure.

### Delta

No recipe changes are included; the production recipe README is untouched.

- Add `WinMLTranslationEvaluator` and lazy/registry wiring for `translation`.
- Add `TranslationMetric` with corpus SacreBLEU 13a and true chrF2, rather than averaging sentence metrics or mislabeled chrF++.
- Add translation task schema with composite `encoder`/`decoder` roles and explicit source/target/tokenizer-language/prefix controls.
- Expose `max_encoder_length` and `max_decode_length` from generic ONNX metadata on `WinMLEncoderDecoderModel`; reject a non-positive/dynamic decoder KV capacity where static cached generation cannot be safe.
- Add regression coverage for nested and flat data, multiple references, language direction, tokenizer IDs, prompt prefixes, empty/malformed rows and outputs, runtime-error propagation, fail-closed behavior, registry/schema, corpus metrics, and tokenizer-free pipelines.

**Bug fix explanation:**

1. **Symptom/trigger:** #1115 explicitly records `winml eval --schema --task translation` as unsupported; attempting Marian's checkpoint-default 4-beam generation against a static batch-1 decoder also expands decoder inputs to batch 4 and fails ORT dimension validation.
2. **Root cause:** no translation evaluator/metric/schema existed, and generic Transformers generation defaults did not honor the static ONNX encoder and KV-cache capacities.
3. **Changed mechanism:** register a task evaluator, adapt flat/nested datasets, use deterministic greedy generation, truncate the encoder to its metadata-derived capacity, and cap generated tokens from the decoder cache shape.
4. **General rule:** behavior derives from task schema, user-provided language semantics, and ONNX I/O metadata. There is no `Helsinki-NLP/opus-mt-fr-en` or model-name branch.
5. **Compatibility/blast radius:** existing evaluator defaults and task registrations are unchanged. New encoder/decoder properties are read-only. Existing static cached models already require a positive concrete cache dimension; malformed metadata now fails early with a clear error. Pipelines without a tokenizer remain supported.
6. **Regression evidence:** final commands/evaluator partition `2400 passed, 8 skipped, 2 deselected`; Marian regression `25 passed`; focused translation/shared-model suite `81 passed`; final translation suite `19 passed`; Ruff passed; Mypy passed for 412 source files; `git diff --check` passed. Two real 100-row fp32/fp16 CLI evaluations completed as reported above.

### Analyze summary ΓÇö component level and op level

Static rule analysis completed with parseable data for all requested EP rule groups; command exit 1 was caused by unavailable host runtime/plugin registration, so status is **ANALYZE-PARTIAL-SUCCESS**. This is static compatibility analysis, not runtime execution on those accelerators.

#### Component-level summary

| Artifact | Architecture coverage | Mapping | Actionable EP findings |
|---|---|---|---|
| fp32 encoder | embeddings/input; 6├ù self-attention, FFN, residual/normalization | 204 mapped, 0 unmapped | No partial/unsupported op type in TensorRT, QNN, or OpenVINO rule sets. |
| fp16 encoder | same encoder regions | 205 mapped, 0 unmapped | No partial/unsupported op type in TensorRT, QNN, or OpenVINO rule sets. |
| fp32 decoder | embeddings/input; 6├ù self-attention, cross-attention, FFN, residual/normalization; KV update; LM head | 392 mapped, 0 unmapped | QNN GPU partial: `Expand`, `Cast`, `Concat`; `ScatterND` remains unknown in several accelerator rule sets. |
| fp16 decoder | same decoder regions | 418 mapped, 0 unmapped | QNN NPU partial: `Expand`; QNN GPU partial: `Expand`, `Concat`, unsupported: `Cast`; `ScatterND` remains unknown. |

Functional MLP and residual/normalization regions are mapped from graph scopes/topology rather than separate traced module boundaries. The model-breakdown topology used fp32 graphs; fp16 topology was checked separately against the converted artifacts.

#### Op-level summary

| Artifact | Graph | Dominant ops | Static EP roll-up |
|---|---|---|---|
| fp32 encoder | 204 ops / 16 types | Reshape 61; Gemm 36; Transpose 24; Add/Mul 19 each | TensorRT/QNN/OpenVINO rule sets classify all 16 types supported. |
| fp16 encoder | 205 ops / 16 types | Reshape 61; Gemm 36; Transpose 24; Add/Mul 19 each | Same supported roll-up; one additional Cast node. |
| fp32 decoder | 392 ops / 20 types | Reshape 112; Gemm 60; Transpose 54; Add 33; Mul 32 | QNN GPU partial as above; ruleful groups otherwise support known types, with `ScatterND` unknown. |
| fp16 decoder | 418 ops / 20 types | Reshape 112; Gemm 60; Transpose 54; Add 33; Mul 32; Cast 30 | QNN NPU/GPU findings as above; `ScatterND` unknown. |

Rule-less CPU, CUDA, MIGraphX, DML, and VitisAI rows report all op types unknown and are not runtime support claims.

### Reproduce commands

```powershell
$MODEL = 'Helsinki-NLP/opus-mt-fr-en'
$OUT = 'temp/opus-mt-fr-en-translation-eval'
$RECIPES = 'examples/recipes/Helsinki-NLP_opus-mt-fr-en/cpu/cpu'

winml build -c $RECIPES/translation_fp32_encoder_config.json -m $MODEL -o $OUT/fp32-encoder
winml build -c $RECIPES/translation_fp32_decoder_config.json -m $MODEL -o $OUT/fp32-decoder
winml build -c $RECIPES/translation_fp16_encoder_config.json -m $MODEL -o $OUT/fp16-encoder
winml build -c $RECIPES/translation_fp16_decoder_config.json -m $MODEL -o $OUT/fp16-decoder

winml perf -m $OUT/fp32-encoder/model.onnx --task feature-extraction --ep cpu --device cpu
winml perf -m $OUT/fp32-decoder/model.onnx --task text2text-generation --ep cpu --device cpu
winml analyze --model $OUT/fp32-encoder/model.onnx --ep all --device all --output $OUT/analyze-fp32-encoder.json
winml analyze --model $OUT/fp32-decoder/model.onnx --ep all --device all --output $OUT/analyze-fp32-decoder.json

winml eval `
  -m encoder=$OUT/fp32-encoder/model.onnx `
  -m decoder=$OUT/fp32-decoder/model.onnx `
  --model-id $MODEL --task translation --ep cpu --device cpu `
  --dataset wmt/wmt14 --dataset-name fr-en `
  --dataset-revision b199e406369ec1b7634206d3ded5ba45de2fe696 `
  --split test --samples 100 --streaming --shuffle `
  --column source_lang=fr --column target_lang=en `
  --format json --output $OUT/eval-fp32.json --overwrite --no-color
```
