### PR TITLE
recipe(wav2vec2): add jonatasgrosman/wav2vec2-large-xlsr-53-portuguese ASR recipes

### DIFF
--- a/examples/recipes/jonatasgrosman_wav2vec2-large-xlsr-53-portuguese/cpu/cpu/automatic-speech-recognition_fp16_config.json
+++ b/examples/recipes/jonatasgrosman_wav2vec2-large-xlsr-53-portuguese/cpu/cpu/automatic-speech-recognition_fp16_config.json
@@ -1,0 +1,53 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_values",
+        "dtype": "float32",
+        "shape": [1, 16000],
+        "value_range": [-1, 1]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "automatic-speech-recognition",
+    "model_class": "AutoModelForCTC",
+    "model_type": "wav2vec2"
+  }
+}

--- a/examples/recipes/jonatasgrosman_wav2vec2-large-xlsr-53-portuguese/cpu/cpu/automatic-speech-recognition_fp32_config.json
+++ b/examples/recipes/jonatasgrosman_wav2vec2-large-xlsr-53-portuguese/cpu/cpu/automatic-speech-recognition_fp32_config.json
@@ -1,0 +1,34 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_values",
+        "dtype": "float32",
+        "shape": [1, 16000],
+        "value_range": [-1, 1]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "automatic-speech-recognition",
+    "model_class": "AutoModelForCTC",
+    "model_type": "wav2vec2"
+  }
+}


### PR DESCRIPTION
## Summary

Add CPU fp32 and fp16 recipes for **jonatasgrosman/wav2vec2-large-xlsr-53-portuguese**, a Portuguese CTC-based automatic speech recognition model. Verified build and perf on CPU; highest outcome L1 (perf).

## Model metadata

**What the model does:** Portuguese automatic speech recognition using a wav2vec2 encoder with CTC decoding. Takes raw audio waveform as input and outputs text transcriptions in Portuguese.

**Primary user stories:**
- Transcribe Portuguese speech audio to text
- Build Portuguese voice-to-text pipelines

**Supported tasks:** `automatic-speech-recognition`

**Model architecture:**
```
Wav2Vec2ForCTC
├── Wav2Vec2FeatureEncoder (CNN, 7 conv layers)
├── Wav2Vec2EncoderStableLayerNorm (24-layer transformer, hidden=1024, 16 heads)
└── Linear (CTC head, 1024 → 46)
```

- **model_type:** `wav2vec2`
- **architectures:** `["Wav2Vec2ForCTC"]`
- **base_model:** `facebook/wav2vec2-large-xlsr-53`

## Validation and support evidence

**Charter:** Effort L0 · Goal ceiling L1 · Outcome L0

**Baseline** (origin/main `59ae788`):
- `winml build -m jonatasgrosman/wav2vec2-large-xlsr-53-portuguese` → ✅ PASS (79.7s)
- `winml perf` → ✅ PASS (143ms avg, 6.97 samples/sec)
- Goal floor: L1 (build + perf inherited from main)

**Recipe-vs-config diff:** Identical to `winml config` auto-config output — filed for verified `cpu/cpu` coverage.

| EP | Device | Precision | L0 (build) | L1 (perf) | Notes |
|---|---|---|---|---|---|
| cpu | cpu | fp32 | ✅ PASS (109s) | ✅ PASS (144ms avg, 6.93 samp/s, +91.7MB RAM) | |
| cpu | cpu | fp16 | ✅ PASS (111s) | ✅ PASS (138ms avg, 7.23 samp/s, +91.5MB RAM) | |

**L3 (eval):** CLI-BLOCKED — `automatic-speech-recognition` not in supported eval tasks.

**Analyze summary:**
- 841 total ops, 14 unique types (opset 17, pytorch v2.13.0)
- DML EP: no rule data available (0/0/0/841 unknown)

**Reproduce commands:**
```bash
# Build fp32
winml build -m jonatasgrosman/wav2vec2-large-xlsr-53-portuguese \
  -c examples/recipes/jonatasgrosman_wav2vec2-large-xlsr-53-portuguese/cpu/cpu/automatic-speech-recognition_fp32_config.json \
  --ep cpu --device cpu

# Build fp16
winml build -m jonatasgrosman/wav2vec2-large-xlsr-53-portuguese \
  -c examples/recipes/jonatasgrosman_wav2vec2-large-xlsr-53-portuguese/cpu/cpu/automatic-speech-recognition_fp16_config.json \
  --ep cpu --device cpu

# Perf
winml perf -m <output>/model.onnx --ep cpu --device cpu
```