### PR TITLE
fix(session): reject unsupported EP/device pairs in resolve_device

### DIFF
--- a/src/winml/modelkit/session/ep_device.py
+++ b/src/winml/modelkit/session/ep_device.py
@@ -802,6 +802,17 @@ def resolve_device(target: EPDeviceTarget) -> EPDeviceTarget:
 
     # --- Final validation + return --------------------------------------
     ep_full = expand_ep_name(ep)
+    # Reject an EP/device pair the shared policy table does not allow. The
+    # ``auto`` branches above only ever select policy-supported specs, so this
+    # can only trip when the caller pinned BOTH axes (e.g. ``--ep vitisai
+    # --device cpu``). Without it the mismatch surfaces much later as a
+    # ``DeviceNotFound`` from deep inside the compile stage.
+    supported_devices = EP_SUPPORTED_DEVICES.get(cast("EPName", ep_full))
+    if supported_devices is not None and device not in supported_devices:
+        raise ValueError(
+            f"EP '{target.ep}' does not support device '{device}'. "
+            f"Supported: {', '.join(supported_devices)}."
+        )
     resolved = EPDeviceTarget(ep=ep_full, device=device, source=target.source)
     logger.info(
         "resolve_device: %s/%s%s -> %s/%s%s",

--- a/tests/unit/session/test_ep_device.py
+++ b/tests/unit/session/test_ep_device.py
@@ -11,13 +11,19 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from winml.modelkit.session import (
+    VALID_DEVICES,
     DeviceNotFound,
     EPDeviceTarget,
     expand_ep_name,
     resolve_device,
     short_ep_name,
 )
-from winml.modelkit.utils.constants import EP_ALIASES, EP_NAMES, normalize_ep_name
+from winml.modelkit.utils.constants import (
+    EP_ALIASES,
+    EP_NAMES,
+    EP_SUPPORTED_DEVICES,
+    normalize_ep_name,
+)
 
 
 def test_ep_device_round_trip() -> None:
@@ -229,6 +235,35 @@ def test_resolve_device_does_not_load_dll() -> None:
         result = resolve_device(EPDeviceTarget(ep="qnn", device="npu"))
     assert result.ep == "QNNExecutionProvider"
     mock_reg.instance.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "ep,device",
+    [
+        (ep, device)
+        for ep, supported in EP_SUPPORTED_DEVICES.items()
+        for device in sorted(set(VALID_DEVICES) - set(supported))
+    ],
+)
+def test_resolve_device_rejects_unsupported_ep_device_pair(ep: str, device: str) -> None:
+    """Pinning both axes to a policy-forbidden pair fails fast with a clear message.
+
+    Without this check the mismatch is only detected later, as a
+    ``DeviceNotFound`` raised from inside the compile stage.
+    """
+    with pytest.raises(ValueError, match=f"does not support device '{device}'"):
+        resolve_device(EPDeviceTarget(ep=ep, device=device))
+
+
+@pytest.mark.parametrize(
+    "ep,device",
+    [(ep, device) for ep, supported in EP_SUPPORTED_DEVICES.items() for device in supported],
+)
+def test_resolve_device_accepts_supported_ep_device_pair(ep: str, device: str) -> None:
+    """Every policy-allowed pair still resolves to itself."""
+    result = resolve_device(EPDeviceTarget(ep=ep, device=device))
+    assert result.ep == ep
+    assert result.device == device
 
 
 def test_resolve_both_auto_falls_back_to_cpu_when_vendor_detection_fails() -> None:


### PR DESCRIPTION
## Problem

Four `tests/e2e/test_compile_e2e.py::test_bad_input_device_ep_conflict` cases fail. Each case is gated on the EP being registered on the host, so which ones fail is host-dependent — on an AMD agent (VitisAI installed) it is:

```
FAILED test_bad_input_device_ep_conflict[cpu-vitisai]
FAILED test_bad_input_device_ep_conflict[gpu-vitisai]
FAILED test_bad_input_device_ep_conflict[cpu-nv_tensorrt_rtx]
FAILED test_bad_input_device_ep_conflict[npu-nv_tensorrt_rtx]
```

`winml compile -m model.onnx --device cpu --ep vitisai` is expected to be rejected at the CLI boundary with `EP 'vitisai' does not support device 'cpu'`. Instead it is accepted, runs into the compile stage, and dies there:

```
[ERROR winml.modelkit.compiler.context] Compilation failed: No source for
VitisAIExecutionProvider/cpu exposed device class 'CPU'
...
winml.modelkit.session.ep_device.DeviceNotFound: No source for
VitisAIExecutionProvider/cpu exposed device class 'CPU'
```

## Root cause

`resolve_device()` documents its contract as:

```
- both given → validate and return
```

but the both-given path performs no validation of the pair. It checks that `device` is in `VALID_DEVICES`, expands the EP alias, and returns. The `auto` branches do filter candidates through `_is_policy_supported_spec` (which consults `EP_SUPPORTED_DEVICES`), so only a caller that pins **both** axes can slip an unsupported combination through.

`winml compile` calls `resolve_device` precisely as that preflight, then builds a `WinMLCompileConfig` from the (invalid) target. The mismatch is finally detected by `WinMLEPRegistry.auto_device` inside `CompileStage`, far from the CLI boundary, as a `DeviceNotFound` about ORT device classes rather than an actionable usage error.

## Change

- `resolve_device`: validate the resolved pair against `EP_SUPPORTED_DEVICES` — the same policy table `resolve_precision` already uses — and raise `ValueError(f"EP '{ep}' does not support device '{device}'. Supported: ...")`. `winml compile` already maps `ValueError` to a `click.UsageError`, so the user now gets the rejection before any compile work starts.
- Two parametrized unit tests derived from the policy table: every forbidden `(ep, device)` pair raises, every allowed pair still resolves to itself.

## Verification

- `pytest tests/e2e/test_compile_e2e.py -m e2e` → 16 passed, 58 skipped, 0 failed (was 4 failed)
- `pytest tests/unit` → 7889 passed, 77 skipped, 3 xfailed
- `ruff check` clean

## Follow-up (not in this PR)

`test_good_input_compiles_and_runs` gates its VitisAI exclusion with `require_not_ep("vitisai")`, which is a *host* check rather than a *parameter* check. On any machine with VitisAI installed — i.e. every AMD agent — this drops the compile happy-path coverage for **all** EPs, not just VitisAI (13 skips on the agent used here). Narrowing it to the parametrized EP was attempted and reverted: it exposes an unrelated native access violation in the `nv_tensorrt_rtx` cases that crashes the pytest process. Worth a separate issue.
