### PR TITLE
feat(hf): add BiRefNet image segmentation support

### DIFF
--- a/src/winml/modelkit/commands/build.py
+++ b/src/winml/modelkit/commands/build.py
@@ -1993,6 +1993,7 @@ def _build_hf_pipeline(
 
     max_iters: int = extra_kwargs.pop("hack_max_optim_iterations", 3)
     allow_unsupported_nodes: bool = extra_kwargs.pop("allow_unsupported_nodes", False)
+    skip_optimize: bool = extra_kwargs.pop("skip_optimize", False)
     model_label = model_id or "random-init"
 
     # ── Validate + setup ─────────────────────────────────────────
@@ -2051,6 +2052,7 @@ def _build_hf_pipeline(
             model_id=model_label,
             task=config.loader.task,
             verbose=False,
+            normalize=not (skip_optimize or config.skip_optimize),
             use_external_data=True,
         )
         _export_elapsed = time.monotonic() - t0
@@ -2078,6 +2080,7 @@ def _build_hf_pipeline(
         show_io_first=False,
         analyze_output_path=analyze_result_path,
         allow_unsupported_nodes=allow_unsupported_nodes,
+        skip_optimize=skip_optimize or config.skip_optimize,
     )
 
     # Persist config after autoconf

--- a/src/winml/modelkit/config/build.py
+++ b/src/winml/modelkit/config/build.py
@@ -764,7 +764,7 @@ def _get_export_batch_size_override(override: BuildConfigOverride | None) -> int
         export_override = override.export
     elif isinstance(override, dict):
         candidate = override.get("export")
-        export_override = candidate if isinstance(candidate, (WinMLExportConfig, dict)) else None
+        export_override = candidate if isinstance(candidate, WinMLExportConfig | dict) else None
     else:
         export_override = None
 
@@ -950,8 +950,20 @@ def generate_hf_build_config(
     # Lazy import to avoid circular dependency: config -> models.hf -> config
     from ..models.hf import MODEL_BUILD_CONFIGS
 
-    _registry_key = loader_config.model_type.replace("_", "-")
-    registered = MODEL_BUILD_CONFIGS.get(_registry_key)
+    _registry_keys = tuple(
+        dict.fromkeys(
+            (
+                loader_config.model_type,
+                loader_config.model_type.lower(),
+                loader_config.model_type.lower().replace("_", "-"),
+            )
+        )
+    )
+    registered = next(
+        (MODEL_BUILD_CONFIGS[key] for key in _registry_keys if key in MODEL_BUILD_CONFIGS),
+        None,
+    )
+    _registry_key = _registry_keys[0]
 
     # =========================================================================
     # STEP 3: Generate export config

--- a/src/winml/modelkit/export/io.py
+++ b/src/winml/modelkit/export/io.py
@@ -181,30 +181,66 @@ def _get_onnx_config(
     from ..loader import resolve_optimum_library
 
     library_name = resolve_optimum_library(model_type, library_name)
+    model_type_candidates = tuple(
+        dict.fromkeys(
+            (
+                model_type,
+                model_type.lower(),
+                model_type.lower().replace("_", "-"),
+            )
+        )
+    )
 
     logger.debug(
-        "Getting OnnxConfig: model_type=%s, task=%s -> %s (library=%s)",
+        "Getting OnnxConfig: model_type=%s, candidates=%s, task=%s -> %s (library=%s)",
         model_type,
+        model_type_candidates,
         task,
         normalized_task,
         library_name,
     )
 
-    try:
-        config_constructor = TasksManager.get_exporter_config_constructor(
+    last_error: KeyError | None = None
+    for candidate_model_type in model_type_candidates:
+        result = _try_get_exporter_config_constructor(
             exporter=exporter,
-            model_type=model_type,
+            model_type=candidate_model_type,
             task=normalized_task,
             library_name=library_name,
         )
-    except KeyError as e:
-        raise ONNXConfigNotFoundError(
-            f"No OnnxConfig registered for model_type='{model_type}' with task='{task}'. "
-            f"Ensure the model's ONNX config is registered with TasksManager. "
-            f"Original error: {e}"
-        ) from e
+        config_constructor, error = result
+        if config_constructor is not None:
+            return config_constructor(hf_config, task=normalized_task)
+        last_error = error
+    raise ONNXConfigNotFoundError(
+        f"No OnnxConfig registered for model_type='{model_type}' with task='{task}'. "
+        f"Ensure the model's ONNX config is registered with TasksManager. "
+        f"Original error: {last_error}"
+    ) from last_error
 
-    return config_constructor(hf_config, task=normalized_task)
+
+def _try_get_exporter_config_constructor(
+    *,
+    exporter: str,
+    model_type: str,
+    task: str,
+    library_name: str,
+) -> tuple[Any | None, KeyError | None]:
+    """Return an Optimum exporter config constructor or its lookup error."""
+    from optimum.exporters.tasks import TasksManager
+
+    try:
+        return (
+            TasksManager.get_exporter_config_constructor(
+                exporter=exporter,
+                model_type=model_type,
+                task=task,
+                library_name=library_name,
+            ),
+            None,
+        )
+    except KeyError as e:
+        return None, e
 
 
 def _populate_image_size_from_preprocessor(
@@ -311,7 +347,7 @@ def _synthesize_preprocessor_dict(hf_config: PretrainedConfig) -> dict:
         return {}
 
     input_size = pretrained_cfg.get("input_size")
-    if isinstance(input_size, (list, tuple)):
+    if isinstance(input_size, list | tuple):
         if len(input_size) == 3:
             return {"size": {"height": input_size[1], "width": input_size[2]}}
         if len(input_size) == 1:

--- a/src/winml/modelkit/models/hf/__init__.py
+++ b/src/winml/modelkit/models/hf/__init__.py
@@ -37,6 +37,9 @@ from .bart import (
     BartSequenceClassificationIOConfig as _BartSequenceClassificationIOConfig,
 )
 from .bert import BERT_CONFIG
+from .birefnet import BIREFNET_CONFIG
+from .birefnet import MODEL_CLASS_MAPPING as _BIREFNET_CLASS_MAPPING
+from .birefnet import BiRefNetIOConfig as _BiRefNetIOConfig  # triggers registration
 from .blip import BLIP_CONFIG
 from .blip import MODEL_CLASS_MAPPING as _BLIP_CLASS_MAPPING
 from .blip import BlipCaptioningIOConfig as _BlipCaptioningIOConfig  # triggers registration
@@ -121,6 +124,7 @@ MODEL_CLASS_MAPPING: dict[tuple[str, str | None], type] = {
     _key: _model_cls
     for _sub_mapping in (
         _BART_CLASS_MAPPING,
+        _BIREFNET_CLASS_MAPPING,
         _BLIP_CLASS_MAPPING,
         _CLIP_CLASS_MAPPING,
         _MARIAN_CLASS_MAPPING,
@@ -145,6 +149,7 @@ MODEL_CLASS_MAPPING: dict[tuple[str, str | None], type] = {
 MODEL_BUILD_CONFIGS = {
     "bart": BART_CONFIG,
     "bert": BERT_CONFIG,
+    "segformerforsemanticsegmentation": BIREFNET_CONFIG,
     "blip": BLIP_CONFIG,
     "camembert": ROBERTA_FAMILY_CONFIG,
     "clip": CLIP_CONFIG,

--- a/src/winml/modelkit/models/hf/birefnet.py
+++ b/src/winml/modelkit/models/hf/birefnet.py
@@ -1,0 +1,139 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""BiRefNet HuggingFace model configuration.
+
+BiRefNet is published as a custom ``AutoModelForImageSegmentation`` model for
+dichotomous image segmentation. The checkpoint config exposes a non-standard
+``model_type`` value (``SegformerForSemanticSegmentation``), so WinML needs an
+explicit class mapping and ONNX I/O config for the image-segmentation task.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import torch
+import torch.nn as nn
+from optimum.exporters.onnx import OnnxConfig
+from optimum.utils import DEFAULT_DUMMY_SHAPES, NormalizedConfig
+from optimum.utils.input_generators import DummyVisionInputGenerator
+from transformers import AutoModelForImageSegmentation
+
+from ...config import WinMLBuildConfig
+from ...export import register_onnx_overwrite
+from ...export.config import WinMLExportConfig
+from ...optim.config import WinMLOptimizationConfig
+
+
+BIREFNET_MODEL_TYPE = "segformerforsemanticsegmentation"
+BIREFNET_DEFAULT_IMAGE_SIZE = 1024
+
+
+class BiRefNetImageSegmentationWrapper(nn.Module):
+    """Export adapter for BiRefNet image segmentation.
+
+    The remote model's public ``forward`` argument is named ``x`` and returns a
+    list of scale predictions. WinML recipes expose the conventional
+    ``pixel_values`` input and a single final ``pred_masks`` output.
+    """
+
+    def __init__(self, model: nn.Module, config: Any) -> None:
+        super().__init__()
+        self.model = model
+        self.config = config
+        self.config.model_type = BIREFNET_MODEL_TYPE
+
+    @classmethod
+    def from_pretrained(
+        cls, model_name_or_path: str, **kwargs: Any
+    ) -> BiRefNetImageSegmentationWrapper:
+        """Load BiRefNet and wrap it for stable ONNX export."""
+        kwargs.setdefault("torch_dtype", torch.float32)
+        model = AutoModelForImageSegmentation.from_pretrained(model_name_or_path, **kwargs)
+        model.float()
+        wrapper = cls(model, model.config)
+        wrapper.eval()
+        return wrapper
+
+    def forward(self, pixel_values: torch.Tensor) -> torch.Tensor:
+        """Return the final-scale segmentation mask logits."""
+        outputs = self.model(pixel_values)
+        return cast("torch.Tensor", outputs[-1])
+
+
+MODEL_CLASS_MAPPING: dict[tuple[str, str | None], type] = {
+    (BIREFNET_MODEL_TYPE, "image-segmentation"): BiRefNetImageSegmentationWrapper,
+    (BIREFNET_MODEL_TYPE, None): BiRefNetImageSegmentationWrapper,
+}
+
+
+BIREFNET_CONFIG = WinMLBuildConfig(
+    export=WinMLExportConfig(dynamo=True, opset_version=19),
+    optim=WinMLOptimizationConfig(),
+)
+
+
+class _BiRefNetVisionInputGenerator(DummyVisionInputGenerator):  # type: ignore[misc]  # optimum base is untyped
+    """Vision input generator using BiRefNet's documented 1024x1024 shape.
+
+    The HF checkpoint does not include ``preprocessor_config.json`` and its
+    custom config has no ``image_size`` field. The model card's inference sample
+    resizes images to 1024x1024 before calling ``BiRefNet.forward``.
+    """
+
+    def __init__(
+        self,
+        task: str,
+        normalized_config: NormalizedConfig,
+        batch_size: int = DEFAULT_DUMMY_SHAPES["batch_size"],
+        num_channels: int = DEFAULT_DUMMY_SHAPES["num_channels"],
+        width: int = BIREFNET_DEFAULT_IMAGE_SIZE,
+        height: int = BIREFNET_DEFAULT_IMAGE_SIZE,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            task,
+            normalized_config,
+            batch_size=batch_size,
+            num_channels=num_channels,
+            width=width,
+            height=height,
+            **kwargs,
+        )
+        self.height = height
+        self.width = width
+        self.image_size = (height, width)
+
+
+@register_onnx_overwrite(BIREFNET_MODEL_TYPE, "image-segmentation", library_name="transformers")
+class BiRefNetIOConfig(OnnxConfig):  # type: ignore[misc]  # optimum base is untyped
+    """ONNX config for BiRefNet dichotomous image segmentation.
+
+    Inputs:
+        - pixel_values: {0: "batch_size", 1: "num_channels", 2: "height", 3: "width"}
+
+    Outputs:
+        - pred_masks: final binary mask logits from the last decoder scale.
+    """
+
+    NORMALIZED_CONFIG_CLASS = NormalizedConfig.with_args(
+        num_channels="num_channels",
+        allow_new=True,
+    )
+    DUMMY_INPUT_GENERATOR_CLASSES = (_BiRefNetVisionInputGenerator,)
+
+    @property
+    def inputs(self) -> dict[str, dict[int, str]]:
+        """Return BiRefNet input tensors."""
+        return {
+            "pixel_values": {0: "batch_size", 1: "num_channels", 2: "height", 3: "width"},
+        }
+
+    @property
+    def outputs(self) -> dict[str, dict[int, str]]:
+        """Return BiRefNet output tensors."""
+        return {
+            "pred_masks": {0: "batch_size", 2: "height", 3: "width"},
+        }

--- a/tests/unit/commands/test_build.py
+++ b/tests/unit/commands/test_build.py
@@ -1936,6 +1936,66 @@ class TestBuildHfPipelineModelType:
         assert config.quant.model_type == "qwen3_transformer_only"
         mock_quantize.assert_called_once()
 
+    @patch("winml.modelkit.commands.build._run_compile_stage")
+    @patch("winml.modelkit.commands.build._run_quantize_stage")
+    @patch("winml.modelkit.commands.build._run_optimize_stage")
+    @patch("winml.modelkit.commands.build._show_io")
+    @patch("winml.modelkit.utils.console.StageLive")
+    @patch("winml.modelkit.export.export_onnx")
+    @patch("winml.modelkit.build.hf._load_model")
+    def test_skip_optimize_reaches_hf_optimize_stage(
+        self,
+        mock_load_model: MagicMock,
+        mock_export_onnx: MagicMock,
+        mock_stage_live: MagicMock,
+        mock_show_io: MagicMock,
+        mock_optimize: MagicMock,
+        mock_quantize: MagicMock,
+        mock_compile: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """The cascaded HF CLI pipeline honors --no-optimize."""
+        from winml.modelkit.commands.build import _build_hf_pipeline
+
+        mock_stage_live.return_value.__enter__ = MagicMock(return_value=MagicMock())
+        mock_stage_live.return_value.__exit__ = MagicMock(return_value=False)
+
+        pytorch_model = MagicMock()
+        pytorch_model.config.model_type = "segformerforsemanticsegmentation"
+        mock_load_model.return_value = pytorch_model
+
+        optimized = tmp_path / "optimized.onnx"
+        optimized.write_bytes(b"fake-onnx")
+        mock_optimize.return_value = (optimized, None)
+        mock_quantize.return_value = optimized
+        mock_compile.return_value = optimized
+
+        config = MagicMock()
+        config.loader.model_type = "segformerforsemanticsegmentation"
+        config.loader.task = "image-segmentation"
+        config.loader.model_class = "BiRefNetImageSegmentationWrapper"
+        config.export = MagicMock()
+        config.quant = None
+        config.compile = None
+        config.skip_optimize = False
+        config.to_dict.return_value = {}
+
+        _build_hf_pipeline(
+            config=config,
+            model_id="ZhengPeng7/BiRefNet",
+            output_dir=tmp_path / "out",
+            rebuild=True,
+            cache_key=None,
+            ep=None,
+            device="cpu",
+            extra_kwargs={"skip_optimize": True},
+            preloaded_hf_config=None,
+        )
+
+        mock_optimize.assert_called_once()
+        assert mock_optimize.call_args.kwargs["skip_optimize"] is True
+        assert mock_export_onnx.call_args.kwargs["normalize"] is False
+
 
 class TestBuildEpResolution:
     """--ep forwarding into config generation + the compile EP-availability gate."""

--- a/tests/unit/config/test_build.py
+++ b/tests/unit/config/test_build.py
@@ -926,6 +926,42 @@ class TestRegistryShortCircuit:
         # Optimum SHOULD have been called
         mock_optimum.assert_called_once()
 
+    def test_registry_lookup_normalizes_mixed_case_model_type(
+        self,
+        mock_hf_config: MagicMock,
+        mock_model_class: MagicMock,
+        mock_export_config: WinMLExportConfig,
+    ) -> None:
+        """Registered build defaults apply to mixed-case HF model_type values."""
+        registered_config = WinMLBuildConfig(
+            export=WinMLExportConfig(dynamo=True, opset_version=19),
+        )
+        loader_config = WinMLLoaderConfig(
+            task="image-segmentation",
+            model_class="BiRefNetImageSegmentationWrapper",
+            model_type="SegformerForSemanticSegmentation",
+        )
+        mock_hf_config.model_type = "SegformerForSemanticSegmentation"
+
+        with (
+            patch(
+                "winml.modelkit.config.build.resolve_loader_config",
+                return_value=(loader_config, mock_hf_config, mock_model_class, MagicMock()),
+            ),
+            patch(
+                "winml.modelkit.config.build._resolve_export_config_from_specs",
+                return_value=mock_export_config,
+            ),
+            patch(
+                "winml.modelkit.models.hf.MODEL_BUILD_CONFIGS",
+                {"segformerforsemanticsegmentation": registered_config},
+            ),
+        ):
+            result = generate_build_config("ZhengPeng7/BiRefNet", task="image-segmentation")
+
+        assert result.export.dynamo is True
+        assert result.export.opset_version == 19
+
     def test_registry_with_none_input_tensors_falls_through(
         self,
         mock_hf_config: MagicMock,

--- a/tests/unit/models/birefnet/test_onnx_config.py
+++ b/tests/unit/models/birefnet/test_onnx_config.py
@@ -1,0 +1,200 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Tests for BiRefNet ONNX export config."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from transformers import PretrainedConfig
+
+# Import triggers ONNX config registration.
+import winml.modelkit.models  # noqa: F401
+from winml.modelkit.export import generate_dummy_inputs
+from winml.modelkit.export.io import _get_onnx_config  # Testing internal implementation
+from winml.modelkit.models.hf.birefnet import (
+    BIREFNET_CONFIG,
+    BIREFNET_DEFAULT_IMAGE_SIZE,
+    BIREFNET_MODEL_TYPE,
+    MODEL_CLASS_MAPPING,
+    BiRefNetImageSegmentationWrapper,
+    BiRefNetIOConfig,
+)
+
+
+class BiRefNetTestConfig(PretrainedConfig):
+    """Minimal config matching ZhengPeng7/BiRefNet metadata."""
+
+    model_type = BIREFNET_MODEL_TYPE
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.architectures = ["BiRefNet"]
+        self.num_channels = 3
+
+
+class TinyBiRefNet(torch.nn.Module):
+    """Small stand-in for BiRefNet's pixel_values-only forward."""
+
+    def forward(self, pixel_values: torch.Tensor) -> list[torch.Tensor]:
+        return [pixel_values.mean(dim=1, keepdim=True)]
+
+
+class TinyMultiScaleBiRefNet(torch.nn.Module):
+    """Small stand-in for BiRefNet's multi-scale output list."""
+
+    def forward(self, x: torch.Tensor) -> list[torch.Tensor]:
+        return [x[:, :1], x[:, :1] + 1]
+
+
+@pytest.fixture(scope="module")
+def birefnet_config() -> BiRefNetTestConfig:
+    """Return a minimal BiRefNet config."""
+    return BiRefNetTestConfig()
+
+
+class TestBiRefNetIOConfig:
+    """BiRefNet ONNX export registration and I/O specs."""
+
+    def test_onnx_config_registered(self, birefnet_config: BiRefNetTestConfig) -> None:
+        """BiRefNetIOConfig is registered for image-segmentation."""
+        config = _get_onnx_config(
+            birefnet_config.model_type,
+            "image-segmentation",
+            birefnet_config,
+        )
+
+        assert isinstance(config, BiRefNetIOConfig)
+
+    def test_inputs_contain_pixel_values(self, birefnet_config: BiRefNetTestConfig) -> None:
+        """Input spec includes pixel_values with spatial axes."""
+        config = _get_onnx_config(
+            birefnet_config.model_type,
+            "image-segmentation",
+            birefnet_config,
+        )
+
+        assert config.inputs == {
+            "pixel_values": {0: "batch_size", 1: "num_channels", 2: "height", 3: "width"}
+        }
+
+    def test_outputs_contain_pred_masks(self, birefnet_config: BiRefNetTestConfig) -> None:
+        """Output spec exposes the final mask as pred_masks."""
+        config = _get_onnx_config(
+            birefnet_config.model_type,
+            "image-segmentation",
+            birefnet_config,
+        )
+
+        assert "pred_masks" in config.outputs
+
+    def test_dummy_inputs_use_documented_resolution(
+        self, birefnet_config: BiRefNetTestConfig
+    ) -> None:
+        """Dummy inputs default to the model card's 1024x1024 inference size."""
+        inputs = generate_dummy_inputs(
+            birefnet_config.model_type,
+            "image-segmentation",
+            birefnet_config,
+            batch_size=1,
+        )
+
+        assert inputs["pixel_values"].shape == (
+            1,
+            3,
+            BIREFNET_DEFAULT_IMAGE_SIZE,
+            BIREFNET_DEFAULT_IMAGE_SIZE,
+        )
+
+    def test_shape_override_is_preserved(self, birefnet_config: BiRefNetTestConfig) -> None:
+        """Explicit shape overrides can shrink export smoke tests."""
+        inputs = generate_dummy_inputs(
+            birefnet_config.model_type,
+            "image-segmentation",
+            birefnet_config,
+            batch_size=1,
+            height=128,
+            width=160,
+        )
+
+        assert inputs["pixel_values"].shape == (1, 3, 128, 160)
+
+    def test_dummy_inputs_can_forward(self, birefnet_config: BiRefNetTestConfig) -> None:
+        """Generated dummy inputs match BiRefNet's pixel_values-only forward."""
+        model = TinyBiRefNet().eval()
+        inputs = generate_dummy_inputs(
+            birefnet_config.model_type,
+            "image-segmentation",
+            birefnet_config,
+            batch_size=1,
+            height=32,
+            width=32,
+        )
+
+        with torch.no_grad():
+            outputs = model(**inputs)
+
+        assert outputs[-1].shape == (1, 1, 32, 32)
+
+
+class TestBiRefNetModelClassMapping:
+    """BiRefNet task routing."""
+
+    def test_maps_to_image_segmentation_auto_class(self) -> None:
+        """image-segmentation routes to the BiRefNet export wrapper."""
+        assert MODEL_CLASS_MAPPING[(BIREFNET_MODEL_TYPE, "image-segmentation")] is (
+            BiRefNetImageSegmentationWrapper
+        )
+
+    def test_declares_default_task_sentinel(self) -> None:
+        """The sentinel makes image-segmentation the default BiRefNet task."""
+        assert MODEL_CLASS_MAPPING[(BIREFNET_MODEL_TYPE, None)] is BiRefNetImageSegmentationWrapper
+
+    def test_model_type_matches_hf_config_normalization(self) -> None:
+        """HF model_type normalization matches the registry key."""
+        hf_config = SimpleNamespace(model_type="SegformerForSemanticSegmentation")
+
+        assert hf_config.model_type.lower().replace("_", "-") == BIREFNET_MODEL_TYPE
+
+    def test_mixed_case_hf_model_type_resolves_registered_config(self) -> None:
+        """The HF-published mixed-case model_type resolves to the registered config."""
+        hf_config = BiRefNetTestConfig()
+        hf_config.model_type = "SegformerForSemanticSegmentation"
+
+        config = _get_onnx_config(
+            hf_config.model_type,
+            "image-segmentation",
+            hf_config,
+        )
+
+        assert isinstance(config, BiRefNetIOConfig)
+
+
+class TestBiRefNetWrapper:
+    """BiRefNet export wrapper behavior."""
+
+    def test_wrapper_uses_pixel_values_and_final_scale_output(
+        self, birefnet_config: BiRefNetTestConfig
+    ) -> None:
+        """Wrapper exposes pixel_values and returns the last scale prediction."""
+        model = BiRefNetImageSegmentationWrapper(TinyMultiScaleBiRefNet(), birefnet_config)
+        pixel_values = torch.zeros(1, 3, 8, 8)
+
+        output = model(pixel_values)
+
+        assert output.shape == (1, 1, 8, 8)
+        assert torch.all(output == 1)
+
+
+class TestBiRefNetBuildConfig:
+    """BiRefNet build defaults."""
+
+    def test_uses_dynamo_and_opset_19_for_deform_conv(self) -> None:
+        """BiRefNet needs dynamo export and ONNX DeformConv from opset 19."""
+        assert BIREFNET_CONFIG.export is not None
+        assert BIREFNET_CONFIG.export.dynamo is True
+        assert BIREFNET_CONFIG.export.opset_version == 19


### PR DESCRIPTION
## Summary

Adds HuggingFace export support for `ZhengPeng7/BiRefNet` as an `image-segmentation` model. The change introduces a BiRefNet wrapper/ONNX config, registers its mixed-case HF `model_type`, and fixes the HF build path so `--no-optimize` also skips export-time ORT normalization.

Highest verified outcome: L0 build/structural export PASS on CPU fp32 at 128x128. CPU runtime/perf is still blocked by ONNX Runtime lacking a `DeformConv(19)` CPU kernel, so this PR does not add a CPU recipe.

## Model metadata

- What the model does: BiRefNet performs dichotomous image segmentation / salient object mask prediction from image tensors.
- Primary user story: users provide an image and receive a single-channel foreground mask.
- Supported task in this PR: `image-segmentation`.
- Architecture/source signals: HF config declares `architectures=["BiRefNet"]`, remote `AutoModelForImageSegmentation`, and mixed-case `model_type="SegformerForSemanticSegmentation"`; the model card inference path resizes to 1024x1024 and uses the final multi-scale output mask.

```text
BiRefNetImageSegmentationWrapper
└── BiRefNet remote model
    ├── SwinTransformer backbone
    ├── multi-stage decoder / refinement modules
    └── final-scale segmentation mask output -> pred_masks
```

## Validation and support evidence

### Baseline

Before this change, `winml config` could not produce a working BiRefNet export path without custom support for the remote image-segmentation class, mixed-case model type, fp32 wrapper behavior, and opset 19 dynamo export.

### Goal

- Effort: L1 code support.
- Goal ceiling reached: L0 build/structural validation.
- Runtime status: L1 CPU perf fails in ORT due to unsupported `DeformConv(19)`.

### Outcome

- Added `BiRefNetImageSegmentationWrapper` to expose stable `pixel_values -> pred_masks` export I/O.
- Added BiRefNet ONNX config with documented 1024x1024 default dummy image size and shape override support.
- Registered build defaults for dynamo export with ONNX opset 19.
- Generalized mixed-case/lowercase model type lookup for ONNX config and build-config registry paths.
- Fixed cascaded HF build `--no-optimize` handling so ORT optimization and export-time normalization are skipped when requested.
- No recipe added: CPU runtime/perf is not a PASS tuple because ORT CPU reports `NOT_IMPLEMENTED` for `DeformConv(19)`.

### Per-EP/device/precision results

| Tier | EP / Device | Precision | Verdict | Evidence |
|---|---|---|---|---|
| L0 | CPUExecutionProvider / cpu | fp32 | PASS | `winml build` completed with `--no-optimize --no-quant --no-compile`; ONNX checker passed; IR 10, opset 19, input `pixel_values [1,3,128,128]`, output `pred_masks [1,1,128,128]`, 2993 nodes. |
| L1 | CPUExecutionProvider / cpu | fp32 | FAIL | `winml perf` failed: `[ONNXRuntimeError] : 9 : NOT_IMPLEMENTED : Could not find an implementation for DeformConv(19) node with name 'node_deform_conv2d'`. |

### Delta

- `src/winml/modelkit/models/hf/birefnet.py`: new wrapper, ONNX I/O config, default export config.
- `src/winml/modelkit/models/hf/__init__.py`: registers BiRefNet model class mapping and build config.
- `src/winml/modelkit/export/io.py`: resolves ONNX config constructors through original, lowercase, and lowercase hyphenated model-type candidates.
- `src/winml/modelkit/config/build.py`: applies the same model-type normalization to `MODEL_BUILD_CONFIGS` lookup.
- `src/winml/modelkit/commands/build.py`: threads `skip_optimize` through the HF build pipeline and disables export normalization when optimization is skipped.
- `examples/recipes/README.md` is untouched.

### Analyze summary

Static ONNX structure was validated. Formal `winml analyze --ep all` evidence was not added because no runtime PASS tuple is claimed and no recipe is shipped.

### Quality gates

```powershell
uv run ruff check src\winml\modelkit\models\hf\birefnet.py src\winml\modelkit\models\hf\__init__.py src\winml\modelkit\commands\build.py src\winml\modelkit\export\io.py src\winml\modelkit\config\build.py tests\unit\models\birefnet\test_onnx_config.py tests\unit\commands\test_build.py tests\unit\config\test_build.py
uv run --extra dev mypy -p winml.modelkit
uv run pytest tests\unit\models tests\unit\loader tests\unit\datasets tests\unit\export --tb=short --no-cov -m "not e2e and not npu and not gpu"
uv run pytest tests\unit\commands tests\unit\config tests\unit\build --tb=short --no-cov -m "not e2e and not npu and not gpu"
```

Results:

- Touched-file Ruff: PASS.
- Mypy: PASS, 427 source files.
- Models/loader/datasets/export partition: 1463 passed, 6 skipped, 2 xfailed.
- Commands/config/build partition: 1689 passed, 1 skipped.

Full `uv run ruff check src\ tests\` currently fails on pre-existing unrelated lint findings outside this diff.

### Reproduce commands

```powershell
$OUT = "temp/birefnet_build_fp32_repro"
uv run winml config -m ZhengPeng7/BiRefNet -t image-segmentation --trust-remote-code --shape-config temp\birefnet_shape_128.json -o temp\baseline_ZhengPeng7_BiRefNet\image-segmentation_fp32_config.json --overwrite
uv run --with einops --with kornia winml build -m ZhengPeng7/BiRefNet -c temp\baseline_ZhengPeng7_BiRefNet\image-segmentation_fp32_config.json -o $OUT --trust-remote-code --no-optimize --no-quant --no-compile --rebuild
uv run python -c "import onnx; p='$OUT/model.onnx'; m=onnx.load(p, load_external_data=False); onnx.checker.check_model(p); print({'ir': m.ir_version, 'opsets': [(o.domain,o.version) for o in m.opset_import], 'inputs': [(i.name,[d.dim_value or d.dim_param for d in i.type.tensor_type.shape.dim]) for i in m.graph.input], 'outputs': [(o.name,[d.dim_value or d.dim_param for d in o.type.tensor_type.shape.dim]) for o in m.graph.output], 'nodes': len(m.graph.node)})"
uv run winml perf -m $OUT\model.onnx --device cpu --ep cpu
```
