### PR TITLE
feat(eval): add generalized zero-shot object detection support

### DIFF
--- a/src/winml/modelkit/commands/eval.py
+++ b/src/winml/modelkit/commands/eval.py
@@ -150,6 +150,16 @@ logger = logging.getLogger(__name__)
     help="Stream dataset instead of downloading fully.",
 )
 @click.option(
+    "--max-queries",
+    "max_queries",
+    type=click.IntRange(min=1),
+    default=None,
+    help=(
+        "Maximum category queries for zero-shot-object-detection evaluation. "
+        "Overrides dataset.max_queries."
+    ),
+)
+@click.option(
     "--column",
     multiple=True,
     help="Column mapping as key=value (e.g. --column input_column=image).",
@@ -251,6 +261,7 @@ def eval(
     split: str,
     shuffle: bool,
     streaming: bool,
+    max_queries: int | None,
     column: tuple[str, ...],
     label_mapping_path: Path | None,
     output: Path | None,

--- a/src/winml/modelkit/eval/__init__.py
+++ b/src/winml/modelkit/eval/__init__.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
     from .token_classification_evaluator import WinMLTokenClassificationEvaluator
     from .zero_shot_classification_evaluator import WinMLZeroShotClassificationEvaluator
     from .zero_shot_image_classification_evaluator import WinMLZeroShotImageClassificationEvaluator
+    from .zero_shot_object_detection_evaluator import WinMLZeroShotObjectDetectionEvaluator
 
 
 _LAZY_ATTRS: dict[str, str] = {
@@ -78,6 +79,9 @@ _LAZY_ATTRS: dict[str, str] = {
     ),
     "WinMLZeroShotImageClassificationEvaluator": (
         ".zero_shot_image_classification_evaluator:WinMLZeroShotImageClassificationEvaluator"
+    ),
+    "WinMLZeroShotObjectDetectionEvaluator": (
+        ".zero_shot_object_detection_evaluator:WinMLZeroShotObjectDetectionEvaluator"
     ),
     "TensorSimilarityEvaluator": ".tensor_similarity_evaluator:TensorSimilarityEvaluator",
     # Metrics (defer numpy / scipy / torch / torchmetrics until first use)
@@ -142,6 +146,7 @@ __all__ = [
     "WinMLTokenClassificationEvaluator",
     "WinMLZeroShotClassificationEvaluator",
     "WinMLZeroShotImageClassificationEvaluator",
+    "WinMLZeroShotObjectDetectionEvaluator",
     "evaluate",
     "get_evaluator_class",
 ]

--- a/src/winml/modelkit/eval/config.py
+++ b/src/winml/modelkit/eval/config.py
@@ -40,6 +40,9 @@ class DatasetConfig:
             ``--output <path>`` before the dataset is loaded.
         label_mapping_file: Path to a JSON file with label mapping.
             Resolved into ``label_mapping`` at eval time.
+        max_queries: Maximum number of category queries used by
+            zero-shot-object-detection evaluation. ``None`` uses the full
+            authoritative vocabulary.
     """
 
     path: str | None = field(default=None, metadata={"cli_name": "dataset_path"})
@@ -50,6 +53,7 @@ class DatasetConfig:
     seed: int = 42
     columns_mapping: dict[str, str] = field(default_factory=dict)
     label_mapping: dict[str, int] | None = None
+    max_queries: int | None = 16
     streaming: bool = False
     revision: str | None = field(default=None, metadata={"cli_name": "dataset_revision"})
     build_script: str | None = field(default=None, metadata={"cli_name": "dataset_script"})
@@ -71,6 +75,8 @@ class DatasetConfig:
             result["columns_mapping"] = self.columns_mapping
         if self.label_mapping:
             result["label_mapping"] = self.label_mapping
+        if self.max_queries is not None:
+            result["max_queries"] = self.max_queries
         if self.streaming:
             result["streaming"] = self.streaming
         if self.revision is not None:
@@ -261,6 +267,7 @@ class WinMLEvaluationConfig:
             seed=ds_data.get("seed", 42),
             columns_mapping=ds_data.get("columns_mapping", {}),
             label_mapping=ds_data.get("label_mapping"),
+            max_queries=ds_data.get("max_queries", 16),
             streaming=ds_data.get("streaming", False),
             revision=ds_data.get("revision"),
             build_script=ds_data.get("build_script"),

--- a/src/winml/modelkit/eval/config.py
+++ b/src/winml/modelkit/eval/config.py
@@ -260,6 +260,7 @@ class WinMLEvaluationConfig:
             shuffle=ds_data.get("shuffle", True),
             seed=ds_data.get("seed", 42),
             columns_mapping=ds_data.get("columns_mapping", {}),
+            label_mapping=ds_data.get("label_mapping"),
             streaming=ds_data.get("streaming", False),
             revision=ds_data.get("revision"),
             build_script=ds_data.get("build_script"),

--- a/src/winml/modelkit/eval/evaluate.py
+++ b/src/winml/modelkit/eval/evaluate.py
@@ -75,6 +75,8 @@ _EVALUATOR_REGISTRY: dict[str, str] = {
         "winml.modelkit.eval.token_classification_evaluator:WinMLTokenClassificationEvaluator",
     "object-detection":
         "winml.modelkit.eval.object_detection_evaluator:WinMLObjectDetectionEvaluator",
+    "zero-shot-object-detection":
+        "winml.modelkit.eval.zero_shot_object_detection_evaluator:WinMLZeroShotObjectDetectionEvaluator",
     "image-segmentation":
         "winml.modelkit.eval.image_segmentation_evaluator:WinMLImageSegmentationEvaluator",
     "question-answering":
@@ -206,6 +208,22 @@ _DEFAULT_DATASETS: dict[str, dict] = {
             "bbox_key": "bbox",
             "category_key": "category",
             "box_format": "xyxy",
+        },
+    },
+    "zero-shot-object-detection": {
+        "path": "detection-datasets/coco",
+        "split": "val",
+        "revision": "cf0b22332314a937e9dc8a1957b21725430bb41d",
+        "streaming": True,
+        "columns_mapping": {
+            "input_column": "image",
+            "annotation_column": "objects",
+            "bbox_key": "bbox",
+            "category_key": "category",
+            "image_id_column": "image_id",
+            "box_format": "xywh",
+            "box_coords": "absolute",
+            "prompt_template": "a photo of a {}",
         },
     },
     "question-answering": {

--- a/src/winml/modelkit/eval/evaluate.py
+++ b/src/winml/modelkit/eval/evaluate.py
@@ -215,6 +215,7 @@ _DEFAULT_DATASETS: dict[str, dict] = {
         "split": "val",
         "revision": "cf0b22332314a937e9dc8a1957b21725430bb41d",
         "streaming": True,
+        "max_queries": 16,
         "columns_mapping": {
             "input_column": "image",
             "annotation_column": "objects",

--- a/src/winml/modelkit/eval/zero_shot_object_detection_evaluator.py
+++ b/src/winml/modelkit/eval/zero_shot_object_detection_evaluator.py
@@ -39,7 +39,6 @@ class QueryChunk:
 
     prompts: tuple[str, ...]
     category_ids: tuple[int, ...]
-    real_size: int
 
 
 def _validate_prompt_template(template: str) -> str:
@@ -145,7 +144,6 @@ def _make_query_chunks(
         QueryChunk(
             prompts=(template.format(name),) * width,
             category_ids=(category_id,) * width,
-            real_size=1,
         )
         for category_id, name in vocabulary
     ]
@@ -243,7 +241,15 @@ class WinMLZeroShotObjectDetectionEvaluator(WinMLEvaluator):
         from transformers import AutoProcessor
 
         pipe = super().prepare_pipeline()
-        processor = AutoProcessor.from_pretrained(self.config.model_id)
+        if self.config.model_id is None:
+            raise ValueError(
+                "zero-shot object detection evaluation requires --model-id "
+                "to load processor metadata"
+            )
+        processor = AutoProcessor.from_pretrained(
+            self.config.model_id,
+            trust_remote_code=self.config.trust_remote_code,
+        )
         processor.tokenizer = pipe.tokenizer
         processor.image_processor = pipe.image_processor
         self._processor = processor

--- a/src/winml/modelkit/eval/zero_shot_object_detection_evaluator.py
+++ b/src/winml/modelkit/eval/zero_shot_object_detection_evaluator.py
@@ -1,0 +1,410 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+"""Open-vocabulary object detection evaluation using grounded processor semantics."""
+
+from __future__ import annotations
+
+import logging
+import string
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from ..utils.eval_utils import DatasetValidationError
+from .base_evaluator import WinMLEvaluator
+
+
+if TYPE_CHECKING:
+    from datasets import Dataset
+    from transformers.pipelines.base import Pipeline
+
+    from ..models.winml.base import WinMLPreTrainedModel
+    from .config import DatasetConfig, WinMLEvaluationConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class QueryChunk:
+    """One model invocation's ordered query vocabulary."""
+
+    prompts: tuple[str, ...]
+    category_ids: tuple[int | None, ...]
+    real_size: int
+
+
+def _validate_prompt_template(template: str) -> str:
+    """Require exactly one positional replacement field."""
+    fields = [field for _, field, _, _ in string.Formatter().parse(template) if field is not None]
+    if len(fields) != 1 or fields[0] not in ("", "0"):
+        raise DatasetValidationError(
+            "prompt_template must contain exactly one positional replacement field '{}'.",
+        )
+    try:
+        template.format("category")
+    except (IndexError, KeyError, ValueError) as error:
+        raise DatasetValidationError(f"invalid prompt_template: {error}") from error
+    return template
+
+
+def _unwrap_sequence_feature(feature: Any) -> Any:
+    """Unwrap datasets.Sequence/List wrappers without depending on their version."""
+    while hasattr(feature, "feature"):
+        feature = feature.feature
+    return feature
+
+
+def _extract_category_vocabulary(
+    features: Any,
+    annotation_column: str,
+    category_key: str,
+    explicit_mapping: dict[str, int] | None = None,
+) -> list[tuple[int, str]]:
+    """Extract ordered ``(dataset ID, name)`` pairs from authoritative metadata."""
+    if explicit_mapping is not None:
+        if not explicit_mapping:
+            raise DatasetValidationError("explicit label mapping must not be empty")
+        ids = list(explicit_mapping.values())
+        if any(not isinstance(value, int) or value < 0 for value in ids):
+            raise DatasetValidationError("explicit label mapping IDs must be non-negative integers")
+        if len(set(ids)) != len(ids):
+            raise DatasetValidationError("explicit label mapping IDs must be unique")
+        return sorted(((category_id, name) for name, category_id in explicit_mapping.items()))
+
+    annotation = features.get(annotation_column)
+    annotation = _unwrap_sequence_feature(annotation)
+    if not isinstance(annotation, dict) or category_key not in annotation:
+        raise DatasetValidationError(
+            f"'{annotation_column}' has no category feature '{category_key}'",
+        )
+    category = _unwrap_sequence_feature(annotation[category_key])
+    names = getattr(category, "names", None)
+    if not isinstance(names, list) or not names or not all(isinstance(name, str) for name in names):
+        raise DatasetValidationError(
+            "category IDs require authoritative names from dataset ClassLabel metadata "
+            "or an explicit validated label mapping",
+        )
+    return list(enumerate(names))
+
+
+def _query_capacity(io_config: dict[str, Any]) -> int | None:
+    """Return the static text-query capacity, or ``None`` for a dynamic axis."""
+    names = io_config.get("input_names", [])
+    shapes = io_config.get("input_shapes", [])
+    try:
+        shape = shapes[names.index("input_ids")]
+    except (ValueError, IndexError):
+        raise ValueError("zero-shot object detection model requires an input_ids input") from None
+    if not shape:
+        return None
+    capacity = shape[0]
+    if isinstance(capacity, int):
+        if capacity < 1:
+            raise ValueError("input_ids query capacity must be at least 1")
+        return capacity
+    return None
+
+
+def _sequence_length(io_config: dict[str, Any]) -> int | None:
+    names = io_config.get("input_names", [])
+    shapes = io_config.get("input_shapes", [])
+    try:
+        shape = shapes[names.index("input_ids")]
+    except (ValueError, IndexError):
+        return None
+    if len(shape) > 1 and isinstance(shape[1], int):
+        return shape[1]
+    return None
+
+
+def _make_query_chunks(
+    vocabulary: list[tuple[int, str]],
+    template: str,
+    capacity: int | None,
+) -> list[QueryChunk]:
+    """Render and deterministically chunk the complete vocabulary.
+
+    A final partial static chunk is padded with a neutral query. Detections for
+    padded query-local labels are discarded during remapping.
+    """
+    if not vocabulary:
+        raise DatasetValidationError("category vocabulary must not be empty")
+    width = capacity or len(vocabulary)
+    chunks: list[QueryChunk] = []
+    for start in range(0, len(vocabulary), width):
+        part = vocabulary[start : start + width]
+        prompts: list[str] = [template.format(name) for _, name in part]
+        category_ids: list[int | None] = [category_id for category_id, _ in part]
+        real_size = len(part)
+        while len(prompts) < width:
+            prompts.append(" ")
+            category_ids.append(None)
+        chunks.append(QueryChunk(tuple(prompts), tuple(category_ids), real_size))
+    return chunks
+
+
+def _select_category_covering_rows(
+    rows: list[tuple[int, int, list[int]]],
+    category_ids: set[int],
+    requested_cap: int,
+) -> tuple[list[int], set[int]]:
+    """Greedily select deterministic category-covering source row indices."""
+    if requested_cap < 1:
+        raise DatasetValidationError("samples must be at least 1")
+    remaining = list(rows)
+    uncovered = set(category_ids)
+    selected: list[int] = []
+    while remaining and len(selected) < requested_cap and uncovered:
+        best = min(
+            remaining,
+            key=lambda row: (
+                -len(set(row[2]) & uncovered),
+                -len(row[2]),
+                row[1],
+                row[0],
+            ),
+        )
+        if not (set(best[2]) & uncovered):
+            break
+        selected.append(best[0])
+        uncovered.difference_update(best[2])
+        remaining.remove(best)
+    return selected, category_ids - uncovered
+
+
+def _remap_grounded_output(output: dict[str, Any], chunk: QueryChunk) -> dict[str, list]:
+    """Map processor query-local labels to authoritative dataset category IDs."""
+    boxes: list = []
+    scores: list = []
+    labels: list[int] = []
+    for box, score, local_label in zip(
+        output["boxes"], output["scores"], output["labels"], strict=True
+    ):
+        local_id = int(local_label.item() if hasattr(local_label, "item") else local_label)
+        if local_id < 0 or local_id >= len(chunk.category_ids):
+            raise ValueError(f"processor returned out-of-range query label {local_id}")
+        category_id = chunk.category_ids[local_id]
+        if category_id is None:
+            continue
+        boxes.append(box.tolist() if hasattr(box, "tolist") else list(box))
+        scores.append(float(score.item() if hasattr(score, "item") else score))
+        labels.append(category_id)
+    return {"boxes": boxes, "scores": scores, "labels": labels}
+
+
+class WinMLZeroShotObjectDetectionEvaluator(WinMLEvaluator):
+    """Evaluate text-conditioned detectors against a complete dataset vocabulary."""
+
+    def __init__(
+        self,
+        config: WinMLEvaluationConfig,
+        model: WinMLPreTrainedModel,
+    ) -> None:
+        from ..utils.eval_utils import get_default
+
+        mapping = config.dataset.columns_mapping
+        task = "zero-shot-object-detection"
+        self._image_col = mapping.get("input_column", get_default(task, "input_column"))
+        self._annotation_col = mapping.get(
+            "annotation_column", get_default(task, "annotation_column")
+        )
+        self._bbox_key = mapping.get("bbox_key", get_default(task, "bbox_key"))
+        self._category_key = mapping.get("category_key", get_default(task, "category_key"))
+        self._image_id_col = mapping.get("image_id_column", get_default(task, "image_id_column"))
+        self._box_format = mapping.get("box_format", get_default(task, "box_format"))
+        self._box_coords = mapping.get("box_coords", get_default(task, "box_coords"))
+        self._prompt_template = _validate_prompt_template(
+            mapping.get("prompt_template", get_default(task, "prompt_template")) or ""
+        )
+        super().__init__(config, model)
+
+    def prepare_pipeline(self) -> Pipeline:
+        """Create the task pipeline and retain its matched processor components."""
+        from transformers import AutoProcessor
+
+        pipe = super().prepare_pipeline()
+        processor = AutoProcessor.from_pretrained(self.config.model_id)
+        processor.tokenizer = pipe.tokenizer
+        processor.image_processor = pipe.image_processor
+        self._processor = processor
+        return pipe
+
+    def align_labels(self, dataset: Dataset, ds_config: DatasetConfig) -> Dataset:
+        """Keep dataset IDs unchanged and capture their authoritative vocabulary."""
+        self._validate_schema(dataset)
+        self._vocabulary = _extract_category_vocabulary(
+            dataset.features,
+            self._annotation_col,
+            self._category_key,
+            ds_config.label_mapping,
+        )
+        return dataset
+
+    def prepare_data(self) -> Dataset:
+        """Scan annotations without image decoding and select category-covering rows."""
+        from pathlib import Path
+
+        from datasets import Dataset, Image, load_dataset, load_from_disk
+
+        ds = self.config.dataset
+        try:
+            ds_path = Path(ds.path).expanduser() if ds.path else None
+            if ds_path and ds_path.is_dir():
+                source = load_from_disk(str(ds_path))
+            else:
+                source = load_dataset(
+                    ds.path,
+                    name=ds.name,
+                    split=ds.split,
+                    streaming=ds.streaming,
+                    revision=ds.revision,
+                )
+        except Exception as error:
+            raise DatasetValidationError(
+                f"Failed to load dataset '{ds.path}' "
+                f"(name={ds.name!r}, split='{ds.split}'): {error}",
+            ) from error
+
+        self._validate_schema(source)
+        self._vocabulary = _extract_category_vocabulary(
+            source.features,
+            self._annotation_col,
+            self._category_key,
+            ds.label_mapping,
+        )
+        category_ids = {category_id for category_id, _ in self._vocabulary}
+        original_features = source.features
+        image_feature = original_features.get(self._image_col)
+        if image_feature is not None:
+            source = source.cast_column(self._image_col, Image(decode=False))
+
+        rows: list[tuple[int, int, list[int]]] = []
+        annotation_source = source.remove_columns(self._image_col)
+        for source_index, sample in enumerate(annotation_source):
+            annotations = sample[self._annotation_col]
+            categories = [int(value) for value in annotations[self._category_key]]
+            unknown = set(categories) - category_ids
+            if unknown:
+                raise DatasetValidationError(
+                    f"annotation has unknown category IDs {sorted(unknown)}"
+                )
+            image_id = int(sample.get(self._image_id_col, source_index))
+            rows.append((source_index, image_id, categories))
+
+        selected_indices, covered = _select_category_covering_rows(rows, category_ids, ds.samples)
+        selected_index_set = set(selected_indices)
+        selected_by_index = {
+            source_index: sample
+            for source_index, sample in enumerate(source)
+            if source_index in selected_index_set
+        }
+        selected = [selected_by_index[index] for index in selected_indices]
+        self._selection_accounting = {
+            "requested": ds.samples,
+            "requested_cap": ds.samples,
+            "source_rows_scanned": len(rows),
+            "selected": len(selected),
+            "category_count": len(category_ids),
+            "categories_covered": len(covered),
+        }
+        return Dataset.from_list(selected, features=original_features)
+
+    def compute(self) -> dict[str, Any]:
+        """Run every category query for every image and compute COCO-style mAP."""
+        import torch
+
+        from .metrics import MAPMetric
+
+        capacity = _query_capacity(self.model.io_config)
+        chunks = _make_query_chunks(self._vocabulary, self._prompt_template, capacity)
+        seq_length = _sequence_length(self.model.io_config)
+        accepted_inputs = set(self.model.io_config.get("input_names", []))
+        predictions: list[dict[str, Any]] = []
+        references: list[dict[str, Any]] = []
+        decoded = processed = query_passes = 0
+
+        for sample in self.data:
+            annotations = sample[self._annotation_col]
+            references.append(
+                {
+                    "boxes": annotations[self._bbox_key],
+                    "labels": [int(value) for value in annotations[self._category_key]],
+                }
+            )
+            image = sample[self._image_col]
+            if image is None or not hasattr(image, "size"):
+                raise DatasetValidationError(
+                    f"column '{self._image_col}' must contain decoded PIL images",
+                )
+            decoded += 1
+            image_predictions = {"boxes": [], "scores": [], "labels": []}
+            for chunk in chunks:
+                text_kwargs: dict[str, Any] = {
+                    "return_tensors": "pt",
+                    "padding": "max_length",
+                    "truncation": True,
+                }
+                if seq_length is not None:
+                    text_kwargs["max_length"] = seq_length
+                text_inputs = self._processor.tokenizer(list(chunk.prompts), **text_kwargs)
+                image_inputs = self._processor.image_processor(image, return_tensors="pt")
+                model_inputs = {
+                    **text_inputs,
+                    **image_inputs,
+                }
+                model_inputs = {
+                    name: value for name, value in model_inputs.items() if name in accepted_inputs
+                }
+                outputs = self.model(**model_inputs)
+                query_passes += 1
+                grounded = self._processor.post_process_grounded_object_detection(
+                    outputs,
+                    threshold=0.0,
+                    target_sizes=torch.tensor([[image.height, image.width]]),
+                )[0]
+                remapped = _remap_grounded_output(grounded, chunk)
+                for key in image_predictions:
+                    image_predictions[key].extend(remapped[key])
+            predictions.append(image_predictions)
+            processed += 1
+
+        metrics = MAPMetric().compute(
+            predictions=predictions,
+            references=references,
+            box_format=self._box_format,
+            box_coords=self._box_coords,
+        )
+        metrics.update(
+            {
+                **self._selection_accounting,
+                "decoded": decoded,
+                "skipped": 0,
+                "processed": processed,
+                "failed": 0,
+                "query_count": len(self._vocabulary),
+                "query_passes": query_passes,
+                "query_capacity": capacity or "dynamic",
+            }
+        )
+        return metrics
+
+    def _validate_schema(self, dataset: Any) -> None:
+        """Validate required columns and nested annotation fields."""
+        columns = set(getattr(dataset, "column_names", []))
+        for column in (self._image_col, self._annotation_col):
+            if column not in columns:
+                raise DatasetValidationError(
+                    f"missing required column '{column}'; dataset has {sorted(columns)}",
+                )
+        annotation = _unwrap_sequence_feature(dataset.features.get(self._annotation_col))
+        if not isinstance(annotation, dict):
+            raise DatasetValidationError(
+                f"column '{self._annotation_col}' must be an annotation struct",
+            )
+        missing = [key for key in (self._bbox_key, self._category_key) if key not in annotation]
+        if missing:
+            raise DatasetValidationError(
+                f"'{self._annotation_col}' is missing required field(s) {missing}",
+            )

--- a/src/winml/modelkit/eval/zero_shot_object_detection_evaluator.py
+++ b/src/winml/modelkit/eval/zero_shot_object_detection_evaluator.py
@@ -95,6 +95,66 @@ def _extract_category_vocabulary(
     return list(enumerate(names))
 
 
+def _normalize_max_queries(max_queries: Any) -> int | None:
+    """Validate configured query budget (or allow explicit unbounded mode)."""
+    if max_queries is None:
+        return None
+    if isinstance(max_queries, bool) or not isinstance(max_queries, int):
+        raise DatasetValidationError("max_queries must be an integer >= 1 or null")
+    if max_queries < 1:
+        raise DatasetValidationError("max_queries must be >= 1")
+    return max_queries
+
+
+def _apply_query_budget(
+    vocabulary: list[tuple[int, str]],
+    max_queries: Any,
+) -> tuple[list[tuple[int, str]], dict[str, int]]:
+    """Apply deterministic query budget to authoritative vocabulary."""
+    if not vocabulary:
+        raise DatasetValidationError("category vocabulary must not be empty")
+    available = len(vocabulary)
+    normalized = _normalize_max_queries(max_queries)
+    requested = available if normalized is None else normalized
+    used = min(requested, available)
+    used_vocabulary = vocabulary[:used]
+    return (
+        used_vocabulary,
+        {
+            "query_requested": requested,
+            "query_available": available,
+            "query_used": used,
+            "query_truncated": available - used,
+        },
+    )
+
+
+def _filter_annotation_to_vocabulary(
+    annotation: dict[str, Any],
+    category_key: str,
+    selected_category_ids: set[int],
+) -> tuple[dict[str, Any], list[int]]:
+    """Drop per-instance annotation entries outside the selected query vocabulary."""
+    raw_categories = [int(value) for value in annotation[category_key]]
+    keep_indices = [
+        index
+        for index, category in enumerate(raw_categories)
+        if category in selected_category_ids
+    ]
+    if len(keep_indices) == len(raw_categories):
+        return annotation, raw_categories
+
+    filtered: dict[str, Any] = {}
+    for key, value in annotation.items():
+        if isinstance(value, list) and len(value) == len(raw_categories):
+            filtered[key] = [value[index] for index in keep_indices]
+        else:
+            filtered[key] = value
+    filtered_categories = [raw_categories[index] for index in keep_indices]
+    filtered[category_key] = filtered_categories
+    return filtered, filtered_categories
+
+
 def _query_capacity(io_config: dict[str, Any]) -> int | None:
     """Return the static text-query capacity, or ``None`` for a dynamic axis."""
     names = io_config.get("input_names", [])
@@ -258,11 +318,15 @@ class WinMLZeroShotObjectDetectionEvaluator(WinMLEvaluator):
     def align_labels(self, dataset: Dataset, ds_config: DatasetConfig) -> Dataset:
         """Keep dataset IDs unchanged and capture their authoritative vocabulary."""
         self._validate_schema(dataset)
-        self._vocabulary = _extract_category_vocabulary(
+        full_vocabulary = _extract_category_vocabulary(
             dataset.features,
             self._annotation_col,
             self._category_key,
             ds_config.label_mapping,
+        )
+        self._vocabulary, self._query_accounting = _apply_query_budget(
+            full_vocabulary,
+            ds_config.max_queries,
         )
         return dataset
 
@@ -292,11 +356,16 @@ class WinMLZeroShotObjectDetectionEvaluator(WinMLEvaluator):
             ) from error
 
         self._validate_schema(source)
-        self._vocabulary = _extract_category_vocabulary(
+        full_vocabulary = _extract_category_vocabulary(
             source.features,
             self._annotation_col,
             self._category_key,
             ds.label_mapping,
+        )
+        all_category_ids = {category_id for category_id, _ in full_vocabulary}
+        self._vocabulary, self._query_accounting = _apply_query_budget(
+            full_vocabulary,
+            ds.max_queries,
         )
         category_ids = {category_id for category_id, _ in self._vocabulary}
         original_features = source.features
@@ -309,18 +378,26 @@ class WinMLZeroShotObjectDetectionEvaluator(WinMLEvaluator):
         for source_index, sample in enumerate(annotation_source):
             annotations = sample[self._annotation_col]
             categories = [int(value) for value in annotations[self._category_key]]
-            unknown = set(categories) - category_ids
+            unknown = set(categories) - all_category_ids
             if unknown:
                 raise DatasetValidationError(
                     f"annotation has unknown category IDs {sorted(unknown)}"
                 )
+            categories = [category for category in categories if category in category_ids]
             image_id = int(sample.get(self._image_id_col, source_index))
             rows.append((source_index, image_id, categories))
 
         selected_indices, covered = _select_category_covering_rows(rows, category_ids, ds.samples)
         selected_index_set = set(selected_indices)
         selected_by_index = {
-            source_index: sample
+            source_index: {
+                **sample,
+                self._annotation_col: _filter_annotation_to_vocabulary(
+                    sample[self._annotation_col],
+                    self._category_key,
+                    category_ids,
+                )[0],
+            }
             for source_index, sample in enumerate(source)
             if source_index in selected_index_set
         }
@@ -332,6 +409,7 @@ class WinMLZeroShotObjectDetectionEvaluator(WinMLEvaluator):
             "selected": len(selected),
             "category_count": len(category_ids),
             "categories_covered": len(covered),
+            **self._query_accounting,
         }
         return Dataset.from_list(selected, features=original_features)
 

--- a/src/winml/modelkit/eval/zero_shot_object_detection_evaluator.py
+++ b/src/winml/modelkit/eval/zero_shot_object_detection_evaluator.py
@@ -26,6 +26,13 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _require_string(value: str | None, field: str) -> str:
+    """Return a required configured string or fail with an actionable error."""
+    if value is None:
+        raise ValueError(f"zero-shot object detection requires '{field}' configuration")
+    return value
+
+
 @dataclass(frozen=True)
 class QueryChunk:
     """One model invocation's ordered query vocabulary."""
@@ -206,15 +213,29 @@ class WinMLZeroShotObjectDetectionEvaluator(WinMLEvaluator):
 
         mapping = config.dataset.columns_mapping
         task = "zero-shot-object-detection"
-        self._image_col = mapping.get("input_column", get_default(task, "input_column"))
-        self._annotation_col = mapping.get(
-            "annotation_column", get_default(task, "annotation_column")
+        self._image_col = _require_string(
+            mapping.get("input_column", get_default(task, "input_column")), "input_column"
         )
-        self._bbox_key = mapping.get("bbox_key", get_default(task, "bbox_key"))
-        self._category_key = mapping.get("category_key", get_default(task, "category_key"))
-        self._image_id_col = mapping.get("image_id_column", get_default(task, "image_id_column"))
-        self._box_format = mapping.get("box_format", get_default(task, "box_format"))
-        self._box_coords = mapping.get("box_coords", get_default(task, "box_coords"))
+        self._annotation_col = _require_string(
+            mapping.get("annotation_column", get_default(task, "annotation_column")),
+            "annotation_column",
+        )
+        self._bbox_key = _require_string(
+            mapping.get("bbox_key", get_default(task, "bbox_key")), "bbox_key"
+        )
+        self._category_key = _require_string(
+            mapping.get("category_key", get_default(task, "category_key")), "category_key"
+        )
+        self._image_id_col = _require_string(
+            mapping.get("image_id_column", get_default(task, "image_id_column")),
+            "image_id_column",
+        )
+        self._box_format = _require_string(
+            mapping.get("box_format", get_default(task, "box_format")), "box_format"
+        )
+        self._box_coords = _require_string(
+            mapping.get("box_coords", get_default(task, "box_coords")), "box_coords"
+        )
         self._prompt_template = _validate_prompt_template(
             mapping.get("prompt_template", get_default(task, "prompt_template")) or ""
         )
@@ -317,10 +338,13 @@ class WinMLZeroShotObjectDetectionEvaluator(WinMLEvaluator):
 
         from .metrics import MAPMetric
 
-        capacity = _query_capacity(self.model.io_config)
+        io_config = getattr(self.model, "io_config", None)
+        if not isinstance(io_config, dict):
+            raise TypeError("zero-shot object detection model requires I/O configuration")
+        capacity = _query_capacity(io_config)
         chunks = _make_query_chunks(self._vocabulary, self._prompt_template, capacity)
-        seq_length = _sequence_length(self.model.io_config)
-        accepted_inputs = set(self.model.io_config.get("input_names", []))
+        seq_length = _sequence_length(io_config)
+        accepted_inputs = set(io_config.get("input_names", []))
         predictions: list[dict[str, Any]] = []
         references: list[dict[str, Any]] = []
         decoded = processed = query_passes = 0
@@ -339,7 +363,11 @@ class WinMLZeroShotObjectDetectionEvaluator(WinMLEvaluator):
                     f"column '{self._image_col}' must contain decoded PIL images",
                 )
             decoded += 1
-            image_predictions = {"boxes": [], "scores": [], "labels": []}
+            image_predictions: dict[str, list[Any]] = {
+                "boxes": [],
+                "scores": [],
+                "labels": [],
+            }
             for chunk in chunks:
                 text_kwargs: dict[str, Any] = {
                     "return_tensors": "pt",
@@ -369,6 +397,9 @@ class WinMLZeroShotObjectDetectionEvaluator(WinMLEvaluator):
                     image_predictions[key].extend(remapped[key])
             predictions.append(image_predictions)
             processed += 1
+
+        if processed == 0:
+            raise DatasetValidationError("evaluation processed no images")
 
         metrics = MAPMetric().compute(
             predictions=predictions,

--- a/src/winml/modelkit/eval/zero_shot_object_detection_evaluator.py
+++ b/src/winml/modelkit/eval/zero_shot_object_detection_evaluator.py
@@ -38,7 +38,7 @@ class QueryChunk:
     """One model invocation's ordered query vocabulary."""
 
     prompts: tuple[str, ...]
-    category_ids: tuple[int | None, ...]
+    category_ids: tuple[int, ...]
     real_size: int
 
 
@@ -131,25 +131,24 @@ def _make_query_chunks(
     template: str,
     capacity: int | None,
 ) -> list[QueryChunk]:
-    """Render and deterministically chunk the complete vocabulary.
+    """Render one independent category per invocation.
 
-    A final partial static chunk is padded with a neutral query. Detections for
-    padded query-local labels are discarded during remapping.
+    Grounded object-detection postprocessing selects the highest query logit for
+    each predicted box. To prevent categories from competing, replicate one real
+    query across every slot required by a static graph. Any selected local slot
+    then maps to the same authoritative category. Dynamic graphs use one slot.
     """
     if not vocabulary:
         raise DatasetValidationError("category vocabulary must not be empty")
-    width = capacity or len(vocabulary)
-    chunks: list[QueryChunk] = []
-    for start in range(0, len(vocabulary), width):
-        part = vocabulary[start : start + width]
-        prompts: list[str] = [template.format(name) for _, name in part]
-        category_ids: list[int | None] = [category_id for category_id, _ in part]
-        real_size = len(part)
-        while len(prompts) < width:
-            prompts.append(" ")
-            category_ids.append(None)
-        chunks.append(QueryChunk(tuple(prompts), tuple(category_ids), real_size))
-    return chunks
+    width = capacity or 1
+    return [
+        QueryChunk(
+            prompts=(template.format(name),) * width,
+            category_ids=(category_id,) * width,
+            real_size=1,
+        )
+        for category_id, name in vocabulary
+    ]
 
 
 def _select_category_covering_rows(
@@ -193,8 +192,6 @@ def _remap_grounded_output(output: dict[str, Any], chunk: QueryChunk) -> dict[st
         if local_id < 0 or local_id >= len(chunk.category_ids):
             raise ValueError(f"processor returned out-of-range query label {local_id}")
         category_id = chunk.category_ids[local_id]
-        if category_id is None:
-            continue
         boxes.append(box.tolist() if hasattr(box, "tolist") else list(box))
         scores.append(float(score.item() if hasattr(score, "item") else score))
         labels.append(category_id)

--- a/src/winml/modelkit/models/winml/__init__.py
+++ b/src/winml/modelkit/models/winml/__init__.py
@@ -40,6 +40,7 @@ TASK_TO_WINML_CLASS: dict[str, str] = {
     "image-segmentation": "WinMLModelForImageSegmentation",
     "semantic-segmentation": "WinMLModelForSemanticSegmentation",
     "object-detection": "WinMLModelForObjectDetection",
+    "zero-shot-object-detection": "WinMLModelForObjectDetection",
     "depth-estimation": "WinMLModelForDepthEstimation",
     # Not yet implemented — falls back to WinMLModelForGenericTask at runtime
     "token-classification": "WinMLModelForTokenClassification",

--- a/src/winml/modelkit/models/winml/object_detection.py
+++ b/src/winml/modelkit/models/winml/object_detection.py
@@ -61,12 +61,10 @@ class WinMLModelForObjectDetection(WinMLPreTrainedModel):
     ) -> ObjectDetectionOutput:
         """Run object detection inference."""
         inputs: dict[str, Any] = {"pixel_values": pixel_values}
-        # Only include pixel_mask if the ONNX model accepts it
-        if pixel_mask is not None:
-            accepted_inputs = set(self.io_config.get("input_names", []))
-            if "pixel_mask" in accepted_inputs:
-                inputs["pixel_mask"] = pixel_mask
         accepted_inputs = set(self.io_config.get("input_names", []))
+        # Only include pixel_mask if the ONNX model accepts it
+        if pixel_mask is not None and "pixel_mask" in accepted_inputs:
+            inputs["pixel_mask"] = pixel_mask
         if input_ids is not None and "input_ids" in accepted_inputs:
             inputs["input_ids"] = input_ids
         if attention_mask is not None and "attention_mask" in accepted_inputs:

--- a/src/winml/modelkit/models/winml/object_detection.py
+++ b/src/winml/modelkit/models/winml/object_detection.py
@@ -55,6 +55,8 @@ class WinMLModelForObjectDetection(WinMLPreTrainedModel):
         self,
         pixel_values: torch.Tensor | np.ndarray,
         pixel_mask: torch.Tensor | np.ndarray | None = None,
+        input_ids: torch.Tensor | np.ndarray | None = None,
+        attention_mask: torch.Tensor | np.ndarray | None = None,
         **kwargs: Any,
     ) -> ObjectDetectionOutput:
         """Run object detection inference."""
@@ -64,6 +66,11 @@ class WinMLModelForObjectDetection(WinMLPreTrainedModel):
             accepted_inputs = set(self.io_config.get("input_names", []))
             if "pixel_mask" in accepted_inputs:
                 inputs["pixel_mask"] = pixel_mask
+        accepted_inputs = set(self.io_config.get("input_names", []))
+        if input_ids is not None and "input_ids" in accepted_inputs:
+            inputs["input_ids"] = input_ids
+        if attention_mask is not None and "attention_mask" in accepted_inputs:
+            inputs["attention_mask"] = attention_mask
 
         formatted = self._format_inputs(**inputs)
         outputs = self._run_inference(formatted)

--- a/src/winml/modelkit/utils/eval_utils.py
+++ b/src/winml/modelkit/utils/eval_utils.py
@@ -139,6 +139,61 @@ _OBJECT_DETECTION_SCHEMA = TaskSchema(
     ),
 )
 
+_ZERO_SHOT_OBJECT_DETECTION_SCHEMA = TaskSchema(
+    columns=(
+        SchemaItem(
+            "input_column",
+            "input image (PIL.Image)",
+            default="image",
+            remap_hint="<your_image_column>",
+        ),
+        SchemaItem(
+            "annotation_column",
+            "annotation dict containing bbox + category fields",
+            default="objects",
+            remap_hint="<your_annotation_column>",
+        ),
+    ),
+    params=(
+        SchemaItem(
+            "bbox_key",
+            "absolute xywh bounding boxes inside the annotation dict",
+            default="bbox",
+            remap_hint="<bbox_field>",
+        ),
+        SchemaItem(
+            "category_key",
+            "category IDs backed by authoritative category names",
+            default="category",
+            remap_hint="<category_field>",
+        ),
+        SchemaItem(
+            "image_id_column",
+            "stable image ID used to break deterministic selection ties",
+            default="image_id",
+            remap_hint="<your_image_id_column>",
+        ),
+        SchemaItem(
+            "prompt_template",
+            "text-query template containing exactly one {} replacement field",
+            default="a photo of a {}",
+            remap_hint="<template with one {} field>",
+        ),
+        SchemaItem(
+            "box_format",
+            "ground-truth bounding box layout",
+            default="xywh",
+            remap_hint="<xywh|xyxy>",
+        ),
+        SchemaItem(
+            "box_coords",
+            "ground-truth bounding box coordinate system",
+            default="absolute",
+            remap_hint="<absolute|normalized>",
+        ),
+    ),
+)
+
 _IMAGE_SEGMENTATION_SCHEMA = TaskSchema(
     columns=(
         SchemaItem(
@@ -455,6 +510,7 @@ TASK_SCHEMAS: dict[str, TaskSchema] = {
     "next-sentence-prediction": _TEXT_CLASSIFICATION_SCHEMA,
     "token-classification": _TOKEN_CLASSIFICATION_SCHEMA,
     "object-detection": _OBJECT_DETECTION_SCHEMA,
+    "zero-shot-object-detection": _ZERO_SHOT_OBJECT_DETECTION_SCHEMA,
     "image-segmentation": _IMAGE_SEGMENTATION_SCHEMA,
     "question-answering": _QUESTION_ANSWERING_SCHEMA,
     "feature-extraction": _FEATURE_EXTRACTION_SCHEMA,

--- a/src/winml/modelkit/utils/eval_utils.py
+++ b/src/winml/modelkit/utils/eval_utils.py
@@ -181,9 +181,8 @@ _ZERO_SHOT_OBJECT_DETECTION_SCHEMA = TaskSchema(
         ),
         SchemaItem(
             "max_queries",
-            "maximum category queries to evaluate (null = full vocabulary)",
+            "maximum category queries to evaluate (set via --max-queries; null = full vocabulary)",
             default="16",
-            remap_hint="<integer >= 1 or null>",
         ),
         SchemaItem(
             "box_format",

--- a/src/winml/modelkit/utils/eval_utils.py
+++ b/src/winml/modelkit/utils/eval_utils.py
@@ -180,6 +180,12 @@ _ZERO_SHOT_OBJECT_DETECTION_SCHEMA = TaskSchema(
             remap_hint="<template with one {} field>",
         ),
         SchemaItem(
+            "max_queries",
+            "maximum category queries to evaluate (null = full vocabulary)",
+            default="16",
+            remap_hint="<integer >= 1 or null>",
+        ),
+        SchemaItem(
             "box_format",
             "ground-truth bounding box layout",
             default="xywh",

--- a/tests/integration/eval/test_zero_shot_object_detection.py
+++ b/tests/integration/eval/test_zero_shot_object_detection.py
@@ -1,0 +1,82 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+"""Pinned-dataset integration coverage for zero-shot object detection Eval."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+_HF_HUB_AVAILABLE = os.environ.get("WINML_TEST_OFFLINE", "0") != "1"
+_COCO_REVISION = "cf0b22332314a937e9dc8a1957b21725430bb41d"
+_EXPECTED_IMAGE_IDS = [
+    441247,
+    435081,
+    190236,
+    254814,
+    16228,
+    435206,
+    231831,
+    357888,
+    366884,
+    542625,
+    327769,
+    561958,
+    217285,
+    87476,
+    59386,
+    463802,
+    524850,
+    286182,
+    184324,
+    213255,
+    239857,
+    540502,
+    178028,
+    229997,
+]
+
+
+@pytest.mark.skipif(not _HF_HUB_AVAILABLE, reason="HF Hub disabled in offline mode")
+def test_pinned_coco_selection_reproduces_all_category_image_ids() -> None:
+    """The frozen full-split greedy selection remains deterministic."""
+    from winml.modelkit.eval import DatasetConfig, WinMLEvaluationConfig
+    from winml.modelkit.eval.zero_shot_object_detection_evaluator import (
+        WinMLZeroShotObjectDetectionEvaluator,
+    )
+
+    evaluator = object.__new__(WinMLZeroShotObjectDetectionEvaluator)
+    evaluator.config = WinMLEvaluationConfig(
+        task="zero-shot-object-detection",
+        dataset=DatasetConfig(
+            path="detection-datasets/coco",
+            revision=_COCO_REVISION,
+            split="val",
+            samples=32,
+            shuffle=False,
+            streaming=True,
+        ),
+    )
+    evaluator._image_col = "image"
+    evaluator._annotation_col = "objects"
+    evaluator._bbox_key = "bbox"
+    evaluator._category_key = "category"
+    evaluator._image_id_col = "image_id"
+
+    data = evaluator.prepare_data()
+
+    assert list(data["image_id"]) == _EXPECTED_IMAGE_IDS
+    assert evaluator._selection_accounting == {
+        "requested": 32,
+        "requested_cap": 32,
+        "source_rows_scanned": 4952,
+        "selected": 24,
+        "category_count": 80,
+        "categories_covered": 80,
+    }
+    assert len(evaluator._vocabulary) == 80

--- a/tests/integration/eval/test_zero_shot_object_detection.py
+++ b/tests/integration/eval/test_zero_shot_object_detection.py
@@ -58,6 +58,7 @@ def test_pinned_coco_selection_reproduces_all_category_image_ids() -> None:
             revision=_COCO_REVISION,
             split="val",
             samples=32,
+            max_queries=None,
             shuffle=False,
             streaming=True,
         ),
@@ -78,5 +79,9 @@ def test_pinned_coco_selection_reproduces_all_category_image_ids() -> None:
         "selected": 24,
         "category_count": 80,
         "categories_covered": 80,
+        "query_requested": 80,
+        "query_available": 80,
+        "query_used": 80,
+        "query_truncated": 0,
     }
     assert len(evaluator._vocabulary) == 80

--- a/tests/unit/commands/test_eval.py
+++ b/tests/unit/commands/test_eval.py
@@ -455,6 +455,28 @@ class TestEvalHelp:
         assert "--use-cache / --no-use-cache" in result.output
         assert "--rebuild / --no-rebuild" in result.output
 
+    def test_help_mentions_max_queries(self, runner: CliRunner):
+        from winml.modelkit.commands.eval import eval as eval_cmd
+
+        result = runner.invoke(eval_cmd, ["--help"])
+
+        assert result.exit_code == 0, result.output
+        assert "--max-queries" in result.output
+        assert "dataset.max_queries" in result.output
+
+    def test_schema_shows_max_queries_without_column_override(self, runner: CliRunner):
+        from winml.modelkit.commands.eval import eval as eval_cmd
+
+        result = runner.invoke(
+            eval_cmd,
+            ["--schema", "--task", "zero-shot-object-detection"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "max_queries" in result.output
+        assert "--max-queries" in result.output
+        assert "--column max_queries=" not in result.output
+
 
 class TestResolveReference:
     def test_none_is_noop(self):
@@ -1189,6 +1211,23 @@ class TestPerTaskDefaultDataset:
             and "timm/mini-imagenet" in m
             for m in msgs
         ), f"expected warning not found in {msgs!r}"
+
+    def test_max_queries_reaches_evaluator(self, runner: CliRunner):
+        """``--max-queries`` survives CLI/config processing and reaches evaluator config."""
+        cfg = self._run_and_capture(
+            runner,
+            [
+                "-m",
+                "some/model",
+                "--task",
+                "zero-shot-object-detection",
+                "--dataset",
+                "detection-datasets/coco",
+                "--max-queries",
+                "3",
+            ],
+        )
+        assert cfg.dataset.max_queries == 3
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/eval/test_eval.py
+++ b/tests/unit/eval/test_eval.py
@@ -98,6 +98,19 @@ class TestEvaluationConfig:
         assert ds.revision is None
         assert "revision" not in ds.to_dict()
 
+    def test_dataset_config_max_queries_default_and_override_roundtrip(self):
+        default_ds = DatasetConfig(path="some-dataset")
+        assert default_ds.max_queries == 16
+        assert default_ds.to_dict()["max_queries"] == 16
+
+        config = WinMLEvaluationConfig(
+            model_id="test/model",
+            task="zero-shot-object-detection",
+            dataset=DatasetConfig(path="test/data", max_queries=3),
+        )
+        restored = WinMLEvaluationConfig.from_dict(config.to_dict())
+        assert restored.dataset.max_queries == 3
+
     def test_input_data_default_is_none(self):
         """input_data defaults to None and is omitted from to_dict."""
         config = WinMLEvaluationConfig(model_id="test/model")

--- a/tests/unit/eval/test_eval.py
+++ b/tests/unit/eval/test_eval.py
@@ -1094,6 +1094,56 @@ class TestEvalCli:
                 "label_column": "lbl",
             }
 
+    def test_cli_max_queries_maps_to_dataset_config(self):
+        from winml.modelkit.commands.eval import eval as eval_cmd
+
+        runner = CliRunner()
+        with patch("winml.modelkit.eval.evaluate") as mock_evaluate:
+            mock_evaluate.return_value = EvalResult(
+                config=WinMLEvaluationConfig(),
+                metrics={},
+            )
+            result = runner.invoke(
+                eval_cmd,
+                [
+                    "-m",
+                    "test/model",
+                    "--task",
+                    "zero-shot-object-detection",
+                    "--dataset",
+                    "detection-datasets/coco",
+                    "--max-queries",
+                    "3",
+                ],
+                catch_exceptions=False,
+            )
+
+            assert result.exit_code == 0, result.output
+            config = mock_evaluate.call_args[0][0]
+            assert config.dataset.max_queries == 3
+
+    @pytest.mark.parametrize("invalid_value", ["0", "-1", "not-an-int"])
+    def test_cli_max_queries_rejects_invalid_values(self, invalid_value: str):
+        from winml.modelkit.commands.eval import eval as eval_cmd
+
+        runner = CliRunner()
+        result = runner.invoke(
+            eval_cmd,
+            [
+                "-m",
+                "test/model",
+                "--task",
+                "zero-shot-object-detection",
+                "--dataset",
+                "detection-datasets/coco",
+                "--max-queries",
+                invalid_value,
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "--max-queries" in result.output
+
     def test_cli_onnx_model_path(self, tmp_path):
         from winml.modelkit.commands.eval import eval as eval_cmd
 

--- a/tests/unit/eval/test_zero_shot_object_detection_evaluator.py
+++ b/tests/unit/eval/test_zero_shot_object_detection_evaluator.py
@@ -74,6 +74,42 @@ class TestRegistrationAndSchema:
         assert "authoritative category names" in params["category_key"].description
         assert params["prompt_template"].default == "a photo of a {}"
 
+    def test_prepare_pipeline_requires_model_id(self):
+        evaluator = object.__new__(WinMLZeroShotObjectDetectionEvaluator)
+        evaluator.config = WinMLEvaluationConfig(
+            model_id=None,
+            task="zero-shot-object-detection",
+        )
+        evaluator.model = MagicMock()
+
+        with (
+            patch("winml.modelkit.eval.base_evaluator.WinMLEvaluator.prepare_pipeline"),
+            pytest.raises(ValueError, match="requires --model-id"),
+        ):
+            evaluator.prepare_pipeline()
+
+    def test_prepare_pipeline_threads_trust_remote_code(self):
+        evaluator = object.__new__(WinMLZeroShotObjectDetectionEvaluator)
+        evaluator.config = WinMLEvaluationConfig(
+            model_id="google/owlv2-base-patch16-finetuned",
+            task="zero-shot-object-detection",
+            trust_remote_code=True,
+        )
+        evaluator.model = MagicMock()
+        pipe = SimpleNamespace(tokenizer=MagicMock(), image_processor=MagicMock())
+
+        with (
+            patch(
+                "winml.modelkit.eval.base_evaluator.WinMLEvaluator.prepare_pipeline",
+                return_value=pipe,
+            ),
+            patch("transformers.AutoProcessor.from_pretrained") as mock_from_pretrained,
+        ):
+            mock_from_pretrained.return_value = SimpleNamespace()
+            evaluator.prepare_pipeline()
+
+        assert mock_from_pretrained.call_args.kwargs["trust_remote_code"] is True
+
 
 class TestVocabularyAndPrompt:
     def test_extracts_classlabel_names_without_model_label_map(self):
@@ -110,7 +146,7 @@ class TestVocabularyAndPrompt:
 
     def test_default_contract_renders_category_name_only(self):
         chunks = _make_query_chunks([(17, "cat")], "a photo of a {}", 1)
-        assert chunks == [QueryChunk(("a photo of a cat",), (17,), 1)]
+        assert chunks == [QueryChunk(("a photo of a cat",), (17,))]
 
 
 class TestCapacityChunkingAndMapping:
@@ -128,9 +164,9 @@ class TestCapacityChunkingAndMapping:
     def test_multi_query_capacity_replicates_each_category_without_padding(self):
         chunks = _make_query_chunks([(4, "cat"), (9, "dog"), (12, "bird")], "{}", 2)
         assert chunks == [
-            QueryChunk(("cat", "cat"), (4, 4), 1),
-            QueryChunk(("dog", "dog"), (9, 9), 1),
-            QueryChunk(("bird", "bird"), (12, 12), 1),
+            QueryChunk(("cat", "cat"), (4, 4)),
+            QueryChunk(("dog", "dog"), (9, 9)),
+            QueryChunk(("bird", "bird"), (12, 12)),
         ]
 
     def test_competing_slot_logits_preserve_replicated_real_query_detections(self):

--- a/tests/unit/eval/test_zero_shot_object_detection_evaluator.py
+++ b/tests/unit/eval/test_zero_shot_object_detection_evaluator.py
@@ -289,6 +289,23 @@ class TestComputeAndAccounting:
         assert metric.call_args.kwargs["predictions"][0]["boxes"] == []
         assert metric.call_args.kwargs["references"][0]["boxes"] == []
 
+    def test_zero_processed_images_fail_closed_without_computing_metric(self):
+        evaluator, _model, _processor = _compute_evaluator()
+        evaluator.data = []
+        evaluator._selection_accounting["selected"] = 0
+        metric = MagicMock(return_value={"map": -1.0})
+
+        with (
+            patch(
+                "winml.modelkit.eval.metrics.mean_average_precision.MAPMetric.compute",
+                metric,
+            ),
+            pytest.raises(DatasetValidationError, match="processed no images"),
+        ):
+            evaluator.compute()
+
+        metric.assert_not_called()
+
     def test_runtime_failure_propagates_instead_of_becoming_skipped(self):
         evaluator, _model, _processor = _compute_evaluator(
             model_side_effect=RuntimeError("ORT inference failed")

--- a/tests/unit/eval/test_zero_shot_object_detection_evaluator.py
+++ b/tests/unit/eval/test_zero_shot_object_detection_evaluator.py
@@ -20,8 +20,11 @@ from winml.modelkit.eval import DatasetConfig, WinMLEvaluationConfig
 from winml.modelkit.eval.zero_shot_object_detection_evaluator import (
     QueryChunk,
     WinMLZeroShotObjectDetectionEvaluator,
+    _apply_query_budget,
     _extract_category_vocabulary,
+    _filter_annotation_to_vocabulary,
     _make_query_chunks,
+    _normalize_max_queries,
     _query_capacity,
     _remap_grounded_output,
     _select_category_covering_rows,
@@ -65,6 +68,7 @@ class TestRegistrationAndSchema:
         assert default["path"] == "detection-datasets/coco"
         assert default["split"] == "val"
         assert default["revision"] == "cf0b22332314a937e9dc8a1957b21725430bb41d"
+        assert default["max_queries"] == 16
         assert default["columns_mapping"]["box_format"] == "xywh"
         assert default["columns_mapping"]["prompt_template"] == "a photo of a {}"
 
@@ -73,6 +77,7 @@ class TestRegistrationAndSchema:
         params = {item.name: item for item in schema.params}
         assert "authoritative category names" in params["category_key"].description
         assert params["prompt_template"].default == "a photo of a {}"
+        assert params["max_queries"].default == "16"
 
     def test_prepare_pipeline_requires_model_id(self):
         evaluator = object.__new__(WinMLZeroShotObjectDetectionEvaluator)
@@ -169,6 +174,29 @@ class TestCapacityChunkingAndMapping:
             QueryChunk(("bird", "bird"), (12, 12)),
         ]
 
+    def test_query_budget_truncates_deterministically_by_authoritative_order(self):
+        vocabulary = [(2, "cat"), (4, "dog"), (9, "bird")]
+        used, accounting = _apply_query_budget(vocabulary, 2)
+        assert used == [(2, "cat"), (4, "dog")]
+        assert accounting == {
+            "query_requested": 2,
+            "query_available": 3,
+            "query_used": 2,
+            "query_truncated": 1,
+        }
+
+    def test_query_budget_none_keeps_full_vocabulary(self):
+        vocabulary = [(2, "cat"), (4, "dog")]
+        used, accounting = _apply_query_budget(vocabulary, None)
+        assert used == vocabulary
+        assert accounting["query_requested"] == 2
+        assert accounting["query_truncated"] == 0
+
+    @pytest.mark.parametrize("invalid", [0, -1, "3", True])
+    def test_max_queries_rejects_invalid_values(self, invalid):
+        with pytest.raises(DatasetValidationError, match="max_queries"):
+            _normalize_max_queries(invalid)
+
     def test_competing_slot_logits_preserve_replicated_real_query_detections(self):
         from transformers import Owlv2ImageProcessor
 
@@ -210,6 +238,18 @@ class TestSelection:
         assert selected == [0]
         assert covered == {0}
 
+    def test_out_of_cap_annotation_entries_are_filtered_not_crashing(self):
+        annotation = {
+            "bbox": [[0.0, 0.0, 1.0, 1.0], [1.0, 1.0, 2.0, 2.0]],
+            "category": [0, 2],
+            "area": [1.0, 4.0],
+        }
+        filtered, categories = _filter_annotation_to_vocabulary(annotation, "category", {0})
+        assert categories == [0]
+        assert filtered["category"] == [0]
+        assert filtered["bbox"] == [[0.0, 0.0, 1.0, 1.0]]
+        assert filtered["area"] == [1.0]
+
 
 def _compute_evaluator(*, model_side_effect=None, empty_annotations=False):
     evaluator = object.__new__(WinMLZeroShotObjectDetectionEvaluator)
@@ -228,6 +268,10 @@ def _compute_evaluator(*, model_side_effect=None, empty_annotations=False):
         "selected": 2,
         "category_count": 3,
         "categories_covered": 3,
+        "query_requested": 3,
+        "query_available": 3,
+        "query_used": 3,
+        "query_truncated": 0,
     }
     from PIL import Image as PILImage
 
@@ -306,6 +350,10 @@ class TestComputeAndAccounting:
             "selected": 2,
             "category_count": 3,
             "categories_covered": 3,
+            "query_requested": 3,
+            "query_available": 3,
+            "query_used": 3,
+            "query_truncated": 0,
             "decoded": 2,
             "skipped": 0,
             "processed": 2,
@@ -443,3 +491,13 @@ def test_dataset_config_roundtrip_preserves_explicit_label_mapping():
     )
     restored = WinMLEvaluationConfig.from_dict(config.to_dict())
     assert restored.dataset.label_mapping == {"cat": 4}
+
+
+def test_dataset_config_roundtrip_preserves_max_queries_override():
+    config = WinMLEvaluationConfig(
+        model_id="test/model",
+        task="zero-shot-object-detection",
+        dataset=DatasetConfig(path="test/data", max_queries=3),
+    )
+    restored = WinMLEvaluationConfig.from_dict(config.to_dict())
+    assert restored.dataset.max_queries == 3

--- a/tests/unit/eval/test_zero_shot_object_detection_evaluator.py
+++ b/tests/unit/eval/test_zero_shot_object_detection_evaluator.py
@@ -125,23 +125,36 @@ class TestCapacityChunkingAndMapping:
         chunks = _make_query_chunks([(4, "cat"), (9, "dog"), (12, "bird")], "{}", 1)
         assert [chunk.category_ids for chunk in chunks] == [(4,), (9,), (12,)]
 
-    def test_multi_query_capacity_pads_final_chunk_deterministically(self):
+    def test_multi_query_capacity_replicates_each_category_without_padding(self):
         chunks = _make_query_chunks([(4, "cat"), (9, "dog"), (12, "bird")], "{}", 2)
         assert chunks == [
-            QueryChunk(("cat", "dog"), (4, 9), 2),
-            QueryChunk(("bird", " "), (12, None), 1),
+            QueryChunk(("cat", "cat"), (4, 4), 1),
+            QueryChunk(("dog", "dog"), (9, 9), 1),
+            QueryChunk(("bird", "bird"), (12, 12), 1),
         ]
 
-    def test_query_local_labels_map_to_dataset_ids_and_drop_padding(self):
-        output = {
-            "boxes": torch.tensor([[1, 2, 3, 4], [5, 6, 7, 8]], dtype=torch.float32),
-            "scores": torch.tensor([0.75, 0.25]),
-            "labels": torch.tensor([0, 1]),
-        }
-        result = _remap_grounded_output(output, QueryChunk(("bird", " "), (12, None), 1))
-        assert result["boxes"] == [[1.0, 2.0, 3.0, 4.0]]
-        assert result["labels"] == [12]
-        assert result["scores"] == [0.75]
+    def test_competing_slot_logits_preserve_replicated_real_query_detections(self):
+        from transformers import Owlv2ImageProcessor
+
+        chunk = _make_query_chunks([(12, "bird")], "{}", 2)[0]
+        outputs = SimpleNamespace(
+            # Transformers takes max over the final axis. Each slot wins once.
+            logits=torch.tensor([[[0.25, 0.75], [0.90, 0.10]]]),
+            pred_boxes=torch.tensor([[[0.25, 0.25, 0.2, 0.2], [0.75, 0.75, 0.2, 0.2]]]),
+        )
+        grounded = Owlv2ImageProcessor().post_process_object_detection(
+            outputs,
+            threshold=0.0,
+            target_sizes=torch.tensor([[10, 20]]),
+        )[0]
+
+        assert grounded["labels"].tolist() == [1, 0]
+        result = _remap_grounded_output(grounded, chunk)
+        assert result["labels"] == [12, 12]
+        assert len(result["boxes"]) == 2
+        assert result["scores"] == pytest.approx(
+            [torch.sigmoid(torch.tensor(0.75)).item(), torch.sigmoid(torch.tensor(0.90)).item()]
+        )
 
 
 class TestSelection:
@@ -198,7 +211,8 @@ def _compute_evaluator(*, model_side_effect=None, empty_annotations=False):
     }
     if model_side_effect is None:
         model.return_value = SimpleNamespace(
-            logits=torch.zeros((1, 1, 2)), pred_boxes=torch.zeros((1, 1, 4))
+            logits=torch.tensor([[[0.25, 0.75]]]),
+            pred_boxes=torch.tensor([[[0.5, 0.5, 0.2, 0.4]]]),
         )
     else:
         model.side_effect = model_side_effect
@@ -209,13 +223,16 @@ def _compute_evaluator(*, model_side_effect=None, empty_annotations=False):
         "attention_mask": torch.ones((2, 16), dtype=torch.int64),
     }
     processor.image_processor.return_value = {"pixel_values": torch.zeros((1, 3, 960, 960))}
-    processor.post_process_grounded_object_detection.return_value = [
-        {
-            "boxes": torch.tensor([[1.0, 2.0, 4.0, 6.0]]),
-            "scores": torch.tensor([0.5]),
-            "labels": torch.tensor([0]),
-        }
-    ]
+    from transformers import Owlv2ImageProcessor
+
+    grounded_processor = Owlv2ImageProcessor()
+    processor.post_process_grounded_object_detection.side_effect = (
+        lambda outputs, threshold, target_sizes: grounded_processor.post_process_object_detection(
+            outputs,
+            threshold=threshold,
+            target_sizes=target_sizes,
+        )
+    )
     evaluator._processor = processor
     return evaluator, model, processor
 
@@ -230,14 +247,16 @@ class TestComputeAndAccounting:
         ):
             result = evaluator.compute()
 
-        # 3 labels, static capacity 2 -> two passes per image, including absent labels.
-        assert model.call_count == 4
+        # Each category gets an independent pass; static slots contain replicas.
+        assert model.call_count == 6
         prompts = [call.args[0] for call in processor.tokenizer.call_args_list]
         assert prompts == [
-            ["a photo of a cat", "a photo of a dog"],
-            ["a photo of a bird", " "],
-            ["a photo of a cat", "a photo of a dog"],
-            ["a photo of a bird", " "],
+            ["a photo of a cat", "a photo of a cat"],
+            ["a photo of a dog", "a photo of a dog"],
+            ["a photo of a bird", "a photo of a bird"],
+            ["a photo of a cat", "a photo of a cat"],
+            ["a photo of a dog", "a photo of a dog"],
+            ["a photo of a bird", "a photo of a bird"],
         ]
         for call in processor.post_process_grounded_object_detection.call_args_list:
             assert call.kwargs["threshold"] == 0.0
@@ -256,14 +275,17 @@ class TestComputeAndAccounting:
             "processed": 2,
             "failed": 0,
             "query_count": 3,
-            "query_passes": 4,
+            "query_passes": 6,
             "query_capacity": 2,
         }
 
         predictions = metric.call_args.kwargs["predictions"]
         references = metric.call_args.kwargs["references"]
-        assert predictions[0]["boxes"] == [[1.0, 2.0, 4.0, 6.0]] * 2
-        assert predictions[0]["labels"] == [3, 13]
+        assert predictions[0]["boxes"] == [[8.0, 6.0, 12.0, 14.0]] * 3
+        assert predictions[0]["labels"] == [3, 8, 13]
+        assert predictions[0]["scores"] == pytest.approx(
+            [torch.sigmoid(torch.tensor(0.75)).item()] * 3
+        )
         assert references[0] == {
             "boxes": [[1.0, 2.0, 3.0, 4.0]],
             "labels": [3],
@@ -273,6 +295,7 @@ class TestComputeAndAccounting:
 
     def test_empty_detections_and_annotations_are_valid_metric_inputs(self):
         evaluator, _model, processor = _compute_evaluator(empty_annotations=True)
+        processor.post_process_grounded_object_detection.side_effect = None
         processor.post_process_grounded_object_detection.return_value = [
             {
                 "boxes": torch.zeros((0, 4)),

--- a/tests/unit/eval/test_zero_shot_object_detection_evaluator.py
+++ b/tests/unit/eval/test_zero_shot_object_detection_evaluator.py
@@ -1,0 +1,369 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+"""Tests for generalized zero-shot object detection evaluation."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+from datasets import ClassLabel, Dataset, Features, Image, Sequence, Value
+
+from winml.modelkit.eval import DatasetConfig, WinMLEvaluationConfig
+from winml.modelkit.eval.zero_shot_object_detection_evaluator import (
+    QueryChunk,
+    WinMLZeroShotObjectDetectionEvaluator,
+    _extract_category_vocabulary,
+    _make_query_chunks,
+    _query_capacity,
+    _remap_grounded_output,
+    _select_category_covering_rows,
+    _validate_prompt_template,
+)
+from winml.modelkit.utils.eval_utils import TASK_SCHEMAS, DatasetValidationError
+
+
+def _features(category_feature=None):
+    category_feature = category_feature or ClassLabel(names=["cat", "dog", "bird"])
+    return Features(
+        {
+            "image": Image(),
+            "image_id": Value("int64"),
+            "objects": {
+                "bbox": Sequence(Sequence(Value("float32"), length=4)),
+                "category": Sequence(category_feature),
+            },
+        }
+    )
+
+
+class TestRegistrationAndSchema:
+    def test_distinct_schema_and_lazy_registry_entry(self):
+        evaluate_module = importlib.import_module("winml.modelkit.eval.evaluate")
+
+        sys.modules.pop("winml.modelkit.eval.zero_shot_object_detection_evaluator", None)
+        task = "zero-shot-object-detection"
+        assert task in TASK_SCHEMAS
+        assert task in evaluate_module._EVALUATOR_REGISTRY
+        assert "winml.modelkit.eval.zero_shot_object_detection_evaluator" not in sys.modules
+
+        cls = evaluate_module.get_evaluator_class(WinMLEvaluationConfig(task=task))
+        assert cls.__name__ == "WinMLZeroShotObjectDetectionEvaluator"
+        assert cls.__module__ == "winml.modelkit.eval.zero_shot_object_detection_evaluator"
+
+    def test_default_dataset_is_pinned_coco_xywh(self):
+        from winml.modelkit.eval.evaluate import _DEFAULT_DATASETS
+
+        default = _DEFAULT_DATASETS["zero-shot-object-detection"]
+        assert default["path"] == "detection-datasets/coco"
+        assert default["split"] == "val"
+        assert default["revision"] == "cf0b22332314a937e9dc8a1957b21725430bb41d"
+        assert default["columns_mapping"]["box_format"] == "xywh"
+        assert default["columns_mapping"]["prompt_template"] == "a photo of a {}"
+
+    def test_schema_documents_authoritative_categories_and_prompt(self):
+        schema = TASK_SCHEMAS["zero-shot-object-detection"]
+        params = {item.name: item for item in schema.params}
+        assert "authoritative category names" in params["category_key"].description
+        assert params["prompt_template"].default == "a photo of a {}"
+
+
+class TestVocabularyAndPrompt:
+    def test_extracts_classlabel_names_without_model_label_map(self):
+        assert _extract_category_vocabulary(_features(), "objects", "category") == [
+            (0, "cat"),
+            (1, "dog"),
+            (2, "bird"),
+        ]
+
+    def test_plain_integer_categories_fail_closed(self):
+        with pytest.raises(DatasetValidationError, match="authoritative names"):
+            _extract_category_vocabulary(_features(Value("int64")), "objects", "category")
+
+    def test_explicit_mapping_is_validated_and_sorted_by_id(self):
+        result = _extract_category_vocabulary(
+            _features(Value("int64")),
+            "objects",
+            "category",
+            {"dog": 4, "cat": 2},
+        )
+        assert result == [(2, "cat"), (4, "dog")]
+        with pytest.raises(DatasetValidationError, match="unique"):
+            _extract_category_vocabulary(
+                _features(Value("int64")),
+                "objects",
+                "category",
+                {"dog": 1, "cat": 1},
+            )
+
+    @pytest.mark.parametrize("template", ["no field", "{} and {}", "{name}"])
+    def test_prompt_requires_one_positional_field(self, template):
+        with pytest.raises(DatasetValidationError, match="exactly one"):
+            _validate_prompt_template(template)
+
+    def test_default_contract_renders_category_name_only(self):
+        chunks = _make_query_chunks([(17, "cat")], "a photo of a {}", 1)
+        assert chunks == [QueryChunk(("a photo of a cat",), (17,), 1)]
+
+
+class TestCapacityChunkingAndMapping:
+    def test_capacity_is_read_by_input_name_not_position(self):
+        io_config = {
+            "input_names": ["pixel_values", "input_ids", "attention_mask"],
+            "input_shapes": [[1, 3, 960, 960], [2, 16], [2, 16]],
+        }
+        assert _query_capacity(io_config) == 2
+
+    def test_static_capacity_one_chunks_every_category(self):
+        chunks = _make_query_chunks([(4, "cat"), (9, "dog"), (12, "bird")], "{}", 1)
+        assert [chunk.category_ids for chunk in chunks] == [(4,), (9,), (12,)]
+
+    def test_multi_query_capacity_pads_final_chunk_deterministically(self):
+        chunks = _make_query_chunks([(4, "cat"), (9, "dog"), (12, "bird")], "{}", 2)
+        assert chunks == [
+            QueryChunk(("cat", "dog"), (4, 9), 2),
+            QueryChunk(("bird", " "), (12, None), 1),
+        ]
+
+    def test_query_local_labels_map_to_dataset_ids_and_drop_padding(self):
+        output = {
+            "boxes": torch.tensor([[1, 2, 3, 4], [5, 6, 7, 8]], dtype=torch.float32),
+            "scores": torch.tensor([0.75, 0.25]),
+            "labels": torch.tensor([0, 1]),
+        }
+        result = _remap_grounded_output(output, QueryChunk(("bird", " "), (12, None), 1))
+        assert result["boxes"] == [[1.0, 2.0, 3.0, 4.0]]
+        assert result["labels"] == [12]
+        assert result["scores"] == [0.75]
+
+
+class TestSelection:
+    def test_greedy_selection_is_category_covering_and_deterministic(self):
+        rows = [
+            (0, 30, [0]),
+            (1, 20, [0, 1]),
+            (2, 10, [2]),
+            (3, 5, [1, 2]),
+        ]
+        selected, covered = _select_category_covering_rows(rows, {0, 1, 2}, 3)
+        assert selected == [3, 1]
+        assert covered == {0, 1, 2}
+
+    def test_cap_is_respected_when_full_coverage_is_impossible(self):
+        selected, covered = _select_category_covering_rows([(0, 0, [0]), (1, 1, [1])], {0, 1}, 1)
+        assert selected == [0]
+        assert covered == {0}
+
+
+def _compute_evaluator(*, model_side_effect=None, empty_annotations=False):
+    evaluator = object.__new__(WinMLZeroShotObjectDetectionEvaluator)
+    evaluator._vocabulary = [(3, "cat"), (8, "dog"), (13, "bird")]
+    evaluator._prompt_template = "a photo of a {}"
+    evaluator._image_col = "image"
+    evaluator._annotation_col = "objects"
+    evaluator._bbox_key = "bbox"
+    evaluator._category_key = "category"
+    evaluator._box_format = "xywh"
+    evaluator._box_coords = "absolute"
+    evaluator._selection_accounting = {
+        "requested": 2,
+        "requested_cap": 2,
+        "source_rows_scanned": 10,
+        "selected": 2,
+        "category_count": 3,
+        "categories_covered": 3,
+    }
+    from PIL import Image as PILImage
+
+    annotation = (
+        {"bbox": [], "category": []}
+        if empty_annotations
+        else {"bbox": [[1.0, 2.0, 3.0, 4.0]], "category": [3]}
+    )
+    evaluator.data = [
+        {"image": PILImage.new("RGB", (20, 10)), "objects": annotation},
+        {"image": PILImage.new("RGB", (20, 10)), "objects": annotation},
+    ]
+    model = MagicMock()
+    model.io_config = {
+        "input_names": ["input_ids", "pixel_values", "attention_mask"],
+        "input_shapes": [[2, 16], [1, 3, 960, 960], [2, 16]],
+    }
+    if model_side_effect is None:
+        model.return_value = SimpleNamespace(
+            logits=torch.zeros((1, 1, 2)), pred_boxes=torch.zeros((1, 1, 4))
+        )
+    else:
+        model.side_effect = model_side_effect
+    evaluator.model = model
+    processor = MagicMock()
+    processor.tokenizer.return_value = {
+        "input_ids": torch.zeros((2, 16), dtype=torch.int64),
+        "attention_mask": torch.ones((2, 16), dtype=torch.int64),
+    }
+    processor.image_processor.return_value = {"pixel_values": torch.zeros((1, 3, 960, 960))}
+    processor.post_process_grounded_object_detection.return_value = [
+        {
+            "boxes": torch.tensor([[1.0, 2.0, 4.0, 6.0]]),
+            "scores": torch.tensor([0.5]),
+            "labels": torch.tensor([0]),
+        }
+    ]
+    evaluator._processor = processor
+    return evaluator, model, processor
+
+
+class TestComputeAndAccounting:
+    def test_every_image_uses_complete_vocabulary_and_threshold_zero(self):
+        evaluator, model, processor = _compute_evaluator()
+        metric = MagicMock(return_value={"map": 0.1, "num_images": 2})
+        with patch(
+            "winml.modelkit.eval.metrics.mean_average_precision.MAPMetric.compute",
+            metric,
+        ):
+            result = evaluator.compute()
+
+        # 3 labels, static capacity 2 -> two passes per image, including absent labels.
+        assert model.call_count == 4
+        prompts = [call.args[0] for call in processor.tokenizer.call_args_list]
+        assert prompts == [
+            ["a photo of a cat", "a photo of a dog"],
+            ["a photo of a bird", " "],
+            ["a photo of a cat", "a photo of a dog"],
+            ["a photo of a bird", " "],
+        ]
+        for call in processor.post_process_grounded_object_detection.call_args_list:
+            assert call.kwargs["threshold"] == 0.0
+            torch.testing.assert_close(call.kwargs["target_sizes"], torch.tensor([[10, 20]]))
+        assert result == {
+            "map": 0.1,
+            "num_images": 2,
+            "requested": 2,
+            "requested_cap": 2,
+            "source_rows_scanned": 10,
+            "selected": 2,
+            "category_count": 3,
+            "categories_covered": 3,
+            "decoded": 2,
+            "skipped": 0,
+            "processed": 2,
+            "failed": 0,
+            "query_count": 3,
+            "query_passes": 4,
+            "query_capacity": 2,
+        }
+
+        predictions = metric.call_args.kwargs["predictions"]
+        references = metric.call_args.kwargs["references"]
+        assert predictions[0]["boxes"] == [[1.0, 2.0, 4.0, 6.0]] * 2
+        assert predictions[0]["labels"] == [3, 13]
+        assert references[0] == {
+            "boxes": [[1.0, 2.0, 3.0, 4.0]],
+            "labels": [3],
+        }
+        assert metric.call_args.kwargs["box_format"] == "xywh"
+        assert metric.call_args.kwargs["box_coords"] == "absolute"
+
+    def test_empty_detections_and_annotations_are_valid_metric_inputs(self):
+        evaluator, _model, processor = _compute_evaluator(empty_annotations=True)
+        processor.post_process_grounded_object_detection.return_value = [
+            {
+                "boxes": torch.zeros((0, 4)),
+                "scores": torch.zeros((0,)),
+                "labels": torch.zeros((0,), dtype=torch.int64),
+            }
+        ]
+        metric = MagicMock(return_value={"map": -1.0})
+        with patch(
+            "winml.modelkit.eval.metrics.mean_average_precision.MAPMetric.compute",
+            metric,
+        ):
+            evaluator.compute()
+        assert metric.call_args.kwargs["predictions"][0]["boxes"] == []
+        assert metric.call_args.kwargs["references"][0]["boxes"] == []
+
+    def test_runtime_failure_propagates_instead_of_becoming_skipped(self):
+        evaluator, _model, _processor = _compute_evaluator(
+            model_side_effect=RuntimeError("ORT inference failed")
+        )
+        with pytest.raises(RuntimeError, match="ORT inference failed"):
+            evaluator.compute()
+
+
+class TestSchemaValidation:
+    def _evaluator(self):
+        evaluator = object.__new__(WinMLZeroShotObjectDetectionEvaluator)
+        evaluator._image_col = "image"
+        evaluator._annotation_col = "objects"
+        evaluator._bbox_key = "bbox"
+        evaluator._category_key = "category"
+        return evaluator
+
+    def test_missing_image_column_is_actionable(self):
+        dataset = Dataset.from_dict(
+            {"objects": [{"bbox": [], "category": []}]},
+            features=Features(
+                {
+                    "objects": {
+                        "bbox": Sequence(Sequence(Value("float32"), length=4)),
+                        "category": Sequence(ClassLabel(names=["cat"])),
+                    }
+                }
+            ),
+        )
+        with pytest.raises(DatasetValidationError, match="missing required column 'image'"):
+            self._evaluator()._validate_schema(dataset)
+
+    def test_missing_bbox_field_is_actionable(self):
+        dataset = Dataset.from_dict(
+            {"image": [None], "objects": [{"category": []}]},
+            features=Features(
+                {
+                    "image": Image(),
+                    "objects": {"category": Sequence(ClassLabel(names=["cat"]))},
+                }
+            ),
+        )
+        with pytest.raises(DatasetValidationError, match="bbox"):
+            self._evaluator()._validate_schema(dataset)
+
+
+def test_model_wrapper_routes_text_and_image_inputs():
+    from winml.modelkit.models.winml import get_winml_class
+    from winml.modelkit.models.winml.object_detection import WinMLModelForObjectDetection
+
+    assert get_winml_class("owlv2", "zero-shot-object-detection") is WinMLModelForObjectDetection
+    model = object.__new__(WinMLModelForObjectDetection)
+    model._session = MagicMock()
+    model._session.io_config = {"input_names": ["input_ids", "pixel_values", "attention_mask"]}
+    model._session.run.return_value = {
+        "logits": torch.zeros((1, 1, 1)).numpy(),
+        "pred_boxes": torch.zeros((1, 1, 4)).numpy(),
+    }
+    model(
+        input_ids=torch.zeros((1, 16), dtype=torch.int64),
+        pixel_values=torch.zeros((1, 3, 2, 2)),
+        attention_mask=torch.ones((1, 16), dtype=torch.int64),
+    )
+    assert set(model._session.run.call_args.args[0]) == {
+        "input_ids",
+        "pixel_values",
+        "attention_mask",
+    }
+
+
+def test_dataset_config_roundtrip_preserves_explicit_label_mapping():
+    config = WinMLEvaluationConfig(
+        model_id="test/model",
+        task="zero-shot-object-detection",
+        dataset=DatasetConfig(path="test/data", label_mapping={"cat": 4}),
+    )
+    restored = WinMLEvaluationConfig.from_dict(config.to_dict())
+    assert restored.dataset.label_mapping == {"cat": 4}


### PR DESCRIPTION
## Summary

This PR adds generalized `zero-shot-object-detection` eval support for `google/owlv2-base-patch16-finetuned` through eval command/config wiring plus tests.

Final candidate and PR head are now `bfe94515d6c85151486a2eb8929e8722e62b0991`.

Scope/outcome:
- Producer scope is CLI/config wiring for query budget (`--max-queries`) and related tests.
- Reused immutable provenance from `a723405f8dc8864c0c0a0aa754a41bddeb2c8a56` for `L0/L1/L2/analyze` artifacts.
- Reran `L3` smoke and core quality gates on final candidate `bfe94515`.
- Highest goal verdict: `L3 PASS`.

## Model metadata

### What the model does
- OWLv2 is an open-vocabulary detector: image + text queries in, query-conditioned detection outputs out.

### Supported tasks
- `zero-shot-object-detection` (checkpoint/transformers/optimum-onnx/winml surfaces).
- `feature-extraction` (optimum-onnx/winml surfaces).

### Architecture (encoding-safe tree)
```text
Owlv2ForObjectDetection
+- Vision encoder backbone (patch embeddings + transformer blocks)
+- Text encoder backbone (token embeddings + transformer blocks)
+- Cross-modal alignment projections (text/image embeddings)
`- Detection heads
   +- logits [image_batch, num_queries, 1]
   `- pred_boxes [image_batch, num_queries, 4]
```

## Validation and support evidence

### Baseline and goal
- Pinned main baseline: `2b9ec0e9e57bba8003d25eaff85f8c7c9e30d75a` (WinML `0.3.0`).
- Committed effort/goal: Effort `L2`, goal ceiling `L3`.
- Final outcome: shipped `L3`, highest goal verdict `L3 PASS`.

### Goal ladder
- `L0 PASS` (reused from `a723405f`): both required CPU tuples built and structurally validated.
- `L1 PASS` (reused from `a723405f`): perf completed for both tuples.
- `L2 PASS` (reused from `a723405f`): PT-vs-ONNX parity completed on real decoded COCO image.
- `L3 PASS` (rerun on `bfe94515`): public CLI smoke with bounded query budget.

| Tier | EP / Device | Precision | Verdict | Mean (ms) | p50 (ms) | Throughput (samples/s) | ΔRAM (MB) | ΔVRAM (MB) |
|---|---|---|---|---:|---:|---:|---:|---|
| L0/L1 | CPUExecutionProvider / cpu | fp32 | PASS | 3253.185 | 3182.379 | 0.31 | 908.88 | null |
| L0/L1 | CPUExecutionProvider / cpu | fp16 | PASS | 5527.614 | 5770.852 | 0.18 | 3027.47 | null |

FP16 is slower than FP32 in this run.

### Final-SHA public smoke (exact)
Command (public-style, no absolute paths):
```powershell
$OUT='temp/pr1217-bfe94515-repro'
New-Item -ItemType Directory -Path $OUT -Force | Out-Null
uv run winml eval -m temp/pr1217-rerun/tester/a723405f-r1/artifacts/fp32/model.onnx --model-id google/owlv2-base-patch16-finetuned --task zero-shot-object-detection --ep cpu --device cpu --samples 1 --dataset detection-datasets/coco --dataset-revision cf0b22332314a937e9dc8a1957b21725430bb41d --split val --no-shuffle --max-queries 3 --trust-remote-code --output $OUT/l3_smoke_eval_maxq3_cli_public.json --overwrite
```
Observed accounting (exact):
- `requested=1`, `selected=1`, `processed=1`, `decoded=1`
- `query_requested=3`, `query_available=80`, `query_used=3`, `query_truncated=77`, `query_passes=3`
- Metric: `map=0.0` (functional smoke semantics only)

### L2 parity breakdown (reused provenance from `a723405f`)
Tester contract note: there is no hard L2 threshold; values are reported as observed.

FP32:
- `logits`: cosine `0.9999999999548849`, max_abs `0.0019044876098632812`
- `pred_boxes`: cosine `0.9999999999735265`, max_abs `0.00014513731002807617`
- `text_embeds`: cosine `0.999999999999833`, max_abs `1.1920928955078125e-07`
- `image_embeds`: cosine `0.9999999999754301`, max_abs `0.0009830594062805176`
- aggregate: min_cosine `0.9999999999548849`, max_abs `0.0019044876098632812` (from `logits`)

FP16:
- `logits`: cosine `0.9999742966056367`, max_abs `1.5570344924926758`
- `pred_boxes`: cosine `0.9999867989005999`, max_abs `0.08713313937187195`
- `text_embeds`: cosine `0.9999998139610052`, max_abs `8.073821663856506e-05`
- `image_embeds`: cosine `0.9999897980460138`, max_abs `0.6433656215667725`
- aggregate: min_cosine `0.9999742966056367`, max_abs `1.5570344924926758` (from `logits`)

Explicit requested detail:
- logits produced `fp32 max_abs = 0.0019044876098632812`
- logits produced `fp16 max_abs = 1.5570344924926758`
- cosines are recorded above exactly as observed.

## Bug fix explanation

User-visible issue:
- Query budget control was misleading in prior path (`--column max_queries=...`) and could fan out unexpectedly.

Fix details:
- Dedicated CLI option added: `--max-queries`.
- Wiring path: command option -> config override -> `DatasetConfig.max_queries` -> evaluator query budget.
- Default bounded behavior is explicit: default is `16`.
- Explicit full-vocabulary mode remains available via config: `max_queries: null`.
- `--column` remains column mapping only (no query-budget semantic overload).
- Evaluator keeps annotation/category filtering semantics for authoritative labels and query-capacity handling.
- Regression tests added/updated for CLI mapping, invalid values, schema/help text, and evaluator delivery path.

Changed files (producer scope):
- `src/winml/modelkit/commands/eval.py`
- `src/winml/modelkit/utils/eval_utils.py`
- `tests/unit/eval/test_eval.py`
- `tests/unit/commands/test_eval.py`

## Analyze and quality gates

- Analyze status: `ANALYZE-PARTIAL-SUCCESS` with non-zero exits but complete JSON payloads consumed.
- Reused analyze provenance: source candidate `a723405f`.
- Rerun quality gates on final candidate `bfe94515`:
  - `ruff`: pass
  - `mypy`: pass
  - query-budget focused tests: pass
  - eval CLI/command focused tests: pass
  - commands partition: pass
  - integration ZSOD pinned-remote: pass
  - models/pipeline partitions: pass (reused provenance from `a723405f`)

## Public reproduce block

```powershell
$OUT='temp/pr1217-bfe94515-repro'
New-Item -ItemType Directory -Path $OUT -Force | Out-Null
uv run winml eval -m temp/pr1217-rerun/tester/a723405f-r1/artifacts/fp32/model.onnx --model-id google/owlv2-base-patch16-finetuned --task zero-shot-object-detection --ep cpu --device cpu --samples 1 --dataset detection-datasets/coco --dataset-revision cf0b22332314a937e9dc8a1957b21725430bb41d --split val --no-shuffle --max-queries 3 --trust-remote-code --output $OUT/l3_smoke_eval_maxq3_cli_public.json --overwrite
uv run pytest tests/unit/eval/test_zero_shot_object_detection_evaluator.py -k 'query_budget or max_queries or out_of_cap or schema_documents_authoritative_categories_and_prompt or default_dataset_is_pinned_coco_xywh' --tb=short --no-cov
uv run pytest tests/unit/eval/test_eval.py -k 'max_queries or TestEvalCli' --tb=short --no-cov
uv run pytest tests/unit/commands/test_eval.py -k 'max_queries or schema_shows_max_queries_without_column_override or max_queries_reaches_evaluator or TestEvalHelp' --tb=short --no-cov
uv run pytest tests/unit/commands tests/unit/config tests/unit/build tests/unit/compiler tests/unit/session tests/unit/eval --tb=short --no-cov -m 'not e2e and not npu and not gpu'
uv run pytest tests/integration/eval/test_zero_shot_object_detection.py --tb=short --no-cov
uv run ruff check src/ tests/
uv run mypy -p winml.modelkit
```

## Owner communication record (internal reviewer findings closure)

No reviewer comment was posted; closure is recorded in canonical body and final evidence.

- Processor trust present at exact code path: public smoke command includes `--trust-remote-code` and uses final candidate pathing.
- Reproduce block present: public commands are included above and use `--max-queries 3` without absolute paths.
- Query budget fixed: final candidate verifies exact accounting `requested=3 available=80 used=3 truncated=77 passes=3`.
- Parity explained: per-output fp32/fp16 cosine and max_abs values are documented, including logits-specific values.
- Live gates rerun expectation: post-push CI gates for `bfe94515` are rerunning now (pending in live snapshot below).

## PR state snapshot

- Draft state: `true` (kept as Draft)
- Label retained: `model-scale-by-skill`
- Head branch: `ssss141414/add-zero-shot-object-detection-eval`
- Head SHA: `bfe94515d6c85151486a2eb8929e8722e62b0991`
- Open review threads: `0`
- Issue comments: `0`
- Reviews: `0`

Checks snapshot at update time:
- license/cla: pass
- Analyze (Python): pending
- lint: pending
- test (analyze): pending
- test (commands): pending
- test (models): pending
- test (optim): pending
- test (remaining): pending
