### PR TITLE
Fix CPU EP resolution for bridge providers

### DIFF
--- a/src/winml/modelkit/config/build.py
+++ b/src/winml/modelkit/config/build.py
@@ -77,7 +77,7 @@ if TYPE_CHECKING:
     from torch import nn
 
     from ..eval.config import WinMLEvaluationConfig  # noqa: TC004
-    from ..utils.constants import EPName, EPNameOrAlias
+    from ..utils.constants import EPNameOrAlias
 
 __all__ = [
     "WinMLBuildConfig",
@@ -347,7 +347,7 @@ def _resolve_policy_target(device: str, ep: str | None) -> tuple[str, str | None
     available_eps = registry.available_eps()
     detection_error: RuntimeError | None = None
     for spec in EP_DEVICE_SPECS:
-        policy_devices = EP_SUPPORTED_DEVICES.get(cast("EPName", spec.ep), ())
+        policy_devices = EP_SUPPORTED_DEVICES[spec.ep]
         if (
             spec.device != detected_device
             or detected_device not in policy_devices

--- a/src/winml/modelkit/models/auto.py
+++ b/src/winml/modelkit/models/auto.py
@@ -63,6 +63,14 @@ def _get_cache_build_controls(
     return build_controls
 
 
+def _resolved_ep_short_name(ep_device: WinMLEPDevice) -> str:
+    """Short alias for the resolved catalog EP behind a runtime device handle."""
+    ep_short_name = getattr(ep_device, "ep_short_name", None)
+    if isinstance(ep_short_name, str):
+        return ep_short_name
+    return short_ep_name(ep_device.device.ep_name)
+
+
 # =============================================================================
 # WinMLAutoModel Factory
 # =============================================================================
@@ -203,7 +211,7 @@ class WinMLAutoModel:
             task=task,
             device=ep_device.device.device_type.lower(),
             precision=precision,
-            ep=short_ep_name(ep_device.device.ep_name),
+            ep=_resolved_ep_short_name(ep_device),
             override=config,
             no_compile=no_compile,
         )
@@ -264,7 +272,7 @@ class WinMLAutoModel:
             config=config,
             output_dir=output_dir,
             rebuild=force_rebuild,
-            ep=short_ep_name(ep_device.device.ep_name),
+            ep=_resolved_ep_short_name(ep_device),
             device=ep_device.device.device_type.lower(),
             cache_key=cache_key,
             **kwargs,
@@ -461,7 +469,7 @@ class WinMLAutoModel:
             shape_config=shape_config,
             device=ep_device.device.device_type.lower(),
             precision=precision,
-            ep=short_ep_name(ep_device.device.ep_name),
+            ep=_resolved_ep_short_name(ep_device),
             model_type=model_type,
             trust_remote_code=trust_remote_code,
             policy_overrides_config=True,
@@ -523,7 +531,7 @@ class WinMLAutoModel:
         if resolved_ep is None and config.compile is not None:
             resolved_ep = config.compile.ep_config.provider
         if resolved_ep is None:
-            resolved_ep = short_ep_name(ep_device.device.ep_name)
+            resolved_ep = _resolved_ep_short_name(ep_device)
         result = build_hf_model(
             config=config,
             output_dir=output_dir,

--- a/src/winml/modelkit/session/ep_device.py
+++ b/src/winml/modelkit/session/ep_device.py
@@ -43,6 +43,7 @@ from ..utils.constants import (
     EP_ALIASES,
     EP_NAMES,
     EP_SUPPORTED_DEVICES,
+    EPName,
     normalize_ep_name,
 )
 
@@ -446,7 +447,8 @@ def default_device_for_ep(ep: str) -> str | None:
 
 def _is_policy_supported_spec(spec: EPDeviceSpec) -> bool:
     """Return whether the shared EP/device policy accepts this catalog row."""
-    return spec.device in EP_SUPPORTED_DEVICES.get(spec.ep, ())
+    supported_devices = EP_SUPPORTED_DEVICES.get(cast("EPName", spec.ep))
+    return supported_devices is not None and spec.device in supported_devices
 
 
 def _devices_for_ep(ep: str) -> tuple[str, ...]:

--- a/src/winml/modelkit/session/ep_device.py
+++ b/src/winml/modelkit/session/ep_device.py
@@ -362,7 +362,7 @@ class EPDeviceSpec:
     Many EPDeviceTargets map to one EPDeviceSpec.
     """
 
-    ep: str
+    ep: EPName
     device: str
     default_provider_options: Mapping[str, str] = field(default_factory=dict)
 
@@ -447,8 +447,7 @@ def default_device_for_ep(ep: str) -> str | None:
 
 def _is_policy_supported_spec(spec: EPDeviceSpec) -> bool:
     """Return whether the shared EP/device policy accepts this catalog row."""
-    supported_devices = EP_SUPPORTED_DEVICES.get(cast("EPName", spec.ep))
-    return supported_devices is not None and spec.device in supported_devices
+    return spec.device in EP_SUPPORTED_DEVICES[spec.ep]
 
 
 def _devices_for_ep(ep: str) -> tuple[str, ...]:

--- a/src/winml/modelkit/session/ep_device.py
+++ b/src/winml/modelkit/session/ep_device.py
@@ -38,7 +38,13 @@ from typing import Any, Final, NamedTuple, cast
 
 import onnxruntime as ort
 
-from ..utils.constants import DEVICE_PRIORITY, EP_ALIASES, EP_NAMES, normalize_ep_name
+from ..utils.constants import (
+    DEVICE_PRIORITY,
+    EP_ALIASES,
+    EP_NAMES,
+    EP_SUPPORTED_DEVICES,
+    normalize_ep_name,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -438,9 +444,20 @@ def default_device_for_ep(ep: str) -> str | None:
     return next((s.device for s in EP_DEVICE_SPECS if s.ep == ep), None)
 
 
+def _is_policy_supported_spec(spec: EPDeviceSpec) -> bool:
+    """Return whether the shared EP/device policy accepts this catalog row."""
+    return spec.device in EP_SUPPORTED_DEVICES.get(spec.ep, ())
+
+
 def _devices_for_ep(ep: str) -> tuple[str, ...]:
     """Catalog-supported devices for *ep*, preserving declaration order."""
-    return tuple(dict.fromkeys(spec.device for spec in EP_DEVICE_SPECS if spec.ep == ep))
+    return tuple(
+        dict.fromkeys(
+            spec.device
+            for spec in EP_DEVICE_SPECS
+            if spec.ep == ep and _is_policy_supported_spec(spec)
+        )
+    )
 
 
 def default_ep_for_device(device: str) -> str | None:
@@ -482,6 +499,7 @@ def default_ep_for_device(device: str) -> str | None:
                 s.ep
                 for s in EP_DEVICE_SPECS
                 if s.device == device
+                and _is_policy_supported_spec(s)
                 and s.ep in eps  # L0: discovered
                 and EP_CATALOG.is_compatible(s.ep)  # L2: vendor-compatible
             ),
@@ -536,7 +554,11 @@ def available_eps_for_device(device: str) -> list[str]:
 
     d = device.lower()
     eps = WinMLEPRegistry.instance().available_eps()
-    return [s.ep for s in EP_DEVICE_SPECS if s.device == d and s.ep in eps]
+    return [
+        s.ep
+        for s in EP_DEVICE_SPECS
+        if s.device == d and _is_policy_supported_spec(s) and s.ep in eps
+    ]
 
 
 def ep_to_device(ep: str) -> str:
@@ -593,6 +615,7 @@ def auto_detect_device() -> str:
             for spec in EP_DEVICE_SPECS:
                 if (
                     spec.device != dev
+                    or not _is_policy_supported_spec(spec)
                     or spec.ep not in available_eps
                     or not EP_CATALOG.is_compatible(spec.ep)
                 ):
@@ -667,7 +690,7 @@ def resolve_device(target: EPDeviceTarget) -> EPDeviceTarget:
         available_eps = registry.available_eps()
         vendor_detection_failed = False
         for spec in EP_DEVICE_SPECS:
-            if spec.ep not in available_eps:
+            if spec.ep not in available_eps or not _is_policy_supported_spec(spec):
                 continue
             if vendor_detection_failed:
                 if spec.device != "cpu":
@@ -739,7 +762,11 @@ def resolve_device(target: EPDeviceTarget) -> EPDeviceTarget:
         selected_ep: str | None = None
         vendor_detection_failed = False
         for spec in EP_DEVICE_SPECS:
-            if spec.device != device or spec.ep not in available_eps:
+            if (
+                spec.device != device
+                or spec.ep not in available_eps
+                or not _is_policy_supported_spec(spec)
+            ):
                 continue
             try:
                 if not EP_CATALOG.is_compatible(spec.ep):

--- a/src/winml/modelkit/session/ep_registry.py
+++ b/src/winml/modelkit/session/ep_registry.py
@@ -272,7 +272,7 @@ class WinMLEPDevice:
     @property
     def ep_short_name(self) -> str:
         """Short EP alias (``"qnn"`` / ``"openvino"`` / ``"cpu"`` / ...)."""
-        return short_ep_name(self.device.ep_name)
+        return short_ep_name(self.ep.source.ep_name)
 
 
 class WinMLEPRegistry:

--- a/tests/unit/models/auto/test_auto_onnx.py
+++ b/tests/unit/models/auto/test_auto_onnx.py
@@ -14,17 +14,15 @@ Verifies:
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, ClassVar
+from pathlib import Path
+from typing import ClassVar
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from winml.modelkit.ep_path import BuiltinSource, EPEntry
 from winml.modelkit.models.auto import WinMLAutoModel
-from winml.modelkit.session import EPDeviceTarget
-
-
-if TYPE_CHECKING:
-    from pathlib import Path
+from winml.modelkit.session import EPDeviceTarget, WinMLDevice, WinMLEP, WinMLEPDevice
 
 
 @pytest.fixture()
@@ -50,6 +48,26 @@ def _make_build_result(tmp_path: Path) -> MagicMock:
     result.final_onnx_path = tmp_path / "model.onnx"
     result.output_dir = tmp_path
     return result
+
+
+def _make_cpu_ep_device_with_bridge_name() -> WinMLEPDevice:
+    """Resolved CPU target whose ORT handle reports a bridge provider name."""
+    ort_device = MagicMock()
+    ort_device.ep_name = "ONNXExecutionProvider"
+    ort_device.ep_metadata = {}
+    ort_device.ep_vendor = "Microsoft"
+    ort_device.device.type.name = "CPU"
+    ort_device.device.metadata = {}
+    ort_device.device.vendor = "Microsoft"
+
+    winml_device = WinMLDevice(ort_device)
+    entry = EPEntry(
+        ep_name="CPUExecutionProvider",
+        dll_path=Path(),
+        source=BuiltinSource(eps=("CPUExecutionProvider",)),
+    )
+    winml_ep = WinMLEP(source=entry, devices=(winml_device,), arg0=entry.ep_name)
+    return WinMLEPDevice(ep=winml_ep, device=winml_device)
 
 
 class TestFromOnnx:
@@ -156,6 +174,37 @@ class TestFromOnnx:
         call_kwargs = mock_build.call_args.kwargs
         assert call_kwargs["ep"] == "qnn"
         assert call_kwargs["device"] == "npu"
+
+    def test_uses_resolved_catalog_ep_when_runtime_handle_reports_bridge_provider(
+        self, fake_onnx: Path, tmp_path: Path
+    ) -> None:
+        """CPU builds use the resolved catalog EP, not ORT bridge handle names."""
+        ep_device = _make_cpu_ep_device_with_bridge_name()
+        mock_config = MagicMock()
+        mock_config.loader = None
+
+        with (
+            patch("winml.modelkit.onnx.is_compiled_onnx", return_value=False),
+            patch(
+                "winml.modelkit.config.generate_onnx_build_config",
+                return_value=mock_config,
+            ) as mock_generate_config,
+            patch("winml.modelkit.build.build_onnx_model") as mock_build,
+            patch("winml.modelkit.models.auto.get_winml_class") as mock_get_class,
+        ):
+            mock_build.return_value = _make_build_result(tmp_path)
+            mock_instance = MagicMock()
+            mock_get_class.return_value = lambda **kw: mock_instance
+
+            WinMLAutoModel.from_onnx(
+                fake_onnx,
+                ep_device=ep_device,
+                task="image-classification",
+            )
+
+        assert mock_generate_config.call_args.kwargs["ep"] == "cpu"
+        assert mock_build.call_args.kwargs["ep"] == "cpu"
+        assert mock_build.call_args.kwargs["device"] == "cpu"
 
     def test_passes_allow_unsupported_nodes_to_build(
         self, fake_onnx: Path, tmp_path: Path, cpu_ep_device: EPDeviceTarget

--- a/tests/unit/session/test_ep_device.py
+++ b/tests/unit/session/test_ep_device.py
@@ -311,6 +311,29 @@ def test_resolve_auto_ep_skips_failed_vendor_probe_for_cpu_fallback() -> None:
     assert result == EPDeviceTarget(ep="CPUExecutionProvider", device="cpu")
 
 
+def test_resolve_auto_ep_for_explicit_cpu_skips_policy_unsupported_candidates() -> None:
+    """A CPU device request must not pick EPs that policy rejects for CPU."""
+    from winml.modelkit.ep_path import EPCatalog
+    from winml.modelkit.session.ep_registry import WinMLEPRegistry
+
+    registry = MagicMock()
+    registry.available_eps.return_value = frozenset(
+        {
+            "QNNExecutionProvider",
+            "CPUExecutionProvider",
+        }
+    )
+    registry.auto_device.return_value = object()
+
+    with (
+        patch.object(WinMLEPRegistry, "instance", return_value=registry),
+        patch.object(EPCatalog, "is_compatible", return_value=True),
+    ):
+        result = resolve_device(EPDeviceTarget(ep="auto", device="cpu"))
+
+    assert result == EPDeviceTarget(ep="CPUExecutionProvider", device="cpu")
+
+
 # --- short_ep_name tests ---------------------------------------------------
 
 


### PR DESCRIPTION
When `--device cpu` resolves to a CPU target, ORT can still report bridge or fallback provider names that are not valid build-policy EPs for CPU. Passing those names into config/build policy made precision validation reject CPU selection even though the user explicitly requested CPU.

This fixes both parts of the resolution path:

- AutoModel/build routing now uses the resolved catalog EP short name from `WinMLEPDevice` instead of the raw runtime handle provider name.
- Session auto EP deduction now filters candidate catalog rows through the shared `EP_SUPPORTED_DEVICES` policy, so `--device cpu` skips QNN CPU fallback rows that build policy rejects and resolves to a CPU-supported EP.

Regression coverage includes CPU targets whose runtime handle reports `ONNXExecutionProvider` and explicit CPU auto-EP selection with QNN available.

**Validation**
- `uv run ruff check --fix src\winml\modelkit\session\ep_device.py tests\unit\session\test_ep_device.py`
- `uv run pytest tests\unit\session\test_ep_device.py tests\unit\session\test_ep_device_specs_order.py tests\unit\commands\test_ep_device_pair.py tests\unit\models\auto\test_from_pretrained_ep.py tests\unit\commands\test_perf_cli.py::TestPerfUnifiedPipeline -q`
- `uv run python -c "from winml.modelkit.session import EPDeviceTarget, resolve_device; print(resolve_device(EPDeviceTarget(ep='auto', device='cpu')))"`
- `uv run winml perf -m facebook/convnext-tiny-224 --device cpu`