### PR TITLE
recipe(dell-research-harvard/names-linking-model): add verified CPU fp32/fp16 recipes

### DIFF
--- a/examples/recipes/dell-research-harvard_names-linking-model/cpu/cpu/feature-extraction_fp16_config.json
+++ b/examples/recipes/dell-research-harvard_names-linking-model/cpu/cpu/feature-extraction_fp16_config.json
@@ -1,0 +1,64 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          30527
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "loader": {
+    "task": "feature-extraction",
+    "model_class": "AutoModel",
+    "model_type": "mpnet"
+  },
+  "eval": {
+    "task": "feature-extraction",
+    "dataset": {
+      "path": "mteb/stsbenchmark-sts",
+      "split": "test",
+      "samples": 100,
+      "columns_mapping": {
+        "input_column_1": "sentence1",
+        "input_column_2": "sentence2",
+        "score_column": "score"
+      }
+    }
+  }
+}

--- a/examples/recipes/dell-research-harvard_names-linking-model/cpu/cpu/feature-extraction_fp32_config.json
+++ b/examples/recipes/dell-research-harvard_names-linking-model/cpu/cpu/feature-extraction_fp32_config.json
@@ -1,0 +1,64 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          30527
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "loader": {
+    "task": "feature-extraction",
+    "model_class": "AutoModel",
+    "model_type": "mpnet"
+  },
+  "eval": {
+    "task": "feature-extraction",
+    "dataset": {
+      "path": "mteb/stsbenchmark-sts",
+      "split": "test",
+      "samples": 100,
+      "columns_mapping": {
+        "input_column_1": "sentence1",
+        "input_column_2": "sentence2",
+        "score_column": "score"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Add verified CPU (fp32/fp16) feature-extraction recipe for `dell-research-harvard/names-linking-model` (MPNet architecture, sentence embeddings for entity name linking).

## Model metadata

- **What the model does**: Sentence-transformer (MPNet-based) fine-tuned for entity name linking — produces dense embeddings for computing similarity between entity name mentions.
- **Primary user stories**: User supplies entity name strings to obtain dense vector embeddings for cosine-similarity-based name matching/linking.
- **Supported tasks**: `feature-extraction` (checkpoint, transformers, optimum-onnx, winml)
- **Model architecture**: MPNetModel (12-layer transformer encoder, 768 hidden, 12 attention heads, vocab 30527)

## Validation and support evidence

**Baseline** (origin/main @ d5f24d2, winml 0.2.0):
- `winml build -m dell-research-harvard/names-linking-model --ep cpu --device cpu` → ✅ Build complete in 42.2s
- `winml perf` → ✅ 227.92ms avg, 4.39 samp/s
- `winml eval --task feature-extraction` → ✅ cosine_spearman = 81.5376

**Goal**: L3 (task metric) — baseline already at L3; contribution establishes verified `cpu/cpu` coverage with recipes.

**Outcome**: L0 — recipe-only (auto-config already correct; recipe captures verified EP/device/precision coverage).

### Per-tuple results

| EP | Device | Precision | L0 (build) | L1 (perf) | L3 (eval) |
|---|---|---|---|---|---|
| cpu | cpu | fp32 | ✅ PASS (35.9s) | ✅ PASS (227.73ms avg, 4.39 samp/s, +116 MB RAM) | ✅ PASS (cosine_spearman=81.5376) |
| cpu | cpu | fp16 | ✅ PASS (42.7s, 213.8 MB) | ✅ PASS (292.67ms avg, 3.42 samp/s, +156 MB RAM) | ✅ PASS (cosine_spearman=81.5376) |

**Delta**: Recipe identical to `winml config` auto-output — filed for verified `cpu/cpu` coverage claim on both precisions.

### Reproduce commands

```bash
# fp32
winml build -m dell-research-harvard/names-linking-model -c examples/recipes/dell-research-harvard_names-linking-model/cpu/cpu/feature-extraction_fp32_config.json -o out/fp32 --ep cpu --device cpu
winml perf -m out/fp32/model.onnx --ep cpu --device cpu
winml eval -m out/fp32/model.onnx --model-id dell-research-harvard/names-linking-model --task feature-extraction --ep cpu --device cpu

# fp16
winml build -m dell-research-harvard/names-linking-model -c examples/recipes/dell-research-harvard_names-linking-model/cpu/cpu/feature-extraction_fp16_config.json -o out/fp16 --ep cpu --device cpu -p fp16
winml perf -m out/fp16/model.onnx --ep cpu --device cpu
winml eval -m out/fp16/model.onnx --model-id dell-research-harvard/names-linking-model --task feature-extraction --ep cpu --device cpu
```