### PR TITLE
feat(optimize/analyze): preview applicable optimizations and check their produced-operator support

### DIFF
--- a/docs/commands/analyze.md
+++ b/docs/commands/analyze.md
@@ -28,7 +28,7 @@ $ winml analyze [options]
 | `--run-unknown-op` / `--no-run-unknown-op` | | flag | disabled | For operators not in the rule database, build a minimal ONNX graph and run it on the target EP locally to determine support. Enable when local EP libraries are available. |
 | `--save-node` | | `partial\|unsupported` | *(none)* | Save partial or unsupported node subgraphs to disk for further investigation. Can be specified multiple times: `--save-node partial --save-node unsupported`. |
 | `--optim-config` | | `PATH` | *(none)* | Save the auto-discovered optimization config (merged across all analyzed EPs) to a JSON file. |
-| `--check-optim-output` / `--no-check-optim-output` | | flag | disabled | For each optimization that would change the model, check whether the operators it *introduces* (its added/modified nodes) are supported on the resolved EP/device. Answers "if I apply this optimization, will its output run on my target?" before you commit to it. |
+| `--check-optim` / `--no-check-optim` | | flag | disabled | For each optimization that would change the model, check whether the operators it *introduces* (its added/modified nodes) are supported on the resolved EP/device. Answers "if I apply this optimization, will its output run on my target?" before you commit to it. |
 
 ## How it works
 
@@ -106,7 +106,7 @@ $ winml analyze --model model.onnx --ep qnn --device NPU --run-unknown-op
 Check whether the operators each applicable optimization would introduce are supported on the target:
 
 ```bash
-$ winml analyze --model model.onnx --ep qnn --device NPU --check-optim-output
+$ winml analyze --model model.onnx --ep qnn --device NPU --check-optim
 ```
 
 ## Common pitfalls

--- a/docs/commands/analyze.md
+++ b/docs/commands/analyze.md
@@ -28,6 +28,7 @@ $ winml analyze [options]
 | `--run-unknown-op` / `--no-run-unknown-op` | | flag | disabled | For operators not in the rule database, build a minimal ONNX graph and run it on the target EP locally to determine support. Enable when local EP libraries are available. |
 | `--save-node` | | `partial\|unsupported` | *(none)* | Save partial or unsupported node subgraphs to disk for further investigation. Can be specified multiple times: `--save-node partial --save-node unsupported`. |
 | `--optim-config` | | `PATH` | *(none)* | Save the auto-discovered optimization config (merged across all analyzed EPs) to a JSON file. |
+| `--check-optim-output` / `--no-check-optim-output` | | flag | disabled | For each optimization that would change the model, check whether the operators it *introduces* (its added/modified nodes) are supported on the resolved EP/device. Answers "if I apply this optimization, will its output run on my target?" before you commit to it. |
 
 ## How it works
 
@@ -100,6 +101,12 @@ Enable local execution for operators not in the rule database:
 
 ```bash
 $ winml analyze --model model.onnx --ep qnn --device NPU --run-unknown-op
+```
+
+Check whether the operators each applicable optimization would introduce are supported on the target:
+
+```bash
+$ winml analyze --model model.onnx --ep qnn --device NPU --check-optim-output
 ```
 
 ## Common pitfalls

--- a/docs/commands/optimize.md
+++ b/docs/commands/optimize.md
@@ -22,6 +22,7 @@ $ winml optimize [options]
 | `--verbose` | `-v` | flag | off | Enable verbose output. |
 | `--list-capabilities` | `-l` | flag | off | Print all registered optimization capabilities grouped by category and exit. Add `--verbose` for descriptions and ORT names. |
 | `--list-rewrites` | | flag | off | Print all available pattern-rewrite families with their source-to-target mappings and exit. |
+| `--dry-run` | | flag | off | Analyze which optimizations would apply to `--model` and the nodes/constants they affect, then exit **without writing any output**. Probes every capability independently. |
 | *(dynamic)* | | flag | *(per capability)* | Each registered capability generates a `--enable-<name>` / `--disable-<name>` pair. Run `--list-capabilities` to see the full current list. Examples: `--enable-gelu-fusion`, `--disable-constant-folding`. Pattern-rewrite flags follow the form `--enable-<source-slug>-<target-slug>`; run `--list-rewrites` to discover all names. |
 
 ### Configuration precedence
@@ -84,6 +85,39 @@ Discover pattern-rewrite families and their flag names:
 ```bash
 $ winml optimize --list-rewrites
 ```
+
+Check which optimizations apply to a model before committing to a run (writes nothing):
+
+```bash
+$ winml optimize -m bert-base-uncased.onnx --dry-run
+```
+
+```text
+Input: bert-base-uncased.onnx
+Dry run — analyzing applicable optimizations (no output written).
+
+Loading model...
+Probing 61 optimization capabilities... (this can take a while on large models)
+
+2 applicable optimization(s):
+
+--enable-matmul-add-fusion  (matmul)
+  Fuse MatMul+Add operations into single kernel
+  nodes: -1 ~1
+    removed: MatMul (1)
+      - MatMul 'mm'
+    modified: Gemm (1)
+      - Gemm 'mm/MatMulAddFusion'
+
+--enable-clamp-constant-values  (surgery)
+  Clamp extreme float constants (e.g., -inf -> -1e3) to prevent quantization issues
+  constants: ~1
+      - BIG
+
+Enable any of the above with its --enable-* flag (dependencies are auto-enabled).
+```
+
+Add `-v` to list every affected node and constant instead of a sample.
 
 ## Common pitfalls
 

--- a/docs/commands/optimize.md
+++ b/docs/commands/optimize.md
@@ -22,7 +22,7 @@ $ winml optimize [options]
 | `--verbose` | `-v` | flag | off | Enable verbose output. |
 | `--list-capabilities` | `-l` | flag | off | Print all registered optimization capabilities grouped by category and exit. Add `--verbose` for descriptions and ORT names. |
 | `--list-rewrites` | | flag | off | Print all available pattern-rewrite families with their source-to-target mappings and exit. |
-| `--dry-run` | | flag | off | Analyze which optimizations would apply to `--model` and the nodes/constants they affect, then exit **without writing any output**. Probes every capability independently. |
+| `--check-optim` | | flag | off | Analyze which optimizations would apply to `--model` and the nodes/constants they affect, then exit **without writing any output**. Probes every capability independently. |
 | *(dynamic)* | | flag | *(per capability)* | Each registered capability generates a `--enable-<name>` / `--disable-<name>` pair. Run `--list-capabilities` to see the full current list. Examples: `--enable-gelu-fusion`, `--disable-constant-folding`. Pattern-rewrite flags follow the form `--enable-<source-slug>-<target-slug>`; run `--list-rewrites` to discover all names. |
 
 ### Configuration precedence
@@ -89,12 +89,12 @@ $ winml optimize --list-rewrites
 Check which optimizations apply to a model before committing to a run (writes nothing):
 
 ```bash
-$ winml optimize -m bert-base-uncased.onnx --dry-run
+$ winml optimize -m bert-base-uncased.onnx --check-optim
 ```
 
 ```text
 Input: bert-base-uncased.onnx
-Dry run — analyzing applicable optimizations (no output written).
+--check-optim — analyzing applicable optimizations (no output written).
 
 Loading model...
 Probing 61 optimization capabilities... (this can take a while on large models)

--- a/src/winml/modelkit/analyze/core/runtime_checker.py
+++ b/src/winml/modelkit/analyze/core/runtime_checker.py
@@ -161,6 +161,7 @@ class RuntimeChecker:
         run_unknown_op: bool = False,
         save_node_types: set[str] | None = None,
         on_node_result: Callable | None = None,
+        node_output_filter: set[str] | None = None,
     ) -> list[PatternRuntime]:
         """Check operator-level runtime support.
 
@@ -185,6 +186,12 @@ class RuntimeChecker:
                   level enum. Call ``.value`` to get the string, e.g.
                   ``"supported"``, ``"partial"``, ``"unsupported"``,
                   ``"unknown"``.
+            node_output_filter: Optional set of output tensor names. When
+                provided, only nodes that produce at least one of these tensors
+                are checked; all other nodes are skipped. This lets callers
+                restrict the check to a specific subset of the graph (e.g. the
+                operators an optimization introduced) without paying to check
+                every node.
 
         Returns:
             List[PatternRuntime]: Runtime results for each operator pattern
@@ -228,6 +235,11 @@ class RuntimeChecker:
         # Use tqdm for progress unless caller provides a callback
         iterator = nodes if on_node_result else tqdm.tqdm(nodes)
         for node in iterator:
+            if node_output_filter is not None and not (
+                node_output_filter.intersection(node.output)
+            ):
+                # Node is outside the requested subset — skip it.
+                continue
             node_start = time.perf_counter()
             result = query.run_for_node(
                 node,

--- a/src/winml/modelkit/analyze/optim_output.py
+++ b/src/winml/modelkit/analyze/optim_output.py
@@ -197,6 +197,11 @@ def _matched_node(runtime: object) -> NodeProto | None:
     matched_nodes = getattr(skeleton, "matched_nodes", None)
     if matched_nodes:
         return cast("NodeProto", matched_nodes[0])
+    logger.debug(
+        "Could not extract matched node from runtime (type=%s); produced operators "
+        "correlated via this runtime will report UNKNOWN support",
+        type(runtime).__name__,
+    )
     return None
 
 

--- a/src/winml/modelkit/analyze/optim_output.py
+++ b/src/winml/modelkit/analyze/optim_output.py
@@ -1,0 +1,239 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""EP/device support of the operators an optimization would produce.
+
+This bridges the optimizer's dry-run applicability analysis with the analyze
+runtime-support rule data. For each applicable optimization it takes the model
+that optimization would produce, then checks whether the operators the
+optimization *introduces* (its added and modified nodes) are supported on a
+target execution provider and device — answering "if I apply this optimization,
+will its output run on my target?".
+
+The check is universal and architecture-agnostic (CARDINAL RULE #1): the set of
+produced operators is derived entirely from the concrete graph diff carried on
+each :class:`~winml.modelkit.optim.CapabilityFinding`; nothing about specific
+operators or model architectures is hardcoded.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, cast
+
+from .models.onnx_model import ONNXModel
+from .models.support_level import SupportLevel
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from onnx import ModelProto, NodeProto
+
+    from ..optim import CapabilityFinding, NodeRef
+    from ..utils.constants import EPName
+
+
+logger = logging.getLogger(__name__)
+
+# Ordering used to summarize a mix of per-operator support levels into a single
+# "worst" level. Higher rank = more concerning for the target.
+_SEVERITY: dict[SupportLevel, int] = {
+    SupportLevel.SUPPORTED: 0,
+    SupportLevel.UNKNOWN: 1,
+    SupportLevel.PARTIAL: 2,
+    SupportLevel.UNSUPPORTED: 3,
+}
+
+
+@dataclass(frozen=True)
+class ProducedOperatorSupport:
+    """Support of a single operator an optimization would introduce.
+
+    Attributes:
+        op_type: The produced operator's op type (e.g. ``"Gemm"``).
+        label: Human-readable node label (op type + name/output).
+        change: Whether the node is ``"added"`` or ``"modified"`` by the
+            optimization.
+        support: Support level of the operator on the target EP/device.
+        reason: Optional reason string from the runtime check.
+    """
+
+    op_type: str
+    label: str
+    change: str
+    support: SupportLevel
+    reason: str | None = None
+
+
+@dataclass
+class OptimizationOutputSupport:
+    """Per-optimization view of its produced operators' target support.
+
+    Attributes:
+        name: Capability name (kebab-case, e.g. ``"matmul-add-fusion"``).
+        enable_flag: CLI flag that turns the optimization on.
+        category: Capability category (e.g. ``"matmul"``).
+        description: Human-readable capability description.
+        pipe_name: Name of the pipe that owns the capability.
+        operators: Per-operator support for every produced (added/modified) node.
+        error: Non-empty when the support check could not be completed.
+    """
+
+    name: str
+    enable_flag: str
+    category: str
+    description: str
+    pipe_name: str
+    operators: list[ProducedOperatorSupport] = field(default_factory=list)
+    error: str | None = None
+
+    @property
+    def worst_support(self) -> SupportLevel:
+        """Most concerning support level across produced operators.
+
+        Returns ``SUPPORTED`` when there are no produced operators to check.
+        """
+        if not self.operators:
+            return SupportLevel.SUPPORTED
+        return max((op.support for op in self.operators), key=lambda level: _SEVERITY[level])
+
+    def support_counts(self) -> dict[SupportLevel, int]:
+        """Return a count of produced operators per support level."""
+        return dict(Counter(op.support for op in self.operators))
+
+
+def _produced_node_refs(
+    finding: CapabilityFinding,
+) -> list[tuple[str, NodeRef]]:
+    """Return ``(change_kind, NodeRef)`` pairs for a finding's produced nodes.
+
+    Produced nodes are those an optimization introduces: newly added nodes and
+    nodes modified in place. Removed nodes are excluded — they no longer exist
+    after the optimization, so their target support is irrelevant.
+    """
+    pairs: list[tuple[str, NodeRef]] = []
+    pairs.extend(("added", ref) for ref in finding.added_nodes)
+    pairs.extend(("modified", ref) for ref in finding.modified_nodes)
+    return pairs
+
+
+def _check_one(
+    finding: CapabilityFinding,
+    produced_model: ModelProto,
+    ep: EPName,
+    device: str,
+    model_path: str,
+) -> OptimizationOutputSupport:
+    """Check target support for the operators one optimization would produce."""
+    from .core.runtime_checker import RuntimeChecker
+
+    result = OptimizationOutputSupport(
+        name=finding.name,
+        enable_flag=finding.enable_flag,
+        category=finding.category,
+        description=finding.description,
+        pipe_name=finding.pipe_name,
+    )
+
+    produced = _produced_node_refs(finding)
+    if not produced:
+        return result
+
+    # Output tensor names uniquely identify produced nodes within the graph.
+    produced_outputs = {out for _, ref in produced for out in ref.outputs}
+
+    try:
+        onnx_model = ONNXModel.from_onnx_model(produced_model, model_path)
+        checker = RuntimeChecker(ep=ep, device=device, model=onnx_model)
+        # Only evaluate the produced nodes; skip the rest of the graph.
+        runtimes = checker.op_support(
+            node_output_filter=produced_outputs,
+            on_node_result=lambda _r: None,
+        )
+    except Exception as exc:  # pragma: no cover - defensive, keeps analyze alive
+        logger.warning(
+            "Could not check produced-operator support for '%s' on %s/%s: %s",
+            finding.name,
+            ep,
+            device,
+            exc,
+        )
+        result.error = str(exc)
+        return result
+
+    # Map each produced output tensor to its support result.
+    support_by_output: dict[str, tuple[SupportLevel, str | None]] = {}
+    for runtime in runtimes:
+        node = _matched_node(runtime)
+        outputs = tuple(node.output) if node is not None else ()
+        classification = runtime.result.classification
+        reason = runtime.result.reason
+        for out in outputs:
+            support_by_output[out] = (classification, reason)
+
+    for change, ref in produced:
+        support, reason = _lookup_support(ref, support_by_output)
+        result.operators.append(
+            ProducedOperatorSupport(
+                op_type=ref.op_type,
+                label=ref.label(),
+                change=change,
+                support=support,
+                reason=reason,
+            )
+        )
+
+    return result
+
+
+def _matched_node(runtime: object) -> NodeProto | None:
+    """Best-effort extraction of the ONNX node behind a ``PatternRuntime``."""
+    pattern_match = getattr(runtime, "pattern_match", None)
+    skeleton = getattr(pattern_match, "skeleton_match_result", None)
+    matched_nodes = getattr(skeleton, "matched_nodes", None)
+    if matched_nodes:
+        return cast("NodeProto", matched_nodes[0])
+    return None
+
+
+def _lookup_support(
+    ref: NodeRef,
+    support_by_output: dict[str, tuple[SupportLevel, str | None]],
+) -> tuple[SupportLevel, str | None]:
+    """Resolve a produced node's support via any of its output tensors."""
+    for out in ref.outputs:
+        if out in support_by_output:
+            return support_by_output[out]
+    return SupportLevel.UNKNOWN, "not evaluated"
+
+
+def check_optimization_output_support(
+    optimization_outputs: Iterable[tuple[CapabilityFinding, ModelProto]],
+    ep: EPName,
+    device: str,
+    model_path: str,
+) -> list[OptimizationOutputSupport]:
+    """Check produced-operator support for applicable optimizations on a target.
+
+    Args:
+        optimization_outputs: ``(finding, produced_model)`` pairs from
+            :func:`winml.modelkit.optim.iter_optimization_outputs`. Materialize
+            the iterator once and reuse it across targets — the dry-run that
+            produces these pairs is target-independent, so only the support
+            lookup needs to run per EP/device.
+        ep: Target execution provider (canonical name).
+        device: Target device string (e.g. ``"NPU"``).
+        model_path: Path to the source model, used for external-data resolution.
+
+    Returns:
+        One :class:`OptimizationOutputSupport` per applicable optimization, in
+        the same order as ``optimization_outputs``.
+    """
+    return [
+        _check_one(finding, produced_model, ep, device, model_path)
+        for finding, produced_model in optimization_outputs
+    ]

--- a/src/winml/modelkit/commands/analyze.py
+++ b/src/winml/modelkit/commands/analyze.py
@@ -914,7 +914,7 @@ def _build_runtime_debug_output_path(model_path: Path, ep_name: str, device_name
     help="Save auto-discovered optimization config to JSON file",
 )
 @click.option(
-    "--check-optim-output/--no-check-optim-output",
+    "--check-optim/--no-check-optim",
     default=False,
     help=(
         "For each optimization that would change the model, check whether the "
@@ -940,7 +940,7 @@ def analyze(
     debug: bool,
     save_node: tuple[str, ...],
     optim_config: Path | None,
-    check_optim_output: bool,
+    check_optim: bool,
 ) -> None:
     r"""Analyze ONNX model for runtime support with live progress.
 
@@ -1194,11 +1194,11 @@ def analyze(
         console = Console(stderr=True)
 
         # Optionally probe which optimizations would change the model and what
-        # operators they would introduce. The dry-run is target-independent, so
+        # operators they would introduce. This probe is target-independent, so
         # materialize it once here and only re-run the (cheap) support lookup per
         # EP/device below. Console-only feature — skipped in quiet mode.
         optim_outputs: list[tuple[Any, Any]] = []
-        if check_optim_output and not quiet:
+        if check_optim and not quiet:
             try:
                 import onnx
 
@@ -1513,7 +1513,7 @@ def analyze(
                         console.print()
 
                     # Optimization output support section (per-EP), when opted in.
-                    if check_optim_output:
+                    if check_optim:
                         from ..analyze.optim_output import check_optimization_output_support
 
                         optim_support = check_optimization_output_support(

--- a/src/winml/modelkit/commands/analyze.py
+++ b/src/winml/modelkit/commands/analyze.py
@@ -24,6 +24,7 @@ import click
 from rich.console import Console
 from rich.live import Live
 from rich.logging import RichHandler
+from rich.markup import escape
 from rich.progress import (
     BarColumn,
     MofNCompleteColumn,
@@ -51,6 +52,7 @@ from ..utils.logging import configure_logging
 
 if TYPE_CHECKING:
     from ..analyze.models.runtime_checks import PatternRuntime
+    from ..analyze.optim_output import OptimizationOutputSupport
 
 
 logger = logging.getLogger(__name__)
@@ -498,6 +500,82 @@ def _render_analysis_summary(
         console.print()
 
 
+def _render_optim_output_support(
+    console: Console,
+    results: list[OptimizationOutputSupport],
+    target_label: str,
+    *,
+    verbose: bool = False,
+) -> None:
+    """Render produced-operator target support for applicable optimizations.
+
+    For each optimization that would change the model, this shows whether the
+    operators it *introduces* (added/modified nodes) are supported on the
+    resolved EP/device, using the same runtime-support rule data as the op
+    check above.
+
+    Args:
+        console: Rich console for output.
+        results: Per-optimization support results for one target, in pipeline
+            order (from :func:`check_optimization_output_support`).
+        target_label: Human-readable EP/device label for the section header.
+        verbose: When True, always show the per-operator reason string.
+    """
+    console.print("\u2550" * 80)
+    console.print(f"\U0001f9e9 [bold]OPTIMIZATION OUTPUT SUPPORT[/bold] \u2014 {target_label}")
+    console.print("\u2550" * 80)
+
+    from ..analyze.models.support_level import SupportLevel
+
+    if not results:
+        console.print(
+            "   [dim]No registered optimization would change this model \u2014 "
+            "nothing to check.[/dim]"
+        )
+        console.print()
+        return
+
+    for opt in results:
+        worst_color = _COLORS.get(opt.worst_support.value, "white")
+        console.print(
+            f"[bold green]{escape(opt.enable_flag)}[/bold green]  "
+            f"[dim]({escape(opt.category)})[/dim]  "
+            f"[{worst_color}]{opt.worst_support.value}[/{worst_color}]"
+        )
+        console.print(f"  [dim]{escape(opt.description)}[/dim]")
+
+        if opt.error:
+            console.print(
+                f"  [yellow]Could not check produced operators: {escape(opt.error)}[/yellow]"
+            )
+            console.print()
+            continue
+
+        if not opt.operators:
+            console.print("  [dim]No new operators produced.[/dim]")
+            console.print()
+            continue
+
+        for op in opt.operators:
+            color = _COLORS.get(op.support.value, "white")
+            marker = "+" if op.change == "added" else "~"
+            line = (
+                f"    [{color}]\u25cf[/{color}] {marker} {escape(op.label)} "
+                f"[{color}]{op.support.value}[/{color}]"
+            )
+            if op.reason and (verbose or op.support is not SupportLevel.SUPPORTED):
+                line += f" [dim]({escape(op.reason)})[/dim]"
+            console.print(line)
+
+        console.print()
+
+    console.print(
+        "  [dim]Shows whether operators an optimization would introduce are supported "
+        "on the target. Enable one with its --enable-* flag (dependencies auto-enabled).[/dim]"
+    )
+    console.print()
+
+
 def _resolve_run_unknown_op(
     ep: EPName,
     device: str,
@@ -835,6 +913,15 @@ def _build_runtime_debug_output_path(model_path: Path, ep_name: str, device_name
     default=None,
     help="Save auto-discovered optimization config to JSON file",
 )
+@click.option(
+    "--check-optim-output/--no-check-optim-output",
+    default=False,
+    help=(
+        "For each optimization that would change the model, check whether the "
+        "operators it introduces are supported on the resolved EP/device "
+        "(default: disabled)"
+    ),
+)
 @click.pass_context
 def analyze(
     ctx: click.Context,
@@ -853,6 +940,7 @@ def analyze(
     debug: bool,
     save_node: tuple[str, ...],
     optim_config: Path | None,
+    check_optim_output: bool,
 ) -> None:
     r"""Analyze ONNX model for runtime support with live progress.
 
@@ -1104,6 +1192,27 @@ def analyze(
 
         # Console for Rich output (stderr so stdout stays clean for JSON)
         console = Console(stderr=True)
+
+        # Optionally probe which optimizations would change the model and what
+        # operators they would introduce. The dry-run is target-independent, so
+        # materialize it once here and only re-run the (cheap) support lookup per
+        # EP/device below. Console-only feature — skipped in quiet mode.
+        optim_outputs: list[tuple[Any, Any]] = []
+        if check_optim_output and not quiet:
+            try:
+                import onnx
+
+                from ..optim import get_all_capabilities, iter_optimization_outputs
+
+                console.print(
+                    "[dim]Probing optimization outputs "
+                    "(this can take a while on large models)…[/dim]"
+                )
+                optim_proto = onnx.load(str(model))
+                optim_outputs = list(iter_optimization_outputs(optim_proto, get_all_capabilities()))
+            except Exception as exc:
+                logger.warning("Could not probe optimization outputs: %s", exc)
+                optim_outputs = []
 
         # Model info header
         if not quiet:
@@ -1402,6 +1511,23 @@ def analyze(
                             "  [bright_black]██[/bright_black] unknown"
                         )
                         console.print()
+
+                    # Optimization output support section (per-EP), when opted in.
+                    if check_optim_output:
+                        from ..analyze.optim_output import check_optimization_output_support
+
+                        optim_support = check_optimization_output_support(
+                            optim_outputs,
+                            ep=target_ep,
+                            device=target_device,
+                            model_path=str(model),
+                        )
+                        _render_optim_output_support(
+                            console,
+                            optim_support,
+                            _ep_name_device_display_name(target_ep, target_device),
+                            verbose=verbose > 0,
+                        )
             finally:
                 # Safety: stop Live if still running (e.g. on exception)
                 _finalize_live(mark_complete=False)

--- a/src/winml/modelkit/commands/analyze.py
+++ b/src/winml/modelkit/commands/analyze.py
@@ -1210,6 +1210,15 @@ def analyze(
                 )
                 optim_proto = onnx.load(str(model))
                 optim_outputs = list(iter_optimization_outputs(optim_proto, get_all_capabilities()))
+                # Each entry retains a full produced-model clone so the (cheap)
+                # per-target support lookup below can reuse them across every
+                # resolved EP/device without re-running the probe. The trade-off
+                # is peak memory ~ (#applicable optimizations x model size); log
+                # the count so that cost is visible for large models.
+                logger.info(
+                    "Probed %d applicable optimization(s) for output support checking",
+                    len(optim_outputs),
+                )
             except Exception as exc:
                 logger.warning("Could not probe optimization outputs: %s", exc)
                 optim_outputs = []

--- a/src/winml/modelkit/commands/optimize.py
+++ b/src/winml/modelkit/commands/optimize.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Any, TypeVar
 
 import click
 from rich.console import Console
+from rich.markup import escape
 
 from ..onnx import load_onnx, save_onnx
 from ..utils import cli as cli_utils
@@ -151,6 +152,113 @@ def capability_options(func: F) -> F:
     return func
 
 
+def _render_dry_run(findings: list[Any], verbose: bool) -> None:
+    """Render the applicability report produced by a dry run.
+
+    Args:
+        findings: Applicable ``CapabilityFinding`` objects in pipeline order.
+        verbose: When True, list every affected node instead of a sample.
+    """
+    if not findings:
+        console.print("\n[yellow]No registered optimizations would change this model.[/yellow]")
+        return
+
+    console.print(f"\n[bold]{len(findings)} applicable optimization(s):[/bold]\n")
+
+    sample_limit = 6
+    for finding in findings:
+        console.print(
+            f"[bold green]{finding.enable_flag}[/bold green]  [dim]({finding.category})[/dim]"
+        )
+        console.print(f"  {escape(finding.description)}")
+
+        segments: list[str] = []
+        if finding.removed_nodes:
+            segments.append(f"[red]-{len(finding.removed_nodes)}[/red]")
+        if finding.added_nodes:
+            segments.append(f"[green]+{len(finding.added_nodes)}[/green]")
+        if finding.modified_nodes:
+            segments.append(f"[yellow]~{len(finding.modified_nodes)}[/yellow]")
+        if segments:
+            console.print(f"  nodes: {' '.join(segments)}")
+
+        for kind, nodes in (
+            ("removed", finding.removed_nodes),
+            ("added", finding.added_nodes),
+            ("modified", finding.modified_nodes),
+        ):
+            if not nodes:
+                continue
+            histogram = ", ".join(
+                f"{escape(op)} ({count})" for op, count in finding.op_histogram(kind)
+            )
+            console.print(f"    {kind}: {histogram}")
+            shown = nodes if verbose else nodes[:sample_limit]
+            for node in shown:
+                console.print(f"      [dim]- {escape(node.label())}[/dim]")
+            if not verbose and len(nodes) > sample_limit:
+                console.print(f"      [dim]… and {len(nodes) - sample_limit} more (use -v)[/dim]")
+
+        const_segments: list[str] = []
+        if finding.modified_initializers:
+            const_segments.append(f"[yellow]~{len(finding.modified_initializers)}[/yellow]")
+        if finding.added_initializers:
+            const_segments.append(f"[green]+{len(finding.added_initializers)}[/green]")
+        if finding.removed_initializers:
+            const_segments.append(f"[red]-{len(finding.removed_initializers)}[/red]")
+        if const_segments:
+            console.print(f"  constants: {' '.join(const_segments)}")
+            touched = (
+                finding.modified_initializers
+                + finding.added_initializers
+                + finding.removed_initializers
+            )
+            shown_inits = touched if verbose else touched[:sample_limit]
+            for name in shown_inits:
+                console.print(f"      [dim]- {escape(name)}[/dim]")
+            if not verbose and len(touched) > sample_limit:
+                console.print(f"      [dim]… and {len(touched) - sample_limit} more (use -v)[/dim]")
+
+        console.print()
+
+    console.print(
+        "[dim]Enable any of the above with its --enable-* flag "
+        "(dependencies are auto-enabled).[/dim]"
+    )
+
+
+def _run_dry_run(model: Path, all_caps: dict[str, Any], verbose: bool) -> None:
+    """Probe which optimizations apply to the model and print a report.
+
+    No output file is written. Every boolean capability that is off by default
+    is evaluated independently against the model.
+
+    Args:
+        model: Path to the input ONNX model.
+        all_caps: The full capability registry.
+        verbose: Whether to show every affected node/constant.
+    """
+    from ..optim import BoolCapability, analyze_model
+
+    probe_count = sum(
+        1 for cap in all_caps.values() if isinstance(cap, BoolCapability) and not cap.default
+    )
+
+    console.print(f"[bold blue]Input:[/bold blue] {model}")
+    console.print("[dim]Dry run — analyzing applicable optimizations (no output written).[/dim]")
+    console.print("\n[bold]Loading model...[/bold]")
+    onnx_model = load_onnx(model)
+
+    console.print(
+        f"[bold]Probing {probe_count} optimization capabilities...[/bold] "
+        "[dim](this can take a while on large models)[/dim]"
+    )
+    with console.status("[bold]Analyzing...[/bold]", spinner="dots"):
+        findings = analyze_model(onnx_model, all_caps)
+
+    _render_dry_run(findings, verbose)
+
+
 @click.command()
 @click.option(
     "--list-capabilities",
@@ -164,6 +272,13 @@ def capability_options(func: F) -> F:
     is_flag=True,
     default=False,
     help="List available pattern rewrite families and exit",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Analyze which optimizations apply to the model (and the nodes they "
+    "affect) without writing any output",
 )
 @cli_utils.model_path_option(
     # Not required when --list-capabilities/--list-rewrites is used
@@ -187,6 +302,7 @@ def optimize(
     ctx: click.Context,
     list_capabilities: bool,
     list_rewrites: bool,
+    dry_run: bool,
     model: Path | None,
     output: Path | None,
     overwrite: bool,
@@ -214,6 +330,10 @@ def optimize(
 
         # List available rewrite pattern families
         winml optimize --list-rewrites
+
+        # Check which optimizations apply to a model (and the nodes they
+        # affect) without writing any output
+        winml optimize -m model.onnx --dry-run
 
         # Pattern rewrite flags follow: --enable-{source-slug}-{target-slug}
         # Run --list-rewrites to discover all available flag names.
@@ -339,6 +459,11 @@ def optimize(
     # Merge top-level -v/-q with subcommand-level flags so either position works.
     verbose, quiet = cli_utils.resolve_verbosity(ctx, verbose, quiet)
     configure_logging(verbosity=verbose, quiet=quiet)
+
+    # Handle --dry-run: report which optimizations apply, write nothing.
+    if dry_run:
+        _run_dry_run(model, all_caps, bool(verbose))
+        return
 
     # Import optimizer
     from ..optim import Optimizer

--- a/src/winml/modelkit/commands/optimize.py
+++ b/src/winml/modelkit/commands/optimize.py
@@ -152,8 +152,8 @@ def capability_options(func: F) -> F:
     return func
 
 
-def _render_dry_run(findings: list[Any], verbose: bool) -> None:
-    """Render the applicability report produced by a dry run.
+def _render_check_optim(findings: list[Any], verbose: bool) -> None:
+    """Render the applicability report produced by a ``--check-optim`` probe.
 
     Args:
         findings: Applicable ``CapabilityFinding`` objects in pipeline order.
@@ -227,7 +227,7 @@ def _render_dry_run(findings: list[Any], verbose: bool) -> None:
     )
 
 
-def _run_dry_run(model: Path, all_caps: dict[str, Any], verbose: bool) -> None:
+def _run_check_optim(model: Path, all_caps: dict[str, Any], verbose: bool) -> None:
     """Probe which optimizations apply to the model and print a report.
 
     No output file is written. Every boolean capability that is off by default
@@ -245,7 +245,9 @@ def _run_dry_run(model: Path, all_caps: dict[str, Any], verbose: bool) -> None:
     )
 
     console.print(f"[bold blue]Input:[/bold blue] {model}")
-    console.print("[dim]Dry run — analyzing applicable optimizations (no output written).[/dim]")
+    console.print(
+        "[dim]--check-optim — analyzing applicable optimizations (no output written).[/dim]"
+    )
     console.print("\n[bold]Loading model...[/bold]")
     onnx_model = load_onnx(model)
 
@@ -256,7 +258,7 @@ def _run_dry_run(model: Path, all_caps: dict[str, Any], verbose: bool) -> None:
     with console.status("[bold]Analyzing...[/bold]", spinner="dots"):
         findings = analyze_model(onnx_model, all_caps)
 
-    _render_dry_run(findings, verbose)
+    _render_check_optim(findings, verbose)
 
 
 @click.command()
@@ -274,7 +276,7 @@ def _run_dry_run(model: Path, all_caps: dict[str, Any], verbose: bool) -> None:
     help="List available pattern rewrite families and exit",
 )
 @click.option(
-    "--dry-run",
+    "--check-optim",
     is_flag=True,
     default=False,
     help="Analyze which optimizations apply to the model (and the nodes they "
@@ -302,7 +304,7 @@ def optimize(
     ctx: click.Context,
     list_capabilities: bool,
     list_rewrites: bool,
-    dry_run: bool,
+    check_optim: bool,
     model: Path | None,
     output: Path | None,
     overwrite: bool,
@@ -333,7 +335,7 @@ def optimize(
 
         # Check which optimizations apply to a model (and the nodes they
         # affect) without writing any output
-        winml optimize -m model.onnx --dry-run
+        winml optimize -m model.onnx --check-optim
 
         # Pattern rewrite flags follow: --enable-{source-slug}-{target-slug}
         # Run --list-rewrites to discover all available flag names.
@@ -460,9 +462,9 @@ def optimize(
     verbose, quiet = cli_utils.resolve_verbosity(ctx, verbose, quiet)
     configure_logging(verbosity=verbose, quiet=quiet)
 
-    # Handle --dry-run: report which optimizations apply, write nothing.
-    if dry_run:
-        _run_dry_run(model, all_caps, bool(verbose))
+    # Handle --check-optim: report which optimizations apply, write nothing.
+    if check_optim:
+        _run_check_optim(model, all_caps, bool(verbose))
         return
 
     # Import optimizer

--- a/src/winml/modelkit/commands/optimize.py
+++ b/src/winml/modelkit/commands/optimize.py
@@ -152,10 +152,11 @@ def capability_options(func: F) -> F:
     return func
 
 
-def _render_check_optim(findings: list[Any], verbose: bool) -> None:
+def _render_check_optim(console: Console, findings: list[Any], verbose: bool) -> None:
     """Render the applicability report produced by a ``--check-optim`` probe.
 
     Args:
+        console: Rich console for output.
         findings: Applicable ``CapabilityFinding`` objects in pipeline order.
         verbose: When True, list every affected node instead of a sample.
     """
@@ -258,7 +259,7 @@ def _run_check_optim(model: Path, all_caps: dict[str, Any], verbose: bool) -> No
     with console.status("[bold]Analyzing...[/bold]", spinner="dots"):
         findings = analyze_model(onnx_model, all_caps)
 
-    _render_check_optim(findings, verbose)
+    _render_check_optim(console, findings, verbose)
 
 
 @click.command()

--- a/src/winml/modelkit/optim/__init__.py
+++ b/src/winml/modelkit/optim/__init__.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from .analysis import CapabilityFinding, NodeRef, analyze_model
 from .api import optimize_onnx
 from .config import WinMLOptimizationConfig
 from .errors import ConfigurationError, ModelValidationError, OptimizationError
@@ -42,13 +43,16 @@ from .registry import (
 
 __all__ = [
     "BoolCapability",
+    "CapabilityFinding",
     "ChoiceCapability",
     "ConfigurationError",
     "IntCapability",
     "ModelValidationError",
+    "NodeRef",
     "OptimizationError",
     "Optimizer",
     "WinMLOptimizationConfig",
+    "analyze_model",
     "auto_enable_dependencies",
     "optimize_onnx",
     "validate",

--- a/src/winml/modelkit/optim/__init__.py
+++ b/src/winml/modelkit/optim/__init__.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from .analysis import CapabilityFinding, NodeRef, analyze_model
+from .analysis import CapabilityFinding, NodeRef, analyze_model, iter_optimization_outputs
 from .api import optimize_onnx
 from .config import WinMLOptimizationConfig
 from .errors import ConfigurationError, ModelValidationError, OptimizationError
@@ -54,6 +54,7 @@ __all__ = [
     "WinMLOptimizationConfig",
     "analyze_model",
     "auto_enable_dependencies",
+    "iter_optimization_outputs",
     "optimize_onnx",
     "validate",
     "validate_dependencies",

--- a/src/winml/modelkit/optim/analysis.py
+++ b/src/winml/modelkit/optim/analysis.py
@@ -28,7 +28,7 @@ from collections import Counter
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from onnx import AttributeProto, GraphProto, ModelProto, NodeProto
+from onnx import AttributeProto, GraphProto, ModelProto, NodeProto, TensorProto
 
 
 if TYPE_CHECKING:
@@ -170,22 +170,27 @@ def _collect_nodes(
 ) -> None:
     """Populate ``table`` with ``{key: (serialized, NodeRef)}`` for every node.
 
-    Recurses into subgraphs (If/Loop/Scan bodies) so nested rewrites are not
-    missed. Keys are scoped by the containing node to keep subgraph nodes
-    distinct from top-level nodes.
+    Walks subgraphs (If/Loop/Scan bodies) so nested rewrites are not missed.
+    Keys are scoped by the containing node to keep subgraph nodes distinct from
+    top-level nodes. Traversal is iterative (explicit stack) rather than
+    recursive so that pathologically deep subgraph nesting cannot exhaust
+    Python's recursion limit.
     """
-    for node in graph.node:
-        key = (scope, _node_identity(node))
-        table[key] = (
-            node.SerializeToString(),
-            NodeRef(node.op_type, node.name, tuple(node.output)),
-        )
-        for attr in node.attribute:
-            if attr.type == AttributeProto.GRAPH:
-                _collect_nodes(attr.g, (*scope, _node_identity(node), attr.name), table)
-            elif attr.type == AttributeProto.GRAPHS:
-                for i, sub in enumerate(attr.graphs):
-                    _collect_nodes(sub, (*scope, _node_identity(node), attr.name, i), table)
+    stack: list[tuple[GraphProto, tuple[Any, ...]]] = [(graph, scope)]
+    while stack:
+        cur_graph, cur_scope = stack.pop()
+        for node in cur_graph.node:
+            key = (cur_scope, _node_identity(node))
+            table[key] = (
+                node.SerializeToString(),
+                NodeRef(node.op_type, node.name, tuple(node.output)),
+            )
+            for attr in node.attribute:
+                if attr.type == AttributeProto.GRAPH:
+                    stack.append((attr.g, (*cur_scope, _node_identity(node), attr.name)))
+                elif attr.type == AttributeProto.GRAPHS:
+                    for i, sub in enumerate(attr.graphs):
+                        stack.append((sub, (*cur_scope, _node_identity(node), attr.name, i)))
 
 
 def _diff_nodes(
@@ -201,9 +206,29 @@ def _diff_nodes(
     return removed, added, modified
 
 
+def _initializer_key(init: TensorProto) -> bytes:
+    """Serialize an initializer for diffing, ignoring external-data location.
+
+    An external-data ``TensorProto`` keeps its file path/offset/length in
+    ``external_data`` (with ``data_location = EXTERNAL``) instead of inline
+    ``raw_data``. Those location fields change whenever a pipe re-saves the
+    model — relocated offsets, a different sidecar path — even when the tensor
+    itself is unchanged, which would otherwise surface as a spurious "modified"
+    initializer. Stripping them keeps the diff keyed on tensor identity/content
+    rather than on where the bytes happen to live.
+    """
+    if init.data_location == TensorProto.EXTERNAL or len(init.external_data):
+        normalized = TensorProto()
+        normalized.CopyFrom(init)
+        normalized.ClearField("external_data")
+        normalized.ClearField("data_location")
+        return normalized.SerializeToString()
+    return init.SerializeToString()
+
+
 def _collect_initializers(model: ModelProto) -> dict[str, bytes]:
-    """Return ``{initializer_name: serialized_bytes}`` for the top-level graph."""
-    return {init.name: init.SerializeToString() for init in model.graph.initializer}
+    """Return ``{initializer_name: signature_bytes}`` for the top-level graph."""
+    return {init.name: _initializer_key(init) for init in model.graph.initializer}
 
 
 def _diff_initializers(
@@ -292,7 +317,18 @@ def _iter_findings(
         pipe = pipe_class()
 
         base_config = pipe.build_config(**default_kwargs)
-        base_out = _run_pipe(pipe, current, base_config)
+        try:
+            base_out = _run_pipe(pipe, current, base_config)
+        except Exception as exc:
+            # A pipe failing on its own default config would otherwise abort the
+            # whole scan. Skip this pipe's probes and leave ``current`` untouched
+            # so downstream pipes still see the last good model.
+            logger.warning(
+                "Skipping pipe '%s' — baseline run failed on default config: %s",
+                getattr(pipe, "name", pipe_class.__name__),
+                exc,
+            )
+            continue
         base_nodes: dict[tuple[Any, ...], tuple[bytes, NodeRef]] = {}
         _collect_nodes(base_out.graph, (), base_nodes)
         base_inits = _collect_initializers(base_out)

--- a/src/winml/modelkit/optim/analysis.py
+++ b/src/winml/modelkit/optim/analysis.py
@@ -1,0 +1,352 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Applicability analysis for the capability-driven optimizer (dry-run).
+
+This module answers the question "which optimizations *could* be applied to
+this model, and on which nodes?" without producing an optimized output.
+
+Approach (universal, architecture-agnostic — CARDINAL RULE #1):
+    The pipeline is walked pipe-by-pipe exactly as the real optimizer runs it.
+    For each pipe a baseline output is produced with the pipe's default config.
+    Every boolean capability owned by the pipe (that is off by default) is then
+    probed independently: the pipe is re-run on the *same upstream model* with
+    only that capability enabled (plus auto-enabled dependencies), and the
+    resulting graph is diffed against the baseline. A non-empty diff means the
+    capability is applicable; the diff itself names the affected nodes and
+    constants.
+
+No operator names, tensor names, or architectures are hardcoded — every result
+is derived from the concrete graph diff.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+
+if TYPE_CHECKING:
+    import onnx
+
+    from .registry import CapabilityDef
+
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# RESULT TYPES
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class NodeRef:
+    """A lightweight reference to a graph node for reporting.
+
+    Attributes:
+        op_type: The node's operator type (e.g. ``"MatMul"``).
+        name: The node's name (may be empty — ONNX names are optional).
+        outputs: The node's output tensor names.
+    """
+
+    op_type: str
+    name: str
+    outputs: tuple[str, ...]
+
+    def label(self) -> str:
+        """Return a human-readable identifier for this node.
+
+        Falls back to the first output tensor name when the node is unnamed,
+        since output names are unique within a graph.
+        """
+        ident = self.name or (self.outputs[0] if self.outputs else "?")
+        return f"{self.op_type} '{ident}'"
+
+
+@dataclass
+class CapabilityFinding:
+    """The result of probing a single optimization capability.
+
+    Attributes:
+        name: Capability name (kebab-case, e.g. ``"matmul-add-fusion"``).
+        python_name: snake_case identifier used in optimizer kwargs.
+        enable_flag: CLI flag that turns the capability on.
+        category: Capability category value (e.g. ``"matmul"``).
+        description: Human-readable capability description.
+        pipe_name: Name of the pipe that owns the capability.
+        removed_nodes: Nodes present in the baseline but gone after the probe
+            (consumed / eliminated by the optimization).
+        added_nodes: Nodes introduced by the probe (e.g. a fused op).
+        modified_nodes: Nodes whose definition changed in place.
+        removed_initializers: Initializer (constant) names removed by the probe.
+        added_initializers: Initializer names added by the probe.
+        modified_initializers: Initializer names whose data changed.
+    """
+
+    name: str
+    python_name: str
+    enable_flag: str
+    category: str
+    description: str
+    pipe_name: str
+    removed_nodes: list[NodeRef] = field(default_factory=list)
+    added_nodes: list[NodeRef] = field(default_factory=list)
+    modified_nodes: list[NodeRef] = field(default_factory=list)
+    removed_initializers: list[str] = field(default_factory=list)
+    added_initializers: list[str] = field(default_factory=list)
+    modified_initializers: list[str] = field(default_factory=list)
+
+    @property
+    def applicable(self) -> bool:
+        """True when the capability changes the model in any observable way."""
+        return bool(
+            self.removed_nodes
+            or self.added_nodes
+            or self.modified_nodes
+            or self.removed_initializers
+            or self.added_initializers
+            or self.modified_initializers
+        )
+
+    @property
+    def affected_node_count(self) -> int:
+        """Total number of nodes touched (removed + added + modified)."""
+        return len(self.removed_nodes) + len(self.added_nodes) + len(self.modified_nodes)
+
+    def op_histogram(self, kind: str) -> list[tuple[str, int]]:
+        """Return an op-type frequency list for one node bucket.
+
+        Args:
+            kind: One of ``"removed"``, ``"added"`` or ``"modified"``.
+
+        Returns:
+            ``(op_type, count)`` pairs ordered from most to least frequent.
+        """
+        nodes = {
+            "removed": self.removed_nodes,
+            "added": self.added_nodes,
+            "modified": self.modified_nodes,
+        }[kind]
+        return Counter(n.op_type for n in nodes).most_common()
+
+
+# =============================================================================
+# GRAPH DIFF HELPERS
+# =============================================================================
+
+
+def _node_identity(node: onnx.NodeProto) -> tuple[Any, ...]:
+    """Return a key that identifies a node stably across transformations.
+
+    Output tensor names are unique within a valid ONNX graph, so they make a
+    node identifiable even when its inputs are rewired or its attributes change
+    (that manifests as a "modified" node rather than a remove+add pair).
+
+    Nodes without outputs (rare) fall back to a structural signature.
+    """
+    if len(node.output) > 0:
+        return tuple(node.output)
+    return ("\0no-output", node.op_type, node.name, tuple(node.input))
+
+
+def _collect_nodes(
+    graph: onnx.GraphProto,
+    scope: tuple[Any, ...],
+    table: dict[tuple[Any, ...], tuple[bytes, NodeRef]],
+) -> None:
+    """Populate ``table`` with ``{key: (serialized, NodeRef)}`` for every node.
+
+    Recurses into subgraphs (If/Loop/Scan bodies) so nested rewrites are not
+    missed. Keys are scoped by the containing node to keep subgraph nodes
+    distinct from top-level nodes.
+    """
+    import onnx
+
+    for node in graph.node:
+        key = (scope, _node_identity(node))
+        table[key] = (
+            node.SerializeToString(),
+            NodeRef(node.op_type, node.name, tuple(node.output)),
+        )
+        for attr in node.attribute:
+            if attr.type == onnx.AttributeProto.GRAPH:
+                _collect_nodes(attr.g, (*scope, _node_identity(node), attr.name), table)
+            elif attr.type == onnx.AttributeProto.GRAPHS:
+                for i, sub in enumerate(attr.graphs):
+                    _collect_nodes(sub, (*scope, _node_identity(node), attr.name, i), table)
+
+
+def _diff_nodes(
+    base: dict[tuple[Any, ...], tuple[bytes, NodeRef]],
+    probe: dict[tuple[Any, ...], tuple[bytes, NodeRef]],
+) -> tuple[list[NodeRef], list[NodeRef], list[NodeRef]]:
+    """Diff two node tables into (removed, added, modified) node lists."""
+    base_keys = set(base)
+    probe_keys = set(probe)
+    removed = [base[k][1] for k in base_keys - probe_keys]
+    added = [probe[k][1] for k in probe_keys - base_keys]
+    modified = [probe[k][1] for k in (base_keys & probe_keys) if base[k][0] != probe[k][0]]
+    return removed, added, modified
+
+
+def _collect_initializers(model: onnx.ModelProto) -> dict[str, bytes]:
+    """Return ``{initializer_name: serialized_bytes}`` for the top-level graph."""
+    return {init.name: init.SerializeToString() for init in model.graph.initializer}
+
+
+def _diff_initializers(
+    base: dict[str, bytes],
+    probe: dict[str, bytes],
+) -> tuple[list[str], list[str], list[str]]:
+    """Diff two initializer tables into (removed, added, modified) name lists."""
+    base_names = set(base)
+    probe_names = set(probe)
+    removed = sorted(base_names - probe_names)
+    added = sorted(probe_names - base_names)
+    modified = sorted(n for n in (base_names & probe_names) if base[n] != probe[n])
+    return removed, added, modified
+
+
+# =============================================================================
+# ANALYSIS DRIVER
+# =============================================================================
+
+
+def _clone(model: onnx.ModelProto) -> onnx.ModelProto:
+    """Deep-copy a model.
+
+    ``CopyFrom`` is used rather than ``SerializeToString`` round-tripping so
+    that models larger than the 2 GiB protobuf serialization limit can still be
+    cloned in memory.
+    """
+    import onnx
+
+    copy = onnx.ModelProto()
+    copy.CopyFrom(model)
+    return copy
+
+
+def _run_pipe(pipe: Any, model: onnx.ModelProto, config: Any) -> onnx.ModelProto:
+    """Run a pipe on a *clone* of ``model``, respecting ``should_process``.
+
+    Cloning is mandatory: some pipes serialize the model via ``save_onnx`` which
+    can rewrite tensors to external-data references in place. Returning the
+    input unchanged when the pipe opts out keeps the baseline faithful to the
+    real pipeline.
+    """
+    should_process = getattr(pipe, "should_process", None)
+    if callable(should_process) and not should_process(config):
+        return model
+    return pipe.process(_clone(model), config)
+
+
+def analyze_model(
+    model: onnx.ModelProto,
+    capabilities: dict[str, CapabilityDef],
+) -> list[CapabilityFinding]:
+    """Probe every applicable optimization capability against ``model``.
+
+    Each boolean capability that is off by default is enabled in isolation and
+    its effect on the graph is measured by diffing against the pipe's baseline
+    output. Integer and choice capabilities are parameters rather than on/off
+    optimizations and are not probed.
+
+    Args:
+        model: The input ONNX model (never modified).
+        capabilities: The full capability registry (kebab-case keyed), e.g.
+            from ``optim.pipes.get_all_capabilities()``.
+
+    Returns:
+        Applicable findings in pipeline order, each naming the affected nodes
+        and constants.
+    """
+    from ..onnx import infer_shapes
+    from .pipes import PIPES
+    from .registry import BoolCapability, auto_enable_dependencies
+
+    # Baseline kwargs = every capability at its default value.
+    default_kwargs = {cap.python_name: cap.default for cap in capabilities.values()}
+    kebab_defaults = {name: cap.default for name, cap in capabilities.items()}
+
+    # Mandatory pre-stage — mirrors Optimizer.optimize().
+    current = infer_shapes(_clone(model))
+
+    findings: list[CapabilityFinding] = []
+
+    for pipe_class in PIPES:
+        pipe = pipe_class()
+
+        base_config = pipe.build_config(**default_kwargs)
+        base_out = _run_pipe(pipe, current, base_config)
+        base_nodes: dict[tuple[Any, ...], tuple[bytes, NodeRef]] = {}
+        _collect_nodes(base_out.graph, (), base_nodes)
+        base_inits = _collect_initializers(base_out)
+
+        probe_caps = [
+            (name, cap)
+            for name, cap in pipe.capabilities.items()
+            if isinstance(cap, BoolCapability) and not cap.default
+        ]
+
+        for cap_name, cap in probe_caps:
+            # Enable only this capability (plus its dependencies) on top of the
+            # all-defaults configuration.
+            kebab = dict(kebab_defaults)
+            kebab[cap_name] = True
+            kebab = auto_enable_dependencies(kebab, capabilities)
+            probe_kwargs = {
+                capabilities[name].python_name: value
+                for name, value in kebab.items()
+                if name in capabilities
+            }
+
+            probe_config = pipe.build_config(**probe_kwargs)
+            should_process = getattr(pipe, "should_process", None)
+            if callable(should_process) and not should_process(probe_config):
+                # Pipe would not run for this capability — nothing to apply.
+                continue
+
+            try:
+                probe_out = pipe.process(_clone(current), probe_config)
+            except Exception as exc:
+                logger.warning(
+                    "Could not evaluate capability '%s' on pipe '%s': %s",
+                    cap_name,
+                    pipe.name,
+                    exc,
+                )
+                continue
+
+            probe_nodes: dict[tuple[Any, ...], tuple[bytes, NodeRef]] = {}
+            _collect_nodes(probe_out.graph, (), probe_nodes)
+            removed, added, modified = _diff_nodes(base_nodes, probe_nodes)
+
+            probe_inits = _collect_initializers(probe_out)
+            rem_init, add_init, mod_init = _diff_initializers(base_inits, probe_inits)
+
+            finding = CapabilityFinding(
+                name=cap.name,
+                python_name=cap.python_name,
+                enable_flag=f"--enable-{cap.name}",
+                category=cap.category.value,
+                description=cap.description,
+                pipe_name=pipe.name,
+                removed_nodes=removed,
+                added_nodes=added,
+                modified_nodes=modified,
+                removed_initializers=rem_init,
+                added_initializers=add_init,
+                modified_initializers=mod_init,
+            )
+
+            if finding.applicable:
+                findings.append(finding)
+
+        # Advance the pipeline exactly as the real optimizer would.
+        current = base_out
+
+    return findings

--- a/src/winml/modelkit/optim/analysis.py
+++ b/src/winml/modelkit/optim/analysis.py
@@ -148,6 +148,14 @@ def _node_identity(node: NodeProto) -> tuple[Any, ...]:
     node identifiable even when its inputs are rewired or its attributes change
     (that manifests as a "modified" node rather than a remove+add pair).
 
+    Conversely, an optimization that *renames* a node's outputs (e.g. a MatMul
+    output ``mm`` -> ``mm/MatMulAddFusion``) changes this key, so the same
+    logical node is reported as a remove + add pair rather than a single
+    modification. This is an intentional semantics choice: the diff describes
+    the concrete graph delta (which tensors/nodes appear and disappear), not a
+    logical node-to-node correspondence, so output renames can inflate the
+    removed/added counts even though the net effect is a single rewritten node.
+
     Nodes without outputs (rare) fall back to a structural signature.
     """
     if len(node.output) > 0:

--- a/src/winml/modelkit/optim/analysis.py
+++ b/src/winml/modelkit/optim/analysis.py
@@ -32,6 +32,8 @@ from onnx import AttributeProto, GraphProto, ModelProto, NodeProto
 
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from .registry import CapabilityDef
 
 
@@ -241,25 +243,24 @@ def _run_pipe(pipe: Any, model: ModelProto, config: Any) -> ModelProto:
     return result
 
 
-def analyze_model(
+def _iter_findings(
     model: ModelProto,
     capabilities: dict[str, CapabilityDef],
-) -> list[CapabilityFinding]:
-    """Probe every applicable optimization capability against ``model``.
+) -> Iterator[tuple[CapabilityFinding, ModelProto]]:
+    """Yield ``(finding, produced_model)`` for every applicable optimization.
 
-    Each boolean capability that is off by default is enabled in isolation and
-    its effect on the graph is measured by diffing against the pipe's baseline
-    output. Integer and choice capabilities are parameters rather than on/off
-    optimizations and are not probed.
+    This is the shared core behind :func:`analyze_model` and
+    :func:`iter_optimization_outputs`. It walks the pipeline pipe-by-pipe
+    exactly as the real optimizer does, probing each default-off boolean
+    capability in isolation and diffing the result against the pipe baseline.
 
-    Args:
-        model: The input ONNX model (never modified).
-        capabilities: The full capability registry (kebab-case keyed), e.g.
-            from ``optim.pipes.get_all_capabilities()``.
+    ``produced_model`` is the concrete ONNX model that results from enabling the
+    single capability (plus auto-enabled dependencies). It contains the added
+    and modified nodes named by the finding, so downstream consumers can inspect
+    the produced operators directly (e.g. to check their EP/device support).
 
-    Returns:
-        Applicable findings in pipeline order, each naming the affected nodes
-        and constants.
+    Findings are yielded lazily in pipeline order; only applicable capabilities
+    (those that actually change the graph or its constants) are emitted.
     """
     from ..onnx import infer_shapes
     from .pipes import PIPES
@@ -271,8 +272,6 @@ def analyze_model(
 
     # Mandatory pre-stage — mirrors Optimizer.optimize().
     current = infer_shapes(_clone(model))
-
-    findings: list[CapabilityFinding] = []
 
     for pipe_class in PIPES:
         pipe = pipe_class()
@@ -341,9 +340,55 @@ def analyze_model(
             )
 
             if finding.applicable:
-                findings.append(finding)
+                yield finding, probe_out
 
         # Advance the pipeline exactly as the real optimizer would.
         current = base_out
 
-    return findings
+
+def analyze_model(
+    model: ModelProto,
+    capabilities: dict[str, CapabilityDef],
+) -> list[CapabilityFinding]:
+    """Probe every applicable optimization capability against ``model``.
+
+    Each boolean capability that is off by default is enabled in isolation and
+    its effect on the graph is measured by diffing against the pipe's baseline
+    output. Integer and choice capabilities are parameters rather than on/off
+    optimizations and are not probed.
+
+    Args:
+        model: The input ONNX model (never modified).
+        capabilities: The full capability registry (kebab-case keyed), e.g.
+            from ``optim.pipes.get_all_capabilities()``.
+
+    Returns:
+        Applicable findings in pipeline order, each naming the affected nodes
+        and constants.
+    """
+    return [finding for finding, _ in _iter_findings(model, capabilities)]
+
+
+def iter_optimization_outputs(
+    model: ModelProto,
+    capabilities: dict[str, CapabilityDef],
+) -> Iterator[tuple[CapabilityFinding, ModelProto]]:
+    """Yield each applicable optimization together with the model it produces.
+
+    Like :func:`analyze_model`, but also exposes the concrete ONNX model that
+    results from applying each optimization in isolation. The produced model
+    contains the finding's added and modified nodes, enabling callers to inspect
+    or further analyze the operators an optimization would introduce — for
+    example, checking whether those operators are supported on a target
+    execution provider and device.
+
+    Args:
+        model: The input ONNX model (never modified).
+        capabilities: The full capability registry (kebab-case keyed).
+
+    Yields:
+        ``(finding, produced_model)`` pairs in pipeline order, one per applicable
+        optimization. The pairs are produced lazily; materialize the iterator if
+        the produced models must outlive iteration.
+    """
+    yield from _iter_findings(model, capabilities)

--- a/src/winml/modelkit/optim/analysis.py
+++ b/src/winml/modelkit/optim/analysis.py
@@ -28,10 +28,10 @@ from collections import Counter
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from onnx import AttributeProto, GraphProto, ModelProto, NodeProto
+
 
 if TYPE_CHECKING:
-    import onnx
-
     from .registry import CapabilityDef
 
 
@@ -139,7 +139,7 @@ class CapabilityFinding:
 # =============================================================================
 
 
-def _node_identity(node: onnx.NodeProto) -> tuple[Any, ...]:
+def _node_identity(node: NodeProto) -> tuple[Any, ...]:
     """Return a key that identifies a node stably across transformations.
 
     Output tensor names are unique within a valid ONNX graph, so they make a
@@ -154,7 +154,7 @@ def _node_identity(node: onnx.NodeProto) -> tuple[Any, ...]:
 
 
 def _collect_nodes(
-    graph: onnx.GraphProto,
+    graph: GraphProto,
     scope: tuple[Any, ...],
     table: dict[tuple[Any, ...], tuple[bytes, NodeRef]],
 ) -> None:
@@ -164,8 +164,6 @@ def _collect_nodes(
     missed. Keys are scoped by the containing node to keep subgraph nodes
     distinct from top-level nodes.
     """
-    import onnx
-
     for node in graph.node:
         key = (scope, _node_identity(node))
         table[key] = (
@@ -173,9 +171,9 @@ def _collect_nodes(
             NodeRef(node.op_type, node.name, tuple(node.output)),
         )
         for attr in node.attribute:
-            if attr.type == onnx.AttributeProto.GRAPH:
+            if attr.type == AttributeProto.GRAPH:
                 _collect_nodes(attr.g, (*scope, _node_identity(node), attr.name), table)
-            elif attr.type == onnx.AttributeProto.GRAPHS:
+            elif attr.type == AttributeProto.GRAPHS:
                 for i, sub in enumerate(attr.graphs):
                     _collect_nodes(sub, (*scope, _node_identity(node), attr.name, i), table)
 
@@ -193,7 +191,7 @@ def _diff_nodes(
     return removed, added, modified
 
 
-def _collect_initializers(model: onnx.ModelProto) -> dict[str, bytes]:
+def _collect_initializers(model: ModelProto) -> dict[str, bytes]:
     """Return ``{initializer_name: serialized_bytes}`` for the top-level graph."""
     return {init.name: init.SerializeToString() for init in model.graph.initializer}
 
@@ -216,21 +214,19 @@ def _diff_initializers(
 # =============================================================================
 
 
-def _clone(model: onnx.ModelProto) -> onnx.ModelProto:
+def _clone(model: ModelProto) -> ModelProto:
     """Deep-copy a model.
 
     ``CopyFrom`` is used rather than ``SerializeToString`` round-tripping so
     that models larger than the 2 GiB protobuf serialization limit can still be
     cloned in memory.
     """
-    import onnx
-
-    copy = onnx.ModelProto()
+    copy = ModelProto()
     copy.CopyFrom(model)
     return copy
 
 
-def _run_pipe(pipe: Any, model: onnx.ModelProto, config: Any) -> onnx.ModelProto:
+def _run_pipe(pipe: Any, model: ModelProto, config: Any) -> ModelProto:
     """Run a pipe on a *clone* of ``model``, respecting ``should_process``.
 
     Cloning is mandatory: some pipes serialize the model via ``save_onnx`` which
@@ -241,11 +237,12 @@ def _run_pipe(pipe: Any, model: onnx.ModelProto, config: Any) -> onnx.ModelProto
     should_process = getattr(pipe, "should_process", None)
     if callable(should_process) and not should_process(config):
         return model
-    return pipe.process(_clone(model), config)
+    result: ModelProto = pipe.process(_clone(model), config)
+    return result
 
 
 def analyze_model(
-    model: onnx.ModelProto,
+    model: ModelProto,
     capabilities: dict[str, CapabilityDef],
 ) -> list[CapabilityFinding]:
     """Probe every applicable optimization capability against ``model``.

--- a/src/winml/modelkit/optim/analysis.py
+++ b/src/winml/modelkit/optim/analysis.py
@@ -235,6 +235,10 @@ def _run_pipe(pipe: Any, model: ModelProto, config: Any) -> ModelProto:
     can rewrite tensors to external-data references in place. Returning the
     input unchanged when the pipe opts out keeps the baseline faithful to the
     real pipeline.
+
+    Because every pipe run operates on a fresh clone, the shared model threaded
+    through the pipeline is never mutated in place, so returning the input
+    object unchanged when the pipe opts out cannot alias into a later probe.
     """
     should_process = getattr(pipe, "should_process", None)
     if callable(should_process) and not should_process(config):
@@ -270,7 +274,10 @@ def _iter_findings(
     default_kwargs = {cap.python_name: cap.default for cap in capabilities.values()}
     kebab_defaults = {name: cap.default for name, cap in capabilities.items()}
 
-    # Mandatory pre-stage — mirrors Optimizer.optimize().
+    # Mandatory pre-stage — mirrors Optimizer.optimize(). The clone is required:
+    # infer_shapes may mutate large models in place (for models over the protobuf
+    # limit it round-trips through save_onnx with external data), and this
+    # function must never modify the caller's input model.
     current = infer_shapes(_clone(model))
 
     for pipe_class in PIPES:
@@ -306,6 +313,12 @@ def _iter_findings(
                 # Pipe would not run for this capability — nothing to apply.
                 continue
 
+            # NB: this deliberately calls pipe.process directly rather than
+            # reusing _run_pipe. The probe must distinguish "pipe opts out"
+            # (handled above by continuing without emitting a finding) from
+            # "pipe ran but changed nothing", and it must isolate a failing
+            # capability in try/except so one bad probe cannot abort the scan —
+            # neither of which _run_pipe's return-unchanged contract expresses.
             try:
                 probe_out = pipe.process(_clone(current), probe_config)
             except Exception as exc:

--- a/tests/unit/analyze/test_optim_output.py
+++ b/tests/unit/analyze/test_optim_output.py
@@ -1,0 +1,239 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Tests for produced-operator EP/device support checking.
+
+Follows the Cardinal Rules:
+- #1 No hardcoded architectures — models are built generically in-test and the
+  produced operators are derived from the real dry-run diff.
+- #2 Code-generated results — expectations derive from the constructed graphs
+  and crafted runtime results, never from an LLM.
+- #4 No skips — deterministic assertions only.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from onnx import ModelProto, TensorProto, helper, numpy_helper
+
+from tests.unit.test_helpers import stable_test_node_keys
+from winml.modelkit.analyze.core import runtime_checker as runtime_checker_module
+from winml.modelkit.analyze.models.runtime_checks import PatternRuntime, RuntimeTestResult
+from winml.modelkit.analyze.models.support_level import SupportLevel
+from winml.modelkit.analyze.optim_output import (
+    OptimizationOutputSupport,
+    ProducedOperatorSupport,
+    check_optimization_output_support,
+)
+from winml.modelkit.optim import iter_optimization_outputs
+from winml.modelkit.optim.pipes import get_all_capabilities
+from winml.modelkit.pattern import (
+    OperatorPattern,
+    PatternMatchResult,
+    PatternType,
+    SkeletonMatchResult,
+)
+
+
+if TYPE_CHECKING:
+    import pytest
+
+
+# =============================================================================
+# MODEL BUILDERS
+# =============================================================================
+
+
+def _matmul_add_model() -> ModelProto:
+    """MatMul followed by Add — a canonical MatMul+Add(->Gemm) fusion candidate."""
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [4, 8])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [4, 16])
+    w = numpy_helper.from_array(np.random.randn(8, 16).astype(np.float32), "W")
+    b = numpy_helper.from_array(np.random.randn(16).astype(np.float32), "B")
+    nodes = [
+        helper.make_node("MatMul", ["x", "W"], ["mm"], name="mm"),
+        helper.make_node("Add", ["mm", "B"], ["y"], name="addbias"),
+    ]
+    graph = helper.make_graph(nodes, "matmul_add", [x], [y], initializer=[w, b])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+    model.ir_version = 10
+    return model
+
+
+def _runtime_for_output(output_name: str, *, compile_ok: bool, run_ok: bool) -> PatternRuntime:
+    """Craft a PatternRuntime whose matched node emits ``output_name``."""
+    pattern = OperatorPattern(
+        pattern_id="OP/ai.onnx/Gemm",
+        pattern_type=PatternType.OPERATOR,
+        namespace="ai.onnx",
+        op_type="Gemm",
+        description="",
+    )
+    node = helper.make_node("Gemm", ["in"], [output_name], name="gemm_node")
+    skeleton = SkeletonMatchResult(
+        pattern=pattern,
+        matched_nodes=[node],
+        matched_node_keys=stable_test_node_keys([node]),
+        matcher=None,
+    )
+    match = PatternMatchResult(
+        skeleton_match_result=skeleton,
+        schema_input_to_value={},
+        schema_output_to_value={},
+        type_param_to_type={},
+    )
+    return PatternRuntime(
+        pattern_id=pattern.pattern_id,
+        result=RuntimeTestResult(compile=compile_ok, run=run_ok),
+        pattern_match=match,
+    )
+
+
+def _patch_op_support(monkeypatch: pytest.MonkeyPatch, *, compile_ok: bool, run_ok: bool) -> None:
+    """Patch RuntimeChecker.op_support to classify every produced node deterministically."""
+
+    def fake_op_support(self, *, node_output_filter=None, on_node_result=None, **_kw):
+        outputs = sorted(node_output_filter or [])
+        return [_runtime_for_output(out, compile_ok=compile_ok, run_ok=run_ok) for out in outputs]
+
+    monkeypatch.setattr(runtime_checker_module.RuntimeChecker, "op_support", fake_op_support)
+
+
+# =============================================================================
+# DATACLASS BEHAVIOUR
+# =============================================================================
+
+
+class TestOptimizationOutputSupport:
+    def test_worst_support_empty_is_supported(self) -> None:
+        opt = OptimizationOutputSupport(
+            name="x",
+            enable_flag="--enable-x",
+            category="misc",
+            description="",
+            pipe_name="p",
+        )
+        assert opt.worst_support is SupportLevel.SUPPORTED
+
+    def test_worst_support_picks_most_concerning(self) -> None:
+        opt = OptimizationOutputSupport(
+            name="x",
+            enable_flag="--enable-x",
+            category="misc",
+            description="",
+            pipe_name="p",
+            operators=[
+                ProducedOperatorSupport("A", "A 'a'", "added", SupportLevel.SUPPORTED),
+                ProducedOperatorSupport("B", "B 'b'", "added", SupportLevel.UNSUPPORTED),
+                ProducedOperatorSupport("C", "C 'c'", "modified", SupportLevel.PARTIAL),
+            ],
+        )
+        assert opt.worst_support is SupportLevel.UNSUPPORTED
+
+    def test_worst_support_unknown_below_partial(self) -> None:
+        opt = OptimizationOutputSupport(
+            name="x",
+            enable_flag="--enable-x",
+            category="misc",
+            description="",
+            pipe_name="p",
+            operators=[
+                ProducedOperatorSupport("A", "A 'a'", "added", SupportLevel.SUPPORTED),
+                ProducedOperatorSupport("B", "B 'b'", "added", SupportLevel.UNKNOWN),
+            ],
+        )
+        assert opt.worst_support is SupportLevel.UNKNOWN
+
+    def test_support_counts(self) -> None:
+        opt = OptimizationOutputSupport(
+            name="x",
+            enable_flag="--enable-x",
+            category="misc",
+            description="",
+            pipe_name="p",
+            operators=[
+                ProducedOperatorSupport("A", "A 'a'", "added", SupportLevel.SUPPORTED),
+                ProducedOperatorSupport("B", "B 'b'", "added", SupportLevel.SUPPORTED),
+                ProducedOperatorSupport("C", "C 'c'", "modified", SupportLevel.PARTIAL),
+            ],
+        )
+        counts = opt.support_counts()
+        assert counts[SupportLevel.SUPPORTED] == 2
+        assert counts[SupportLevel.PARTIAL] == 1
+
+
+# =============================================================================
+# END-TO-END SUPPORT CHECK
+# =============================================================================
+
+
+class TestCheckOptimizationOutputSupport:
+    def test_produced_operator_marked_supported(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_op_support(monkeypatch, compile_ok=True, run_ok=True)
+        outputs = list(iter_optimization_outputs(_matmul_add_model(), get_all_capabilities()))
+
+        results = check_optimization_output_support(
+            outputs, ep="QNNExecutionProvider", device="NPU", model_path="model.onnx"
+        )
+
+        by_name = {r.name: r for r in results}
+        assert "matmul-add-fusion" in by_name, sorted(by_name)
+        fusion = by_name["matmul-add-fusion"]
+        assert fusion.error is None
+        assert fusion.operators, "expected at least one produced operator"
+        assert all(op.support is SupportLevel.SUPPORTED for op in fusion.operators)
+        assert fusion.worst_support is SupportLevel.SUPPORTED
+
+    def test_produced_operator_marked_unsupported(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_op_support(monkeypatch, compile_ok=False, run_ok=False)
+        outputs = list(iter_optimization_outputs(_matmul_add_model(), get_all_capabilities()))
+
+        results = check_optimization_output_support(
+            outputs, ep="QNNExecutionProvider", device="NPU", model_path="model.onnx"
+        )
+
+        fusion = next(r for r in results if r.name == "matmul-add-fusion")
+        assert fusion.worst_support is SupportLevel.UNSUPPORTED
+        assert all(op.support is SupportLevel.UNSUPPORTED for op in fusion.operators)
+
+    def test_partial_classification(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_op_support(monkeypatch, compile_ok=False, run_ok=True)
+        outputs = list(iter_optimization_outputs(_matmul_add_model(), get_all_capabilities()))
+
+        results = check_optimization_output_support(
+            outputs, ep="QNNExecutionProvider", device="NPU", model_path="model.onnx"
+        )
+
+        fusion = next(r for r in results if r.name == "matmul-add-fusion")
+        assert fusion.worst_support is SupportLevel.PARTIAL
+
+    def test_check_failure_is_captured_as_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def boom(self, **_kw):
+            raise RuntimeError("checker exploded")
+
+        monkeypatch.setattr(runtime_checker_module.RuntimeChecker, "op_support", boom)
+        outputs = list(iter_optimization_outputs(_matmul_add_model(), get_all_capabilities()))
+
+        results = check_optimization_output_support(
+            outputs, ep="QNNExecutionProvider", device="NPU", model_path="model.onnx"
+        )
+
+        fusion = next(r for r in results if r.name == "matmul-add-fusion")
+        assert fusion.error is not None
+        assert "checker exploded" in fusion.error
+        # With no operator data the optimization degrades to "supported" (nothing
+        # concerning was found), keeping the report non-alarming.
+        assert fusion.worst_support is SupportLevel.SUPPORTED
+
+    def test_preserves_input_order(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_op_support(monkeypatch, compile_ok=True, run_ok=True)
+        outputs = list(iter_optimization_outputs(_matmul_add_model(), get_all_capabilities()))
+
+        results = check_optimization_output_support(
+            outputs, ep="QNNExecutionProvider", device="NPU", model_path="model.onnx"
+        )
+
+        assert [r.name for r in results] == [finding.name for finding, _ in outputs]

--- a/tests/unit/analyze/test_static_analyzer_cli.py
+++ b/tests/unit/analyze/test_static_analyzer_cli.py
@@ -2140,8 +2140,8 @@ class TestAnalyzeFormatJson:
         assert "metadata" in file_data
 
 
-class TestAnalyzeCheckOptimOutput:
-    """Test the --check-optim-output flag wiring and rendering."""
+class TestAnalyzeCheckOptim:
+    """Test the --check-optim flag wiring and rendering."""
 
     @staticmethod
     def _write_model(path: Path) -> None:
@@ -2166,7 +2166,7 @@ class TestAnalyzeCheckOptimOutput:
     def test_flag_appears_in_help(self, runner: CliRunner) -> None:
         result = runner.invoke(analyze, ["--help"])
         assert result.exit_code == 0
-        assert "--check-optim-output" in result.output
+        assert "--check-optim" in result.output
 
     @patch("winml.modelkit.analyze.ONNXStaticAnalyzer")
     def test_opt_in_renders_section(
@@ -2177,7 +2177,7 @@ class TestAnalyzeCheckOptimOutput:
         mock_analyzer_result: Mock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """--check-optim-output renders a produced-operator support section."""
+        """--check-optim renders a produced-operator support section."""
         from winml.modelkit.analyze.models.support_level import SupportLevel
         from winml.modelkit.analyze.optim_output import (
             OptimizationOutputSupport,
@@ -2219,7 +2219,7 @@ class TestAnalyzeCheckOptimOutput:
                 "qnn",
                 "--device",
                 "NPU",
-                "--check-optim-output",
+                "--check-optim",
             ],
         )
 

--- a/tests/unit/analyze/test_static_analyzer_cli.py
+++ b/tests/unit/analyze/test_static_analyzer_cli.py
@@ -2138,3 +2138,132 @@ class TestAnalyzeFormatJson:
         assert output_file.exists()
         file_data = json.loads(output_file.read_text())
         assert "metadata" in file_data
+
+
+class TestAnalyzeCheckOptimOutput:
+    """Test the --check-optim-output flag wiring and rendering."""
+
+    @staticmethod
+    def _write_model(path: Path) -> None:
+        """Write a small valid MatMul+Add model (a Gemm-fusion candidate)."""
+        import numpy as np
+        import onnx
+        from onnx import TensorProto, helper, numpy_helper
+
+        x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [4, 8])
+        y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [4, 16])
+        w = numpy_helper.from_array(np.random.randn(8, 16).astype(np.float32), "W")
+        b = numpy_helper.from_array(np.random.randn(16).astype(np.float32), "B")
+        nodes = [
+            helper.make_node("MatMul", ["x", "W"], ["mm"], name="mm"),
+            helper.make_node("Add", ["mm", "B"], ["y"], name="addbias"),
+        ]
+        graph = helper.make_graph(nodes, "matmul_add", [x], [y], initializer=[w, b])
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+        model.ir_version = 10
+        onnx.save(model, str(path))
+
+    def test_flag_appears_in_help(self, runner: CliRunner) -> None:
+        result = runner.invoke(analyze, ["--help"])
+        assert result.exit_code == 0
+        assert "--check-optim-output" in result.output
+
+    @patch("winml.modelkit.analyze.ONNXStaticAnalyzer")
+    def test_opt_in_renders_section(
+        self,
+        mock_analyzer_class: MagicMock,
+        runner: CliRunner,
+        tmp_path: Path,
+        mock_analyzer_result: Mock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """--check-optim-output renders a produced-operator support section."""
+        from winml.modelkit.analyze.models.support_level import SupportLevel
+        from winml.modelkit.analyze.optim_output import (
+            OptimizationOutputSupport,
+            ProducedOperatorSupport,
+        )
+
+        model_file = tmp_path / "model.onnx"
+        self._write_model(model_file)
+
+        mock_instance = Mock()
+        mock_instance.analyze.return_value = mock_analyzer_result
+        mock_analyzer_class.return_value = mock_instance
+
+        crafted = [
+            OptimizationOutputSupport(
+                name="matmul-add-fusion",
+                enable_flag="--enable-matmul-add-fusion",
+                category="matmul",
+                description="Fuse MatMul followed by Add into a single Gemm.",
+                pipe_name="fusion",
+                operators=[
+                    ProducedOperatorSupport(
+                        "Gemm", "Gemm 'gemm'", "modified", SupportLevel.SUPPORTED
+                    )
+                ],
+            )
+        ]
+        monkeypatch.setattr(
+            "winml.modelkit.analyze.optim_output.check_optimization_output_support",
+            lambda *a, **k: crafted,
+        )
+
+        result = runner.invoke(
+            analyze,
+            [
+                "--model",
+                str(model_file),
+                "--ep",
+                "qnn",
+                "--device",
+                "NPU",
+                "--check-optim-output",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "OPTIMIZATION OUTPUT SUPPORT" in result.output
+        assert "--enable-matmul-add-fusion" in result.output
+        assert "supported" in result.output.lower()
+
+    @patch("winml.modelkit.analyze.ONNXStaticAnalyzer")
+    def test_disabled_by_default(
+        self,
+        mock_analyzer_class: MagicMock,
+        runner: CliRunner,
+        tmp_path: Path,
+        mock_analyzer_result: Mock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Without the flag the section is not rendered and the bridge is not called."""
+        model_file = tmp_path / "model.onnx"
+        self._write_model(model_file)
+
+        mock_instance = Mock()
+        mock_instance.analyze.return_value = mock_analyzer_result
+        mock_analyzer_class.return_value = mock_instance
+
+        def _should_not_run(*_a: object, **_k: object) -> list:
+            raise AssertionError("check_optimization_output_support should not be called")
+
+        monkeypatch.setattr(
+            "winml.modelkit.analyze.optim_output.check_optimization_output_support",
+            _should_not_run,
+        )
+
+        result = runner.invoke(
+            analyze,
+            [
+                "--model",
+                str(model_file),
+                "--ep",
+                "qnn",
+                "--device",
+                "NPU",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "OPTIMIZATION OUTPUT SUPPORT" not in result.output

--- a/tests/unit/analyze/test_static_analyzer_cli.py
+++ b/tests/unit/analyze/test_static_analyzer_cli.py
@@ -2147,8 +2147,7 @@ class TestAnalyzeCheckOptim:
     def _write_model(path: Path) -> None:
         """Write a small valid MatMul+Add model (a Gemm-fusion candidate)."""
         import numpy as np
-        import onnx
-        from onnx import TensorProto, helper, numpy_helper
+        from onnx import TensorProto, helper, numpy_helper, save
 
         x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [4, 8])
         y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [4, 16])
@@ -2161,7 +2160,7 @@ class TestAnalyzeCheckOptim:
         graph = helper.make_graph(nodes, "matmul_add", [x], [y], initializer=[w, b])
         model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
         model.ir_version = 10
-        onnx.save(model, str(path))
+        save(model, str(path))
 
     def test_flag_appears_in_help(self, runner: CliRunner) -> None:
         result = runner.invoke(analyze, ["--help"])

--- a/tests/unit/commands/test_optimize_cli.py
+++ b/tests/unit/commands/test_optimize_cli.py
@@ -192,8 +192,83 @@ class TestOptimizeInvocation:
 
 
 # =============================================================================
-# CONFIG FILE TESTS
+# --dry-run TESTS
 # =============================================================================
+
+_ANALYZE_MODEL = "winml.modelkit.optim.analyze_model"
+
+
+def _make_finding(name: str = "clamp-constant-values") -> MagicMock:
+    """Build a stand-in CapabilityFinding for renderer tests."""
+    from winml.modelkit.optim import CapabilityFinding, NodeRef
+
+    return CapabilityFinding(
+        name=name,
+        python_name=name.replace("-", "_"),
+        enable_flag=f"--enable-{name}",
+        category="surgery",
+        description="clamp things",
+        pipe_name="surgery",
+        modified_initializers=["BIG"],
+        removed_nodes=[NodeRef("MatMul", "mm", ("mm",))],
+    )
+
+
+class TestDryRun:
+    """--dry-run reports applicability and never writes output."""
+
+    def test_dry_run_flag_in_help(self, runner: CliRunner) -> None:
+        result = runner.invoke(optimize, ["--help"])
+        assert result.exit_code == 0
+        assert "--dry-run" in result.output
+
+    def test_dry_run_requires_model(self, runner: CliRunner) -> None:
+        result = runner.invoke(optimize, ["--dry-run"], obj={})
+        assert result.exit_code != 0
+
+    def test_dry_run_does_not_write_output(self, runner: CliRunner, tmp_path: Path) -> None:
+        model_file = tmp_path / "model.onnx"
+        model_file.touch()
+
+        with (
+            patch(_LOAD_ONNX, return_value=_make_mock_model()),
+            patch(_SAVE_ONNX) as mock_save,
+            patch(_ANALYZE_MODEL, return_value=[_make_finding()]) as mock_analyze,
+        ):
+            result = runner.invoke(optimize, ["-m", str(model_file), "--dry-run"])
+
+        assert result.exit_code == 0, result.output
+        mock_analyze.assert_called_once()
+        mock_save.assert_not_called()
+        # No optimized artifact should be produced next to the input.
+        assert not (tmp_path / "model_opt.onnx").exists()
+
+    def test_dry_run_lists_applicable_flag(self, runner: CliRunner, tmp_path: Path) -> None:
+        model_file = tmp_path / "model.onnx"
+        model_file.touch()
+
+        with (
+            patch(_LOAD_ONNX, return_value=_make_mock_model()),
+            patch(_ANALYZE_MODEL, return_value=[_make_finding("matmul-add-fusion")]),
+        ):
+            result = runner.invoke(optimize, ["-m", str(model_file), "--dry-run"])
+
+        assert result.exit_code == 0, result.output
+        assert "--enable-matmul-add-fusion" in result.output
+        assert "1 applicable optimization" in result.output
+
+    def test_dry_run_no_findings_message(self, runner: CliRunner, tmp_path: Path) -> None:
+        model_file = tmp_path / "model.onnx"
+        model_file.touch()
+
+        with (
+            patch(_LOAD_ONNX, return_value=_make_mock_model()),
+            patch(_ANALYZE_MODEL, return_value=[]),
+        ):
+            result = runner.invoke(optimize, ["-m", str(model_file), "--dry-run"])
+
+        assert result.exit_code == 0, result.output
+        assert "No registered optimizations" in result.output
 
 
 class TestConfigFile:

--- a/tests/unit/commands/test_optimize_cli.py
+++ b/tests/unit/commands/test_optimize_cli.py
@@ -192,7 +192,7 @@ class TestOptimizeInvocation:
 
 
 # =============================================================================
-# --dry-run TESTS
+# --check-optim TESTS
 # =============================================================================
 
 _ANALYZE_MODEL = "winml.modelkit.optim.analyze_model"
@@ -214,19 +214,19 @@ def _make_finding(name: str = "clamp-constant-values") -> MagicMock:
     )
 
 
-class TestDryRun:
-    """--dry-run reports applicability and never writes output."""
+class TestCheckOptim:
+    """--check-optim reports applicability and never writes output."""
 
-    def test_dry_run_flag_in_help(self, runner: CliRunner) -> None:
+    def test_check_optim_flag_in_help(self, runner: CliRunner) -> None:
         result = runner.invoke(optimize, ["--help"])
         assert result.exit_code == 0
-        assert "--dry-run" in result.output
+        assert "--check-optim" in result.output
 
-    def test_dry_run_requires_model(self, runner: CliRunner) -> None:
-        result = runner.invoke(optimize, ["--dry-run"], obj={})
+    def test_check_optim_requires_model(self, runner: CliRunner) -> None:
+        result = runner.invoke(optimize, ["--check-optim"], obj={})
         assert result.exit_code != 0
 
-    def test_dry_run_does_not_write_output(self, runner: CliRunner, tmp_path: Path) -> None:
+    def test_check_optim_does_not_write_output(self, runner: CliRunner, tmp_path: Path) -> None:
         model_file = tmp_path / "model.onnx"
         model_file.touch()
 
@@ -235,7 +235,7 @@ class TestDryRun:
             patch(_SAVE_ONNX) as mock_save,
             patch(_ANALYZE_MODEL, return_value=[_make_finding()]) as mock_analyze,
         ):
-            result = runner.invoke(optimize, ["-m", str(model_file), "--dry-run"])
+            result = runner.invoke(optimize, ["-m", str(model_file), "--check-optim"])
 
         assert result.exit_code == 0, result.output
         mock_analyze.assert_called_once()
@@ -243,7 +243,7 @@ class TestDryRun:
         # No optimized artifact should be produced next to the input.
         assert not (tmp_path / "model_opt.onnx").exists()
 
-    def test_dry_run_lists_applicable_flag(self, runner: CliRunner, tmp_path: Path) -> None:
+    def test_check_optim_lists_applicable_flag(self, runner: CliRunner, tmp_path: Path) -> None:
         model_file = tmp_path / "model.onnx"
         model_file.touch()
 
@@ -251,13 +251,13 @@ class TestDryRun:
             patch(_LOAD_ONNX, return_value=_make_mock_model()),
             patch(_ANALYZE_MODEL, return_value=[_make_finding("matmul-add-fusion")]),
         ):
-            result = runner.invoke(optimize, ["-m", str(model_file), "--dry-run"])
+            result = runner.invoke(optimize, ["-m", str(model_file), "--check-optim"])
 
         assert result.exit_code == 0, result.output
         assert "--enable-matmul-add-fusion" in result.output
         assert "1 applicable optimization" in result.output
 
-    def test_dry_run_no_findings_message(self, runner: CliRunner, tmp_path: Path) -> None:
+    def test_check_optim_no_findings_message(self, runner: CliRunner, tmp_path: Path) -> None:
         model_file = tmp_path / "model.onnx"
         model_file.touch()
 
@@ -265,7 +265,7 @@ class TestDryRun:
             patch(_LOAD_ONNX, return_value=_make_mock_model()),
             patch(_ANALYZE_MODEL, return_value=[]),
         ):
-            result = runner.invoke(optimize, ["-m", str(model_file), "--dry-run"])
+            result = runner.invoke(optimize, ["-m", str(model_file), "--check-optim"])
 
         assert result.exit_code == 0, result.output
         assert "No registered optimizations" in result.output

--- a/tests/unit/optim/test_analysis.py
+++ b/tests/unit/optim/test_analysis.py
@@ -15,7 +15,12 @@ from __future__ import annotations
 import numpy as np
 from onnx import GraphProto, ModelProto, TensorProto, helper, numpy_helper
 
-from winml.modelkit.optim import CapabilityFinding, NodeRef, analyze_model
+from winml.modelkit.optim import (
+    CapabilityFinding,
+    NodeRef,
+    analyze_model,
+    iter_optimization_outputs,
+)
 from winml.modelkit.optim.analysis import (
     _collect_initializers,
     _collect_nodes,
@@ -256,3 +261,43 @@ class TestAnalyzeModel:
         assert len(model.graph.initializer) == before_inits
         after_value = numpy_helper.to_array(model.graph.initializer[0])
         np.testing.assert_array_equal(before_value, after_value)
+
+
+# =============================================================================
+# OPTIMIZATION OUTPUT ITERATION
+# =============================================================================
+
+
+class TestIterOptimizationOutputs:
+    """iter_optimization_outputs yields findings paired with produced models."""
+
+    def test_yields_finding_and_produced_model(self) -> None:
+        pairs = list(iter_optimization_outputs(_matmul_add_model(), get_all_capabilities()))
+        by_name = {finding.name: (finding, produced) for finding, produced in pairs}
+        assert "matmul-add-fusion" in by_name, sorted(by_name)
+
+        finding, produced = by_name["matmul-add-fusion"]
+        assert isinstance(finding, CapabilityFinding)
+        assert isinstance(produced, ModelProto)
+        # The produced model is the post-optimization graph: the fusion collapses
+        # MatMul+Add into a single Gemm, so a Gemm node exists in the output.
+        produced_op_types = {n.op_type for n in produced.graph.node}
+        assert "Gemm" in produced_op_types
+
+    def test_produced_model_contains_produced_node_outputs(self) -> None:
+        pairs = list(iter_optimization_outputs(_matmul_add_model(), get_all_capabilities()))
+        by_name = {finding.name: (finding, produced) for finding, produced in pairs}
+        finding, produced = by_name["matmul-add-fusion"]
+
+        produced_outputs = {out for node in produced.graph.node for out in node.output}
+        # Every added/modified node's output tensors exist in the produced graph,
+        # which is what the support-check layer relies on to correlate nodes.
+        for ref in [*finding.added_nodes, *finding.modified_nodes]:
+            assert any(out in produced_outputs for out in ref.outputs)
+
+    def test_findings_match_analyze_model(self) -> None:
+        caps = get_all_capabilities()
+        model = _matmul_add_model()
+        iter_names = {finding.name for finding, _ in iter_optimization_outputs(model, caps)}
+        analyze_names = {finding.name for finding in analyze_model(_matmul_add_model(), caps)}
+        assert iter_names == analyze_names

--- a/tests/unit/optim/test_analysis.py
+++ b/tests/unit/optim/test_analysis.py
@@ -22,6 +22,7 @@ from winml.modelkit.optim import (
     iter_optimization_outputs,
 )
 from winml.modelkit.optim.analysis import (
+    _clone,
     _collect_initializers,
     _collect_nodes,
     _diff_initializers,
@@ -177,6 +178,64 @@ class TestInitializerDiff:
         assert removed == []
         assert added == []
         assert modified == ["BIG"]
+
+
+class TestClone:
+    """_clone produces a fully independent deep copy (subgraphs + initializers)."""
+
+    @staticmethod
+    def _model_with_subgraph() -> ModelProto:
+        then_graph = helper.make_graph(
+            [helper.make_node("Identity", ["x"], ["t"], name="then_id")],
+            "then",
+            [],
+            [helper.make_tensor_value_info("t", TensorProto.FLOAT, [1])],
+        )
+        else_graph = helper.make_graph(
+            [helper.make_node("Identity", ["x"], ["e"], name="else_id")],
+            "else",
+            [],
+            [helper.make_tensor_value_info("e", TensorProto.FLOAT, [1])],
+        )
+        w = numpy_helper.from_array(np.ones(4, np.float32), "W")
+        outer = helper.make_graph(
+            [
+                helper.make_node(
+                    "If",
+                    ["cond"],
+                    ["out"],
+                    name="if",
+                    then_branch=then_graph,
+                    else_branch=else_graph,
+                )
+            ],
+            "outer",
+            [helper.make_tensor_value_info("cond", TensorProto.BOOL, [])],
+            [helper.make_tensor_value_info("out", TensorProto.FLOAT, [1])],
+            initializer=[w],
+        )
+        return _finalize(outer)
+
+    def test_mutating_original_does_not_affect_clone(self) -> None:
+        model = self._model_with_subgraph()
+        clone = _clone(model)
+        snapshot = clone.SerializeToString()
+
+        # Mutate the original in several places, including a nested subgraph node
+        # and an initializer, to prove the copy shares no nested state.
+        model.graph.node[0].name = "if_renamed"
+        then_attr = next(a for a in model.graph.node[0].attribute if a.name == "then_branch")
+        then_attr.g.node[0].op_type = "Relu"
+        model.graph.initializer[0].CopyFrom(numpy_helper.from_array(np.zeros(4, np.float32), "W"))
+
+        # The clone is byte-for-byte unchanged by any of those mutations.
+        assert clone.SerializeToString() == snapshot
+        assert clone.graph.node[0].name == "if"
+        clone_then = next(a for a in clone.graph.node[0].attribute if a.name == "then_branch").g
+        assert clone_then.node[0].op_type == "Identity"
+        np.testing.assert_array_equal(
+            numpy_helper.to_array(clone.graph.initializer[0]), np.ones(4, np.float32)
+        )
 
 
 # =============================================================================

--- a/tests/unit/optim/test_analysis.py
+++ b/tests/unit/optim/test_analysis.py
@@ -1,0 +1,259 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Tests for the optimizer applicability analysis (dry-run) module.
+
+Follows the Cardinal Rules:
+- #1 No hardcoded architectures — models are built generically in-test.
+- #2 Code-generated results — expectations derive from the constructed graphs.
+- #4 No skips — deterministic assertions only (clamp/surgery, graph diffing).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import onnx
+from onnx import TensorProto, helper, numpy_helper
+
+from winml.modelkit.optim import CapabilityFinding, NodeRef, analyze_model
+from winml.modelkit.optim.analysis import (
+    _collect_initializers,
+    _collect_nodes,
+    _diff_initializers,
+    _diff_nodes,
+)
+from winml.modelkit.optim.pipes import get_all_capabilities
+
+
+# =============================================================================
+# MODEL BUILDERS (code-generated, no hardcoded architecture assumptions)
+# =============================================================================
+
+
+def _finalize(graph: onnx.GraphProto) -> onnx.ModelProto:
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+    model.ir_version = 8
+    return model
+
+
+def _matmul_add_model() -> onnx.ModelProto:
+    """MatMul followed by Add — a canonical MatMul+Add(->Gemm) fusion candidate."""
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [4, 8])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [4, 16])
+    w = numpy_helper.from_array(np.random.randn(8, 16).astype(np.float32), "W")
+    b = numpy_helper.from_array(np.random.randn(16).astype(np.float32), "B")
+    nodes = [
+        helper.make_node("MatMul", ["x", "W"], ["mm"], name="mm"),
+        helper.make_node("Add", ["mm", "B"], ["y"], name="addbias"),
+    ]
+    return _finalize(helper.make_graph(nodes, "matmul_add", [x], [y], initializer=[w, b]))
+
+
+def _extreme_constant_model() -> onnx.ModelProto:
+    """Add of a runtime input and an initializer holding an extreme value."""
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [4])
+    z = helper.make_tensor_value_info("z", TensorProto.FLOAT, [4])
+    big = numpy_helper.from_array(np.full(4, 1e30, dtype=np.float32), "BIG")
+    node = helper.make_node("Add", ["x", "BIG"], ["z"], name="addbig")
+    return _finalize(helper.make_graph([node], "extreme_const", [x], [z], initializer=[big]))
+
+
+def _benign_model() -> onnx.ModelProto:
+    """Add of a runtime input and an initializer with ordinary values."""
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [4])
+    z = helper.make_tensor_value_info("z", TensorProto.FLOAT, [4])
+    small = numpy_helper.from_array(np.ones(4, dtype=np.float32), "SMALL")
+    node = helper.make_node("Add", ["x", "SMALL"], ["z"], name="addsmall")
+    return _finalize(helper.make_graph([node], "benign", [x], [z], initializer=[small]))
+
+
+# =============================================================================
+# NODE / INITIALIZER DIFF HELPERS
+# =============================================================================
+
+
+class TestNodeDiff:
+    """The node diff distinguishes removed, added and modified nodes."""
+
+    def test_removed_added_modified(self) -> None:
+        x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [4, 8])
+        w = numpy_helper.from_array(np.zeros((8, 8), np.float32), "W")
+
+        base_graph = helper.make_graph(
+            [
+                helper.make_node("Relu", ["x"], ["r"], name="relu"),
+                helper.make_node("Add", ["r", "W"], ["y"], name="add"),
+            ],
+            "base",
+            [x],
+            [helper.make_tensor_value_info("y", TensorProto.FLOAT, [4, 8])],
+            initializer=[w],
+        )
+        probe_graph = helper.make_graph(
+            [
+                # 'r'-producing node gone -> removed; 'y' now a Gemm -> modified.
+                helper.make_node("Gemm", ["x", "W"], ["y"], name="gemm"),
+                # brand-new output 'z' -> added.
+                helper.make_node("Identity", ["y"], ["z"], name="cast"),
+            ],
+            "probe",
+            [x],
+            [helper.make_tensor_value_info("z", TensorProto.FLOAT, [4, 8])],
+            initializer=[w],
+        )
+
+        base_table: dict = {}
+        probe_table: dict = {}
+        _collect_nodes(base_graph, (), base_table)
+        _collect_nodes(probe_graph, (), probe_table)
+        removed, added, modified = _diff_nodes(base_table, probe_table)
+
+        assert [n.op_type for n in removed] == ["Relu"]
+        assert [n.op_type for n in added] == ["Identity"]
+        assert [n.op_type for n in modified] == ["Gemm"]
+
+    def test_identical_graphs_have_no_diff(self) -> None:
+        model = _matmul_add_model()
+        table_a: dict = {}
+        table_b: dict = {}
+        _collect_nodes(model.graph, (), table_a)
+        _collect_nodes(model.graph, (), table_b)
+        removed, added, modified = _diff_nodes(table_a, table_b)
+        assert not removed and not added and not modified
+
+    def test_subgraph_nodes_are_collected(self) -> None:
+        """Nodes inside a control-flow subgraph are included in the table."""
+        then_graph = helper.make_graph(
+            [helper.make_node("Identity", ["x"], ["t"], name="then_id")],
+            "then",
+            [],
+            [helper.make_tensor_value_info("t", TensorProto.FLOAT, [1])],
+        )
+        else_graph = helper.make_graph(
+            [helper.make_node("Identity", ["x"], ["e"], name="else_id")],
+            "else",
+            [],
+            [helper.make_tensor_value_info("e", TensorProto.FLOAT, [1])],
+        )
+        outer = helper.make_graph(
+            [
+                helper.make_node(
+                    "If",
+                    ["cond"],
+                    ["out"],
+                    name="if",
+                    then_branch=then_graph,
+                    else_branch=else_graph,
+                )
+            ],
+            "outer",
+            [helper.make_tensor_value_info("cond", TensorProto.BOOL, [])],
+            [helper.make_tensor_value_info("out", TensorProto.FLOAT, [1])],
+        )
+        table: dict = {}
+        _collect_nodes(outer, (), table)
+        op_types = sorted(ref.op_type for _, ref in table.values())
+        assert op_types == ["Identity", "Identity", "If"]
+
+
+class TestInitializerDiff:
+    """The initializer diff reports removed, added and modified constants."""
+
+    def test_modified_initializer_detected(self) -> None:
+        base = _extreme_constant_model()
+        probe = _extreme_constant_model()
+        # Clamp the probe's initializer in place.
+        clamped = numpy_helper.from_array(np.full(4, 1e3, dtype=np.float32), "BIG")
+        probe.graph.initializer[0].CopyFrom(clamped)
+
+        removed, added, modified = _diff_initializers(
+            _collect_initializers(base), _collect_initializers(probe)
+        )
+        assert removed == []
+        assert added == []
+        assert modified == ["BIG"]
+
+
+# =============================================================================
+# RESULT TYPES
+# =============================================================================
+
+
+class TestCapabilityFinding:
+    def test_applicable_reflects_any_change(self) -> None:
+        empty = CapabilityFinding(
+            name="x",
+            python_name="x",
+            enable_flag="--enable-x",
+            category="misc",
+            description="",
+            pipe_name="p",
+        )
+        assert empty.applicable is False
+
+        node = NodeRef("MatMul", "mm", ("mm",))
+        with_change = CapabilityFinding(
+            name="x",
+            python_name="x",
+            enable_flag="--enable-x",
+            category="misc",
+            description="",
+            pipe_name="p",
+            removed_nodes=[node],
+        )
+        assert with_change.applicable is True
+        assert with_change.affected_node_count == 1
+        assert with_change.op_histogram("removed") == [("MatMul", 1)]
+
+    def test_node_ref_label_uses_name_then_output(self) -> None:
+        assert NodeRef("MatMul", "mm", ("mm_out",)).label() == "MatMul 'mm'"
+        assert NodeRef("Add", "", ("y",)).label() == "Add 'y'"
+
+
+# =============================================================================
+# END-TO-END ANALYSIS
+# =============================================================================
+
+
+class TestAnalyzeModel:
+    """analyze_model probes the real pipeline and reports applicable caps."""
+
+    def test_clamp_reported_for_extreme_constant(self) -> None:
+        findings = analyze_model(_extreme_constant_model(), get_all_capabilities())
+        by_name = {f.name: f for f in findings}
+        assert "clamp-constant-values" in by_name
+        clamp = by_name["clamp-constant-values"]
+        assert clamp.applicable
+        assert "BIG" in clamp.modified_initializers
+
+    def test_clamp_not_reported_for_benign_constant(self) -> None:
+        findings = analyze_model(_benign_model(), get_all_capabilities())
+        names = {f.name for f in findings}
+        assert "clamp-constant-values" not in names
+
+    def test_matmul_add_fusion_detected(self) -> None:
+        findings = analyze_model(_matmul_add_model(), get_all_capabilities())
+        by_name = {f.name: f for f in findings}
+        assert "matmul-add-fusion" in by_name, sorted(by_name)
+        finding = by_name["matmul-add-fusion"]
+        # The standalone MatMul is consumed by the fusion.
+        assert any(n.op_type == "MatMul" for n in finding.removed_nodes)
+
+    def test_findings_are_capability_findings(self) -> None:
+        findings = analyze_model(_extreme_constant_model(), get_all_capabilities())
+        assert all(isinstance(f, CapabilityFinding) for f in findings)
+        assert all(f.applicable for f in findings)
+
+    def test_input_model_not_mutated(self) -> None:
+        model = _extreme_constant_model()
+        before_nodes = len(model.graph.node)
+        before_inits = len(model.graph.initializer)
+        before_value = numpy_helper.to_array(model.graph.initializer[0]).copy()
+
+        analyze_model(model, get_all_capabilities())
+
+        assert len(model.graph.node) == before_nodes
+        assert len(model.graph.initializer) == before_inits
+        after_value = numpy_helper.to_array(model.graph.initializer[0])
+        np.testing.assert_array_equal(before_value, after_value)

--- a/tests/unit/optim/test_analysis.py
+++ b/tests/unit/optim/test_analysis.py
@@ -161,6 +161,47 @@ class TestNodeDiff:
         op_types = sorted(ref.op_type for _, ref in table.values())
         assert op_types == ["Identity", "Identity", "If"]
 
+    def test_deeply_nested_subgraphs_collected(self) -> None:
+        """Iterative traversal collects multi-level nested nodes correctly.
+
+        Builds a chain of nested ``If`` subgraphs to exercise the explicit-stack
+        traversal across many levels (protobuf itself caps message nesting, so
+        this also bounds how deep any real model can be — the traversal is no
+        longer the limiting factor).
+        """
+        depth = 12
+
+        def _leaf(i: int) -> GraphProto:
+            return helper.make_graph(
+                [helper.make_node("Identity", ["x"], [f"o{i}"], name=f"id{i}")],
+                f"g{i}",
+                [],
+                [helper.make_tensor_value_info(f"o{i}", TensorProto.FLOAT, [1])],
+            )
+
+        inner = _leaf(0)
+        for i in range(1, depth):
+            if_node = helper.make_node(
+                "If",
+                ["cond"],
+                [f"out{i}"],
+                name=f"if{i}",
+                then_branch=inner,
+                else_branch=_leaf(i),
+            )
+            inner = helper.make_graph(
+                [if_node],
+                f"wrap{i}",
+                [],
+                [helper.make_tensor_value_info(f"out{i}", TensorProto.FLOAT, [1])],
+            )
+
+        table: dict = {}
+        _collect_nodes(inner, (), table)
+        collected = [ref.op_type for _, ref in table.values()]
+        assert collected.count("If") == depth - 1
+        assert collected.count("Identity") == depth
+
 
 class TestInitializerDiff:
     """The initializer diff reports removed, added and modified constants."""
@@ -178,6 +219,47 @@ class TestInitializerDiff:
         assert removed == []
         assert added == []
         assert modified == ["BIG"]
+
+
+class TestExternalDataInitializerDiff:
+    """External-data location churn must not read as a modified initializer."""
+
+    @staticmethod
+    def _external_init_model(offset: str, dims: tuple[int, ...] = (4,)) -> ModelProto:
+        init = TensorProto()
+        init.name = "W"
+        init.data_type = TensorProto.FLOAT
+        init.dims.extend(dims)
+        init.data_location = TensorProto.EXTERNAL
+        for key, value in (("location", "weights.bin"), ("offset", offset), ("length", "16")):
+            entry = init.external_data.add()
+            entry.key = key
+            entry.value = value
+        x = helper.make_tensor_value_info("x", TensorProto.FLOAT, list(dims))
+        z = helper.make_tensor_value_info("z", TensorProto.FLOAT, list(dims))
+        node = helper.make_node("Add", ["x", "W"], ["z"], name="add")
+        return _finalize(helper.make_graph([node], "ext", [x], [z], initializer=[init]))
+
+    def test_offset_change_is_not_a_modification(self) -> None:
+        # Same tensor identity, only the external offset moved (e.g. after a
+        # pipe re-saved the model) — this must not be reported as modified.
+        base = self._external_init_model("0")
+        probe = self._external_init_model("1024")
+        removed, added, modified = _diff_initializers(
+            _collect_initializers(base), _collect_initializers(probe)
+        )
+        assert removed == []
+        assert added == []
+        assert modified == []
+
+    def test_shape_change_still_detected(self) -> None:
+        # A genuine change to an external-data initializer is still caught.
+        base = self._external_init_model("0", dims=(4,))
+        probe = self._external_init_model("0", dims=(8,))
+        _, _, modified = _diff_initializers(
+            _collect_initializers(base), _collect_initializers(probe)
+        )
+        assert modified == ["W"]
 
 
 class TestClone:

--- a/tests/unit/optim/test_analysis.py
+++ b/tests/unit/optim/test_analysis.py
@@ -13,8 +13,7 @@ Follows the Cardinal Rules:
 from __future__ import annotations
 
 import numpy as np
-import onnx
-from onnx import TensorProto, helper, numpy_helper
+from onnx import GraphProto, ModelProto, TensorProto, helper, numpy_helper
 
 from winml.modelkit.optim import CapabilityFinding, NodeRef, analyze_model
 from winml.modelkit.optim.analysis import (
@@ -31,13 +30,13 @@ from winml.modelkit.optim.pipes import get_all_capabilities
 # =============================================================================
 
 
-def _finalize(graph: onnx.GraphProto) -> onnx.ModelProto:
+def _finalize(graph: GraphProto) -> ModelProto:
     model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
     model.ir_version = 8
     return model
 
 
-def _matmul_add_model() -> onnx.ModelProto:
+def _matmul_add_model() -> ModelProto:
     """MatMul followed by Add — a canonical MatMul+Add(->Gemm) fusion candidate."""
     x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [4, 8])
     y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [4, 16])
@@ -50,7 +49,7 @@ def _matmul_add_model() -> onnx.ModelProto:
     return _finalize(helper.make_graph(nodes, "matmul_add", [x], [y], initializer=[w, b]))
 
 
-def _extreme_constant_model() -> onnx.ModelProto:
+def _extreme_constant_model() -> ModelProto:
     """Add of a runtime input and an initializer holding an extreme value."""
     x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [4])
     z = helper.make_tensor_value_info("z", TensorProto.FLOAT, [4])
@@ -59,7 +58,7 @@ def _extreme_constant_model() -> onnx.ModelProto:
     return _finalize(helper.make_graph([node], "extreme_const", [x], [z], initializer=[big]))
 
 
-def _benign_model() -> onnx.ModelProto:
+def _benign_model() -> ModelProto:
     """Add of a runtime input and an initializer with ordinary values."""
     x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [4])
     z = helper.make_tensor_value_info("z", TensorProto.FLOAT, [4])


### PR DESCRIPTION
## Summary

Two related, opt-in features for reasoning about optimizations before applying them, sharing one consistent flag name `--check-optim`:

1. **`winml optimize --check-optim`** — answers "which optimizations actually apply to *this* model, and on which nodes?" without writing any output.
2. **`winml analyze --check-optim`** — for each optimization that would change the model, checks whether the operators it *introduces* are supported on the resolved EP/device.

### `optimize --check-optim`

Probes **every** registered optimization capability independently against the given model and reports only the ones that would genuinely change it, along with the specific nodes and constants affected.

```bash
$ winml optimize -m model.onnx --check-optim
2 applicable optimization(s):

--enable-matmul-add-fusion  (matmul)
  Fuse MatMul+Add operations into single kernel
  nodes: -1 ~1
    removed: MatMul (1)
    modified: Gemm (1)

--enable-clamp-constant-values  (surgery)
  constants: ~1
```

Add `-v` to list every affected node/constant instead of a sample. `--check-optim` requires `--model` and writes nothing to disk.

### `analyze --check-optim`

Reuses the optimize probe engine to obtain the model each optimization would produce, then feeds the produced (added/modified) nodes into analyze's `RuntimeChecker` and classifies them against the target EP/device rule data. Answers "if I apply this optimization, will its output run on my target?".

```bash
$ winml analyze --model model.onnx --ep qnn --device NPU --check-optim
```

Renders a per-target **OPTIMIZATION OUTPUT SUPPORT** section listing each applicable optimization, its `--enable-*` flag, and the support level (supported / partial / unsupported / unknown) of every operator it would introduce. The probe is target-independent, so it is materialized once and reused across all resolved targets; only the support lookup runs per EP/device. Disabled by default; console-only.

## How it works (universal, no hardcoding)

The probe mirrors `Optimizer.optimize()`: run mandatory shape inference, then walk the pipes in order. For each pipe it computes a baseline output, then re-runs the pipe on a **clone** of the upstream model with only one default-off capability enabled (plus auto-enabled dependencies) and diffs the result:

- Node diff is keyed by **output tensor names** (unique and stable within a valid ONNX graph across input rewiring / attribute changes), yielding removed / added / modified buckets; recurses into subgraphs.
- Initializer diff catches constant-only surgery ops (e.g. `clamp-constant-values`) that modify no nodes.
- Cloning uses `CopyFrom` (not a serialize round-trip) because saving can convert tensors to external data in place, and to avoid the 2 GB protobuf limit.
- Each probe is isolated in try/except so a single failing capability is logged and skipped rather than aborting the run.

The support check correlates produced nodes back to `op_support` results by output-tensor name, and `RuntimeChecker.op_support(node_output_filter=...)` restricts the check to just the produced nodes. No op/tensor/architecture names are hardcoded (CLAUDE.md Cardinal Rule #1).

## Changes

- **New** `src/winml/modelkit/optim/analysis.py` — `analyze_model`, `iter_optimization_outputs`, `CapabilityFinding`, `NodeRef` and diff helpers (shared `_iter_findings` generator)
- `src/winml/modelkit/optim/__init__.py` — export the new public API
- `src/winml/modelkit/commands/optimize.py` — `--check-optim` option + report renderer (with rich-markup escaping of dynamic labels)
- **New** `src/winml/modelkit/analyze/optim_output.py` — bridge that checks produced-operator EP/device support
- `src/winml/modelkit/analyze/core/runtime_checker.py` — `op_support(node_output_filter=...)` to restrict the check to a node subset
- `src/winml/modelkit/commands/analyze.py` — `--check-optim` flag + per-target renderer
- **New/updated tests** — `tests/unit/optim/test_analysis.py`, `tests/unit/analyze/test_optim_output.py`, and CLI coverage in `tests/unit/commands/test_optimize_cli.py` and `tests/unit/analyze/test_static_analyzer_cli.py`
- `docs/commands/optimize.md` and `docs/commands/analyze.md` — flag-table rows + worked examples

## Validation

- `ruff` clean; `mypy -p winml.modelkit` clean; doc/code flag-alignment check ✅
- Targeted `optim` + `analyze` suites pass (hardware/fixture-gated skips and one pre-existing xfail only)