### PR TITLE
Release native sessions before process exit

### DIFF
--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -764,6 +764,24 @@ class PerfBenchmark:
         """Concrete EP driving the build/inference (``None`` until resolved)."""
         return self._resolved_ep
 
+    def close(self) -> None:
+        """Release native sessions held by the benchmarked model."""
+        model = self._model
+        self._model = None
+        self._inputs = None
+        if model is not None:
+            self._release_model_sessions(model)
+
+    def _release_model_sessions(self, model: Any) -> None:
+        sub_models = getattr(model, "sub_models", None)
+        if isinstance(sub_models, dict):
+            for sub_model in sub_models.values():
+                self._release_model_sessions(sub_model)
+
+        session = getattr(model, "_session", None)
+        if session is not None:
+            session.reset()
+
     @property
     def _is_composite(self) -> bool:
         """Composite models orchestrate multiple sub-sessions (e.g. CLIP/SigLIP).
@@ -3232,6 +3250,9 @@ def perf(
         if verbose:
             logger.exception("Benchmark failed")
         raise click.ClickException(f"Benchmark failed: {e}") from e
+    finally:
+        if benchmark is not None:
+            benchmark.close()
 
 
 # =============================================================================

--- a/src/winml/modelkit/compiler/compiler.py
+++ b/src/winml/modelkit/compiler/compiler.py
@@ -164,6 +164,8 @@ class Compiler:
             # so the next model in a shared-context run reuses the same EP + group.
             self.shared_session_options = context.shared_session_options
             self.n_compiled_models += 1
+            if self.n_compiled_models >= self.n_total_models:
+                self.shared_session_options = None
 
             # Build result
             total_time = time.time() - start_time

--- a/src/winml/modelkit/compiler/stages/compile.py
+++ b/src/winml/modelkit/compiler/stages/compile.py
@@ -107,15 +107,19 @@ class CompileStage(BaseStage):
             ep_device=ep_device,
             ep_config=ep_config,
         )
-        winml_session.compile()
+        try:
+            winml_session.compile()
 
-        session = winml_session._session
-        context.session = session
-        if session is not None:
-            context.log(f"Actual providers: {session.get_providers()}")
-            if context.validate:
-                self._validate_model(session, context)
-            self._collect_model_info(session, context)
+            session = winml_session._session
+            context.session = session
+            if session is not None:
+                context.log(f"Actual providers: {session.get_providers()}")
+                if context.validate:
+                    self._validate_model(session, context)
+                self._collect_model_info(session, context)
+        finally:
+            context.session = None
+            winml_session.reset()
 
         if ep_config.enable_ep_context:
             self._finalize_output(
@@ -170,11 +174,15 @@ class CompileStage(BaseStage):
         if context.use_inference_session:
             session_options.add_session_config_entry("ep.context_file_path", str(ctx_path))
             session = ort.InferenceSession(str(model_path), sess_options=session_options)
-            context.session = session
-            context.log(f"Actual providers: {session.get_providers()}")
-            if context.validate:
-                self._validate_model(session, context)
-            self._collect_model_info(session, context)
+            try:
+                context.session = session
+                context.log(f"Actual providers: {session.get_providers()}")
+                if context.validate:
+                    self._validate_model(session, context)
+                self._collect_model_info(session, context)
+            finally:
+                context.session = None
+                session = None
         else:
             ort.ModelCompiler(
                 session_options,

--- a/src/winml/modelkit/compiler/stages/compile.py
+++ b/src/winml/modelkit/compiler/stages/compile.py
@@ -182,7 +182,7 @@ class CompileStage(BaseStage):
                 self._collect_model_info(session, context)
             finally:
                 context.session = None
-                session = None
+                del session
         else:
             ort.ModelCompiler(
                 session_options,

--- a/tests/unit/commands/test_perf_cli.py
+++ b/tests/unit/commands/test_perf_cli.py
@@ -186,6 +186,38 @@ class TestPerfOutputPath:
 class TestPerfUnifiedPipeline:
     """Test that both ONNX and HF models go through PerfBenchmark._load_model."""
 
+    def test_close_releases_single_model_session(self) -> None:
+        """Closing a benchmark resets the loaded model's native session."""
+        benchmark = PerfBenchmark(BenchmarkConfig(model_id="m"))
+        model = MagicMock()
+        model._session = MagicMock()
+        benchmark._model = model
+        benchmark._inputs = {"x": object()}
+
+        benchmark.close()
+
+        model._session.reset.assert_called_once()
+        assert benchmark._model is None
+        assert benchmark._inputs is None
+
+    def test_close_releases_composite_sub_model_sessions(self) -> None:
+        """Composite benchmarks reset every sub-model session before process teardown."""
+        benchmark = PerfBenchmark(BenchmarkConfig(model_id="m"))
+        first = MagicMock()
+        first._session = MagicMock()
+        second = MagicMock()
+        second._session = MagicMock()
+        composite = MagicMock()
+        composite._session = None
+        composite.sub_models = {"first": first, "second": second}
+        benchmark._model = composite
+
+        benchmark.close()
+
+        first._session.reset.assert_called_once()
+        second._session.reset.assert_called_once()
+        assert benchmark._model is None
+
     def test_onnx_load_model_calls_from_onnx(self, tmp_path: Path) -> None:
         """ONNX file input should use WinMLAutoModel.from_onnx in _load_model."""
         onnx_file = tmp_path / "model.onnx"
@@ -1415,6 +1447,40 @@ class TestPerfFormatJson:
         # Should NOT be parseable as JSON (it's console text)
         with pytest.raises(json.JSONDecodeError):
             json.loads(result.output)
+
+    @patch("winml.modelkit.commands.perf.PerfBenchmark")
+    def test_cli_closes_benchmark_after_success(
+        self, mock_benchmark_class: MagicMock, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """Successful CLI runs release native sessions before process teardown."""
+        mock_result = BenchmarkResult(
+            config=BenchmarkConfig(model_id="test", output_path=tmp_path / "result.json"),
+            actual_device="cpu",
+            actual_task="cls",
+            mean_ms=1.0,
+            min_ms=1.0,
+            max_ms=1.0,
+            p50_ms=1.0,
+            p90_ms=1.0,
+            p95_ms=1.0,
+            p99_ms=1.0,
+            samples_per_sec=1.0,
+            batches_per_sec=1.0,
+        )
+        mock_instance = MagicMock()
+        mock_instance.run.return_value = mock_result
+        mock_benchmark_class.return_value = mock_instance
+
+        output_file = tmp_path / "result.json"
+
+        result = runner.invoke(
+            perf,
+            ["-m", "test", "--output", str(output_file)],
+            obj={},
+        )
+
+        assert result.exit_code == 0, result.output
+        mock_instance.close.assert_called_once()
 
 
 class TestDisplayConsoleReport:

--- a/tests/unit/compiler/test_compiler_stages.py
+++ b/tests/unit/compiler/test_compiler_stages.py
@@ -393,6 +393,7 @@ class TestCompileStageProcess:
 
         inference_session.assert_called_once()
         assert context.shared_session_options is session_options
+        assert context.session is None
 
     def test_process_preserves_trtrtx_provider_options(self, tmp_path):
         from unittest.mock import MagicMock, patch
@@ -431,6 +432,8 @@ class TestCompileStageProcess:
 
         passed_ep_config = mock_session_cls.call_args.kwargs["ep_config"]
         assert passed_ep_config.provider_options == {"device_type": "GPU", "precision": "fp16"}
+        fake_winml_session.reset.assert_called_once()
+        assert context.session is None
 
     def test_process_reconstructs_explicit_serialized_device(self, tmp_path):
         from unittest.mock import MagicMock, patch
@@ -1334,3 +1337,37 @@ class TestCompilerPipeline:
 
         assert result.success is True
         assert "passthrough" in result.warnings[0].lower()
+
+    def test_final_compile_releases_shared_session_options(self, tmp_path):
+        """The last compile in a run must not retain native ORT SessionOptions."""
+        from unittest.mock import MagicMock
+
+        from winml.modelkit.compiler import Compiler
+
+        model_path = tmp_path / "model.onnx"
+        create_simple_model(model_path)
+        shared_options = object()
+
+        class _Stage:
+            name = "fake"
+
+            @classmethod
+            def should_run(cls, _context):
+                return True
+
+            def process(self, context):
+                context.shared_session_options = shared_options
+                return context
+
+        old_stages = Compiler._stages
+        Compiler._stages = [_Stage]
+        try:
+            config = MagicMock()
+            config.to_dict.return_value = {"execution_provider": "qnn"}
+            config.verbose = False
+            compiler = Compiler()
+            compiler.compile(model_path, config=config)
+        finally:
+            Compiler._stages = old_stages
+
+        assert compiler.shared_session_options is None


### PR DESCRIPTION
Successful QNN perf/build runs can produce valid output but still leave ORT/QNN native objects alive until Python process teardown, which can surface as a Windows access-violation exit code. This change releases those native session references before the CLI and compiler paths return.

## Summary
- Add `PerfBenchmark.close()` and call it from `winml perf` in a `finally` block so single and composite model sessions are reset before process exit.
- Clear compiler `context.session` references after metadata/validation collection and reset `WinMLSession` instances after compile.
- Clear shared ORT `SessionOptions` after the final model in a compile run.
- Add regression coverage for perf cleanup, compiler session release, and final shared-session cleanup.

## Validation
- `uv tool run ruff check --fix src\winml\modelkit\commands\perf.py src\winml\modelkit\compiler\stages\compile.py src\winml\modelkit\compiler\compiler.py tests\unit\compiler\test_compiler_stages.py tests\unit\commands\test_perf_cli.py`
- `uv run --no-sync pytest tests\unit\commands\test_perf_cli.py::TestPerfUnifiedPipeline::test_close_releases_single_model_session tests\unit\commands\test_perf_cli.py::TestPerfUnifiedPipeline::test_close_releases_composite_sub_model_sessions tests\unit\commands\test_perf_cli.py::TestPerfFormatJson::test_cli_closes_benchmark_after_success tests\unit\compiler\test_compiler_stages.py::TestCompileStageProcess::test_ort_session_uses_inference_session_path tests\unit\compiler\test_compiler_stages.py::TestCompileStageProcess::test_process_preserves_trtrtx_provider_options tests\unit\compiler\test_compiler_stages.py::TestCompilerPipeline::test_final_compile_releases_shared_session_options`