### PR TITLE
fix: drain native stderr pipe concurrently to unblock EP compilation

### DIFF
--- a/scripts/e2e_eval/run_eval.py
+++ b/scripts/e2e_eval/run_eval.py
@@ -191,6 +191,17 @@ _NO_SPACE_PATTERNS = (
 
 _HF_CACHE = Path.home() / ".cache" / "huggingface"
 _WINML_CACHE = Path.home() / ".cache" / "winml"
+# VitisAI EP compilation cache. It lives outside the user profile -- AMD's
+# default is ``C:\temp\<user>\vaip\.cache`` -- so clearing the HF/WinML caches
+# alone leaves compiled NPU artifacts behind. AMD documents that these
+# directories must not be reused across VitisAI EP or NPU driver versions, and a
+# stale entry also lets a run load a previously compiled model instead of
+# exercising the compile path under test.
+_VAIP_CACHE = (
+    Path("C:/temp") / os.environ["USERNAME"] / "vaip" / ".cache"
+    if platform.system() == "Windows" and os.environ.get("USERNAME")
+    else None
+)
 _TEMP_DIR = Path(os.environ.get("TEMP", os.environ.get("TMP", tempfile.gettempdir())))
 _TEMP_PREFIXES = ("winmlcli_", "winmlcli_compat_")
 
@@ -202,9 +213,9 @@ def _is_no_space_error(proc: dict) -> bool:
 
 
 def _clear_disk_caches() -> None:
-    """Delete HuggingFace, WinML cache directories and leaked temp files."""
-    for cache_dir in (_HF_CACHE, _WINML_CACHE):
-        if cache_dir.exists():
+    """Delete HuggingFace, WinML, VitisAI EP caches and leaked temp files."""
+    for cache_dir in (_HF_CACHE, _WINML_CACHE, _VAIP_CACHE):
+        if cache_dir is not None and cache_dir.exists():
             safe_print(f"  [cleanup] Removing cache: {cache_dir}")
             try:
                 shutil.rmtree(cache_dir)

--- a/src/winml/modelkit/utils/native_stderr.py
+++ b/src/winml/modelkit/utils/native_stderr.py
@@ -20,6 +20,7 @@ import logging
 import os
 import re
 import sys
+import threading
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
@@ -83,25 +84,42 @@ def capture_native_stderr(level: int = logging.INFO) -> Iterator[None]:
         return
 
     read_fd, write_fd = os.pipe()
+    # Drain the pipe on a background thread *while* the wrapped block runs.
+    # A chatty native EP (e.g. a VitisAI model compilation) can emit far more
+    # than the OS pipe buffer holds (~64 KB on Windows) before we regain
+    # control. If the pipe were only drained after the yield, the native
+    # write() would block on a full buffer and stall the process indefinitely.
+    # Reading concurrently keeps the buffer from ever filling up.
+    chunks: list[bytes] = []
+
+    def _drain() -> None:
+        try:
+            while chunk := os.read(read_fd, 4096):
+                chunks.append(chunk)
+        except OSError:
+            pass  # read end closed or broken; stop draining
+        finally:
+            os.close(read_fd)
+
+    reader = threading.Thread(target=_drain, name="capture-native-stderr", daemon=True)
+
     old_fd = os.dup(2)
     old_w32 = _k32.GetStdHandle(_STD_ERROR_HANDLE)
     os.dup2(write_fd, 2)
     os.close(write_fd)
     _k32.SetStdHandle(_STD_ERROR_HANDLE, msvcrt.get_osfhandle(2))
+    reader.start()
     try:
         yield
     finally:
+        # Restoring fd 2 drops the last reference to the pipe's write end, which
+        # signals EOF to the reader thread so it can finish and close the read end.
         os.dup2(old_fd, 2)
         os.close(old_fd)
         _k32.SetStdHandle(_STD_ERROR_HANDLE, old_w32)
-        # Drain pipe and re-emit each line.
+        reader.join()
+        # Re-emit each captured line through Python logging.
         _ansi_re = re.compile(r"\x1b\[[0-9;]*m")
-        chunks: list[bytes] = []
-        try:
-            while chunk := os.read(read_fd, 4096):
-                chunks.append(chunk)
-        finally:
-            os.close(read_fd)
         for raw in b"".join(chunks).decode("utf-8", errors="replace").splitlines():
             line = _ansi_re.sub("", raw).strip()
             if line:

--- a/tests/unit/eval/test_run_eval_script.py
+++ b/tests/unit/eval/test_run_eval_script.py
@@ -1378,3 +1378,47 @@ class TestAccuracyBackfill:
             "accuracy": {"skipped": True, "skip_reason": "perf_failed"},
         }
         assert run_eval._needs_accuracy_backfill(res, "both") is False
+
+
+class TestClearDiskCaches:
+    """``_clear_disk_caches`` must also drop the VitisAI EP compile cache.
+
+    The VitisAI cache lives outside the user profile (AMD's default is
+    ``C:\\temp\\<user>\\vaip\\.cache``), so removing only the HuggingFace and
+    WinML caches leaves compiled NPU artifacts behind. A stale entry lets a run
+    load a previously compiled model instead of exercising the compile path.
+    """
+
+    def test_removes_hf_winml_and_vaip_caches(self, run_eval, tmp_path, monkeypatch):
+        hf = tmp_path / "huggingface"
+        winml = tmp_path / "winml"
+        vaip = tmp_path / "vaip" / ".cache"
+        for cache in (hf, winml, vaip):
+            cache.mkdir(parents=True)
+            (cache / "artifact.bin").write_bytes(b"stale")
+
+        monkeypatch.setattr(run_eval, "_HF_CACHE", hf)
+        monkeypatch.setattr(run_eval, "_WINML_CACHE", winml)
+        monkeypatch.setattr(run_eval, "_VAIP_CACHE", vaip)
+        # Keep the temp-file sweep away from the real TEMP directory.
+        monkeypatch.setattr(run_eval, "_TEMP_DIR", tmp_path / "empty_temp")
+
+        run_eval._clear_disk_caches()
+
+        assert not hf.exists()
+        assert not winml.exists()
+        assert not vaip.exists()
+
+    def test_skips_vaip_cache_when_unset(self, run_eval, tmp_path, monkeypatch):
+        # ``_VAIP_CACHE`` is None off Windows; the sweep must not raise.
+        winml = tmp_path / "winml"
+        winml.mkdir()
+
+        monkeypatch.setattr(run_eval, "_HF_CACHE", tmp_path / "missing_hf")
+        monkeypatch.setattr(run_eval, "_WINML_CACHE", winml)
+        monkeypatch.setattr(run_eval, "_VAIP_CACHE", None)
+        monkeypatch.setattr(run_eval, "_TEMP_DIR", tmp_path / "empty_temp")
+
+        run_eval._clear_disk_caches()
+
+        assert not winml.exists()

--- a/tests/unit/utils/test_native_stderr.py
+++ b/tests/unit/utils/test_native_stderr.py
@@ -89,3 +89,29 @@ class TestCaptureNativeStderr:
         messages = [r.message for r in caplog.records]
         assert any("keep" in m for m in messages)
         assert not any(m == "  " for m in messages)
+
+    @pytest.mark.timeout(30)
+    def test_no_deadlock_on_large_output(self, caplog):
+        """Regression: a native writer emitting more than the OS pipe buffer
+        (~64 KB on Windows) inside the context must not stall.
+
+        The pipe used to be drained only after the wrapped block returned, so a
+        native write() that filled the buffer blocked forever -- observed as an
+        indefinite stall while an EP compiled a model. The reader thread now
+        drains concurrently, so this loop completes immediately. The timeout
+        marker turns a reintroduced deadlock into a failure instead of a hang.
+        """
+        line = b"[ORT] partitioning subgraph node ...\n"
+        written = 0
+        with (
+            caplog.at_level(logging.INFO, logger="winml.modelkit.utils.native_stderr"),
+            capture_native_stderr(logging.INFO),
+        ):
+            for _ in range(20000):  # ~720 KB, dwarfs the ~64 KB pipe buffer
+                os.write(2, line)
+                written += len(line)
+        assert written > 64 * 1024
+        # On Windows the redirected output is re-logged; elsewhere the context is
+        # a no-op. Either way the point is that the loop above did not deadlock.
+        if sys.platform == "win32":
+            assert any("partitioning subgraph" in r.message for r in caplog.records)


### PR DESCRIPTION
## Why

`capture_native_stderr` redirected fd 2 into an OS pipe but only drained it
after the wrapped block returned. A native EP that wrote more than the pipe
buffer holds (~64 KB on Windows) blocked in `write()` and never returned, so the
wrapped block never completed and the drain never ran.

VitisAI model compilation emits several hundred lines of compiler output on
native stderr and reliably filled the buffer, stalling session creation
indefinitely.

Measured on an AMD Ryzen AI 9 HX 370 (VitisAI EP 1.8.72.0, EP cache emptied
before each run):

| Scenario | Result |
| --- | --- |
| `winml perf ... --ep vitisai --precision fp16` | ran 17m52s without completing; no compile artifacts written for the last 14m45s |
| Same model + EP, session created outside the context manager | completed in 185s |
| Same model + EP, session created inside `capture_native_stderr` | stalled at the same compilation stage |

The last variant isolates the context manager as the cause: same model, same EP,
same session options, same empty cache.

## What changed

- **`capture_native_stderr` drains concurrently.** A daemon reader thread starts
  before the `yield`, so the pipe is emptied while the wrapped block runs and the
  buffer never fills. Restoring fd 2 drops the last write-end reference, which
  signals EOF to the reader; it is then joined and the captured lines are
  re-emitted through logging exactly as before. No change to the public
  behaviour (capture, ANSI stripping, `[ORT]` prefix).

- **The eval harness now clears the VitisAI EP compilation cache.** It lives
  outside the user profile (`C:\temp\<user>\vaip\.cache`), so clearing only the
  HuggingFace and WinML caches left compiled NPU artifacts behind. AMD documents
  that these directories must not be reused across VitisAI EP or NPU driver
  versions, and a stale entry also lets a run load a previously compiled model
  instead of exercising the compile path under test.

- **Regression coverage.** `test_no_deadlock_on_large_output` writes ~720 KB
  inside the context manager under a 30s timeout, so a reintroduced deadlock
  fails instead of hanging. `TestClearDiskCaches` covers the new cache directory
  and the `None` case on non-Windows.

## Validation

- `pytest tests/unit/utils/test_native_stderr.py` — 8 passed, 1 skipped
- `pytest tests/unit/eval/test_run_eval_script.py` — 111 passed
- `ruff check` clean on all touched files
- `winml perf -m facebook/convnext-tiny-224 --device npu --ep vitisai --precision fp16`
  completes in 3m23s (was: no completion after 17m52s)
- `run_eval.py --hf-model facebook/convnext-tiny-224 --device npu --ep vitisai`
  reports `[PASS] 172.4s`, perf pass 1/1 (was: `[FAIL (TIMEOUT)] 601.9s`)
