### PR TITLE
feat: Add --input-data to winml eval --mode compare

### DIFF
--- a/docs/commands/eval.md
+++ b/docs/commands/eval.md
@@ -40,7 +40,7 @@ $ winml eval [options]
 | `--output` | `-o` | `PATH` | — | Output JSON file path for the evaluation results. |
 | `--schema` | | flag | `false` | Print the expected dataset schema for the given `--task` and exit. Does not run evaluation. |
 | `--mode` | | `onnx\|compare` | `onnx` | Evaluation mode. `onnx` evaluates the ONNX candidate on a dataset. `compare` runs the ONNX candidate and the HuggingFace reference on identical random inputs and reports per-tensor similarity metrics — no dataset required. |
-| `--input-data` | | `PATH` | — | Path to a `.npz` file of real input tensors to compare with instead of randomly generated ones (used with `--mode compare`). Keys must match the candidate model's input names. The **leading axis of each array is the sample axis**, so an archive whose arrays have shape `(N, ...)` yields `N` samples (mean/std/min/max are computed across them); all inputs must share the same `N`. |
+| `--input-data` | | `PATH` | — | Path to a `.npz` file of real input tensors to compare with instead of randomly generated ones (used with `--mode compare`). Keys must match the candidate model's input names. The **leading axis of each array is the sample axis**, so an archive shaped `(N, ...)` yields `N` samples (mean/std/min/max are computed across them); all inputs must share the same `N`. Each run is shaped to the candidate's batch size — a dynamic batch runs one row per sample, a static batch `B` chunks the axis into `N // B` batches (trailing rows are dropped with a warning). Note this differs from `winml perf --input-data`, which runs the **whole archive as a single batch**. |
 
 ## How it works
 

--- a/docs/commands/eval.md
+++ b/docs/commands/eval.md
@@ -40,6 +40,7 @@ $ winml eval [options]
 | `--output` | `-o` | `PATH` | — | Output JSON file path for the evaluation results. |
 | `--schema` | | flag | `false` | Print the expected dataset schema for the given `--task` and exit. Does not run evaluation. |
 | `--mode` | | `onnx\|compare` | `onnx` | Evaluation mode. `onnx` evaluates the ONNX candidate on a dataset. `compare` runs the ONNX candidate and the HuggingFace reference on identical random inputs and reports per-tensor similarity metrics — no dataset required. |
+| `--input-data` | | `PATH` | — | Path to a `.npz` file of real input tensors to compare with instead of randomly generated ones (used with `--mode compare`). Keys must match the candidate model's input names. The **leading axis of each array is the sample axis**, so an archive whose arrays have shape `(N, ...)` yields `N` samples (mean/std/min/max are computed across them); all inputs must share the same `N`. |
 
 ## How it works
 
@@ -73,6 +74,12 @@ Evaluate a BERT model on the MRPC paraphrase task with column remapping:
 
 ```bash
 $ winml eval -m Intel/bert-base-uncased-mrpc --dataset nyu-mll/glue --dataset-name mrpc --column input_column=sentence1 --column second_input_column=sentence2 --samples 500
+```
+
+Compare an ONNX candidate against its HuggingFace reference on real input tensors instead of random ones by passing a `.npz` archive whose keys match the candidate's input names. The leading axis of each array is the sample axis, so an archive shaped `(N, ...)` runs `N` samples:
+
+```bash
+$ winml eval --mode compare -m model.onnx --model-id microsoft/resnet-50 --input-data inputs.npz
 ```
 
 Check what dataset columns are expected before running, then remap them to match your dataset:

--- a/src/winml/modelkit/commands/eval.py
+++ b/src/winml/modelkit/commands/eval.py
@@ -186,6 +186,18 @@ logger = logging.getLogger(__name__)
         "random inputs and report tensor-similarity metrics per output tensor."
     ),
 )
+@click.option(
+    "--input-data",
+    "input_data",
+    type=click.Path(exists=True, dir_okay=False),
+    default=None,
+    help=(
+        "Path to a .npz file of real input tensors to compare with instead of "
+        "randomly generated ones (use with --mode compare). Keys must match the "
+        "candidate model's input names; the leading axis of each array is the "
+        "sample axis (N samples), and all inputs must share the same N."
+    ),
+)
 @cli_utils.skip_build_option()
 @cli_utils.format_option()
 @cli_utils.build_config_option()
@@ -227,6 +239,7 @@ def eval(
     allow_unsupported_nodes: bool,
     show_schema: bool,
     mode: EvalMode,
+    input_data: str | None,
     config_file: Path | None,
     skip_build: bool,
 ) -> None:
@@ -236,6 +249,8 @@ def eval(
         winml eval -m microsoft/resnet-50
 
         winml eval -m model.onnx --model-id microsoft/resnet-50
+
+        winml eval --mode compare -m cand.onnx --model-id microsoft/resnet-50 --input-data data.npz
 
     Run `winml eval --schema --task <task>` to see the dataset columns
     and options expected by each task.
@@ -268,6 +283,9 @@ def eval(
 
     # ── 1. Build config: defaults ← config file ← CLI ──
     cfg = _build_eval_config(ctx, config_file, column, label_mapping_path)
+
+    if cfg.input_data is not None and cfg.mode != "compare":
+        raise click.UsageError("--input-data is only valid with --mode compare.")
 
     # ── 2. Resolve in place ──
     _resolve_model(cfg, model, model_id)
@@ -664,7 +682,9 @@ def display_eval_report(result: EvalResult, console: Console) -> None:
     console.print()
     console.print(f"[dim]Task:[/dim]       {cfg.task}")
     console.print(f"[dim]Device:[/dim]     {cfg.device}")
-    if ds.path:
+    if cfg.input_data:
+        console.print(f"[dim]Input data:[/dim] {cfg.input_data}")
+    elif ds.path:
         console.print(f"[dim]Dataset:[/dim]    {ds.path}")
     console.print(f"[dim]Samples:[/dim]    {ds.samples}")
     if cfg.model_path:

--- a/src/winml/modelkit/commands/eval.py
+++ b/src/winml/modelkit/commands/eval.py
@@ -305,6 +305,16 @@ def eval(
             cfg.precision,
         )
 
+    # --samples sizes the random/dataset sample count; with --input-data the
+    # count comes from the archive's leading axis, so an explicit --samples is
+    # ignored — warn instead of silently discarding it (mirrors perf's
+    # --batch-size warning).
+    if cfg.input_data is not None and cli_utils.is_cli_provided(ctx, "samples"):
+        logger.warning(
+            "--samples is ignored when --input-data is set; the sample count "
+            "comes from the leading axis of the provided tensors."
+        )
+
     # The build-pipeline flags only take effect when eval rebuilds the model.
     # With a pre-built ONNX path and skip_build (the default), they are no-ops
     # forwarded to from_onnx, so warn the user that they were ignored — mirrors
@@ -668,6 +678,9 @@ def display_eval_report(result: EvalResult, console: Console) -> None:
     cfg = result.config
     ds = cfg.dataset
     metrics = result.metrics
+    # For --input-data compare the effective sample count comes from the
+    # archive (via EvalResult.num_samples), not the unused config default.
+    samples = result.num_samples if result.num_samples is not None else ds.samples
 
     # Header
     console.print()
@@ -686,7 +699,7 @@ def display_eval_report(result: EvalResult, console: Console) -> None:
         console.print(f"[dim]Input data:[/dim] {cfg.input_data}")
     elif ds.path:
         console.print(f"[dim]Dataset:[/dim]    {ds.path}")
-    console.print(f"[dim]Samples:[/dim]    {ds.samples}")
+    console.print(f"[dim]Samples:[/dim]    {samples}")
     if cfg.model_path:
         console.print(f"[dim]ONNX:[/dim]       {cfg.model_path}")
 

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -561,85 +561,15 @@ def load_input_data(
 ) -> dict[str, np.ndarray]:
     """Load benchmark inputs from a ``.npz`` file, validated against the model.
 
-    Lets ``winml perf`` profile with real input tensors instead of randomly
-    generated ones. Only ``.npz`` (a named-array archive) is supported today;
-    a single-array ``.npy`` carries no input names to bind against and is
-    rejected with guidance to repackage as ``.npz``.
-
-    Validation:
-
-    * the archive's keys must exactly match the model's input names -- any
-      missing or unexpected key is an error (an unexpected key is usually a
-      typo that would otherwise leave a required input silently unset);
-    * an array whose dtype differs from the model's expected input dtype is
-      cast to the expected dtype with a warning, matching the silent casting
-      ``WinMLSession._prepare_inputs`` does on a normal run (e.g. numpy's
-      default int64 literals binding to an int32 input).
-
-    Shapes are taken from the arrays as-is; correctness beyond dtype (e.g. a
-    static dimension the data violates) surfaces as a runtime error from the
-    inference session.
-
-    Args:
-        path: Path to the ``.npz`` file.
-        io_config: Model I/O configuration (``input_names``, ``input_types``).
-
-    Returns:
-        Dictionary of ``input_name -> numpy array``.
-
-    Raises:
-        click.UsageError: On a non-``.npz`` file or a key mismatch.
+    Thin wrapper over the shared
+    :func:`winml.modelkit.datasets.input_data.load_input_data`, which is also
+    used by ``winml eval --mode compare --input-data``. Imported lazily so
+    ``winml perf`` startup does not pull in the datasets package unless
+    ``--input-data`` is actually used.
     """
-    if path.suffix.lower() == ".npy":
-        raise click.UsageError(
-            f"--input-data does not support .npy files ({path.name}). A single "
-            f"array carries no input names; save your inputs as a named .npz "
-            f"archive instead (e.g. np.savez('inputs.npz', input_ids=..., "
-            f"attention_mask=...))."
-        )
-    if path.suffix.lower() != ".npz":
-        raise click.UsageError(
-            f"--input-data must be a .npz file, got '{path.suffix or path.name}'."
-        )
+    from ..datasets.input_data import load_input_data as _load_input_data
 
-    try:
-        with np.load(path, allow_pickle=False) as archive:
-            provided = {name: archive[name] for name in archive.files}
-    except Exception as exc:
-        raise click.UsageError(f"Could not read --input-data file {path}: {exc}") from exc
-
-    expected_names = list(io_config["input_names"])
-    expected_types = list(io_config["input_types"])
-
-    missing = [name for name in expected_names if name not in provided]
-    unexpected = [name for name in provided if name not in expected_names]
-    if missing or unexpected:
-        parts = []
-        if missing:
-            parts.append(f"missing {missing}")
-        if unexpected:
-            parts.append(f"unexpected {unexpected}")
-        raise click.UsageError(
-            f"--input-data keys do not match the model inputs ({', '.join(parts)}). "
-            f"Expected exactly: {expected_names}."
-        )
-
-    # Cast dtype mismatches instead of failing, mirroring the session's
-    # _prepare_inputs, so inputs that would run fine on a normal invocation
-    # (e.g. int64 literals against an int32 input) don't hard-error here.
-    for name, expected_dtype in zip(expected_names, expected_types, strict=True):
-        want = np.dtype(expected_dtype)
-        got = provided[name].dtype
-        if got != want:
-            logger.warning(
-                "--input-data dtype for '%s' is %s; casting to the model's expected %s.",
-                name,
-                got,
-                want,
-            )
-            provided[name] = provided[name].astype(want)
-
-    return provided
+    return _load_input_data(path, io_config)
 
 
 def effective_batch_size(

--- a/src/winml/modelkit/datasets/input_data.py
+++ b/src/winml/modelkit/datasets/input_data.py
@@ -1,0 +1,187 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+"""Real input tensors loaded from a ``.npz`` archive.
+
+Shared by ``winml perf`` (benchmark on real tensors instead of random ones)
+and ``winml eval --mode compare`` (compare a candidate and reference on the
+same real inputs). :func:`load_input_data` validates and dtype-casts the
+archive against a model's I/O config; :class:`InputDataDataset` wraps the
+loaded archive as a torch dataset (leading axis = sample axis) the compare
+loop can iterate.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import click
+import numpy as np
+
+
+if TYPE_CHECKING:
+    import torch
+
+logger = logging.getLogger(__name__)
+
+
+def load_input_data(
+    path: Path,
+    io_config: dict[str, Any],
+) -> dict[str, np.ndarray]:
+    """Load model inputs from a ``.npz`` file, validated against the model.
+
+    Lets ``winml perf`` / ``winml eval`` run with real input tensors instead
+    of randomly generated ones. Only ``.npz`` (a named-array archive) is
+    supported today; a single-array ``.npy`` carries no input names to bind
+    against and is rejected with guidance to repackage as ``.npz``.
+
+    Validation:
+
+    * the archive's keys must exactly match the model's input names -- any
+      missing or unexpected key is an error (an unexpected key is usually a
+      typo that would otherwise leave a required input silently unset);
+    * an array whose dtype differs from the model's expected input dtype is
+      cast to the expected dtype with a warning, matching the silent casting
+      ``WinMLSession._prepare_inputs`` does on a normal run (e.g. numpy's
+      default int64 literals binding to an int32 input).
+
+    Shapes are taken from the arrays as-is; correctness beyond dtype (e.g. a
+    static dimension the data violates) surfaces as a runtime error from the
+    inference session.
+
+    Args:
+        path: Path to the ``.npz`` file.
+        io_config: Model I/O configuration (``input_names``, ``input_types``).
+
+    Returns:
+        Dictionary of ``input_name -> numpy array``.
+
+    Raises:
+        click.UsageError: On a non-``.npz`` file or a key mismatch.
+    """
+    path = Path(path)
+    if path.suffix.lower() == ".npy":
+        raise click.UsageError(
+            f"--input-data does not support .npy files ({path.name}). A single "
+            f"array carries no input names; save your inputs as a named .npz "
+            f"archive instead (e.g. np.savez('inputs.npz', input_ids=..., "
+            f"attention_mask=...))."
+        )
+    if path.suffix.lower() != ".npz":
+        raise click.UsageError(
+            f"--input-data must be a .npz file, got '{path.suffix or path.name}'."
+        )
+
+    try:
+        with np.load(path, allow_pickle=False) as archive:
+            provided = {name: archive[name] for name in archive.files}
+    except Exception as exc:
+        raise click.UsageError(f"Could not read --input-data file {path}: {exc}") from exc
+
+    expected_names = list(io_config["input_names"])
+    expected_types = list(io_config["input_types"])
+
+    missing = [name for name in expected_names if name not in provided]
+    unexpected = [name for name in provided if name not in expected_names]
+    if missing or unexpected:
+        parts = []
+        if missing:
+            parts.append(f"missing {missing}")
+        if unexpected:
+            parts.append(f"unexpected {unexpected}")
+        raise click.UsageError(
+            f"--input-data keys do not match the model inputs ({', '.join(parts)}). "
+            f"Expected exactly: {expected_names}."
+        )
+
+    # Cast dtype mismatches instead of failing, mirroring the session's
+    # _prepare_inputs, so inputs that would run fine on a normal invocation
+    # (e.g. int64 literals against an int32 input) don't hard-error here.
+    for name, expected_dtype in zip(expected_names, expected_types, strict=True):
+        want = np.dtype(expected_dtype)
+        got = provided[name].dtype
+        if got != want:
+            logger.warning(
+                "--input-data dtype for '%s' is %s; casting to the model's expected %s.",
+                name,
+                got,
+                want,
+            )
+            provided[name] = provided[name].astype(want)
+
+    return provided
+
+
+class InputDataDataset:
+    """Multi-sample dataset backed by a validated ``.npz`` of real tensors.
+
+    Loads the archive once via :func:`load_input_data` (keys and dtypes
+    validated/cast against ``io_config``), then treats the **leading axis of
+    each array as the sample axis**: an archive whose arrays have shape
+    ``(N, ...)`` yields ``N`` samples, so ``--mode compare`` can run the
+    candidate and reference on many real inputs and report a real
+    distribution (mean/std/min/max) instead of a single point.
+
+    Every input must share the same leading length ``N`` (a clear error is
+    raised otherwise). Each sample keeps a leading batch dim of 1
+    (``arr[i:i+1]``), so any dynamic-batch model accepts it and no assumption
+    is made about output layout — each run is compared independently, exactly
+    like :class:`RandomDataset`'s per-sample flow.
+
+    Args:
+        path: Path to the ``.npz`` file of real input tensors.
+        io_config: Candidate model I/O config (``input_names``, ``input_types``).
+    """
+
+    TASK_TYPE = "input_data"
+
+    def __init__(self, path: str | Path, io_config: dict[str, Any]) -> None:
+        import torch
+
+        arrays = load_input_data(Path(path), io_config)
+
+        # Leading axis = sample axis. Reject scalars (no sample axis) and any
+        # disagreement on N so a silent mis-pairing can't produce bogus metrics.
+        leading: dict[str, int] = {}
+        for name, arr in arrays.items():
+            if arr.ndim == 0:
+                raise click.UsageError(
+                    f"--input-data array '{name}' is a scalar (0-d); the leading "
+                    "axis is the sample axis, so each input needs at least one dim."
+                )
+            leading[name] = int(arr.shape[0])
+
+        distinct = set(leading.values())
+        if len(distinct) != 1:
+            detail = ", ".join(f"{name}={leading[name]}" for name in arrays)
+            raise click.UsageError(
+                "--input-data arrays must share the same leading (sample) axis "
+                f"length; got {detail}."
+            )
+
+        self._num_samples = distinct.pop()
+        if self._num_samples == 0:
+            raise click.UsageError("--input-data arrays are empty (sample axis length 0).")
+
+        # np.load arrays are owned/writable; ascontiguousarray avoids the
+        # non-contiguous from_numpy warning without an extra copy when possible.
+        self._arrays: dict[str, torch.Tensor] = {
+            name: torch.from_numpy(np.ascontiguousarray(arr)) for name, arr in arrays.items()
+        }
+
+    def __len__(self) -> int:
+        """Number of samples (the shared leading-axis length of the inputs)."""
+        return self._num_samples
+
+    def __getitem__(self, idx: int) -> dict[str, torch.Tensor]:
+        """Return sample ``idx`` with each input sliced to a batch of 1."""
+        if not 0 <= idx < self._num_samples:
+            raise IndexError(
+                f"InputDataDataset index {idx} out of range for {self._num_samples} samples."
+            )
+        return {name: tensor[idx : idx + 1] for name, tensor in self._arrays.items()}

--- a/src/winml/modelkit/datasets/input_data.py
+++ b/src/winml/modelkit/datasets/input_data.py
@@ -9,8 +9,17 @@ Shared by ``winml perf`` (benchmark on real tensors instead of random ones)
 and ``winml eval --mode compare`` (compare a candidate and reference on the
 same real inputs). :func:`load_input_data` validates and dtype-casts the
 archive against a model's I/O config; :class:`InputDataDataset` wraps the
-loaded archive as a torch dataset (leading axis = sample axis) the compare
-loop can iterate.
+loaded archive as a torch dataset the compare loop can iterate.
+
+The two commands interpret the *same* ``.npz`` differently, so an archive is
+not always reusable across them:
+
+* ``winml perf`` runs the whole archive as a **single batch** (its leading
+  axis is the batch dimension of one benchmarked call).
+* ``winml eval --mode compare`` treats the leading axis as the **sample
+  axis** and runs each sample independently, chunked to the candidate's batch
+  size (a dynamic batch collapses to one row per run), so the similarity table
+  reflects a distribution across samples rather than a single call.
 """
 
 from __future__ import annotations
@@ -117,25 +126,65 @@ def load_input_data(
     return provided
 
 
+def _model_batch_size(io_config: dict[str, Any]) -> int:
+    """The candidate's expected batch size from its ONNX input shapes.
+
+    Reads the leading (batch) axis of each input: a positive static dim is the
+    required batch, while a dynamic dim (``None`` / symbolic / ``<= 0``) accepts
+    any batch and collapses to ``1`` -- the same "static preserved, dynamic ->
+    1" convention :class:`RandomDataset` uses when sizing synthetic inputs, so
+    a statically-batched model behaves consistently on the random and
+    real-input paths. Inputs that declare conflicting static batch sizes are
+    rejected (one archive cannot satisfy both). Returns ``1`` when no shape
+    metadata is available.
+    """
+    shapes = io_config.get("input_shapes")
+    if not shapes:
+        return 1
+    statics: set[int] = set()
+    for shape in shapes:
+        if not shape:
+            continue
+        lead = shape[0]
+        if isinstance(lead, (int, np.integer)) and not isinstance(lead, bool) and int(lead) > 0:
+            statics.add(int(lead))
+    if not statics:
+        return 1
+    if len(statics) > 1:
+        raise click.UsageError(
+            "--input-data: the model's inputs declare conflicting static batch "
+            f"sizes {sorted(statics)}; cannot batch the provided tensors "
+            "unambiguously."
+        )
+    return statics.pop()
+
+
 class InputDataDataset:
     """Multi-sample dataset backed by a validated ``.npz`` of real tensors.
 
     Loads the archive once via :func:`load_input_data` (keys and dtypes
     validated/cast against ``io_config``), then treats the **leading axis of
     each array as the sample axis**: an archive whose arrays have shape
-    ``(N, ...)`` yields ``N`` samples, so ``--mode compare`` can run the
+    ``(N, ...)`` yields samples over ``N``, so ``--mode compare`` can run the
     candidate and reference on many real inputs and report a real
     distribution (mean/std/min/max) instead of a single point.
 
+    Each run is shaped to the candidate's **batch size** (see
+    :func:`_model_batch_size`): a dynamic batch dim runs one row per sample
+    (``arr[i:i+1]``), while a static batch dim ``B`` chunks the leading axis
+    into groups of ``B`` (``arr[i*B:(i+1)*B]``), yielding ``N // B`` samples.
+    When ``N`` is not a multiple of ``B`` the trailing rows are dropped with a
+    warning; ``N`` smaller than ``B`` is an error. No assumption is made about
+    output layout -- each run is compared independently, like
+    :class:`RandomDataset`'s per-sample flow.
+
     Every input must share the same leading length ``N`` (a clear error is
-    raised otherwise). Each sample keeps a leading batch dim of 1
-    (``arr[i:i+1]``), so any dynamic-batch model accepts it and no assumption
-    is made about output layout — each run is compared independently, exactly
-    like :class:`RandomDataset`'s per-sample flow.
+    raised otherwise).
 
     Args:
         path: Path to the ``.npz`` file of real input tensors.
-        io_config: Candidate model I/O config (``input_names``, ``input_types``).
+        io_config: Candidate model I/O config (``input_names``, ``input_types``,
+            and optionally ``input_shapes`` to honor a static batch dim).
     """
 
     TASK_TYPE = "input_data"
@@ -164,9 +213,31 @@ class InputDataDataset:
                 f"length; got {detail}."
             )
 
-        self._num_samples = distinct.pop()
-        if self._num_samples == 0:
+        total_rows = distinct.pop()
+        if total_rows == 0:
             raise click.UsageError("--input-data arrays are empty (sample axis length 0).")
+
+        # Honor the candidate's batch dim: a statically-batched model (e.g. a
+        # fixed batch of 4) needs each run shaped to that batch, so chunk the
+        # leading axis into groups of ``batch`` rows. A dynamic batch dim
+        # collapses to 1 (one row per run), matching RandomDataset.
+        self._batch = _model_batch_size(io_config)
+        if total_rows < self._batch:
+            raise click.UsageError(
+                f"--input-data has {total_rows} row(s) on the sample axis but the "
+                f"model needs a batch of {self._batch}; provide at least "
+                f"{self._batch} rows."
+            )
+        self._num_samples = total_rows // self._batch
+        remainder = total_rows % self._batch
+        if remainder:
+            logger.warning(
+                "--input-data has %d rows, not a multiple of the model's batch "
+                "size %d; dropping the trailing %d row(s).",
+                total_rows,
+                self._batch,
+                remainder,
+            )
 
         # np.load arrays are owned/writable; ascontiguousarray avoids the
         # non-contiguous from_numpy warning without an extra copy when possible.
@@ -175,13 +246,15 @@ class InputDataDataset:
         }
 
     def __len__(self) -> int:
-        """Number of samples (the shared leading-axis length of the inputs)."""
+        """Number of samples run (leading-axis length // the model's batch size)."""
         return self._num_samples
 
     def __getitem__(self, idx: int) -> dict[str, torch.Tensor]:
-        """Return sample ``idx`` with each input sliced to a batch of 1."""
+        """Return sample ``idx`` as a batch of the model's batch size."""
         if not 0 <= idx < self._num_samples:
             raise IndexError(
                 f"InputDataDataset index {idx} out of range for {self._num_samples} samples."
             )
-        return {name: tensor[idx : idx + 1] for name, tensor in self._arrays.items()}
+        start = idx * self._batch
+        stop = start + self._batch
+        return {name: tensor[start:stop] for name, tensor in self._arrays.items()}

--- a/src/winml/modelkit/eval/config.py
+++ b/src/winml/modelkit/eval/config.py
@@ -107,6 +107,12 @@ class WinMLEvaluationConfig:
         model_path: Path to .onnx model file, or a ``{role: path}`` dict for
             composite models (e.g. ``{"image-encoder": "...", "text-encoder": "..."}``).
             None = build from model_id.
+        input_data: Path to a ``.npz`` archive of real input tensors for
+            ``--mode compare``. When set, the candidate and reference are compared
+            on these tensors (validated against the candidate's inputs) instead of
+            randomly generated ones. The leading axis of each array is the sample
+            axis, so one archive can hold ``N`` samples; all inputs must share the
+            same leading length.
         task: HF pipeline task. Auto-detected from model_id if omitted.
         device: Target device for inference.
         ep: Explicit execution provider (e.g., "qnn", "dml"). Overrides
@@ -137,6 +143,7 @@ class WinMLEvaluationConfig:
 
     model_id: str | None = None
     model_path: str | dict[str, str] | None = None
+    input_data: str | None = None
     task: str | None = None
     device: str = "auto"
     precision: str = "auto"
@@ -168,6 +175,8 @@ class WinMLEvaluationConfig:
             result["model_id"] = self.model_id
         if self.model_path is not None:
             result["model_path"] = self.model_path
+        if self.input_data is not None:
+            result["input_data"] = self.input_data
         if self.task is not None:
             result["task"] = self.task
         result["device"] = self.device
@@ -219,6 +228,7 @@ class WinMLEvaluationConfig:
         return cls(
             model_id=data.get("model_id"),
             model_path=data.get("model_path"),
+            input_data=data.get("input_data"),
             task=data.get("task"),
             device=data.get("device", "auto"),
             precision=data.get("precision", "auto"),

--- a/src/winml/modelkit/eval/evaluate.py
+++ b/src/winml/modelkit/eval/evaluate.py
@@ -210,13 +210,22 @@ class EvalResult:
 
     config: WinMLEvaluationConfig
     metrics: dict[str, Any] = field(default_factory=dict)
+    # Effective number of samples actually run, when it differs from
+    # ``config.dataset.samples`` (e.g. ``--mode compare --input-data`` derives
+    # it from the archive). ``None`` means "use ``config.dataset.samples``".
+    num_samples: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON serialization."""
-        return {
+        result = {
             **self.config.to_dict(),
             "metrics": self.metrics,
         }
+        # Reflect the real sample count without mutating the config: override the
+        # serialized dataset's ``samples`` so the JSON matches the console report.
+        if self.num_samples is not None and isinstance(result.get("dataset"), dict):
+            result["dataset"] = {**result["dataset"], "samples": self.num_samples}
+        return result
 
 
 def _load_model(config: WinMLEvaluationConfig) -> WinMLPreTrainedModel | WinMLCompositeModel | None:
@@ -432,7 +441,16 @@ def evaluate(config: WinMLEvaluationConfig) -> EvalResult:
             f"Run 'winml eval --schema --task {config.task}' to see the expected schema.",
         ) from error
 
-    return EvalResult(config=config, metrics=metrics)
+    # For --input-data compare, the real sample count comes from the archive
+    # (leading axis, chunked to the model's batch). Surface it on the result so
+    # the report/JSON reflect N without writing back into the (copied) config.
+    num_samples: int | None = None
+    if config.input_data is not None:
+        data = getattr(task_evaluator, "data", None)
+        if data is not None:
+            num_samples = len(data)
+
+    return EvalResult(config=config, metrics=metrics, num_samples=num_samples)
 
 
 def print_config(config: WinMLEvaluationConfig) -> None:

--- a/src/winml/modelkit/eval/evaluate.py
+++ b/src/winml/modelkit/eval/evaluate.py
@@ -442,6 +442,8 @@ def print_config(config: WinMLEvaluationConfig) -> None:
     output_console.print(f"[bold blue]Model:[/bold blue] {config.model_id}")
     if config.model_path is not None:
         output_console.print(f"[bold blue]Model path:[/bold blue] {config.model_path}")
+    if config.input_data is not None:
+        output_console.print(f"[bold blue]Input data:[/bold blue] {config.input_data}")
     output_console.print(f"[bold blue]Task:[/bold blue] {config.task}")
     output_console.print(f"[bold blue]Device:[/bold blue] {config.device}")
     if config.ep is not None:

--- a/src/winml/modelkit/eval/tensor_similarity_evaluator.py
+++ b/src/winml/modelkit/eval/tensor_similarity_evaluator.py
@@ -5,10 +5,13 @@
 
 """Tensor-similarity evaluator.
 
-Runs an ONNX candidate and an HF PyTorch reference on identical random
-inputs (drawn from :class:`RandomDataset` over the candidate's ONNX I/O)
-and reports per-output tensor-parity metrics (SQNR, PSNR, cosine, MSE,
-max absolute diff) via :class:`TensorSimilarityMetric`.
+Runs an ONNX candidate and an HF PyTorch reference on identical inputs
+(random by default, drawn from :class:`RandomDataset` over the candidate's
+ONNX I/O) and reports per-output tensor-parity metrics (SQNR, PSNR, cosine,
+MSE, max absolute diff) via :class:`TensorSimilarityMetric`.
+
+When ``config.input_data`` is set, both sides run on real tensors from a
+``.npz`` archive instead of random inputs.
 
 No labeled dataset, no HF pipeline, no preprocessor — any divergence
 reflects the build pipeline (optimize / quantize / compile) only.
@@ -80,7 +83,23 @@ class TensorSimilarityEvaluator:
         ).eval()
 
     def prepare_data(self) -> Any:
-        """Build a RandomDataset over the candidate ONNX's I/O spec."""
+        """Build the compare dataset over the candidate ONNX's I/O spec.
+
+        Uses real tensors from ``config.input_data`` (wrapped as a multi-sample
+        :class:`InputDataDataset` whose leading axis is the sample axis and
+        validated against the candidate's inputs) when provided, otherwise a
+        :class:`RandomDataset` of synthetic inputs sized by ``config.dataset``.
+        """
+        if self.config.input_data is not None:
+            from ..datasets.input_data import InputDataDataset
+
+            dataset = InputDataDataset(self.config.input_data, self.model.io_config)
+            # Reflect the real sample count (leading axis of the .npz) in the
+            # effective config so the report header / JSON show N, not the
+            # unused dataset default.
+            self.config.dataset.samples = len(dataset)
+            return dataset
+
         from ..datasets.random_dataset import RandomDataset
 
         ds = self.config.dataset

--- a/src/winml/modelkit/eval/tensor_similarity_evaluator.py
+++ b/src/winml/modelkit/eval/tensor_similarity_evaluator.py
@@ -89,16 +89,14 @@ class TensorSimilarityEvaluator:
         :class:`InputDataDataset` whose leading axis is the sample axis and
         validated against the candidate's inputs) when provided, otherwise a
         :class:`RandomDataset` of synthetic inputs sized by ``config.dataset``.
+
+        The real sample count is reported via ``EvalResult.num_samples`` (set by
+        :func:`evaluate`), not by mutating ``config`` here.
         """
         if self.config.input_data is not None:
             from ..datasets.input_data import InputDataDataset
 
-            dataset = InputDataDataset(self.config.input_data, self.model.io_config)
-            # Reflect the real sample count (leading axis of the .npz) in the
-            # effective config so the report header / JSON show N, not the
-            # unused dataset default.
-            self.config.dataset.samples = len(dataset)
-            return dataset
+            return InputDataDataset(self.config.input_data, self.model.io_config)
 
         from ..datasets.random_dataset import RandomDataset
 

--- a/tests/unit/commands/test_eval.py
+++ b/tests/unit/commands/test_eval.py
@@ -327,6 +327,32 @@ class TestEvalHelp:
         assert "requires --model-id" in result.output
         assert "role=path" in result.output
 
+    def test_help_mentions_input_data(self, runner: CliRunner):
+        from winml.modelkit.commands.eval import eval as eval_cmd
+
+        result = runner.invoke(eval_cmd, ["--help"])
+
+        assert result.exit_code == 0, result.output
+        assert "--input-data" in result.output
+
+
+class TestInputDataModeGuard:
+    def test_input_data_requires_compare_mode(self, runner: CliRunner, onnx_file, tmp_path):
+        import numpy as np
+
+        from winml.modelkit.commands.eval import eval as eval_cmd
+
+        npz = tmp_path / "inputs.npz"
+        np.savez(npz, x=np.zeros((1, 4), dtype=np.float32))
+
+        result = runner.invoke(
+            eval_cmd,
+            ["-m", str(onnx_file), "--input-data", str(npz)],
+            obj={"debug": False},
+        )
+        assert result.exit_code != 0
+        assert "--input-data is only valid with --mode compare" in result.output
+
 
 @pytest.fixture
 def eval_config_file(tmp_path):

--- a/tests/unit/commands/test_perf_cli.py
+++ b/tests/unit/commands/test_perf_cli.py
@@ -1087,7 +1087,7 @@ class TestLoadInputData:
         }
         path = self._write_npz(tmp_path, input_ids=np.zeros((1, 8), dtype=np.int64))
 
-        with caplog.at_level(logging.WARNING, logger="winml.modelkit.commands.perf"):
+        with caplog.at_level(logging.WARNING, logger="winml.modelkit.datasets.input_data"):
             inputs = load_input_data(path, io)
 
         assert inputs["input_ids"].dtype == np.int32

--- a/tests/unit/datasets/test_input_data.py
+++ b/tests/unit/datasets/test_input_data.py
@@ -1,0 +1,131 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+"""Unit tests for winml.modelkit.datasets.input_data.
+
+Covers the shared ``.npz`` loader (also exercised via ``winml perf``) and the
+multi-sample :class:`InputDataDataset` used by ``winml eval --mode compare``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import ClassVar
+
+import click
+import numpy as np
+import pytest
+import torch
+
+from winml.modelkit.datasets.input_data import InputDataDataset, load_input_data
+
+
+class TestLoadInputData:
+    _IO: ClassVar[dict] = {
+        "input_names": ["pixel_values"],
+        "input_shapes": [[None, 3, 8, 8]],
+        "input_types": ["float32"],
+    }
+
+    def _write_npz(self, tmp_path, **arrays):
+        path = tmp_path / "inputs.npz"
+        np.savez(path, **arrays)
+        return path
+
+    def test_loads_matching_npz(self, tmp_path) -> None:
+        path = self._write_npz(tmp_path, pixel_values=np.zeros((2, 3, 8, 8), dtype=np.float32))
+        inputs = load_input_data(path, self._IO)
+        assert list(inputs) == ["pixel_values"]
+        assert inputs["pixel_values"].shape == (2, 3, 8, 8)
+
+    def test_key_mismatch_errors(self, tmp_path) -> None:
+        path = self._write_npz(tmp_path, wrong=np.zeros((1, 3, 8, 8), dtype=np.float32))
+        with pytest.raises(click.UsageError, match="do not match"):
+            load_input_data(path, self._IO)
+
+    def test_dtype_cast_with_warning(self, tmp_path, caplog) -> None:
+        io = {"input_names": ["input_ids"], "input_shapes": [[None, 8]], "input_types": ["int32"]}
+        path = self._write_npz(tmp_path, input_ids=np.zeros((1, 8), dtype=np.int64))
+        with caplog.at_level(logging.WARNING, logger="winml.modelkit.datasets.input_data"):
+            inputs = load_input_data(path, io)
+        assert inputs["input_ids"].dtype == np.int32
+        assert "casting" in caplog.text.lower()
+
+    def test_npy_rejected(self, tmp_path) -> None:
+        path = tmp_path / "inputs.npy"
+        np.save(path, np.zeros((1, 3, 8, 8), dtype=np.float32))
+        with pytest.raises(click.UsageError, match=r"does not support \.npy"):
+            load_input_data(path, self._IO)
+
+
+class TestInputDataDataset:
+    _IO: ClassVar[dict] = {
+        "input_names": ["x"],
+        "input_shapes": [[None, 4]],
+        "input_types": ["float32"],
+    }
+
+    _IO2: ClassVar[dict] = {
+        "input_names": ["x", "y"],
+        "input_shapes": [[None, 4], [None, 2]],
+        "input_types": ["float32", "float32"],
+    }
+
+    def _write_npz(self, tmp_path, **arrays):
+        path = tmp_path / "inputs.npz"
+        np.savez(path, **arrays)
+        return path
+
+    def test_leading_axis_is_sample_axis(self, tmp_path) -> None:
+        # (3, 4) -> 3 samples, each sliced to a batch of 1: (1, 4).
+        path = self._write_npz(tmp_path, x=np.arange(12, dtype=np.float32).reshape(3, 4))
+        ds = InputDataDataset(path, self._IO)
+
+        assert len(ds) == 3
+        for i in range(3):
+            sample = ds[i]
+            assert set(sample) == {"x"}
+            assert isinstance(sample["x"], torch.Tensor)
+            assert sample["x"].shape == (1, 4)
+        # Rows are the original rows, in order.
+        assert ds[0]["x"].tolist() == [[0.0, 1.0, 2.0, 3.0]]
+        assert ds[2]["x"].tolist() == [[8.0, 9.0, 10.0, 11.0]]
+
+    def test_single_row_is_one_sample(self, tmp_path) -> None:
+        path = self._write_npz(tmp_path, x=np.ones((1, 4), dtype=np.float32))
+        ds = InputDataDataset(path, self._IO)
+        assert len(ds) == 1
+        assert ds[0]["x"].shape == (1, 4)
+
+    def test_multiple_inputs_share_leading_dim(self, tmp_path) -> None:
+        path = self._write_npz(
+            tmp_path,
+            x=np.zeros((2, 4), dtype=np.float32),
+            y=np.ones((2, 2), dtype=np.float32),
+        )
+        ds = InputDataDataset(path, self._IO2)
+        assert len(ds) == 2
+        assert ds[1]["x"].shape == (1, 4)
+        assert ds[1]["y"].shape == (1, 2)
+
+    def test_mismatched_leading_dims_error(self, tmp_path) -> None:
+        path = self._write_npz(
+            tmp_path,
+            x=np.zeros((3, 4), dtype=np.float32),
+            y=np.ones((2, 2), dtype=np.float32),
+        )
+        with pytest.raises(click.UsageError, match="same leading"):
+            InputDataDataset(path, self._IO2)
+
+    def test_index_out_of_range(self, tmp_path) -> None:
+        path = self._write_npz(tmp_path, x=np.ones((2, 4), dtype=np.float32))
+        ds = InputDataDataset(path, self._IO)
+        with pytest.raises(IndexError):
+            _ = ds[2]
+
+    def test_validates_keys_against_io_config(self, tmp_path) -> None:
+        path = self._write_npz(tmp_path, wrong=np.ones((1, 4), dtype=np.float32))
+        with pytest.raises(click.UsageError, match="do not match"):
+            InputDataDataset(path, self._IO)

--- a/tests/unit/datasets/test_input_data.py
+++ b/tests/unit/datasets/test_input_data.py
@@ -129,3 +129,69 @@ class TestInputDataDataset:
         path = self._write_npz(tmp_path, wrong=np.ones((1, 4), dtype=np.float32))
         with pytest.raises(click.UsageError, match="do not match"):
             InputDataDataset(path, self._IO)
+
+
+class TestStaticBatchHonoring:
+    """The dataset chunks the sample axis to the candidate's static batch dim."""
+
+    _IO_STATIC4: ClassVar[dict] = {
+        "input_names": ["x"],
+        "input_shapes": [[4, 3]],
+        "input_types": ["float32"],
+    }
+
+    def _write_npz(self, tmp_path, **arrays):
+        path = tmp_path / "inputs.npz"
+        np.savez(path, **arrays)
+        return path
+
+    def test_static_batch_chunks_leading_axis(self, tmp_path) -> None:
+        # Model batch=4, 8 rows -> 2 samples, each a contiguous batch of 4.
+        path = self._write_npz(tmp_path, x=np.arange(24, dtype=np.float32).reshape(8, 3))
+        ds = InputDataDataset(path, self._IO_STATIC4)
+        assert len(ds) == 2
+        assert ds[0]["x"].shape == (4, 3)
+        assert ds[1]["x"].shape == (4, 3)
+        assert ds[0]["x"][0].tolist() == [0.0, 1.0, 2.0]
+        assert ds[1]["x"][0].tolist() == [12.0, 13.0, 14.0]
+
+    def test_static_batch_drops_remainder_with_warning(self, tmp_path, caplog) -> None:
+        # 9 rows, batch 4 -> 2 full batches; the trailing row is dropped.
+        path = self._write_npz(tmp_path, x=np.zeros((9, 3), dtype=np.float32))
+        with caplog.at_level(logging.WARNING, logger="winml.modelkit.datasets.input_data"):
+            ds = InputDataDataset(path, self._IO_STATIC4)
+        assert len(ds) == 2
+        assert "dropping" in caplog.text.lower()
+
+    def test_fewer_rows_than_batch_errors(self, tmp_path) -> None:
+        path = self._write_npz(tmp_path, x=np.zeros((2, 3), dtype=np.float32))
+        with pytest.raises(click.UsageError, match="needs a batch of 4"):
+            InputDataDataset(path, self._IO_STATIC4)
+
+    def test_conflicting_static_batches_error(self, tmp_path) -> None:
+        io = {
+            "input_names": ["x", "y"],
+            "input_shapes": [[4, 3], [2, 3]],
+            "input_types": ["float32", "float32"],
+        }
+        path = self._write_npz(
+            tmp_path,
+            x=np.zeros((8, 3), dtype=np.float32),
+            y=np.zeros((8, 3), dtype=np.float32),
+        )
+        with pytest.raises(click.UsageError, match="conflicting static batch"):
+            InputDataDataset(path, io)
+
+    def test_dynamic_batch_is_one_row_per_sample(self, tmp_path) -> None:
+        io = {"input_names": ["x"], "input_shapes": [[None, 3]], "input_types": ["float32"]}
+        path = self._write_npz(tmp_path, x=np.zeros((5, 3), dtype=np.float32))
+        ds = InputDataDataset(path, io)
+        assert len(ds) == 5
+        assert ds[0]["x"].shape == (1, 3)
+
+    def test_missing_input_shapes_defaults_to_batch_one(self, tmp_path) -> None:
+        io = {"input_names": ["x"], "input_types": ["float32"]}
+        path = self._write_npz(tmp_path, x=np.zeros((3, 3), dtype=np.float32))
+        ds = InputDataDataset(path, io)
+        assert len(ds) == 3
+        assert ds[0]["x"].shape == (1, 3)

--- a/tests/unit/eval/test_eval.py
+++ b/tests/unit/eval/test_eval.py
@@ -95,6 +95,22 @@ class TestEvaluationConfig:
         assert ds.revision is None
         assert "revision" not in ds.to_dict()
 
+    def test_input_data_default_is_none(self):
+        """input_data defaults to None and is omitted from to_dict."""
+        config = WinMLEvaluationConfig(model_id="test/model")
+        assert config.input_data is None
+        assert "input_data" not in config.to_dict()
+
+    def test_config_roundtrip_preserves_input_data(self):
+        """input_data survives to_dict/from_dict roundtrip."""
+        config = WinMLEvaluationConfig(
+            model_path="cand.onnx",
+            input_data="inputs.npz",
+            mode="compare",
+        )
+        restored = WinMLEvaluationConfig.from_dict(config.to_dict())
+        assert restored.input_data == "inputs.npz"
+
     def test_eval_result_to_dict(self):
         config = WinMLEvaluationConfig(
             model_id="test/model",

--- a/tests/unit/eval/test_eval.py
+++ b/tests/unit/eval/test_eval.py
@@ -122,6 +122,29 @@ class TestEvaluationConfig:
         assert d["metrics"]["accuracy"] == 0.9
         assert d["dataset"]["path"] == "imagenet-1k"
 
+    def test_eval_result_num_samples_overrides_dataset_samples(self):
+        """num_samples surfaces the effective count in to_dict without mutating config."""
+        config = WinMLEvaluationConfig(
+            model_path="cand.onnx",
+            model_id="test/model",
+            mode="compare",
+            input_data="inputs.npz",
+        )
+        result = EvalResult(config=config, metrics={}, num_samples=2)
+        d = result.to_dict()
+        assert d["dataset"]["samples"] == 2
+        # The config itself is untouched (still the default).
+        assert config.dataset.samples == 100
+
+    def test_eval_result_num_samples_defaults_to_config(self):
+        """Without num_samples, to_dict keeps the config's dataset samples."""
+        config = WinMLEvaluationConfig(
+            model_id="test/model",
+            dataset=DatasetConfig(path="imagenet-1k", samples=33),
+        )
+        result = EvalResult(config=config, metrics={})
+        assert result.to_dict()["dataset"]["samples"] == 33
+
 
 class TestResolveTask:
     """Tests for _resolve_task."""

--- a/tests/unit/eval/test_tensor_similarity_evaluator.py
+++ b/tests/unit/eval/test_tensor_similarity_evaluator.py
@@ -30,6 +30,7 @@ from winml.modelkit.models.winml.composite_model import WinMLCompositeModel
 # _inference_model
 # ---------------------------------------------------------------------------
 
+
 class _EchoModel:
     """Minimal stand-in that returns a BaseModelOutput from the inputs."""
 
@@ -77,6 +78,7 @@ class TestInferenceModel:
 # composite-model guard in __init__
 # ---------------------------------------------------------------------------
 
+
 class _FakeCompositeModel(WinMLCompositeModel):
     _SUB_MODEL_CONFIG: ClassVar[dict[str, str]] = {
         "encoder": "image-feature-extraction",
@@ -86,9 +88,7 @@ class _FakeCompositeModel(WinMLCompositeModel):
 
 class TestCompositeGuard:
     def test_rejects_composite_with_helpful_message(self):
-        composite = _FakeCompositeModel(
-            sub_models={}, config=PretrainedConfig()
-        )
+        composite = _FakeCompositeModel(sub_models={}, config=PretrainedConfig())
         config = WinMLEvaluationConfig(
             model_id="Salesforce/blip-image-captioning-base",
             task="image-to-text",
@@ -102,3 +102,47 @@ class TestCompositeGuard:
         assert "image-feature-extraction" in msg
         assert "text-generation" in msg
         assert "Salesforce/blip-image-captioning-base" in msg
+
+
+# ---------------------------------------------------------------------------
+# Real-input compare (input_data set)
+# ---------------------------------------------------------------------------
+
+
+class _FakeCandidateModel:
+    """Minimal candidate stand-in exposing the ONNX I/O config prepare_data reads."""
+
+    def __init__(self, io_config: dict) -> None:
+        self.io_config = io_config
+
+
+class TestInputDataCompare:
+    def test_prepare_data_uses_input_data_npz(self, monkeypatch, tmp_path):
+        from winml.modelkit.datasets.input_data import InputDataDataset
+
+        # Skip loading the HF reference model (network) -- this test only
+        # exercises prepare_data's dataset selection off the candidate I/O.
+        monkeypatch.setattr(TensorSimilarityEvaluator, "_load_reference_model", lambda self: None)
+
+        npz = tmp_path / "inputs.npz"
+        np.savez(npz, input=np.ones((2, 3), dtype=np.float32))
+
+        config = WinMLEvaluationConfig(
+            model_path="cand.onnx",
+            model_id="test/model",
+            mode="compare",
+            input_data=str(npz),
+        )
+        model = _FakeCandidateModel({"input_names": ["input"], "input_types": ["float32"]})
+
+        evaluator = TensorSimilarityEvaluator(config, model)  # type: ignore[arg-type]
+
+        assert isinstance(evaluator.data, InputDataDataset)
+        # Leading axis is the sample axis: (2, 3) -> 2 samples of shape (1, 3).
+        assert len(evaluator.data) == 2
+        sample = evaluator.data[0]
+        assert set(sample) == {"input"}
+        assert isinstance(sample["input"], torch.Tensor)
+        assert sample["input"].shape == (1, 3)
+        # The effective config reflects the real sample count for the report/JSON.
+        assert evaluator.config.dataset.samples == 2

--- a/tests/unit/eval/test_tensor_similarity_evaluator.py
+++ b/tests/unit/eval/test_tensor_similarity_evaluator.py
@@ -144,5 +144,6 @@ class TestInputDataCompare:
         assert set(sample) == {"input"}
         assert isinstance(sample["input"], torch.Tensor)
         assert sample["input"].shape == (1, 3)
-        # The effective config reflects the real sample count for the report/JSON.
-        assert evaluator.config.dataset.samples == 2
+        # prepare_data must NOT mutate the config -- the real sample count is
+        # surfaced via EvalResult.num_samples, not written back here.
+        assert evaluator.config.dataset.samples == 100


### PR DESCRIPTION
## Summary

Adds `--input-data` to `winml eval --mode compare`, letting you compare an ONNX candidate against its HuggingFace reference on **real input tensors** from a `.npz` archive instead of randomly generated ones — mirroring `winml perf`'s `--input-data`.

The archive keys must match the candidate model's input names and are validated/dtype-cast against them. The **leading axis of each array is the sample axis**, so an archive shaped `(N, ...)` runs `N` samples and the similarity table reflects a real distribution (mean/std/min/max); all inputs must share the same `N`. The flag is only valid with `--mode compare`.

```bash
winml eval --mode compare -m cand.onnx --model-id microsoft/resnet-50 --input-data inputs.npz
```

## Changes

- **`datasets/input_data.py`** (new): shared `load_input_data` (extracted from `perf`) plus a multi-sample `InputDataDataset` wrapper (leading axis = sample axis, each sample sliced to a batch of 1).
- **`commands/perf.py`**: `load_input_data` now delegates to the shared module via a thin lazy import (same public symbol, unchanged behavior).
- **`eval/config.py`**: new `input_data` field with `to_dict`/`from_dict` support.
- **`commands/eval.py`**: `--input-data` option, compare-mode guard (`UsageError` when `mode != compare`, checked before model resolution), docstring example, and the report header now shows `Input data` / the real sample count.
- **`eval/tensor_similarity_evaluator.py`**: `prepare_data` builds `InputDataDataset` when `input_data` is set and propagates `len(dataset)` into the effective config so the report/JSON reflect the real `N`.
- **`eval/evaluate.py`**: `print_config` prints the input-data path in the config summary.
- **docs**: `docs/commands/eval.md` flag row + example.
- **tests**: new `tests/unit/datasets/test_input_data.py`; input-data cases added to the eval command/config/evaluator test suites; `test_perf_cli.py` logger target retargeted to the shared module.

## Notes

This cherry-picks **only** the `--input-data` parts of #1139, decoupled from that PR's two-ONNX `--reference` feature (not included here). The guard runs before model resolution so it fires cleanly even without `--model-id`.