### PR TITLE
Skip quantized recipe variants for unquantized-track EPs (VitisAI)

### DIFF
--- a/scripts/e2e_eval/README.md
+++ b/scripts/e2e_eval/README.md
@@ -62,9 +62,10 @@ an NPU model without a recipe falls back to `winml config` and is expanded into
 registry overrides this and builds that single precision instead). On CPU/GPU (and
 `auto`) the runner builds only the **non-quantized** recipe variants (e.g. `fp16`),
 dropping quantized ones, and a model with no applicable recipe variant builds a
-single `winml config` fallback. The runner writes one `eval_result.json` per
-`(model, task, precision)` containing facts only (perf output + the winml-eval
-`metrics`/`dataset`).
+single `winml config` fallback. EPs evaluated on the unquantized model (VitisAI)
+follow the same non-quantized-only rule on NPU. The runner writes one
+`eval_result.json` per `(model, task, precision)` containing facts only (perf
+output + the winml-eval `metrics`/`dataset`).
 Delta/verdict grading against the PyTorch baseline is done by the report site.
 
 ```bash
@@ -108,7 +109,7 @@ uv run python scripts/e2e_eval/run_eval.py --update-baseline --eval-type accurac
 | `--registry` | `testsets/models_all.json` | Model registry file |
 | `--hf-model` | — | Single model (overrides registry) |
 | `--output-dir` | `eval_results/{date}` | Output directory |
-| `--recipes-dir` | `examples/recipes` | Authored recipe configs. NPU builds every precision variant (`winml config` `w8a8`+`w8a16` fallback when a model has none); CPU/GPU build only the non-quantized variants (e.g. `fp16`), else a `winml config` fallback |
+| `--recipes-dir` | `examples/recipes` | Authored recipe configs. NPU builds every precision variant (`winml config` `w8a8`+`w8a16` fallback when a model has none); CPU/GPU (and unquantized-track EPs like VitisAI) build only the non-quantized variants (e.g. `fp16`), else a `winml config` fallback |
 | `--no-recipes` | off | Ignore recipes; build every model via `winml config` (on NPU still expands the `w8a8`+`w8a16` fallback) |
 | `--eval-type` | `perf` | `perf`, `accuracy`, or `both` (perf-gated accuracy) |
 | `--task` | — | Filter by HF task |

--- a/scripts/e2e_eval/run_eval.py
+++ b/scripts/e2e_eval/run_eval.py
@@ -13,7 +13,9 @@ every authored recipe variant under ``examples/recipes/`` (``winml build -c``),
 and a recipe-less NPU model falls back to ``winml config`` expanded into ``w8a8``
 + ``w8a16`` jobs (an explicit per-model precision overrides this). CPU/GPU build
 only the non-quantized recipe variants (e.g. ``fp16``), or a single ``winml
-config`` fallback when a model has no applicable recipe.
+config`` fallback when a model has no applicable recipe. EPs that are evaluated
+unquantized (see ``_EPS_SKIP_WINML_QUANT``) follow the same non-quantized-only
+rule even on NPU.
 
 The runner records facts only (perf output + the winml-eval metrics/dataset).
 The per-model report HTML — perf latency and the "Model Accuracy Report" delta
@@ -106,7 +108,9 @@ _NPU_FALLBACK_PRECISIONS: tuple[str, ...] = ("w8a8", "w8a16")
 # choice -- e.g. VitisAI / AMD Ryzen AI is benchmarked on the fp32/fp16
 # model -- not a claim about the EP's internal pipeline.  For these EPs
 # the harness passes ``--no-quant`` to both ``winml config`` and
-# ``winml build`` (see :func:`_run_build` and :func:`run_model`).
+# ``winml build`` (see :func:`_run_build` and :func:`run_model`) and skips
+# authored quantized recipe variants (see :func:`_build_jobs`), which carry
+# their own ``quant`` section that ``--no-quant`` cannot override.
 #
 # Entries are canonical ``EPName`` values (the ``*ExecutionProvider`` form);
 # user-facing aliases like ``vitisai`` are normalised via
@@ -2375,7 +2379,7 @@ def _build_jobs(
 
     Recipes carry the accuracy eval/dataset config, so they are consulted
     regardless of device -- but quantized recipe variants (``w8a16``/``w8a8``)
-    only make sense on the NPU. For each entry:
+    only make sense on an NPU running a quantizing EP. For each entry:
 
     * NPU + recipe variants on disk → one job per variant (``fp16`` + any
       quantized).
@@ -2386,16 +2390,19 @@ def _build_jobs(
       unquantized artifact (``_resolve_precision`` forces the flag off).
     * NPU + no recipe + explicit per-model precision → a single fallback job
       honoring that precision (``winml config``).
-    * non-NPU + non-quantized recipe variants → one job per such variant
-      (quantized variants are dropped).
-    * non-NPU with no applicable recipe variant → a single ``winml config``
-      fallback job (``variant=None``).
+    * non-NPU (or a skip-quant EP) + non-quantized recipe variants → one job
+      per such variant (quantized variants are dropped).
+    * non-NPU (or a skip-quant EP) with no applicable recipe variant → a single
+      ``winml config`` fallback job (``variant=None``).
     """
     npu = device == "npu"
-    # Skip-quant EPs (VitisAI) build the model unquantized regardless of
-    # precision, so the NPU multi-precision expansion would produce duplicate
-    # artifacts under distinct precision slugs -- fall back to a single job.
-    expand_npu_quant = npu and not _should_skip_winml_quant(ep)
+    # Skip-quant EPs (VitisAI) are evaluated on the unquantized model: the
+    # fallback path forces --no-quant, so the NPU multi-precision expansion
+    # would produce duplicate artifacts under distinct precision slugs, and an
+    # authored quantized recipe would hand the EP a QDQ graph its compiler is
+    # not expected to consume.  Both are suppressed.
+    skip_quant = _should_skip_winml_quant(ep)
+    expand_npu_quant = npu and not skip_quant
     jobs: list[EvalJob] = []
     for entry in entries:
         variants = (
@@ -2403,9 +2410,10 @@ def _build_jobs(
             if recipes_dir is not None
             else []
         )
-        if not npu:
-            # Off-NPU still uses recipes for their eval config, but drops
-            # quantized variants -- quantization is an NPU-only concern here.
+        if not npu or skip_quant:
+            # Off-NPU and skip-quant EPs still use recipes for their eval
+            # config, but drop quantized variants -- quantization here is only
+            # for NPU EPs that consume a winml-quantized model.
             variants = [v for v in variants if not _is_quantized_precision(v.precision)]
         if variants:
             jobs.extend(EvalJob(entry, variant) for variant in variants)

--- a/tests/unit/eval/test_run_eval_script.py
+++ b/tests/unit/eval/test_run_eval_script.py
@@ -908,6 +908,30 @@ class TestBuildJobs:
         assert jobs[0].variant is None
         assert jobs[0].precision is None
 
+    def test_npu_skip_quant_ep_drops_quantized_recipe_variants(self, run_eval, tmp_path):
+        # A skip-quant EP is evaluated on the unquantized model, so an authored
+        # quantized recipe (which bakes its own quant section that --no-quant
+        # cannot override) must not be scheduled even on NPU.
+        self._make_single_recipe(
+            tmp_path, "microsoft_resnet-50", "image-classification", ["fp16", "w8a16"]
+        )
+        entry = _entry()
+        jobs = run_eval._build_jobs([entry], tmp_path, "npu", ep="vitisai")
+        assert [j.precision for j in jobs] == ["fp16"]
+        assert jobs[0].variant is not None
+
+    def test_npu_skip_quant_ep_recipe_only_quantized_falls_back(self, run_eval, tmp_path):
+        # Dropping every quantized variant leaves nothing to build, so the model
+        # goes through the single unquantized winml-config fallback.
+        self._make_single_recipe(
+            tmp_path, "microsoft_resnet-50", "image-classification", ["w8a16"]
+        )
+        entry = _entry()
+        jobs = run_eval._build_jobs([entry], tmp_path, "npu", ep="vitisai")
+        assert len(jobs) == 1
+        assert jobs[0].variant is None
+        assert jobs[0].precision is None
+
     def test_non_npu_no_recipe_single_fallback(self, run_eval, tmp_path):
         entry = _entry("some/model", "text-classification")
         jobs = run_eval._build_jobs([entry], tmp_path, "cpu")


### PR DESCRIPTION
## Problem

The `vitisai_npu` e2e eval leg fails on `openai/clip-vit-base-patch32` / `feature-extraction`:

```
[1/2] openai/clip-vit-base-patch32 / feature-extraction [fp16]   [PASS] 206.9s
[2/2] openai/clip-vit-base-patch32 / feature-extraction [w8a16]  [FAIL (UNKNOWN)] 90.2s
    ... xir::Op{... type = quantize-linear} is partitioned to CPU as : doesn't supported by target [AMD_AIE2P_4x8_CMC_Overlay].
    ... xir::Op{... type = const-fix} is partitioned to CPU as : The op's fanout is out of DPU subgraph.
    F attrs_imp.cpp:38] Check failed: attrs_.count(key) > 0 Attrs doesn't contain attribute data
    *** Check failure stack trace: ***
```

A `w8a16` job should never have been scheduled for VitisAI in the first place.

## Root cause

The harness evaluates VitisAI on the unquantized model (`_EPS_SKIP_WINML_QUANT`): `_resolve_precision` drops any explicit precision, and both `winml config` and `winml build` receive `--no-quant`. That policy only covered the `winml config` fallback path.

In `_build_jobs` the quantized-variant filter was gated on `not npu`, so on NPU an authored recipe variant (`examples/recipes/openai_clip-vit-base-patch32/feature-extraction_w8a16_config.json`, `weight_type: uint8` / `activation_type: uint16`) was still expanded into a job. `_run_recipe_build` cannot suppress it either — a recipe config carries its own `quant` section, which `--no-quant` does not override.

The resulting `w8a16` QDQ graph is then handed to `AMD_AIE2P_4x8_CMC_Overlay`. VitisAI quantizes internally (XINT8) and is not meant to consume a winml-produced `w8a16` QDQ graph: it partitions the quantize/dequantize and const-fix ops back to CPU and then aborts inside xir, killing the process — hence the `UNKNOWN` classification rather than a normal failure.

## Change

- `_build_jobs`: filter quantized recipe variants for skip-quant EPs as well (`if not npu or skip_quant`). When that leaves no variant, the model falls through to the existing single unquantized `winml config` fallback.
- Module docstring, `_EPS_SKIP_WINML_QUANT` comment and `scripts/e2e_eval/README.md` updated to state the rule.
- Two unit tests: an `fp16` + `w8a16` recipe keeps only `fp16` on VitisAI; a `w8a16`-only recipe falls back to the unquantized `winml config` job.

Every recipe directory under `examples/recipes/` has an `fp16` variant, so no model loses all of its jobs.
