### PR TITLE
recipe(dell-research-harvard/names-linking-model): add verified CPU fp32/fp16 recipes

### DIFF
--- a/examples/recipes/dell-research-harvard_names-linking-model/cpu/cpu/feature-extraction_fp16_config.json
+++ b/examples/recipes/dell-research-harvard_names-linking-model/cpu/cpu/feature-extraction_fp16_config.json
@@ -1,0 +1,86 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          30527
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "feature-extraction",
+    "model_id": "dell-research-harvard/names-linking-model",
+    "model_type": "mpnet",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "loader": {
+    "task": "feature-extraction",
+    "model_class": "AutoModel",
+    "model_type": "mpnet"
+  },
+  "eval": {
+    "task": "feature-extraction",
+    "dataset": {
+      "path": "mteb/stsbenchmark-sts",
+      "split": "test",
+      "samples": 100,
+      "columns_mapping": {
+        "input_column_1": "sentence1",
+        "input_column_2": "sentence2",
+        "score_column": "score"
+      }
+    }
+  }
+}

--- a/examples/recipes/dell-research-harvard_names-linking-model/cpu/cpu/feature-extraction_fp32_config.json
+++ b/examples/recipes/dell-research-harvard_names-linking-model/cpu/cpu/feature-extraction_fp32_config.json
@@ -1,0 +1,64 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          30527
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "loader": {
+    "task": "feature-extraction",
+    "model_class": "AutoModel",
+    "model_type": "mpnet"
+  },
+  "eval": {
+    "task": "feature-extraction",
+    "dataset": {
+      "path": "mteb/stsbenchmark-sts",
+      "split": "test",
+      "samples": 100,
+      "columns_mapping": {
+        "input_column_1": "sentence1",
+        "input_column_2": "sentence2",
+        "score_column": "score"
+      }
+    }
+  }
+}


### PR DESCRIPTION
  ## Summary

  Add verified CPU (fp32/fp16) feature-extraction recipes for `dell-research-harvard/names-linking-model`, an MPNet-based sentence-transformer for entity name linking. Recipe-only contribution (Effort L0); auto-config already resolves correctly — recipes establish
  verified `cpu/cpu` coverage.

  ## Model metadata

  - **What the model does**: MPNet-based sentence-transformer fine-tuned for entity name linking — produces 768-dim dense embeddings for computing cosine similarity between entity name mentions.
  - **Primary user stories**: User supplies entity name strings to obtain dense vector embeddings for similarity-based name matching and linking.
  - **Supported tasks**: `feature-extraction` (checkpoint, transformers, optimum-onnx, winml)
  - **Model architecture**:
    MPNetModel (mpnet)
    ├── MPNetEmbeddings (word + position embeddings, LayerNorm, dropout)
    ├── MPNetEncoder (12× MPNetLayer: attention + intermediate + output)
    └── MPNetPooler (dense + tanh)
  - Hidden size: 768, attention heads: 12, vocab: 30527, max position: 512

  ## Validation and support evidence

  **Baseline** (`origin/main` @ `d5f24d2`, winml 0.2.0):
  - `winml build -m dell-research-harvard/names-linking-model --ep cpu --device cpu` → ✅ Build complete in 42.2s
  - `winml perf` → ✅ 227.92ms avg, 4.39 samp/s, +116.1 MB RAM
  - `winml eval --task feature-extraction` → ✅ cosine_spearman = 81.5376 (mteb/stsbenchmark-sts, test split, 100 samples)

  **Goal**: L3 (task metric) — baseline already at L3; contribution establishes verified `cpu/cpu` coverage.

  **Outcome**: L0 — recipe-only (auto-config correct; no code changes).

  **Delta**: fp32 recipe identical to `winml config` auto-output; fp16 recipe adds `quant` section matching `winml config -p fp16` output. Filed for verified `cpu/cpu` coverage claim on both precisions.

  ### Per-tuple results

  | EP | Device | Precision | L0 (build) | L1 (perf) | L3 (eval) |
  |---|---|---|---|---|---|
  | cpu | cpu | fp32 | ✅ PASS (35.9s) | ✅ PASS (avg 227.73ms, 4.39 samp/s, +116.2 MB RAM) | ✅ PASS (cosine_spearman = 81.5376) |
  | cpu | cpu | fp16 | ✅ PASS (42.7s, artifact 213.8 MB) | ✅ PASS (avg 292.67ms, 3.42 samp/s, +156.3 MB RAM) | ✅ PASS (cosine_spearman = 81.5376) |

  ### Reproduce commands

  ```bash
  # fp32
  winml build -m dell-research-harvard/names-linking-model \
  -c examples/recipes/dell-research-harvard_names-linking-model/cpu/cpu/feature-extraction_fp32_config.json \
  -o out/fp32 --ep cpu --device cpu
  winml perf -m out/fp32/model.onnx --ep cpu --device cpu
  winml eval -m out/fp32/model.onnx --model-id dell-research-harvard/names-linking-model \
  --task feature-extraction --ep cpu --device cpu

  # fp16
  winml build -m dell-research-harvard/names-linking-model \
  -c examples/recipes/dell-research-harvard_names-linking-model/cpu/cpu/feature-extraction_fp16_config.json \
  -o out/fp16 --ep cpu --device cpu -p fp16
  winml perf -m out/fp16/model.onnx --ep cpu --device cpu
  winml eval -m out/fp16/model.onnx --model-id dell-research-harvard/names-linking-model \
  --task feature-extraction --ep cpu --device cpu