### PR TITLE
Hide inspect warning noise

### DIFF
--- a/src/winml/modelkit/commands/inspect.py
+++ b/src/winml/modelkit/commands/inspect.py
@@ -16,6 +16,7 @@ Usage:
 
 from __future__ import annotations
 
+import importlib
 import logging
 from typing import TYPE_CHECKING
 
@@ -297,6 +298,8 @@ def inspect(
             from ..inspect import InspectError, ModelNotFoundError, NetworkError
             from ..inspect.formatter import output_json, output_table
 
+            _load_inspect_model_v2_dependencies()
+
         try:
             if quiet or json_mode:
                 result = _inspect_model_v2(
@@ -305,7 +308,7 @@ def inspect(
                     model_type_override=model_type,
                     model_class_override=model_class,
                     include_hierarchy=hierarchy,
-                    suppress_native_stderr_output=suppress_third_party_stderr,
+                    suppress_native_stderr_output=False,
                 )
             else:
                 with _stderr_console.status(
@@ -318,7 +321,7 @@ def inspect(
                         model_type_override=model_type,
                         model_class_override=model_class,
                         include_hierarchy=hierarchy,
-                        suppress_native_stderr_output=suppress_third_party_stderr,
+                        suppress_native_stderr_output=False,
                     )
 
             if output_format == "json":
@@ -338,6 +341,20 @@ def inspect(
         except (ValueError, RuntimeError, OSError) as e:
             logger.exception("Failed to inspect model")
             raise click.ClickException(f"Failed to inspect model: {e}") from e
+
+
+def _load_inspect_model_v2_dependencies() -> None:
+    """Preload inspect dependencies that can trigger native startup diagnostics."""
+    from transformers import AutoConfig as _AutoConfig  # noqa: F401
+
+    for module_name in (
+        "..export",
+        "..inspect",
+        "..inspect.formatter",
+        "..loader",
+        "..models",
+    ):
+        importlib.import_module(module_name, package=__package__)
 
 
 def _inspect_model_v2(
@@ -361,33 +378,35 @@ def _inspect_model_v2(
         InspectResult dataclass
     """
     with suppress_native_stderr(enabled=suppress_native_stderr_output):
-        import functools
+        _load_inspect_model_v2_dependencies()
 
-        from transformers import AutoConfig
+    import functools
 
-        from ..export import resolve_io_specs
-        from ..inspect import (
-            ExporterInfo,
-            InspectError,
-            InspectResult,
-            LoaderInfo,
-            ModelNotFoundError,
-            NetworkError,
-            SupportLevel,
-            TensorInfo,
-            build_tensor_infos_from_io_specs,
-            compile_support_status,
-            resolve_cache,
-            resolve_composite_info,
-            resolve_io_config,
-            resolve_processor,
-            resolve_winml,
-        )
-        from ..loader import HF_TASK_DEFAULTS, load_hf_config, resolve_loader_config
-        from ..models import (
-            HF_MODEL_CLASS_MAPPING,
-            MODEL_BUILD_CONFIGS,
-        )
+    from transformers import AutoConfig
+
+    from ..export import resolve_io_specs
+    from ..inspect import (
+        ExporterInfo,
+        InspectError,
+        InspectResult,
+        LoaderInfo,
+        ModelNotFoundError,
+        NetworkError,
+        SupportLevel,
+        TensorInfo,
+        build_tensor_infos_from_io_specs,
+        compile_support_status,
+        resolve_cache,
+        resolve_composite_info,
+        resolve_io_config,
+        resolve_processor,
+        resolve_winml,
+    )
+    from ..loader import HF_TASK_DEFAULTS, load_hf_config, resolve_loader_config
+    from ..models import (
+        HF_MODEL_CLASS_MAPPING,
+        MODEL_BUILD_CONFIGS,
+    )
 
     # =========================================================================
     # STEP 1: Load parent hf_config once and feed it into resolve_loader_config

--- a/src/winml/modelkit/commands/inspect.py
+++ b/src/winml/modelkit/commands/inspect.py
@@ -26,9 +26,11 @@ if TYPE_CHECKING:
 import click
 from rich.console import Console
 
+from .._env import env_flag_enabled
 from ..utils import cli as cli_utils
-from ..utils.logging import configure_logging
+from ..utils.logging import configure_logging, suppress_huggingface_warning_logs
 from ..utils.model_input import ModelInputKind, classify_model_input
+from ..utils.native_stderr import suppress_native_stderr
 
 
 logger = logging.getLogger(__name__)
@@ -288,50 +290,54 @@ def inspect(
     if not quiet and not json_mode:
         _stderr_console.print(f"[dim]Inspecting [bold]{target}[/bold] …[/dim]")
 
-    from ..inspect import InspectError, ModelNotFoundError, NetworkError
-    from ..inspect.formatter import output_json, output_table
-
+    suppress_third_party_stderr = not verbose and not env_flag_enabled("WINMLCLI_SHOW_ALL_WARNINGS")
     configure_logging(verbosity=verbose, quiet=quiet)
+    with suppress_huggingface_warning_logs(verbosity=verbose, quiet=quiet):
+        with suppress_native_stderr(enabled=suppress_third_party_stderr):
+            from ..inspect import InspectError, ModelNotFoundError, NetworkError
+            from ..inspect.formatter import output_json, output_table
 
-    try:
-        if quiet or json_mode:
-            result = _inspect_model_v2(
-                model_id=model,
-                task_override=task,
-                model_type_override=model_type,
-                model_class_override=model_class,
-                include_hierarchy=hierarchy,
-            )
-        else:
-            with _stderr_console.status(
-                f"[bold cyan]Resolving {target}…[/bold cyan]",
-                spinner="dots",
-            ):
+        try:
+            if quiet or json_mode:
                 result = _inspect_model_v2(
                     model_id=model,
                     task_override=task,
                     model_type_override=model_type,
                     model_class_override=model_class,
                     include_hierarchy=hierarchy,
+                    suppress_native_stderr_output=suppress_third_party_stderr,
                 )
+            else:
+                with _stderr_console.status(
+                    f"[bold cyan]Resolving {target}…[/bold cyan]",
+                    spinner="dots",
+                ):
+                    result = _inspect_model_v2(
+                        model_id=model,
+                        task_override=task,
+                        model_type_override=model_type,
+                        model_class_override=model_class,
+                        include_hierarchy=hierarchy,
+                        suppress_native_stderr_output=suppress_third_party_stderr,
+                    )
 
-        if output_format == "json":
-            click.echo(output_json(result, verbose=bool(verbose)))
-        else:
-            output_table(console, result, verbose=bool(verbose))
+            if output_format == "json":
+                click.echo(output_json(result, verbose=bool(verbose)))
+            else:
+                output_table(console, result, verbose=bool(verbose))
 
-    except ModelNotFoundError as e:
-        raise click.ClickException(f"Model not found: {e}") from e
+        except ModelNotFoundError as e:
+            raise click.ClickException(f"Model not found: {e}") from e
 
-    except NetworkError as e:
-        raise click.ClickException(f"Network error: {e}") from e
+        except NetworkError as e:
+            raise click.ClickException(f"Network error: {e}") from e
 
-    except InspectError as e:
-        raise click.ClickException(f"Inspection error: {e}") from e
+        except InspectError as e:
+            raise click.ClickException(f"Inspection error: {e}") from e
 
-    except (ValueError, RuntimeError, OSError) as e:
-        logger.exception("Failed to inspect model")
-        raise click.ClickException(f"Failed to inspect model: {e}") from e
+        except (ValueError, RuntimeError, OSError) as e:
+            logger.exception("Failed to inspect model")
+            raise click.ClickException(f"Failed to inspect model: {e}") from e
 
 
 def _inspect_model_v2(
@@ -340,6 +346,7 @@ def _inspect_model_v2(
     model_type_override: str | None = None,
     model_class_override: str | None = None,
     include_hierarchy: bool = False,
+    suppress_native_stderr_output: bool = True,
 ) -> InspectResult:
     """Inspect v2 core — calls shared loader/export modules directly.
 
@@ -353,33 +360,34 @@ def _inspect_model_v2(
     Returns:
         InspectResult dataclass
     """
-    import functools
+    with suppress_native_stderr(enabled=suppress_native_stderr_output):
+        import functools
 
-    from transformers import AutoConfig
+        from transformers import AutoConfig
 
-    from ..export import resolve_io_specs
-    from ..inspect import (
-        ExporterInfo,
-        InspectError,
-        InspectResult,
-        LoaderInfo,
-        ModelNotFoundError,
-        NetworkError,
-        SupportLevel,
-        TensorInfo,
-        build_tensor_infos_from_io_specs,
-        compile_support_status,
-        resolve_cache,
-        resolve_composite_info,
-        resolve_io_config,
-        resolve_processor,
-        resolve_winml,
-    )
-    from ..loader import HF_TASK_DEFAULTS, load_hf_config, resolve_loader_config
-    from ..models import (
-        HF_MODEL_CLASS_MAPPING,
-        MODEL_BUILD_CONFIGS,
-    )
+        from ..export import resolve_io_specs
+        from ..inspect import (
+            ExporterInfo,
+            InspectError,
+            InspectResult,
+            LoaderInfo,
+            ModelNotFoundError,
+            NetworkError,
+            SupportLevel,
+            TensorInfo,
+            build_tensor_infos_from_io_specs,
+            compile_support_status,
+            resolve_cache,
+            resolve_composite_info,
+            resolve_io_config,
+            resolve_processor,
+            resolve_winml,
+        )
+        from ..loader import HF_TASK_DEFAULTS, load_hf_config, resolve_loader_config
+        from ..models import (
+            HF_MODEL_CLASS_MAPPING,
+            MODEL_BUILD_CONFIGS,
+        )
 
     # =========================================================================
     # STEP 1: Load parent hf_config once and feed it into resolve_loader_config

--- a/src/winml/modelkit/utils/logging.py
+++ b/src/winml/modelkit/utils/logging.py
@@ -63,7 +63,6 @@ _HUGGINGFACE_WARNING_LOGGERS = (
     "transformers",
 )
 _HUGGINGFACE_VERBOSITY_ENVS = ("TRANSFORMERS_VERBOSITY", "HF_HUB_VERBOSITY")
-_MISSING = object()
 
 
 def configure_logging(
@@ -136,7 +135,7 @@ def suppress_huggingface_warning_logs(
     saved_logger_levels = {
         name: logging.getLogger(name).level for name in _HUGGINGFACE_WARNING_LOGGERS
     }
-    saved_env = {name: os.environ.get(name, _MISSING) for name in _HUGGINGFACE_VERBOSITY_ENVS}
+    saved_env = {name: os.environ.get(name) for name in _HUGGINGFACE_VERBOSITY_ENVS}
     saved_library_verbosity = _get_imported_huggingface_verbosity()
 
     try:
@@ -150,7 +149,7 @@ def suppress_huggingface_warning_logs(
         yield
     finally:
         for env_name, value in saved_env.items():
-            if value is _MISSING:
+            if value is None:
                 os.environ.pop(env_name, None)
             else:
                 os.environ[env_name] = value

--- a/src/winml/modelkit/utils/logging.py
+++ b/src/winml/modelkit/utils/logging.py
@@ -27,7 +27,16 @@ Sample line: ``[14:32:11 INFO    winml.modelkit.export] Loaded config.json``
 """
 
 import logging
+import os
 import sys
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+from .._env import env_flag_enabled
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 _HANDLER_MARKER = "_winml_cli_handler"
@@ -48,6 +57,13 @@ _NOISY_LIBRARY_LOGGERS = (
     "onnxscript.version_converter",
     "torch.onnx._internal.exporter._compat",
 )
+
+_HUGGINGFACE_WARNING_LOGGERS = (
+    "huggingface_hub",
+    "transformers",
+)
+_HUGGINGFACE_VERBOSITY_ENVS = ("TRANSFORMERS_VERBOSITY", "HF_HUB_VERBOSITY")
+_MISSING = object()
 
 
 def configure_logging(
@@ -71,12 +87,8 @@ def configure_logging(
                  True and verbosity is 0. Existing callers that pass
                  ``verbose=True`` keep working without changes.
     """
-    # Backward compat: bool verbose → int, also handles count passthrough
-    if verbose and verbosity == 0:
-        verbosity = int(verbose)
-
-    # Clamp between DEBUG (10) and WARNING (30); quiet overrides to ERROR
-    log_level = logging.ERROR if quiet else max(logging.DEBUG, logging.WARNING - verbosity * 10)
+    verbosity = _normalize_verbosity(verbosity, verbose)
+    log_level = _cli_log_level(verbosity, quiet)
 
     root = logging.getLogger()
     # Drop any prior WinML handler and install a fresh one bound to the
@@ -98,12 +110,116 @@ def configure_logging(
     root.setLevel(log_level)
 
     # Keep noisy third-party library chatter out of normal output. Their loggers float
-    # up to the CLI level only when the user opts into verbosity (-v/-vv); otherwise they
-    # are pinned at ERROR so library notices never leak into / interleave with output.
-    # (verbose=True is folded into verbosity above, so verbosity > 0 covers it.)
-    library_level = log_level if verbosity > 0 else logging.ERROR
+    # up to the CLI level only when the user opts into verbosity (-v/-vv) or explicitly
+    # asks for all warnings; otherwise they are pinned at ERROR so library notices never
+    # leak into / interleave with output. (verbose=True is folded into verbosity above,
+    # so verbosity > 0 covers it.)
+    show_all_warnings = env_flag_enabled("WINMLCLI_SHOW_ALL_WARNINGS")
+    library_level = log_level if verbosity > 0 or show_all_warnings else logging.ERROR
     for name in _NOISY_LIBRARY_LOGGERS:
         logging.getLogger(name).setLevel(library_level)
+
+
+@contextmanager
+def suppress_huggingface_warning_logs(
+    verbosity: int = 0,
+    quiet: bool = False,
+    *,
+    verbose: bool = False,
+) -> "Iterator[None]":
+    """Temporarily hide Hugging Face warning chatter for an inspect operation."""
+    verbosity = _normalize_verbosity(verbosity, verbose)
+    log_level = _cli_log_level(verbosity, quiet)
+    show_all_warnings = env_flag_enabled("WINMLCLI_SHOW_ALL_WARNINGS")
+    huggingface_level = log_level if verbosity > 0 or show_all_warnings else logging.ERROR
+
+    saved_logger_levels = {
+        name: logging.getLogger(name).level for name in _HUGGINGFACE_WARNING_LOGGERS
+    }
+    saved_env = {name: os.environ.get(name, _MISSING) for name in _HUGGINGFACE_VERBOSITY_ENVS}
+    saved_library_verbosity = _get_imported_huggingface_verbosity()
+
+    try:
+        for name in _HUGGINGFACE_WARNING_LOGGERS:
+            logging.getLogger(name).setLevel(huggingface_level)
+
+        library_verbosity = _library_verbosity_name(huggingface_level)
+        for env_name in _HUGGINGFACE_VERBOSITY_ENVS:
+            os.environ[env_name] = library_verbosity
+        _sync_imported_huggingface_verbosity(huggingface_level)
+        yield
+    finally:
+        for env_name, value in saved_env.items():
+            if value is _MISSING:
+                os.environ.pop(env_name, None)
+            else:
+                os.environ[env_name] = value
+        _restore_imported_huggingface_verbosity(saved_library_verbosity)
+        for name, level in saved_logger_levels.items():
+            logging.getLogger(name).setLevel(level)
+
+
+def _normalize_verbosity(verbosity: int, verbose: bool) -> int:
+    # Backward compat: bool verbose -> int, also handles count passthrough.
+    if verbose and verbosity == 0:
+        return int(verbose)
+    return verbosity
+
+
+def _cli_log_level(verbosity: int, quiet: bool) -> int:
+    # Clamp between DEBUG (10) and WARNING (30); quiet overrides to ERROR.
+    return logging.ERROR if quiet else max(logging.DEBUG, logging.WARNING - verbosity * 10)
+
+
+def _library_verbosity_name(level: int) -> str:
+    if level <= logging.DEBUG:
+        return "debug"
+    if level <= logging.INFO:
+        return "info"
+    if level <= logging.WARNING:
+        return "warning"
+    if level <= logging.ERROR:
+        return "error"
+    return "critical"
+
+
+def _sync_imported_huggingface_verbosity(verbosity: int) -> None:
+    if sys.modules.get("transformers") is not None:
+        from transformers.utils import logging as transformers_logging
+
+        transformers_logging.set_verbosity(verbosity)
+
+    if sys.modules.get("huggingface_hub") is not None:
+        from huggingface_hub.utils import logging as hub_logging
+
+        hub_logging.set_verbosity(verbosity)
+
+
+def _get_imported_huggingface_verbosity() -> dict[str, int]:
+    saved: dict[str, int] = {}
+    if sys.modules.get("transformers") is not None:
+        from transformers.utils import logging as transformers_logging
+
+        saved["transformers"] = transformers_logging.get_verbosity()
+
+    if sys.modules.get("huggingface_hub") is not None:
+        from huggingface_hub.utils import logging as hub_logging
+
+        saved["huggingface_hub"] = hub_logging.get_verbosity()
+
+    return saved
+
+
+def _restore_imported_huggingface_verbosity(saved: dict[str, int]) -> None:
+    if "transformers" in saved and sys.modules.get("transformers") is not None:
+        from transformers.utils import logging as transformers_logging
+
+        transformers_logging.set_verbosity(saved["transformers"])
+
+    if "huggingface_hub" in saved and sys.modules.get("huggingface_hub") is not None:
+        from huggingface_hub.utils import logging as hub_logging
+
+        hub_logging.set_verbosity(saved["huggingface_hub"])
 
 
 def flush_ort_startup_logs() -> None:

--- a/src/winml/modelkit/utils/native_stderr.py
+++ b/src/winml/modelkit/utils/native_stderr.py
@@ -53,8 +53,11 @@ if sys.platform == "win32":
 
 
 @contextmanager
-def suppress_native_stderr() -> Iterator[None]:
+def suppress_native_stderr(*, enabled: bool = True) -> Iterator[None]:
     """Redirect native stderr to devnull.  No-op on non-Windows."""
+    if not enabled:
+        yield
+        return
     if sys.platform != "win32":
         yield
         return

--- a/tests/cli/test_import_time.py
+++ b/tests/cli/test_import_time.py
@@ -411,6 +411,18 @@ class TestCommandHelp:
         """
         assert_cli_no_heavy_imports(["inspect", "--list-tasks"])
 
+    def test_inspect_model_type_hides_onnxruntime_startup_warning(self) -> None:
+        """``winml inspect --model-type`` must not leak ORT native warning noise."""
+        script = textwrap.dedent("""\
+            from winml.modelkit.cli import main
+
+            main(["inspect", "--model-type", "bert", "--format", "json"], standalone_mode=False)
+        """)
+        result = _run_in_subprocess(script)
+        assert result.returncode == 0, result.stderr.strip()
+        assert "Init provider bridge failed" not in result.stderr
+        assert "onnxruntime" not in result.stderr
+
 
 class TestCommandWithModel:
     """Verify import budgets when commands are invoked with --model.

--- a/tests/unit/commands/test_inspect_cli.py
+++ b/tests/unit/commands/test_inspect_cli.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 import os
+from contextlib import contextmanager
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
@@ -275,18 +276,95 @@ class TestInspectFlagCombinations:
         self,
         runner: CliRunner,
         mock_inspect_result: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        from winml.modelkit.commands.inspect import inspect
+        from winml.modelkit.commands import inspect as inspect_module
+
+        suppression_active = False
+        preload_called_under_suppression = False
+        original_suppress_native_stderr = inspect_module.suppress_native_stderr
+
+        @contextmanager
+        def _track_suppress_native_stderr(*args, **kwargs):
+            nonlocal suppression_active
+            with original_suppress_native_stderr(*args, **kwargs):
+                suppression_active = kwargs.get("enabled", True)
+                try:
+                    yield
+                finally:
+                    suppression_active = False
+
+        def _preload_dependencies():
+            nonlocal preload_called_under_suppression
+            preload_called_under_suppression = suppression_active
+
+        monkeypatch.setattr(inspect_module, "suppress_native_stderr", _track_suppress_native_stderr)
+        monkeypatch.setattr(
+            inspect_module,
+            "_load_inspect_model_v2_dependencies",
+            _preload_dependencies,
+        )
 
         with (
             patch(_INSPECT_MODEL, return_value=mock_inspect_result) as mock_api,
             patch(_OUTPUT_TABLE),
         ):
-            result = runner.invoke(inspect, ["-m", "test"], obj={})
+            result = runner.invoke(inspect_module.inspect, ["-m", "test"], obj={})
 
         assert result.exit_code == 0, f"Failed: {result.output}"
+        assert preload_called_under_suppression
         _, call_kwargs = mock_api.call_args
-        assert call_kwargs["suppress_native_stderr_output"] is True
+        assert call_kwargs["suppress_native_stderr_output"] is False
+
+    def test_default_inspection_does_not_suppress_status_stderr(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from winml.modelkit.commands import inspect as inspect_module
+
+        status_active = False
+        native_suppressed_while_status_active = False
+        original_suppress_native_stderr = inspect_module.suppress_native_stderr
+
+        @contextmanager
+        def _track_suppress_native_stderr(*args, **kwargs):
+            nonlocal native_suppressed_while_status_active
+            enabled = kwargs.get("enabled", True)
+            if enabled and status_active:
+                native_suppressed_while_status_active = True
+            with original_suppress_native_stderr(*args, **kwargs):
+                yield
+
+        class _Status:
+            def __enter__(self):
+                nonlocal status_active
+                status_active = True
+
+            def __exit__(self, exc_type, exc, traceback):
+                nonlocal status_active
+                status_active = False
+                return False
+
+        class _StderrConsole:
+            def print(self, *args, **kwargs):
+                pass
+
+            def status(self, *args, **kwargs):
+                return _Status()
+
+        monkeypatch.setattr(inspect_module, "_stderr_console", _StderrConsole())
+        monkeypatch.setattr(inspect_module, "suppress_native_stderr", _track_suppress_native_stderr)
+
+        with patch(_OUTPUT_TABLE):
+            result = runner.invoke(
+                inspect_module.inspect,
+                ["--model-type", "bert", "--task", "fill-mask"],
+                obj={},
+            )
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert not native_suppressed_while_status_active
 
     def test_default_inspection_suppresses_huggingface_warning_logs(
         self,

--- a/tests/unit/commands/test_inspect_cli.py
+++ b/tests/unit/commands/test_inspect_cli.py
@@ -10,6 +10,8 @@ NO actual HuggingFace downloads or model loading.
 
 from __future__ import annotations
 
+import logging
+import os
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
@@ -268,6 +270,119 @@ class TestInspectFlagCombinations:
             # output_table(console, result, verbose=verbose)
             _, call_kwargs = mock_table.call_args
             assert call_kwargs["verbose"] is False
+
+    def test_default_inspection_suppresses_native_stderr_import_noise(
+        self,
+        runner: CliRunner,
+        mock_inspect_result: MagicMock,
+    ) -> None:
+        from winml.modelkit.commands.inspect import inspect
+
+        with (
+            patch(_INSPECT_MODEL, return_value=mock_inspect_result) as mock_api,
+            patch(_OUTPUT_TABLE),
+        ):
+            result = runner.invoke(inspect, ["-m", "test"], obj={})
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        _, call_kwargs = mock_api.call_args
+        assert call_kwargs["suppress_native_stderr_output"] is True
+
+    def test_default_inspection_suppresses_huggingface_warning_logs(
+        self,
+        runner: CliRunner,
+        mock_inspect_result: MagicMock,
+    ) -> None:
+        from winml.modelkit.commands.inspect import inspect
+
+        def _emit_warning_logs(*args, **kwargs):
+            logging.getLogger("huggingface_hub.utils._http").warning(
+                "Warning: You are sending unauthenticated requests to the HF Hub."
+            )
+            logging.getLogger("transformers").warning("The `use_fast` parameter is deprecated.")
+            return mock_inspect_result
+
+        with (
+            patch(_INSPECT_MODEL, side_effect=_emit_warning_logs),
+            patch(_OUTPUT_TABLE),
+        ):
+            result = runner.invoke(inspect, ["-m", "test"], obj={})
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "unauthenticated requests" not in result.output
+        assert "use_fast" not in result.output
+        assert "unauthenticated requests" not in result.stderr
+        assert "use_fast" not in result.stderr
+
+    def test_default_inspection_restores_huggingface_warning_state(
+        self,
+        runner: CliRunner,
+        mock_inspect_result: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from winml.modelkit.commands.inspect import inspect
+
+        logger_levels = {
+            "huggingface_hub": logging.WARNING,
+            "transformers": logging.NOTSET,
+        }
+        saved_levels = {name: logging.getLogger(name).level for name in logger_levels}
+        try:
+            monkeypatch.setenv("TRANSFORMERS_VERBOSITY", "warning")
+            monkeypatch.delenv("HF_HUB_VERBOSITY", raising=False)
+
+            with (
+                patch(_INSPECT_MODEL, return_value=mock_inspect_result),
+                patch(_OUTPUT_TABLE),
+            ):
+                for name, level in logger_levels.items():
+                    logging.getLogger(name).setLevel(level)
+                result = runner.invoke(inspect, ["-m", "test"], obj={})
+
+            assert result.exit_code == 0, f"Failed: {result.output}"
+            assert logging.getLogger("huggingface_hub").level == logging.WARNING
+            assert logging.getLogger("transformers").level == logging.NOTSET
+            assert os.environ["TRANSFORMERS_VERBOSITY"] == "warning"
+            assert "HF_HUB_VERBOSITY" not in os.environ
+        finally:
+            for name, level in saved_levels.items():
+                logging.getLogger(name).setLevel(level)
+
+    def test_verbose_inspection_keeps_native_stderr_visible(
+        self,
+        runner: CliRunner,
+        mock_inspect_result: MagicMock,
+    ) -> None:
+        from winml.modelkit.commands.inspect import inspect
+
+        with (
+            patch(_INSPECT_MODEL, return_value=mock_inspect_result) as mock_api,
+            patch(_OUTPUT_TABLE),
+        ):
+            result = runner.invoke(inspect, ["-m", "test", "-v"], obj={})
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        _, call_kwargs = mock_api.call_args
+        assert call_kwargs["suppress_native_stderr_output"] is False
+
+    def test_show_all_warnings_keeps_native_stderr_visible(
+        self,
+        runner: CliRunner,
+        mock_inspect_result: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from winml.modelkit.commands.inspect import inspect
+
+        monkeypatch.setenv("WINMLCLI_SHOW_ALL_WARNINGS", "1")
+        with (
+            patch(_INSPECT_MODEL, return_value=mock_inspect_result) as mock_api,
+            patch(_OUTPUT_TABLE),
+        ):
+            result = runner.invoke(inspect, ["-m", "test"], obj={})
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        _, call_kwargs = mock_api.call_args
+        assert call_kwargs["suppress_native_stderr_output"] is False
 
 
 # =============================================================================

--- a/tests/unit/utils/test_logging.py
+++ b/tests/unit/utils/test_logging.py
@@ -5,23 +5,40 @@
 """Unit tests for configure_logging — third-party logger noise control."""
 
 import logging
+import os
+import sys
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
-from winml.modelkit.utils.logging import _NOISY_LIBRARY_LOGGERS, configure_logging
+from winml.modelkit.utils.logging import (
+    _HUGGINGFACE_WARNING_LOGGERS,
+    _NOISY_LIBRARY_LOGGERS,
+    configure_logging,
+    suppress_huggingface_warning_logs,
+)
+
+
+_MISSING = object()
+_HUGGINGFACE_VERBOSITY_ENVS = ("TRANSFORMERS_VERBOSITY", "HF_HUB_VERBOSITY")
 
 
 @pytest.fixture(autouse=True)
-def _restore_logger_levels():
-    """configure_logging mutates global logger state (root + the noisy library loggers);
-    restore all of them after each test so verbosity changes don't leak across tests."""
+def _restore_logging_state():
+    """Restore global logger/env state mutated by configure_logging."""
     saved = [(logging.getLogger(), logging.getLogger().level)]
-    for name in _NOISY_LIBRARY_LOGGERS:
+    for name in (*_NOISY_LIBRARY_LOGGERS, *_HUGGINGFACE_WARNING_LOGGERS):
         logger = logging.getLogger(name)
         saved.append((logger, logger.level))
+    saved_env = {name: os.environ.get(name, _MISSING) for name in _HUGGINGFACE_VERBOSITY_ENVS}
     yield
     for logger, level in saved:
         logger.setLevel(level)
+    for name, value in saved_env.items():
+        if value is _MISSING:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = value
 
 
 def test_library_loggers_floored_at_error_in_normal_mode():
@@ -100,3 +117,158 @@ def test_torch_compat_opset_notice_revealed_when_verbose(verbosity, expected):
     configure_logging(verbosity=verbosity)
     assert logger.level == expected
     assert logger.isEnabledFor(logging.WARNING)
+
+
+@pytest.mark.parametrize("logger_name", _HUGGINGFACE_WARNING_LOGGERS)
+def test_huggingface_warning_loggers_not_floored_by_default(logger_name):
+    logger = logging.getLogger(logger_name)
+    logger.setLevel(logging.NOTSET)
+
+    configure_logging(verbosity=0)
+
+    assert logger.isEnabledFor(logging.WARNING)
+
+
+@pytest.mark.parametrize("logger_name", _HUGGINGFACE_WARNING_LOGGERS)
+def test_huggingface_warning_loggers_floored_when_requested(logger_name):
+    # Transformers emits cosmetic image-processor deprecation notices and
+    # huggingface_hub emits unauthenticated-download warnings at WARNING. They
+    # should not interleave with inspect's normal progress output.
+    with suppress_huggingface_warning_logs(verbosity=0):
+        assert not logging.getLogger(logger_name).isEnabledFor(logging.WARNING)
+
+
+@pytest.mark.parametrize("logger_name", _HUGGINGFACE_WARNING_LOGGERS)
+@pytest.mark.parametrize("verbosity,expected", [(1, logging.INFO), (2, logging.DEBUG)])
+def test_huggingface_warning_loggers_revealed_when_verbose(logger_name, verbosity, expected):
+    logger = logging.getLogger(logger_name)
+
+    with suppress_huggingface_warning_logs(verbosity=0):
+        assert not logger.isEnabledFor(logging.WARNING)
+
+    with suppress_huggingface_warning_logs(verbosity=verbosity):
+        assert logger.level == expected
+        assert logger.isEnabledFor(logging.WARNING)
+
+
+@pytest.mark.parametrize("logger_name", _HUGGINGFACE_WARNING_LOGGERS)
+def test_show_all_warnings_env_reveals_huggingface_loggers(monkeypatch, logger_name):
+    monkeypatch.setenv("WINMLCLI_SHOW_ALL_WARNINGS", "1")
+
+    with suppress_huggingface_warning_logs(verbosity=0):
+        logger = logging.getLogger(logger_name)
+        assert logger.level == logging.WARNING
+        assert logger.isEnabledFor(logging.WARNING)
+
+
+@pytest.mark.parametrize("env_name", ["TRANSFORMERS_VERBOSITY", "HF_HUB_VERBOSITY"])
+def test_default_logging_does_not_mutate_huggingface_library_verbosity(monkeypatch, env_name):
+    monkeypatch.delenv("WINMLCLI_SHOW_ALL_WARNINGS", raising=False)
+    monkeypatch.delenv(env_name, raising=False)
+
+    configure_logging(verbosity=0)
+
+    assert env_name not in os.environ
+
+
+@pytest.mark.parametrize("env_name", ["TRANSFORMERS_VERBOSITY", "HF_HUB_VERBOSITY"])
+def test_requested_suppression_sets_huggingface_library_verbosity_to_error(monkeypatch, env_name):
+    monkeypatch.delenv("WINMLCLI_SHOW_ALL_WARNINGS", raising=False)
+    monkeypatch.delenv(env_name, raising=False)
+
+    with suppress_huggingface_warning_logs(verbosity=0):
+        assert os.environ[env_name] == "error"
+
+    assert env_name not in os.environ
+
+
+@pytest.mark.parametrize(
+    ("verbosity", "expected"),
+    [
+        (1, "info"),
+        (2, "debug"),
+    ],
+)
+@pytest.mark.parametrize("env_name", ["TRANSFORMERS_VERBOSITY", "HF_HUB_VERBOSITY"])
+def test_verbose_logging_sets_huggingface_library_verbosity(
+    monkeypatch, env_name, verbosity, expected
+):
+    monkeypatch.delenv("WINMLCLI_SHOW_ALL_WARNINGS", raising=False)
+    monkeypatch.delenv(env_name, raising=False)
+
+    with suppress_huggingface_warning_logs(verbosity=verbosity):
+        assert os.environ[env_name] == expected
+
+    assert env_name not in os.environ
+
+
+@pytest.mark.parametrize("env_name", ["TRANSFORMERS_VERBOSITY", "HF_HUB_VERBOSITY"])
+def test_show_all_warnings_sets_huggingface_library_verbosity_to_warning(monkeypatch, env_name):
+    monkeypatch.setenv("WINMLCLI_SHOW_ALL_WARNINGS", "1")
+    monkeypatch.delenv(env_name, raising=False)
+
+    with suppress_huggingface_warning_logs(verbosity=0):
+        assert os.environ[env_name] == "warning"
+
+    assert env_name not in os.environ
+
+
+def test_huggingface_warning_context_restores_logger_levels():
+    baseline = {
+        "huggingface_hub": logging.WARNING,
+        "transformers": logging.NOTSET,
+    }
+    for name, level in baseline.items():
+        logging.getLogger(name).setLevel(level)
+
+    with suppress_huggingface_warning_logs(verbosity=0):
+        assert logging.getLogger("huggingface_hub").level == logging.ERROR
+        assert logging.getLogger("transformers").level == logging.ERROR
+
+    for name, level in baseline.items():
+        assert logging.getLogger(name).level == level
+
+
+@pytest.mark.parametrize("env_name", ["TRANSFORMERS_VERBOSITY", "HF_HUB_VERBOSITY"])
+def test_huggingface_warning_context_restores_existing_env_values(monkeypatch, env_name):
+    monkeypatch.delenv("WINMLCLI_SHOW_ALL_WARNINGS", raising=False)
+    monkeypatch.setenv(env_name, "warning")
+
+    with suppress_huggingface_warning_logs(verbosity=0):
+        assert os.environ[env_name] == "error"
+
+    assert os.environ[env_name] == "warning"
+
+
+def test_huggingface_warning_context_restores_imported_library_verbosity(monkeypatch):
+    transformers_state = _install_fake_huggingface_logging(
+        monkeypatch, "transformers", logging.WARNING
+    )
+    hub_state = _install_fake_huggingface_logging(monkeypatch, "huggingface_hub", logging.INFO)
+
+    with suppress_huggingface_warning_logs(verbosity=0):
+        assert transformers_state.level == logging.ERROR
+        assert hub_state.level == logging.ERROR
+
+    assert transformers_state.level == logging.WARNING
+    assert hub_state.level == logging.INFO
+
+
+def _install_fake_huggingface_logging(
+    monkeypatch: pytest.MonkeyPatch,
+    package_name: str,
+    initial_level: int,
+) -> SimpleNamespace:
+    state = SimpleNamespace(level=initial_level)
+    logging_api = SimpleNamespace(
+        get_verbosity=lambda: state.level,
+        set_verbosity=lambda level: setattr(state, "level", level),
+    )
+    package = ModuleType(package_name)
+    utils = ModuleType(f"{package_name}.utils")
+    utils.logging = logging_api
+    package.utils = utils
+
+    monkeypatch.setitem(sys.modules, package_name, package)
+    monkeypatch.setitem(sys.modules, f"{package_name}.utils", utils)
+    return state

--- a/tests/unit/utils/test_native_stderr.py
+++ b/tests/unit/utils/test_native_stderr.py
@@ -32,6 +32,11 @@ class TestSuppressNativeStderr:
         os.write(2, b"after\n")
         assert "after" in capfd.readouterr().err
 
+    def test_disabled_leaves_native_stderr_visible(self, capfd):
+        with suppress_native_stderr(enabled=False):
+            os.write(2, b"visible when disabled\n")
+        assert "visible when disabled" in capfd.readouterr().err
+
     @pytest.mark.skipif(sys.platform != "win32", reason="Win32 only")
     def test_win32_std_error_handle_restored(self):
         import ctypes.wintypes


### PR DESCRIPTION
## Summary
- Hide Hugging Face, Transformers, and native ONNX Runtime warning noise during normal `winml inspect` runs.
- Preserve diagnostics through `-v`, `-vv`, and `WINMLCLI_SHOW_ALL_WARNINGS=1`.
- Scope Hugging Face warning suppression to inspect and restore logger/env/library verbosity state afterward.
- Add regression coverage for suppression, opt-outs, native stderr behavior, and state restoration.

## Validation
- `python -m ruff check src\winml\modelkit\commands\inspect.py src\winml\modelkit\utils\logging.py src\winml\modelkit\utils\native_stderr.py tests\cli\test_import_time.py tests\unit\commands\test_inspect_cli.py tests\unit\utils\test_logging.py tests\unit\utils\test_native_stderr.py`
- `python -m pytest tests\unit\utils\test_logging.py tests\unit\commands\test_inspect_cli.py tests\unit\utils\test_native_stderr.py tests\cli\test_import_time.py::TestCommandHelp::test_inspect_model_type_hides_onnxruntime_startup_warning -q`
- `python -m winml.modelkit inspect -m facebook/convnext-tiny-224` default / `-v` / `WINMLCLI_SHOW_ALL_WARNINGS=1` smoke checks