### PR TITLE
fix: register WindowsML catalog execution providers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -554,11 +554,8 @@ module = [
   # Not a dependency of the main/CI environment, so it has no stubs here.
   "qairt",
   "qairt.*",
-  # WinUI3 / Windows App SDK bootstrap, WinRT projections, and pywin32 — Windows
-  # runtime packages imported in ep_path.py / ep_device.py. Installed and usable
-  # at runtime but ship no type stubs, so treat as untyped here.
-  "winui3",
-  "winui3.*",
+  # WinRT projections and pywin32 are used by the legacy MSIX enumerator and
+  # device discovery. They ship no type stubs, so treat them as untyped.
   "winrt.*",
   "win32api",
 ]

--- a/src/winml/modelkit/ep_path.py
+++ b/src/winml/modelkit/ep_path.py
@@ -947,7 +947,7 @@ def _get_pkg_manager() -> Any | None:
     except ImportError as e:
         logger.debug(
             "MSIXPackageSource: WinRT PackageManager binding not installed; "
-            "install the 'winml-catalog' extra to enable MSIX EP version "
+            "install 'winrt-Windows.Management.Deployment' to enable MSIX EP version "
             "discovery (%s)",
             e,
         )
@@ -1218,11 +1218,10 @@ def _default_ep_sources() -> list[EPSource]:
     dll_path)`` collapses any catalog/MSIX overlap; catalog precedence
     wins.
 
-    The ``WinMLCatalogSource`` rows are live: they yield nothing
-    silently when the optional ``winml-catalog`` extra is not installed
-    (no ``wasdk-*`` packages on this machine). On machines with the
-    extra installed, they pick up MSIX-delivered EPs that Windows Update
-    has already provisioned.
+    The ``WinMLCatalogSource`` rows are live: on Windows they use the
+    required ``windowsml`` dependency to pick up MSIX-delivered EPs that
+    Windows Update has provisioned. On unsupported platforms or when
+    catalog construction fails, they yield nothing.
 
     The ``NuGetSource`` rows are also live: they yield nothing silently
     when the relevant package is not in ``~/.nuget/packages``. Only EPs

--- a/src/winml/modelkit/ep_path.py
+++ b/src/winml/modelkit/ep_path.py
@@ -714,30 +714,26 @@ class DirectorySource(EPSource):
 
 
 # ---------------------------------------------------------------------------
-# WinAppSDK ExecutionProviderCatalog singleton.
+# windowsml EpCatalog singleton.
 # ---------------------------------------------------------------------------
-# Lazy, process-wide initialization of the WinAppSDK Application Runtime
-# bootstrap handle and the ``ExecutionProviderCatalog``. The bootstrap
-# handle holds the runtime alive for the lifetime of the process; we
-# register an ``atexit`` cleanup so it is released on interpreter shutdown.
-# ``__del__`` is intentionally NOT used — Python does not guarantee it is
-# invoked on shutdown, which would leak the runtime activation.
+# Lazy, process-wide initialization of the ``windowsml.EpCatalog``.
+# We register an ``atexit`` cleanup so the catalog is closed on interpreter
+# shutdown. ``__del__`` is intentionally NOT used — Python does not
+# guarantee it is invoked on shutdown.
 _winml_catalog_warned_keys: set[str] = set()
 
 
-def _release_winml_handle(handle: Any) -> None:
-    """``atexit`` callback: release the WinAppSDK bootstrap handle."""
+def _release_winml_catalog(catalog: Any) -> None:
+    """Close the process-wide Windows ML catalog during interpreter shutdown."""
     try:
-        # ``handle`` is the value returned by ``initialize(...)``; the
-        # context-manager protocol's ``__exit__`` deactivates the runtime.
-        handle.__exit__(None, None, None)
+        catalog.close()
     except Exception as e:  # pragma: no cover - shutdown best-effort
-        logger.debug("WinAppSDK bootstrap handle cleanup raised: %s", e)
+        logger.debug("Windows ML catalog cleanup raised: %s", e)
 
 
 @functools.cache
 def _get_catalog() -> Any | None:
-    """Return the cached ``ExecutionProviderCatalog`` or ``None``.
+    """Return the cached ``windowsml.EpCatalog`` or ``None``.
 
     Runs exactly once per process via ``functools.cache`` (thread-safe via
     its internal lock). Failures cache as ``None`` and never retry; tests
@@ -745,66 +741,29 @@ def _get_catalog() -> Any | None:
 
     Returns ``None`` (not raises) when:
 
-    * The WinAppSDK ML Python binding is not importable (no ``wasdk-*``
-      install). Logged at DEBUG; this is the common case on machines
-      without the optional ``winml-catalog`` extra.
-    * The bootstrap initialize call raises. Logged at DEBUG with a
-      pointer to the WinAppSDK runtime download page.
-    * ``ExecutionProviderCatalog.get_default()`` raises. Logged at WARN.
+    * The ``windowsml`` package is not installed. Logged at DEBUG; this
+      is the common case on machines without the pinned
+      ``windowsml==2.0.300`` C API wrapper.
+    * ``windowsml.EpCatalog()`` raises. Logged at WARN.
     """
-    # Lazy import so we do not pay the binding-load cost (or fail
-    # outright on machines without the wasdk extra) at module import.
     try:
-        import winui3.microsoft.windows.ai.machinelearning as winml
-        from winui3.microsoft.windows.applicationmodel.dynamicdependency.bootstrap import (
-            InitializeOptions,
-            initialize,
-        )
+        import windowsml
     except ImportError as e:
         logger.debug(
-            "WinMLCatalogSource: WinAppSDK ML Python binding not "
-            "installed; install the 'winml-catalog' extra to enable "
-            "MSIX-delivered EP discovery (%s)",
+            "WinMLCatalogSource: windowsml package is not installed; "
+            "MSIX-delivered EP discovery is unavailable (%s)",
             e,
         )
         return None
-
-    # Initialize the WinAppSDK Application Runtime bootstrap. The handle
-    # holds the runtime active for the rest of the process.
-    #
-    # InitializeOptions.NONE: silent fail if the OS-level Windows App
-    # Runtime is not installed. We log at DEBUG (not WARN) for that case
-    # because it's expected — users opt into the Python wasdk packages
-    # via the [winml-catalog] extra but may not yet have the runtime
-    # installed (which is a separate Microsoft installer at
-    # https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/downloads).
-    # ON_NO_MATCH_SHOW_UI would open that page in a browser on every
-    # invocation — too disruptive for an opt-in capability.
-    try:
-        handle = initialize(options=InitializeOptions.NONE)
-        handle.__enter__()
-    except Exception as e:
-        logger.debug(
-            "WinMLCatalogSource: WinAppSDK bootstrap initialize() "
-            "failed (%s). Install the Windows App SDK runtime from "
-            "https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/downloads "
-            "to enable MSIX-delivered EP discovery.",
-            e,
-        )
-        return None
-
-    # Register cleanup BEFORE accessing the catalog so a catalog
-    # error still releases the runtime.
-    atexit.register(_release_winml_handle, handle)
 
     try:
-        return winml.ExecutionProviderCatalog.get_default()
+        catalog = windowsml.EpCatalog()
     except Exception as e:
-        logger.warning(
-            "WinMLCatalogSource: ExecutionProviderCatalog.get_default() failed: %s",
-            e,
-        )
+        logger.warning("WinMLCatalogSource: EpCatalog() failed: %s", e)
         return None
+
+    atexit.register(_release_winml_catalog, catalog)
+    return catalog
 
 
 def _winml_warn_once(key: str, msg: str, *args: Any) -> None:
@@ -818,25 +777,24 @@ def _winml_warn_once(key: str, msg: str, *args: Any) -> None:
 
 @dataclass(frozen=True)
 class WinMLCatalogSource(EPSource):
-    """An MSIX EP delivered via the WinAppSDK ``ExecutionProviderCatalog``.
+    """An MSIX EP delivered via the ``windowsml.EpCatalog`` C API wrapper.
 
     The on-disk DLL path for an MSIX-delivered EP is decided by the
     Windows package manager and is queryable only at runtime via
-    ``provider.library_path`` (populated after ``ensure_ready_async()
-    .get()`` returns ``Success``). This source lazily binds to the
-    WinAppSDK ML Python binding on first ``resolve()``; if the binding
-    is not installed the source yields nothing silently (the optional
-    ``winml-catalog`` extra ships the binding).
+    ``provider.library_path`` (populated after ``ensure_ready()``
+    returns). This source lazily binds to the ``windowsml`` package on
+    first ``resolve()``; if the package is not installed the source
+    yields nothing silently.
 
     Args:
-        catalog_name: The provider name reported by the WinAppSDK
-            catalog (e.g. ``"VitisAI"``, ``"QNN"``, ``"OpenVINO"``,
-            ``"MIGraphX"``, ``"NvTensorRTRTX"``).
+        catalog_name: The provider name reported by the windowsml
+            catalog (e.g. ``"VitisAIExecutionProvider"``,
+            ``"QNNExecutionProvider"``).
         eps: Canonical EP names this source provides. Typically a single
             name, but listed as a tuple for symmetry with the other
             sources.
         auto_download: If ``True``, providers in the ``NotPresent`` ready
-            state will be (eventually) downloaded by ``ensure_ready_async``.
+            state will be downloaded by ``ensure_ready()``.
             Defaults to ``False`` to avoid surprising the user with a
             multi-second to multi-minute network operation on first call;
             see ``docs/ep-path-design.md`` Interaction section.
@@ -849,14 +807,12 @@ class WinMLCatalogSource(EPSource):
     def resolve(self) -> Iterator[EPEntry]:
         """Yield one :class:`EPEntry` per ready provider.
 
-        Yields nothing (silently) when the WinAppSDK binding is not
-        installed. Logs a WARN (once per provider per process) when an
-        installed-but-not-ready provider's ``ensure_ready_async`` returns
-        a non-Success status. Per the design doc, registration is done
-        by the caller via ``ort.register_execution_provider_library`` —
-        this source does NOT call ``provider.TryRegister()`` or any of
-        the WinAppSDK ``EnsureAndRegisterCertifiedAsync`` /
-        ``RegisterCertifiedAsync`` methods.
+        Yields nothing (silently) when the ``windowsml`` package is not
+        installed. Logs a WARN (once per provider per process) when
+        ``ensure_ready()`` raises or leaves the provider in a non-ready
+        state. Per the design doc, registration is done by the caller via
+        ``ort.register_execution_provider_library`` — this source does
+        NOT call any WinML registration methods directly.
 
         Yielded entries carry ``version=None``; probing
         ``provider.version`` is a follow-up (the OQ-2 deferral was
@@ -908,29 +864,27 @@ class WinMLCatalogSource(EPSource):
             )
             return
 
-        # ensure_ready_async().get() blocks until the EP is ready or
-        # fails. ``library_path`` is populated only after Success.
-        try:
-            result = provider.ensure_ready_async().get()
-        except Exception as e:
-            _winml_warn_once(
-                f"ensure-ready:{self.catalog_name}",
-                "WinMLCatalogSource(%s): ensure_ready_async raised %s",
-                self.catalog_name,
-                e,
-            )
-            return
+        if not self._is_ready(ready_state):
+            try:
+                provider.ensure_ready()
+            except Exception as e:
+                _winml_warn_once(
+                    f"ensure-ready:{self.catalog_name}",
+                    "WinMLCatalogSource(%s): ensure_ready raised %s",
+                    self.catalog_name,
+                    e,
+                )
+                return
 
-        status = getattr(result, "status", None)
-        if status is not None and not self._is_success(status):
-            _winml_warn_once(
-                f"ensure-ready-status:{self.catalog_name}",
-                "WinMLCatalogSource(%s): ensure_ready_async returned "
-                "non-Success status %r; skipping",
-                self.catalog_name,
-                status,
-            )
-            return
+            ready_state = getattr(provider, "ready_state", None)
+            if ready_state is not None and not self._is_ready(ready_state):
+                _winml_warn_once(
+                    f"ensure-ready-state:{self.catalog_name}",
+                    "WinMLCatalogSource(%s): ensure_ready left provider in state %r; skipping",
+                    self.catalog_name,
+                    ready_state,
+                )
+                return
 
         library_path = getattr(provider, "library_path", "") or ""
         if not library_path:
@@ -955,26 +909,22 @@ class WinMLCatalogSource(EPSource):
     def _is_not_present(ready_state: Any) -> bool:
         """Return True iff the provider's ready_state is ``NotPresent``.
 
-        ``ready_state`` is an enum from the WinAppSDK ML binding; we
-        avoid importing the enum type directly (which would mean another
-        import that fails when the binding is absent) by comparing on the
-        string ``name`` attribute, falling back to ``str(...)``. The
-        wasdk 2.0 binding exposes the name as ``NOT_PRESENT``
-        (UPPER_SNAKE_CASE) while WinML docs spell it ``NotPresent``
-        (PascalCase); normalize underscores + casing to match either form.
+        ``ready_state`` is a value from the ``windowsml`` C API wrapper;
+        we avoid importing the type directly by comparing on the string
+        ``name`` attribute, falling back to ``str(...)``. The binding may
+        expose the name as ``NOT_PRESENT`` (UPPER_SNAKE_CASE) or
+        ``NotPresent`` (PascalCase); normalize underscores + casing to
+        match either form.
         """
         name = getattr(ready_state, "name", None) or str(ready_state)
         return name.replace("_", "").lower().endswith("notpresent")
 
     @staticmethod
-    def _is_success(status: Any) -> bool:
-        """Return True iff the ensure-ready status enum is ``Success``.
-
-        Accepts both ``SUCCESS`` and ``Success`` spellings (see
-        ``_is_not_present`` rationale).
-        """
-        name = getattr(status, "name", None) or str(status)
-        return name.replace("_", "").lower().endswith("success")
+    def _is_ready(ready_state: Any) -> bool:
+        """Return whether the catalog provider is ready in this process."""
+        name = getattr(ready_state, "name", None) or str(ready_state)
+        normalized = name.replace("_", "").lower()
+        return normalized.endswith("ready") and not normalized.endswith("notready")
 
     def iter_eps(self) -> Iterable[str]:
         """Return the canonical EP names this source provides."""

--- a/tests/integration/ep_path/test_live_msix.py
+++ b/tests/integration/ep_path/test_live_msix.py
@@ -9,8 +9,8 @@ discovery logic against synthetic ``_FakePackage`` / fake catalog objects.
 That covers the implementation but cannot detect breakage at the WinRT
 binding boundary (e.g., shape changes when the wasdk MSIX is upgraded).
 
-These integration tests run only on Windows with the ``[winml-catalog]``
-extra installed. They are minimal smoke checks: confirm the binding
+These integration tests run only on Windows with the required ``windowsml``
+package installed. They are minimal smoke checks: confirm the binding
 loads, the call returns the expected shape, and at least one realistic
 MSIX EP package is reachable on a developer machine. They do NOT assert
 on specific package versions.
@@ -40,7 +40,7 @@ def test_pkg_manager_returns_handle() -> None:
     if pm is None:
         pytest.skip(
             "winrt-Windows.Management.Deployment binding not installed "
-            "(install via the [winml-catalog] extra)"
+            "(install the winrt optional dependency)"
         )
     assert hasattr(pm, "find_packages_by_user_security_id")
 
@@ -51,9 +51,7 @@ def test_list_msix_eps_returns_list() -> None:
 
     _get_pkg_manager.cache_clear()
     if _get_pkg_manager() is None:
-        pytest.skip(
-            "WinRT PackageManager unavailable; install via [winml-catalog]"
-        )
+        pytest.skip("WinRT PackageManager unavailable; install the winrt optional dependency")
 
     results = _list_msix_eps()
     assert isinstance(results, list)
@@ -66,18 +64,15 @@ def test_list_msix_eps_returns_list() -> None:
 
 
 def test_winml_catalog_find_all_providers_works() -> None:
-    """`_get_catalog()` returns a usable catalog or None (binding missing)."""
+    """The required windowsml package exposes the live EP catalog."""
     from winml.modelkit.ep_path import _get_catalog
 
     _get_catalog.cache_clear()
     catalog = _get_catalog()
-    if catalog is None:
-        pytest.skip(
-            "WinAppSDK ML binding unavailable; install via [winml-catalog]"
-        )
+    assert catalog is not None
     providers = list(catalog.find_all_providers())
-    # Shape-only check: each provider has the expected attribute surface.
     for provider in providers:
         assert hasattr(provider, "name")
         assert hasattr(provider, "ready_state")
         assert hasattr(provider, "library_path")
+        assert hasattr(provider, "ensure_ready")

--- a/tests/integration/ep_path/test_live_msix.py
+++ b/tests/integration/ep_path/test_live_msix.py
@@ -38,10 +38,7 @@ def test_pkg_manager_returns_handle() -> None:
     _get_pkg_manager.cache_clear()
     pm = _get_pkg_manager()
     if pm is None:
-        pytest.skip(
-            "winrt-Windows.Management.Deployment binding not installed "
-            "(install the winrt optional dependency)"
-        )
+        pytest.skip("winrt-Windows.Management.Deployment binding not installed")
     assert hasattr(pm, "find_packages_by_user_security_id")
 
 
@@ -51,7 +48,7 @@ def test_list_msix_eps_returns_list() -> None:
 
     _get_pkg_manager.cache_clear()
     if _get_pkg_manager() is None:
-        pytest.skip("WinRT PackageManager unavailable; install the winrt optional dependency")
+        pytest.skip("WinRT PackageManager unavailable; install winrt-Windows.Management.Deployment")
 
     results = _list_msix_eps()
     assert isinstance(results, list)
@@ -72,7 +69,7 @@ def test_winml_catalog_find_all_providers_works() -> None:
     assert catalog is not None
     providers = list(catalog.find_all_providers())
     for provider in providers:
-        assert hasattr(provider, "name")
-        assert hasattr(provider, "ready_state")
-        assert hasattr(provider, "library_path")
-        assert hasattr(provider, "ensure_ready")
+        # Check descriptors without evaluating readiness-sensitive properties.
+        provider_type = type(provider)
+        for attribute in ("name", "ready_state", "library_path", "ensure_ready"):
+            assert hasattr(provider_type, attribute)

--- a/tests/integration/ep_path/test_live_msix.py
+++ b/tests/integration/ep_path/test_live_msix.py
@@ -62,14 +62,13 @@ def test_list_msix_eps_returns_list() -> None:
 
 def test_winml_catalog_find_all_providers_works() -> None:
     """The required windowsml package exposes the live EP catalog."""
+    from windowsml import ExecutionProvider
+
     from winml.modelkit.ep_path import _get_catalog
 
     _get_catalog.cache_clear()
     catalog = _get_catalog()
     assert catalog is not None
-    providers = list(catalog.find_all_providers())
-    for provider in providers:
-        # Check descriptors without evaluating readiness-sensitive properties.
-        provider_type = type(provider)
-        for attribute in ("name", "ready_state", "library_path", "ensure_ready"):
-            assert hasattr(provider_type, attribute)
+    list(catalog.find_all_providers())
+    for attribute in ("name", "ready_state", "library_path", "ensure_ready"):
+        assert hasattr(ExecutionProvider, attribute)

--- a/tests/integration/ep_path/test_live_msix_openvino.py
+++ b/tests/integration/ep_path/test_live_msix_openvino.py
@@ -70,7 +70,7 @@ def test_windows_workload_openvino_ep_runs_inference(tmp_path):
     """Discover, register, and run the OEM-channel OpenVINO EP end-to-end.
 
     Skips when:
-        - PackageManager binding unavailable (no ``[winml-catalog]`` extra)
+        - ``winrt-Windows.Management.Deployment`` is not installed
         - No ``WindowsWorkload.EP.Intel.OpenVINO.*`` MSIX on this machine
         - Hardware is incompatible (no Intel CPU/GPU/NPU detected)
     """
@@ -85,7 +85,7 @@ def test_windows_workload_openvino_ep_runs_inference(tmp_path):
 
     _get_pkg_manager.cache_clear()
     if _get_pkg_manager() is None:
-        pytest.skip("WinRT PackageManager unavailable; install via [winml-catalog]")
+        pytest.skip("WinRT PackageManager unavailable; install winrt-Windows.Management.Deployment")
 
     # Filter to the OEM channel only so this test exercises the
     # WindowsWorkload-published OpenVINO EP specifically (not the PyPI

--- a/tests/unit/ep_path/test_ep_path.py
+++ b/tests/unit/ep_path/test_ep_path.py
@@ -74,12 +74,12 @@ def _winners(entries: list[EPEntry]) -> dict[str, tuple[Path, EPSource]]:
 
 # ---------------------------------------------------------------------------
 # File-scoped autouse: prevent any test in this file from loading the live
-# wasdk binding via ``_get_catalog``. None of the tests here need it; without
-# this gate, tests that call ``_winners(discover_all_eps())`` (which walks the default
-# EP source list including WinMLCatalogSource entries) would lazy-load the binding
-# on machines with the [winml-catalog] extra installed and the OS-level
-# Windows App Runtime present, polluting the module-level catalog singleton
-# state for downstream fake-binding tests in test_winml_catalog_source.py.
+# ``windowsml`` catalog via ``_get_catalog``. None of the tests here need it;
+# without this gate, tests that call ``_winners(discover_all_eps())`` (which walks
+# the default EP source list including WinMLCatalogSource entries) would lazy-load
+# the catalog on machines with ``windowsml`` installed, polluting the module-level
+# catalog singleton state for downstream fake-binding tests in
+# test_winml_catalog_source.py.
 #
 # Tests in test_winml_catalog_source.py do not see this fixture (it is
 # defined at file scope in test_ep_path.py, not in conftest.py), so they
@@ -90,7 +90,7 @@ def _winners(entries: list[EPEntry]) -> dict[str, tuple[Path, EPSource]]:
 
 @pytest.fixture(autouse=True)
 def _skip_live_catalog_in_ep_path_tests(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Force ``_get_catalog`` to return None so the default EP source list stays inert."""
+    """Force ``_get_catalog`` to return None so the live ``windowsml`` catalog is not loaded."""
     from winml.modelkit import ep_path as _ep
 
     monkeypatch.setattr(_ep, "_get_catalog", lambda: None)

--- a/tests/unit/ep_path/test_winml_catalog_source.py
+++ b/tests/unit/ep_path/test_winml_catalog_source.py
@@ -401,6 +401,8 @@ class TestWithFakeCatalog:
         assert len(results) == 1
         assert results[0].ep_name == "OpenVINOExecutionProvider"
         assert results[0].dll_path == Path(str(good_dll))
+        warn_messages = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("ensure_ready raised" in m for m in warn_messages), warn_messages
 
     def test_find_all_providers_raises_yields_nothing(
         self,
@@ -481,7 +483,7 @@ def test_ready_provider_is_not_prepared_again(
     assert len(entries) == 1
 
 
-def test_not_present_provider_download_requires_opt_in(
+def test_not_present_provider_is_not_downloaded_by_default(
     reset_catalog_singleton: None,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -499,8 +501,17 @@ def test_not_present_provider_download_requires_opt_in(
     assert list(default_source.resolve()) == []
     assert provider.ensure_ready_calls == 0
 
-    _ep._get_catalog.cache_clear()
-    _install_windowsml_module(monkeypatch, catalog)
+
+def test_not_present_provider_downloads_with_opt_in(
+    reset_catalog_singleton: None,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    dll = tmp_path / "qnn.dll"
+    dll.write_bytes(b"")
+    provider = _FakeProvider("QNNExecutionProvider", "NotPresent", str(dll))
+    _install_windowsml_module(monkeypatch, _FakeCatalog([provider]))
+
     download_source = WinMLCatalogSource(
         catalog_name="QNNExecutionProvider",
         eps=("QNNExecutionProvider",),

--- a/tests/unit/ep_path/test_winml_catalog_source.py
+++ b/tests/unit/ep_path/test_winml_catalog_source.py
@@ -4,15 +4,13 @@
 # --------------------------------------------------------------------------
 """Detailed unit tests for ``WinMLCatalogSource`` and the ``_get_catalog`` singleton.
 
-These tests inject a fake WinAppSDK ML Python binding into ``sys.modules``
-to exercise every branch of ``WinMLCatalogSource.resolve()`` without
-requiring the optional ``winml-catalog`` extra to be installed.
+These tests inject a fake ``windowsml`` module into ``sys.modules`` to
+exercise every branch of ``WinMLCatalogSource.resolve()`` without
+requiring the ``windowsml`` package to be installed.
 
-The ONLY mocked surface is the WinAppSDK Python binding itself
-(``winui3.microsoft.windows.ai.machinelearning`` and
-``winui3.microsoft.windows.applicationmodel.dynamicdependency.bootstrap``)
-— per CLAUDE.md / project test conventions, no mocks for ``importlib.metadata``,
-``pathlib``, etc.
+The ONLY mocked surface is the ``windowsml`` Python package itself
+— per CLAUDE.md / project test conventions, no mocks for
+``importlib.metadata``, ``pathlib``, etc.
 
 Also covers:
     - The default EP source list includes the 5 ``WinMLCatalogSource`` rows
@@ -44,39 +42,19 @@ from winml.modelkit.ep_path import (
 
 
 # ---------------------------------------------------------------------------
-# Fake WinAppSDK binding helpers.
+# Fake windowsml binding helpers.
 # ---------------------------------------------------------------------------
 
 
 class _FakeReadyState:
-    """Mimic the WinAppSDK ML ``ProviderReadyState`` enum."""
+    """Mimic the ``windowsml`` provider ready-state value."""
 
     def __init__(self, name: str) -> None:
         self.name = name
-
-
-class _FakeStatus:
-    """Mimic the WinAppSDK ML ``EnsureReadyResult.status`` enum."""
-
-    def __init__(self, name: str) -> None:
-        self.name = name
-
-
-class _FakeAsyncOp:
-    """Mimic the WinAppSDK ML async-op object returned by ensure_ready_async."""
-
-    def __init__(self, status: str, *, raises: Exception | None = None) -> None:
-        self._status = status
-        self._raises = raises
-
-    def get(self) -> Any:
-        if self._raises is not None:
-            raise self._raises
-        return types.SimpleNamespace(status=_FakeStatus(self._status))
 
 
 class _FakeProvider:
-    """Mimic the WinAppSDK ML ``ExecutionProvider`` row."""
+    """Mimic a ``windowsml`` execution-provider row."""
 
     def __init__(
         self,
@@ -84,96 +62,57 @@ class _FakeProvider:
         ready_state: str,
         library_path: str,
         *,
-        status: str = "Success",
         ensure_ready_raises: Exception | None = None,
     ) -> None:
         self.name = name
         self.ready_state = _FakeReadyState(ready_state)
         self.library_path = library_path
-        self._status = status
+        self.ensure_ready_calls = 0
         self._ensure_ready_raises = ensure_ready_raises
 
-    def ensure_ready_async(self) -> _FakeAsyncOp:
-        return _FakeAsyncOp(self._status, raises=self._ensure_ready_raises)
+    def ensure_ready(self) -> None:
+        self.ensure_ready_calls += 1
+        if self._ensure_ready_raises is not None:
+            raise self._ensure_ready_raises
+        self.ready_state = _FakeReadyState("Ready")
 
 
 class _FakeCatalog:
-    """Mimic the WinAppSDK ML ``ExecutionProviderCatalog``."""
+    """Mimic ``windowsml.EpCatalog``."""
 
-    def __init__(self, providers: list[_FakeProvider]) -> None:
+    def __init__(
+        self,
+        providers: list[_FakeProvider],
+        *,
+        find_raises: Exception | None = None,
+    ) -> None:
         self._providers = providers
+        self._find_raises = find_raises
+        self.closed = False
 
     def find_all_providers(self) -> list[_FakeProvider]:
+        if self._find_raises is not None:
+            raise self._find_raises
         return list(self._providers)
 
+    def close(self) -> None:
+        self.closed = True
 
-def _build_fake_binding(catalog: _FakeCatalog | Exception) -> dict[str, types.ModuleType]:
-    """Build the minimal module shape the lazy import needs.
 
-    Returns a dict suitable for ``monkeypatch.setitem(sys.modules, ...)``.
-    """
-    # winui3.microsoft.windows.ai.machinelearning module:
-    ml = types.ModuleType("winui3.microsoft.windows.ai.machinelearning")
+def _install_windowsml_module(
+    monkeypatch: pytest.MonkeyPatch,
+    catalog: _FakeCatalog | Exception,
+) -> None:
+    module = types.ModuleType("windowsml")
 
-    class _Catalog:
-        @staticmethod
-        def get_default() -> Any:
+    class _EpCatalog:
+        def __new__(cls) -> _FakeCatalog:
             if isinstance(catalog, Exception):
                 raise catalog
             return catalog
 
-    ml.ExecutionProviderCatalog = _Catalog  # type: ignore[attr-defined]
-
-    # winui3.microsoft.windows.applicationmodel.dynamicdependency.bootstrap:
-    boot = types.ModuleType("winui3.microsoft.windows.applicationmodel.dynamicdependency.bootstrap")
-
-    class _Options:
-        NONE = "NONE"
-        ON_ERROR_DEBUG_BREAK = "ON_ERROR_DEBUG_BREAK"
-        ON_ERROR_DEBUG_BREAK_IF_DEBUGGER_ATTACHED = "ON_ERROR_DEBUG_BREAK_IF_DEBUGGER_ATTACHED"
-        ON_ERROR_FAIL_FAST = "ON_ERROR_FAIL_FAST"
-        ON_NO_MATCH_SHOW_UI = "ON_NO_MATCH_SHOW_UI"
-        ON_PACKAGE_IDENTITY_NOOP = "ON_PACKAGE_IDENTITY_NOOP"
-
-    class _Handle:
-        entered = 0
-        exited = 0
-
-        def __enter__(self) -> _Handle:
-            type(self).entered += 1
-            return self
-
-        def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
-            type(self).exited += 1
-
-    def _initialize(options: Any = None) -> _Handle:
-        return _Handle()
-
-    boot.InitializeOptions = _Options  # type: ignore[attr-defined]
-    boot.initialize = _initialize  # type: ignore[attr-defined]
-    boot._Handle = _Handle  # type: ignore[attr-defined]
-
-    # Parent placeholder modules so ``import winui3.microsoft...`` can
-    # walk the package chain.
-    parents: list[tuple[str, types.ModuleType]] = []
-    name = "winui3.microsoft.windows.ai.machinelearning"
-    parts = name.split(".")
-    for i in range(1, len(parts)):
-        parent_name = ".".join(parts[:i])
-        if parent_name not in sys.modules:
-            parents.append((parent_name, types.ModuleType(parent_name)))
-
-    boot_name = "winui3.microsoft.windows.applicationmodel.dynamicdependency.bootstrap"
-    parts = boot_name.split(".")
-    for i in range(1, len(parts)):
-        parent_name = ".".join(parts[:i])
-        if parent_name not in sys.modules:
-            parents.append((parent_name, types.ModuleType(parent_name)))
-
-    out: dict[str, types.ModuleType] = dict(parents)
-    out["winui3.microsoft.windows.ai.machinelearning"] = ml
-    out[boot_name] = boot
-    return out
+    module.EpCatalog = _EpCatalog  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "windowsml", module)
 
 
 @pytest.fixture
@@ -214,7 +153,7 @@ class TestDefaultEpPathIncludesCatalogEntries:
         # The catalog API returns provider.name as the full canonical EP
         # name (e.g. "QNNExecutionProvider"), so catalog_name in the
         # default source list must match. Verified empirically against the
-        # live WinAppSDK ML 2.0.1 binding on Snapdragon X Elite —
+        # live windowsml 2.0.300 binding on Snapdragon X Elite —
         # find_all_providers() returns provider.name == "QNNExecutionProvider",
         # not the short "QNN" form used by older Microsoft Learn
         # supported-execution-providers tables.
@@ -261,7 +200,7 @@ class TestDefaultEpPathIncludesCatalogEntries:
 
 
 class TestBindingMissing:
-    """When the WinAppSDK ML Python binding is not importable, resolve() yields nothing."""
+    """When the windowsml package is not importable, resolve() yields nothing."""
 
     def test_yields_nothing_when_binding_missing(
         self,
@@ -269,18 +208,17 @@ class TestBindingMissing:
         monkeypatch: pytest.MonkeyPatch,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        # Force the lazy import to fail by mapping the binding module to
-        # ``None`` in sys.modules. Python's import machinery treats a
-        # ``None`` entry in sys.modules as "module is known to be
-        # unimportable" and raises ImportError on import.
-        monkeypatch.setitem(sys.modules, "winui3.microsoft.windows.ai.machinelearning", None)
+        # Force the lazy import to fail by mapping the module to ``None``
+        # in sys.modules. Python's import machinery treats a ``None`` entry
+        # as "module is known to be unimportable" and raises ImportError.
+        monkeypatch.setitem(sys.modules, "windowsml", None)
         source = WinMLCatalogSource(catalog_name="VitisAI", eps=("VitisAIExecutionProvider",))
         with caplog.at_level(logging.DEBUG, logger="winml.modelkit.ep_path"):
             assert list(source.resolve()) == []
         # DEBUG-once semantics: the failure was logged at DEBUG level,
         # not WARN.
         debug_messages = [r.getMessage() for r in caplog.records if r.levelno == logging.DEBUG]
-        assert any("WinAppSDK ML Python binding not installed" in m for m in debug_messages)
+        assert any("windowsml package is not installed" in m for m in debug_messages)
         warn_messages = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
         assert not warn_messages
 
@@ -290,7 +228,7 @@ class TestBindingMissing:
         monkeypatch: pytest.MonkeyPatch,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        monkeypatch.setitem(sys.modules, "winui3.microsoft.windows.ai.machinelearning", None)
+        monkeypatch.setitem(sys.modules, "windowsml", None)
         s1 = WinMLCatalogSource(catalog_name="VitisAI", eps=("VitisAIExecutionProvider",))
         s2 = WinMLCatalogSource(catalog_name="QNN", eps=("QNNExecutionProvider",))
         with caplog.at_level(logging.DEBUG, logger="winml.modelkit.ep_path"):
@@ -300,7 +238,7 @@ class TestBindingMissing:
         debug_messages = [
             r.getMessage()
             for r in caplog.records
-            if "WinAppSDK ML Python binding not installed" in r.getMessage()
+            if "windowsml package is not installed" in r.getMessage()
         ]
         assert len(debug_messages) == 1
 
@@ -311,13 +249,7 @@ class TestBindingMissing:
 
 
 class TestWithFakeCatalog:
-    """Inject a fake WinAppSDK ML binding and exercise every resolve() branch."""
-
-    def _install_binding(
-        self, monkeypatch: pytest.MonkeyPatch, catalog: _FakeCatalog | Exception
-    ) -> None:
-        for name, mod in _build_fake_binding(catalog).items():
-            monkeypatch.setitem(sys.modules, name, mod)
+    """Inject a fake windowsml module and exercise every resolve() branch."""
 
     def test_yields_for_ready_provider(
         self,
@@ -333,11 +265,10 @@ class TestWithFakeCatalog:
                     name="VitisAI",
                     ready_state="Ready",
                     library_path=str(dll),
-                    status="Success",
                 ),
             ]
         )
-        self._install_binding(monkeypatch, catalog)
+        _install_windowsml_module(monkeypatch, catalog)
 
         source = WinMLCatalogSource(catalog_name="VitisAI", eps=("VitisAIExecutionProvider",))
         results = list(source.resolve())
@@ -365,7 +296,7 @@ class TestWithFakeCatalog:
                 ),
             ]
         )
-        self._install_binding(monkeypatch, catalog)
+        _install_windowsml_module(monkeypatch, catalog)
 
         source = WinMLCatalogSource(catalog_name="VitisAI", eps=("VitisAIExecutionProvider",))
         # No provider with name "VitisAI" -> nothing yielded.
@@ -385,7 +316,7 @@ class TestWithFakeCatalog:
                 ),
             ]
         )
-        self._install_binding(monkeypatch, catalog)
+        _install_windowsml_module(monkeypatch, catalog)
 
         source = WinMLCatalogSource(catalog_name="MIGraphX", eps=("MIGraphXExecutionProvider",))
         # NotPresent providers are skipped by default (auto_download=False).
@@ -402,39 +333,38 @@ class TestWithFakeCatalog:
                     name="QNN",
                     ready_state="Ready",
                     library_path="",
-                    status="Success",
                 ),
             ]
         )
-        self._install_binding(monkeypatch, catalog)
+        _install_windowsml_module(monkeypatch, catalog)
 
         source = WinMLCatalogSource(catalog_name="QNN", eps=("QNNExecutionProvider",))
         assert list(source.resolve()) == []
 
-    def test_non_success_status_warns_and_skips(
+    def test_ensure_ready_leaves_not_ready_warns_and_skips(
         self,
         reset_catalog_singleton: None,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        catalog = _FakeCatalog(
-            [
-                _FakeProvider(
-                    name="VitisAI",
-                    ready_state="NotReady",
-                    library_path=str(tmp_path / "v.dll"),
-                    status="Failed",
-                ),
-            ]
-        )
-        self._install_binding(monkeypatch, catalog)
+        # Provider whose ensure_ready() is called but doesn't become Ready.
+        class _StuckProvider:
+            name = "VitisAI"
+            ready_state = _FakeReadyState("NotReady")
+            library_path = str(tmp_path / "v.dll")
+
+            def ensure_ready(self) -> None:
+                pass  # intentionally does NOT update ready_state
+
+        catalog = _FakeCatalog([_StuckProvider()])  # type: ignore[list-item]
+        _install_windowsml_module(monkeypatch, catalog)
 
         source = WinMLCatalogSource(catalog_name="VitisAI", eps=("VitisAIExecutionProvider",))
         with caplog.at_level(logging.WARNING, logger="winml.modelkit.ep_path"):
             assert list(source.resolve()) == []
         warn_messages = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
-        assert any("non-Success status" in m for m in warn_messages), warn_messages
+        assert any("ensure_ready left provider in state" in m for m in warn_messages), warn_messages
 
     def test_ensure_ready_raises_warns_and_continues(
         self,
@@ -443,14 +373,15 @@ class TestWithFakeCatalog:
         tmp_path: Path,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        # First provider raises, second is good — the walk must continue.
+        # First provider raises during ensure_ready, second is already Ready
+        # — the walk must continue past the first failure.
         good_dll = tmp_path / "good.dll"
         good_dll.write_bytes(b"")
         catalog = _FakeCatalog(
             [
                 _FakeProvider(
                     name="OpenVINO",
-                    ready_state="Ready",
+                    ready_state="NotReady",
                     library_path="ignored",
                     ensure_ready_raises=RuntimeError("fake hardware missing"),
                 ),
@@ -458,11 +389,10 @@ class TestWithFakeCatalog:
                     name="OpenVINO",
                     ready_state="Ready",
                     library_path=str(good_dll),
-                    status="Success",
                 ),
             ]
         )
-        self._install_binding(monkeypatch, catalog)
+        _install_windowsml_module(monkeypatch, catalog)
 
         source = WinMLCatalogSource(catalog_name="OpenVINO", eps=("OpenVINOExecutionProvider",))
         with caplog.at_level(logging.WARNING, logger="winml.modelkit.ep_path"):
@@ -478,23 +408,11 @@ class TestWithFakeCatalog:
         monkeypatch: pytest.MonkeyPatch,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        class _BadCatalog:
-            def find_all_providers(self) -> list[Any]:
-                raise RuntimeError("catalog query failed")
-
-        # _build_fake_binding takes a real catalog or an exception; here
-        # we want a catalog object whose method raises, so install
-        # manually.
-        for name, mod in _build_fake_binding(_FakeCatalog([])).items():
-            monkeypatch.setitem(sys.modules, name, mod)
-        ml = sys.modules["winui3.microsoft.windows.ai.machinelearning"]
-
-        class _Catalog2:
-            @staticmethod
-            def get_default() -> Any:
-                return _BadCatalog()
-
-        monkeypatch.setattr(ml, "ExecutionProviderCatalog", _Catalog2)
+        catalog = _FakeCatalog(
+            [],
+            find_raises=RuntimeError("catalog query failed"),
+        )
+        _install_windowsml_module(monkeypatch, catalog)
 
         source = WinMLCatalogSource(catalog_name="QNN", eps=("QNNExecutionProvider",))
         with caplog.at_level(logging.WARNING, logger="winml.modelkit.ep_path"):
@@ -502,18 +420,114 @@ class TestWithFakeCatalog:
         warn_messages = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
         assert any("find_all_providers" in m for m in warn_messages)
 
-    def test_get_default_raises_yields_nothing(
+    def test_epcatalog_constructor_raises_yields_nothing(
         self,
         reset_catalog_singleton: None,
         monkeypatch: pytest.MonkeyPatch,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        self._install_binding(monkeypatch, RuntimeError("get_default boom"))
+        _install_windowsml_module(monkeypatch, RuntimeError("EpCatalog() failed"))
         source = WinMLCatalogSource(catalog_name="QNN", eps=("QNNExecutionProvider",))
         with caplog.at_level(logging.WARNING, logger="winml.modelkit.ep_path"):
             assert list(source.resolve()) == []
         warn_messages = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
-        assert any("get_default" in m for m in warn_messages)
+        assert any("EpCatalog()" in m for m in warn_messages)
+
+
+# ---------------------------------------------------------------------------
+# Readiness and lifecycle expectations (new synchronous API).
+# ---------------------------------------------------------------------------
+
+
+def test_not_ready_provider_is_prepared_and_yielded(
+    reset_catalog_singleton: None,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    dll = tmp_path / "qnn.dll"
+    dll.write_bytes(b"")
+    provider = _FakeProvider("QNNExecutionProvider", "NotReady", str(dll))
+    _install_windowsml_module(monkeypatch, _FakeCatalog([provider]))
+
+    entries = list(
+        WinMLCatalogSource(
+            catalog_name="QNNExecutionProvider",
+            eps=("QNNExecutionProvider",),
+        ).resolve()
+    )
+
+    assert provider.ensure_ready_calls == 1
+    assert [entry.dll_path for entry in entries] == [dll]
+
+
+def test_ready_provider_is_not_prepared_again(
+    reset_catalog_singleton: None,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    dll = tmp_path / "qnn.dll"
+    dll.write_bytes(b"")
+    provider = _FakeProvider("QNNExecutionProvider", "Ready", str(dll))
+    _install_windowsml_module(monkeypatch, _FakeCatalog([provider]))
+
+    entries = list(
+        WinMLCatalogSource(
+            catalog_name="QNNExecutionProvider",
+            eps=("QNNExecutionProvider",),
+        ).resolve()
+    )
+
+    assert provider.ensure_ready_calls == 0
+    assert len(entries) == 1
+
+
+def test_not_present_provider_download_requires_opt_in(
+    reset_catalog_singleton: None,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    dll = tmp_path / "qnn.dll"
+    dll.write_bytes(b"")
+    provider = _FakeProvider("QNNExecutionProvider", "NotPresent", str(dll))
+    catalog = _FakeCatalog([provider])
+    _install_windowsml_module(monkeypatch, catalog)
+
+    default_source = WinMLCatalogSource(
+        catalog_name="QNNExecutionProvider",
+        eps=("QNNExecutionProvider",),
+    )
+    assert list(default_source.resolve()) == []
+    assert provider.ensure_ready_calls == 0
+
+    _ep._get_catalog.cache_clear()
+    _install_windowsml_module(monkeypatch, catalog)
+    download_source = WinMLCatalogSource(
+        catalog_name="QNNExecutionProvider",
+        eps=("QNNExecutionProvider",),
+        auto_download=True,
+    )
+    assert len(list(download_source.resolve())) == 1
+    assert provider.ensure_ready_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# _is_ready helper.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (_FakeReadyState("Ready"), True),
+        (_FakeReadyState("READY"), True),
+        (_FakeReadyState("NotReady"), False),
+        (_FakeReadyState("NOT_READY"), False),
+        (_FakeReadyState("NotPresent"), False),
+        (None, False),
+    ],
+)
+def test_is_ready(value: Any, expected: bool) -> None:
+    assert WinMLCatalogSource._is_ready(value) is expected
 
 
 # ---------------------------------------------------------------------------
@@ -522,7 +536,7 @@ class TestWithFakeCatalog:
 
 
 class TestAtexitCleanup:
-    """The bootstrap handle is registered for cleanup exactly once."""
+    """The catalog is registered for cleanup exactly once."""
 
     def test_atexit_registered_once_across_multiple_calls(
         self,
@@ -539,7 +553,7 @@ class TestAtexitCleanup:
 
         monkeypatch.setattr(_ep.atexit, "register", fake_register)
 
-        # Install a working fake binding.
+        # Install a working fake module.
         dll = tmp_path / "x.dll"
         dll.write_bytes(b"")
         catalog = _FakeCatalog(
@@ -548,12 +562,10 @@ class TestAtexitCleanup:
                     name="VitisAI",
                     ready_state="Ready",
                     library_path=str(dll),
-                    status="Success",
                 ),
             ]
         )
-        for name, mod in _build_fake_binding(catalog).items():
-            monkeypatch.setitem(sys.modules, name, mod)
+        _install_windowsml_module(monkeypatch, catalog)
 
         # First call — initializes and registers.
         c1 = _ep._get_catalog()
@@ -564,14 +576,21 @@ class TestAtexitCleanup:
         assert c2 is c1
         assert c3 is c1
         # Exactly one atexit registration.
-        cleanup_callbacks = [r for r in registered if r[0] is _ep._release_winml_handle]
+        cleanup_callbacks = [r for r in registered if r[0] is _ep._release_winml_catalog]
         assert len(cleanup_callbacks) == 1
+        # The catalog object itself is what gets registered for cleanup.
+        assert cleanup_callbacks[0][1][0] is catalog
 
-    def test_release_handle_swallows_exceptions(self, caplog: pytest.LogCaptureFixture) -> None:
+    def test_release_catalog_swallows_exceptions(self, caplog: pytest.LogCaptureFixture) -> None:
         # Cleanup must not propagate exceptions during interpreter shutdown.
-        class _BoomHandle:
-            def __exit__(self, *args: Any) -> None:
+        class _BoomCatalog:
+            def close(self) -> None:
                 raise RuntimeError("cleanup failure")
 
         # Should not raise.
-        _ep._release_winml_handle(_BoomHandle())
+        _ep._release_winml_catalog(_BoomCatalog())
+
+    def test_release_catalog_calls_close(self) -> None:
+        catalog = _FakeCatalog([])
+        _ep._release_winml_catalog(catalog)
+        assert catalog.closed is True


### PR DESCRIPTION
## Summary
- replace the stale WinUI3 catalog bootstrap with the pinned `windowsml.EpCatalog` API
- prepare `NotReady` providers while keeping `NotPresent` downloads opt-in and ORT registration in `WinMLEPRegistry`
- align catalog tests, dependency guidance, and live Windows smoke coverage

## Validation
- `uv run pytest tests\unit\ep_path tests\unit\session\test_ep_registry.py tests\unit\session\test_auto_device.py tests\integration\ep_path\test_live_msix.py tests\integration\ep_path\test_live_msix_openvino.py -q` (`194 passed, 5 skipped`)
- `uv run mypy -p winml.modelkit`
- `uv run winml sys --list-ep --format json` (WindowsML QNN MSIX registered with NPU, GPU, and CPU devices)