### PR TITLE
feat: restore EP-download progress bar for provider.ensure_ready()

### DIFF
--- a/src/winml/modelkit/ep_path.py
+++ b/src/winml/modelkit/ep_path.py
@@ -46,6 +46,7 @@ import functools
 import logging
 import os
 import platform
+import sys
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable, Iterator, Mapping
 from dataclasses import dataclass
@@ -775,6 +776,206 @@ def _winml_warn_once(key: str, msg: str, *args: Any) -> None:
     logger.warning(msg, *args)
 
 
+def _ep_download_timeout_default() -> int:
+    """Read ``WINMLCLI_EP_DOWNLOAD_TIMEOUT`` (seconds) or fall back to 5 minutes.
+
+    Lets users on slow networks raise the cap without code changes. Falls back
+    to the default when the env var is unset, empty, or non-integer.
+    """
+    raw = os.environ.get("WINMLCLI_EP_DOWNLOAD_TIMEOUT")
+    if not raw:
+        return 5 * 60
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("Invalid WINMLCLI_EP_DOWNLOAD_TIMEOUT=%r; using default 300s.", raw)
+        return 5 * 60
+
+
+# Evaluated once at module import. Changing WINMLCLI_EP_DOWNLOAD_TIMEOUT
+# after import does NOT take effect for the running process; tests that need
+# a different value should monkeypatch ep_path.EP_DOWNLOAD_TIMEOUT_SECONDS
+# directly.
+EP_DOWNLOAD_TIMEOUT_SECONDS = _ep_download_timeout_default()
+
+
+class _NoopBar:
+    """No-op stand-in for tqdm when the optional dependency is missing.
+
+    Exposes the attribute (``n``) and methods (``refresh``, ``close``) that
+    ``_ensure_provider_ready`` touches, so the helper can stay branch-free.
+    """
+
+    def __init__(self) -> None:
+        self.n = 0
+
+    def refresh(self) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+
+def _make_progress_bar() -> Any:
+    """Return a tqdm bar if tqdm is installed, else a silent no-op stand-in.
+
+    tqdm is a dev-only optional dep in this package, so production installs
+    without it must still complete EP downloads — they just lose the live bar.
+    In Windows spawn workers, ``sys.stderr`` can be unavailable; tqdm write
+    failures must not abort provider readiness and leave child EP paths empty.
+    Also tolerates non-interactive runtimes where ``sys.stderr`` may be None
+    (e.g., GUI/no-console hosts) so progress rendering failures cannot block
+    EP discovery.
+    The pre-download Console notice is emitted by the caller and is unaffected.
+
+    Format: ``Downloading... ████████████░░░░░░ 62%``
+    """
+    if sys.stderr is None or not hasattr(sys.stderr, "write"):
+        logger.debug("stderr is unavailable; using no-op progress bar.")
+        return _NoopBar()
+
+    try:
+        from tqdm import tqdm
+    except ImportError:
+        return _NoopBar()
+
+    try:
+        return tqdm(
+            total=100,
+            bar_format="Downloading... {bar} {percentage:3.0f}%",
+            ascii="░█",
+            leave=True,
+            file=sys.stderr,
+        )
+    except Exception as e:
+        logger.debug("Failed to initialize tqdm progress bar; falling back to no-op: %s", e)
+        return _NoopBar()
+
+
+def _parse_ep_metadata_from_path(library_path: str) -> tuple[str, str]:
+    r"""Best-effort ``(version, package_family_name)`` from an EP's install path.
+
+    WinML's ``ExecutionProvider`` handle sometimes returns empty ``version`` /
+    ``package_family_name`` even after the EP is Ready. When the EP is delivered
+    as an MSIX package its ``library_path`` lives under ``WindowsApps`` in a
+    folder named with the full package identity::
+
+        ...\\WindowsApps\\<Name>_<Version>_<Arch>_<ResourceId>_<PublisherId>\\...
+
+    e.g. ``MicrosoftCorporationII.WinML.Intel.OpenVINO.EP.1.8_1.8.79.0_x64__8wekyb3d8bbwe``
+    yields version ``1.8.79.0`` and package family name
+    ``MicrosoftCorporationII.WinML.Intel.OpenVINO.EP.1.8_8wekyb3d8bbwe`` (the
+    package family name is ``<Name>_<PublisherId>``).
+
+    Returns ``("", "")`` when the path is empty or does not match this layout.
+    """
+    import re
+    from itertools import pairwise
+    from pathlib import PurePath
+
+    if not library_path:
+        return "", ""
+
+    parts = PurePath(library_path).parts
+    pkg_folder = next(
+        (child for parent, child in pairwise(parts) if parent.lower() == "windowsapps"),
+        "",
+    )
+    # Full MSIX package name: Name_Version_Arch_ResourceId_PublisherId (ResourceId
+    # is usually empty, giving the doubled "__" before the publisher id).
+    segments = pkg_folder.split("_")
+    if len(segments) < 5:
+        return "", ""
+
+    name, version, publisher = segments[0], segments[1], segments[-1]
+    # Guard against unexpected folder shapes: version must be dotted-numeric.
+    if not re.fullmatch(r"\d+(\.\d+)*", version):
+        version = ""
+    package_family_name = f"{name}_{publisher}" if name and publisher else ""
+    return version, package_family_name
+
+
+def _ensure_provider_ready(provider: Any) -> None:
+    """Ensure an EP is ready, showing a tqdm progress bar while downloading.
+
+    Only invoked by ``WinMLCatalogSource._resolve_provider`` on the cold path
+    (the provider is not already ``Ready``), so it always drives the download
+    flow: a tqdm bar fed by ``ensure_ready_async``'s ``on_progress`` callback
+    (cumulative fraction 0.0-1.0, per windowsml docs) while waiting for the
+    ``on_complete`` callback via a ``threading.Event`` with an
+    ``EP_DOWNLOAD_TIMEOUT_SECONDS`` timeout. On timeout the async op is
+    cancelled and ``TimeoutError`` is raised.
+    """
+    import threading
+
+    # Lazy-import to keep ep_path import cheap (rich pulls in pygments etc.);
+    # this branch only runs on the cold "EP needs download" path.
+    from .utils.console import get_console
+
+    console = get_console()
+    console.print(f"[WinML] Installing Execution Provider: [bold]{provider.name}[/bold]")
+
+    bar = _make_progress_bar()
+    done = threading.Event()
+
+    def _on_progress(fraction: float) -> None:
+        # Native ops may fire a stale on_progress after on_complete; once done
+        # is set the main thread owns bar.n (forces it to 100 and closes the
+        # bar), so silently drop late callbacks instead of clobbering 100 with
+        # an earlier fraction or writing to a closed bar.
+        if done.is_set():
+            return
+        bar.n = max(0, min(100, int(fraction * 100)))
+        bar.refresh()
+
+    op = None
+    success = False
+    try:
+        op = provider.ensure_ready_async(on_complete=done.set, on_progress=_on_progress)
+        if not done.wait(timeout=EP_DOWNLOAD_TIMEOUT_SECONDS):
+            op.cancel()
+            raise TimeoutError(
+                f"EP {provider.name!r} download did not complete within "
+                f"{EP_DOWNLOAD_TIMEOUT_SECONDS}s; cancelled."
+            )
+        # Surface any native failure (raises OSError on error).
+        op.get_status()
+        # Success: providers usually fire on_progress(1.0) before on_complete,
+        # but force the bar to 100 in case they didn't.
+        bar.n = 100
+        bar.refresh()
+        success = True
+    finally:
+        bar.close()
+        if op is not None:
+            op.close()
+        if not success:
+            # Failure-path notice — kept in finally so it fires for every
+            # non-success exit (launch failure, timeout, get_status OSError).
+            # Printed after bar.close() so it appears below the bar's last frame.
+            console.print(f"[red]❌ Failed to download {provider.name} EP[/red]")
+            console.print("Try:")
+            console.print("  1. Check your internet connection")
+            console.print("  2. Troubleshoot: https://aka.ms/winmlcli/ep-errors")
+
+    console.print(f"{provider.name} EP installed successfully.")
+
+    # The native handle sometimes reports empty version/PFN even once Ready;
+    # fall back to parsing them from the MSIX install path. Skip a line entirely
+    # when its value can't be determined rather than printing a blank field.
+    version = provider.version
+    package_family_name = provider.package_family_name
+    if not version or not package_family_name:
+        parsed_version, parsed_pfn = _parse_ep_metadata_from_path(provider.library_path)
+        version = version or parsed_version
+        package_family_name = package_family_name or parsed_pfn
+    if version:
+        console.print(f"- Version: {version}", soft_wrap=True)
+    if package_family_name:
+        # soft_wrap so long package family names aren't hard-wrapped mid-string.
+        console.print(f"- Package Family Name: {package_family_name}", soft_wrap=True)
+
+
 @dataclass(frozen=True)
 class WinMLCatalogSource(EPSource):
     """An MSIX EP delivered via the ``windowsml.EpCatalog`` C API wrapper.
@@ -866,7 +1067,7 @@ class WinMLCatalogSource(EPSource):
 
         if not self._is_ready(ready_state):
             try:
-                provider.ensure_ready()
+                _ensure_provider_ready(provider)
             except Exception as e:
                 _winml_warn_once(
                     f"ensure-ready:{self.catalog_name}",

--- a/src/winml/modelkit/ep_path.py
+++ b/src/winml/modelkit/ep_path.py
@@ -816,6 +816,57 @@ class _NoopBar:
         return None
 
 
+class _SafeProgressBar:
+    """Wrap a tqdm bar so rendering I/O failures never abort the EP download.
+
+    ``_make_progress_bar`` only guards bar *construction*; tqdm still writes to
+    ``sys.stderr`` on every ``refresh()``/``close()``. If the stream is closed
+    or starts failing mid-download (spawn workers, redirected/closed consoles),
+    those writes raise — including from the native ``on_progress`` callback
+    thread — and can turn a successful provider install into a discovery
+    failure. This wrapper makes rendering best-effort: on the first I/O error it
+    drops the underlying bar and every later call becomes a silent no-op.
+    """
+
+    def __init__(self, bar: Any) -> None:
+        self._bar: Any = bar
+
+    @property
+    def n(self) -> int:
+        bar = self._bar
+        return int(getattr(bar, "n", 0)) if bar is not None else 0
+
+    @n.setter
+    def n(self, value: int) -> None:
+        if self._bar is None:
+            return
+        try:
+            self._bar.n = value
+        except Exception:
+            self._degrade()
+
+    def refresh(self) -> None:
+        if self._bar is None:
+            return
+        try:
+            self._bar.refresh()
+        except Exception:
+            self._degrade()
+
+    def close(self) -> None:
+        if self._bar is None:
+            return
+        try:
+            self._bar.close()
+        except Exception:
+            self._degrade()
+
+    def _degrade(self) -> None:
+        # Drop the real bar; subsequent refresh/close/n calls become no-ops.
+        logger.debug("Progress bar rendering failed; disabling live progress.")
+        self._bar = None
+
+
 def _make_progress_bar() -> Any:
     """Return a tqdm bar if tqdm is installed, else a silent no-op stand-in.
 
@@ -825,7 +876,9 @@ def _make_progress_bar() -> Any:
     failures must not abort provider readiness and leave child EP paths empty.
     Also tolerates non-interactive runtimes where ``sys.stderr`` may be None
     (e.g., GUI/no-console hosts) so progress rendering failures cannot block
-    EP discovery.
+    EP discovery. A live bar is wrapped in :class:`_SafeProgressBar` so a
+    *mid-download* rendering failure also degrades to a no-op rather than
+    aborting the install.
     The pre-download Console notice is emitted by the caller and is unaffected.
 
     Format: ``Downloading... ████████████░░░░░░ 62%``
@@ -840,7 +893,7 @@ def _make_progress_bar() -> Any:
         return _NoopBar()
 
     try:
-        return tqdm(
+        bar = tqdm(
             total=100,
             bar_format="Downloading... {bar} {percentage:3.0f}%",
             ascii="░█",
@@ -850,6 +903,7 @@ def _make_progress_bar() -> Any:
     except Exception as e:
         logger.debug("Failed to initialize tqdm progress bar; falling back to no-op: %s", e)
         return _NoopBar()
+    return _SafeProgressBar(bar)
 
 
 def _parse_ep_metadata_from_path(library_path: str) -> tuple[str, str]:
@@ -871,12 +925,12 @@ def _parse_ep_metadata_from_path(library_path: str) -> tuple[str, str]:
     """
     import re
     from itertools import pairwise
-    from pathlib import PurePath
+    from pathlib import PureWindowsPath
 
     if not library_path:
         return "", ""
 
-    parts = PurePath(library_path).parts
+    parts = PureWindowsPath(library_path).parts
     pkg_folder = next(
         (child for parent, child in pairwise(parts) if parent.lower() == "windowsapps"),
         "",

--- a/src/winml/modelkit/ep_path.py
+++ b/src/winml/modelkit/ep_path.py
@@ -949,6 +949,23 @@ def _parse_ep_metadata_from_path(library_path: str) -> tuple[str, str]:
     return version, package_family_name
 
 
+def _safe_console_print(console: Any, *args: Any, **kwargs: Any) -> None:
+    """Print via the ``rich`` Console, swallowing rendering/I-O errors.
+
+    ``get_console()`` writes to ``sys.stderr``; if that stream is closed or
+    otherwise unwritable (spawn workers, redirected/closed consoles) a ``print``
+    raises. ``_ensure_provider_ready`` runs inside ``WinMLCatalogSource.resolve``,
+    where an exception aborts the provider iteration and silently drops an EP that
+    is actually Ready. Status rendering must never block provider readiness, so —
+    mirroring :class:`_SafeProgressBar` — failures are logged at debug and
+    otherwise ignored.
+    """
+    try:
+        console.print(*args, **kwargs)
+    except Exception as e:
+        logger.debug("Console status print failed; ignoring: %s", e)
+
+
 def _ensure_provider_ready(provider: Any) -> None:
     """Ensure an EP is ready, showing a tqdm progress bar while downloading.
 
@@ -967,7 +984,9 @@ def _ensure_provider_ready(provider: Any) -> None:
     from .utils.console import get_console
 
     console = get_console()
-    console.print(f"[WinML] Installing Execution Provider: [bold]{provider.name}[/bold]")
+    _safe_console_print(
+        console, f"[WinML] Installing Execution Provider: [bold]{provider.name}[/bold]"
+    )
 
     bar = _make_progress_bar()
     done = threading.Event()
@@ -1007,12 +1026,12 @@ def _ensure_provider_ready(provider: Any) -> None:
             # Failure-path notice — kept in finally so it fires for every
             # non-success exit (launch failure, timeout, get_status OSError).
             # Printed after bar.close() so it appears below the bar's last frame.
-            console.print(f"[red]❌ Failed to download {provider.name} EP[/red]")
-            console.print("Try:")
-            console.print("  1. Check your internet connection")
-            console.print("  2. Troubleshoot: https://aka.ms/winmlcli/ep-errors")
+            _safe_console_print(console, f"[red]❌ Failed to download {provider.name} EP[/red]")
+            _safe_console_print(console, "Try:")
+            _safe_console_print(console, "  1. Check your internet connection")
+            _safe_console_print(console, "  2. Troubleshoot: https://aka.ms/winmlcli/ep-errors")
 
-    console.print(f"{provider.name} EP installed successfully.")
+    _safe_console_print(console, f"{provider.name} EP installed successfully.")
 
     # The native handle sometimes reports empty version/PFN even once Ready;
     # fall back to parsing them from the MSIX install path. Skip a line entirely
@@ -1024,10 +1043,12 @@ def _ensure_provider_ready(provider: Any) -> None:
         version = version or parsed_version
         package_family_name = package_family_name or parsed_pfn
     if version:
-        console.print(f"- Version: {version}", soft_wrap=True)
+        _safe_console_print(console, f"- Version: {version}", soft_wrap=True)
     if package_family_name:
         # soft_wrap so long package family names aren't hard-wrapped mid-string.
-        console.print(f"- Package Family Name: {package_family_name}", soft_wrap=True)
+        _safe_console_print(
+            console, f"- Package Family Name: {package_family_name}", soft_wrap=True
+        )
 
 
 @dataclass(frozen=True)

--- a/tests/unit/ep_path/test_ensure_provider_ready.py
+++ b/tests/unit/ep_path/test_ensure_provider_ready.py
@@ -400,6 +400,45 @@ def test_ensure_provider_ready_survives_progress_render_failure(
     op.close.assert_called_once_with()
 
 
+def test_ensure_provider_ready_survives_console_sink_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failing rich Console sink (e.g. stderr closed) must not abort the install.
+
+    The install/success/metadata prints run inside ``WinMLCatalogSource.resolve``,
+    where any raised exception drops the EP. Status rendering must degrade to a
+    no-op so a provider that is actually Ready is still surfaced."""
+    _install_fake_tqdm(monkeypatch)
+
+    # Every console.print raises, as if stderr were closed/unwritable.
+    failing_console = MagicMock()
+    failing_console.print.side_effect = ValueError("I/O operation on closed file")
+    monkeypatch.setattr("winml.modelkit.utils.console.get_console", lambda: failing_console)
+
+    op = MagicMock()
+
+    def fake_ensure_async(on_complete=None, on_progress=None):
+        on_progress(0.5)
+        on_complete()
+        return op
+
+    provider = MagicMock()
+    provider.name = "FakeEP"
+    provider.version = "1.2.3"
+    provider.package_family_name = "Some.Pkg_hash"
+    provider.library_path = r"C:\some\local\path\provider.dll"
+    provider.ensure_ready_async.side_effect = fake_ensure_async
+
+    # Must NOT raise despite every console.print failing.
+    ep_path._ensure_provider_ready(provider)
+
+    op.get_status.assert_called_once_with()
+    op.close.assert_called_once_with()
+    # The status prints were attempted (install notice, success, metadata) and
+    # every failure was swallowed rather than propagated.
+    assert failing_console.print.call_count >= 1
+
+
 class TestParseEpMetadataFromPath:
     """`_parse_ep_metadata_from_path` recovers (version, PFN) from install paths."""
 

--- a/tests/unit/ep_path/test_ensure_provider_ready.py
+++ b/tests/unit/ep_path/test_ensure_provider_ready.py
@@ -369,6 +369,37 @@ def test_ensure_provider_ready_works_without_tqdm(
     op.close.assert_called_once_with()
 
 
+def test_ensure_provider_ready_survives_progress_render_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tqdm rendering I/O error mid-download (e.g. stderr closed) must not
+    abort the install: the bar degrades to a no-op and readiness still completes."""
+    fake_bar = _install_fake_tqdm(monkeypatch)
+    # Bar construction succeeds, but every render write fails from here on.
+    fake_bar.refresh.side_effect = OSError("stderr closed")
+    fake_bar.close.side_effect = OSError("stderr closed")
+
+    op = MagicMock()
+
+    def fake_ensure_async(on_complete=None, on_progress=None):
+        on_progress(0.5)  # triggers bar.refresh() -> raises -> degrades to no-op
+        on_complete()
+        return op
+
+    provider = MagicMock()
+    provider.name = "FakeEP"
+    provider.version = ""
+    provider.package_family_name = ""
+    provider.library_path = r"C:\some\local\path\provider.dll"
+    provider.ensure_ready_async.side_effect = fake_ensure_async
+
+    # Must NOT raise despite the render/close I/O failures.
+    ep_path._ensure_provider_ready(provider)
+
+    op.get_status.assert_called_once_with()
+    op.close.assert_called_once_with()
+
+
 class TestParseEpMetadataFromPath:
     """`_parse_ep_metadata_from_path` recovers (version, PFN) from install paths."""
 

--- a/tests/unit/ep_path/test_ensure_provider_ready.py
+++ b/tests/unit/ep_path/test_ensure_provider_ready.py
@@ -1,0 +1,421 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Tests for the EP-download progress helpers in ``ep_path``.
+
+Covers ``_ensure_provider_ready`` (the tqdm-backed download UX driven by
+``ensure_ready_async``), ``_parse_ep_metadata_from_path`` and
+``_ep_download_timeout_default``.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from winml.modelkit import ep_path
+
+
+def _install_fake_tqdm(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Inject a fake ``tqdm.tqdm``. Helper writes ``bar.n`` directly + refresh()."""
+    fake_bar = MagicMock()
+    fake_bar.n = 0
+
+    tqdm_mod = types.ModuleType("tqdm")
+    tqdm_mod.tqdm = MagicMock(return_value=fake_bar)  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "tqdm", tqdm_mod)
+    return fake_bar
+
+
+def test_ensure_provider_ready_drives_progress_bar(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The download goes through ensure_ready_async; on_progress drives a tqdm bar."""
+    fake_bar = _install_fake_tqdm(monkeypatch)
+
+    op = MagicMock()
+
+    def fake_ensure_async(on_complete=None, on_progress=None):
+        # Simulate cumulative-fraction progress callbacks, then completion.
+        for fraction in (0.0, 0.25, 0.5, 1.0):
+            on_progress(fraction)
+        on_complete()
+        return op
+
+    provider = MagicMock()
+    provider.name = "FakeEP"
+    provider.ensure_ready_async.side_effect = fake_ensure_async
+
+    ep_path._ensure_provider_ready(provider)
+
+    provider.ensure_ready_async.assert_called_once()
+    op.get_status.assert_called_once_with()
+    op.cancel.assert_not_called()
+    op.close.assert_called_once_with()
+    fake_bar.close.assert_called_once_with()
+    # Success path forces bar.n to 100 even though the last fraction was 1.0.
+    assert fake_bar.n == 100
+    fake_bar.refresh.assert_called()
+
+
+def test_ensure_provider_ready_ignores_stale_progress_after_complete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stale on_progress fired after on_complete must NOT clobber bar.n.
+
+    The native layer can fire a late progress callback from its own thread
+    after on_complete; once `done` is set, the main thread owns bar.n and the
+    callback should drop instead of writing an earlier fraction back over the
+    forced 100 (or worse, writing to an already-closed bar)."""
+    fake_bar = _install_fake_tqdm(monkeypatch)
+
+    op = MagicMock()
+    saved_progress: list = []
+
+    def fake_ensure_async(on_complete=None, on_progress=None):
+        on_progress(0.5)
+        on_complete()
+        saved_progress.append(on_progress)  # Fire a stale callback after.
+        return op
+
+    provider = MagicMock()
+    provider.name = "FakeEP"
+    provider.ensure_ready_async.side_effect = fake_ensure_async
+
+    ep_path._ensure_provider_ready(provider)
+
+    # Fire the stale callback as if it arrived after _ensure_provider_ready
+    # already set bar.n = 100 and closed the bar.
+    assert fake_bar.n == 100
+    saved_progress[0](0.62)
+    # Stale callback must have been dropped — bar.n stays at 100.
+    assert fake_bar.n == 100
+
+
+def test_ensure_provider_ready_warns_before_download(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A notice is printed to the stderr Console before download
+    so users know the wait is expected."""
+    _install_fake_tqdm(monkeypatch)
+
+    op = MagicMock()
+
+    def fake_ensure_async(on_complete=None, on_progress=None):
+        on_complete()
+        return op
+
+    provider = MagicMock()
+    provider.name = "FakeEP"
+    provider.ensure_ready_async.side_effect = fake_ensure_async
+
+    ep_path._ensure_provider_ready(provider)
+
+    err = capsys.readouterr().err
+    assert "[WinML] Installing Execution Provider" in err
+    assert "FakeEP" in err
+
+
+def test_ensure_provider_ready_forces_bar_to_100_on_success_without_progress(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the async op completes successfully without ever firing on_progress,
+    the success path forces the bar to 100 so the final render shows full."""
+    fake_bar = _install_fake_tqdm(monkeypatch)
+
+    op = MagicMock()
+
+    def fake_ensure_async(on_complete=None, on_progress=None):
+        on_complete()  # No progress firings, but completes immediately.
+        return op
+
+    provider = MagicMock()
+    provider.name = "FakeEP"
+    provider.ensure_ready_async.side_effect = fake_ensure_async
+
+    ep_path._ensure_provider_ready(provider)
+
+    assert fake_bar.n == 100
+    fake_bar.close.assert_called_once_with()
+    op.close.assert_called_once_with()
+
+
+def test_ensure_provider_ready_times_out_and_cancels(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When on_complete never fires within the timeout, cancel and raise TimeoutError."""
+    fake_bar = _install_fake_tqdm(monkeypatch)
+
+    # Shrink the timeout so the test runs in milliseconds, not minutes.
+    monkeypatch.setattr(ep_path, "EP_DOWNLOAD_TIMEOUT_SECONDS", 0.05)
+
+    op = MagicMock()
+    provider = MagicMock()
+    provider.name = "SlowEP"
+    # ensure_ready_async returns op but never calls on_complete -> times out.
+    provider.ensure_ready_async.return_value = op
+
+    with pytest.raises(TimeoutError, match="SlowEP"):
+        ep_path._ensure_provider_ready(provider)
+
+    op.cancel.assert_called_once_with()
+    op.close.assert_called_once_with()
+    fake_bar.close.assert_called_once_with()
+    # Bar must NOT be force-filled on timeout — it should reflect where the
+    # download stalled (here: 0 because no progress callbacks ever fired).
+    assert fake_bar.n == 0
+
+
+def test_ensure_provider_ready_surfaces_get_status_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failure surfaced by get_status() propagates after cleanup."""
+    fake_bar = _install_fake_tqdm(monkeypatch)
+
+    op = MagicMock()
+    op.get_status.side_effect = OSError("native error")
+
+    def fake_ensure_async(on_complete=None, on_progress=None):
+        on_complete()
+        return op
+
+    provider = MagicMock()
+    provider.name = "FakeEP"
+    provider.ensure_ready_async.side_effect = fake_ensure_async
+
+    with pytest.raises(OSError, match="native error"):
+        ep_path._ensure_provider_ready(provider)
+
+    fake_bar.close.assert_called_once_with()
+    op.close.assert_called_once_with()
+    # Native error must NOT force-fill the bar — it should reflect where
+    # the download failed (here: 0 because no progress callbacks fired).
+    assert fake_bar.n == 0
+
+
+def test_ensure_provider_ready_prints_success_with_metadata(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """After a successful install, print '<EP> EP installed successfully.'
+    followed by Version and Package Family Name lines."""
+    _install_fake_tqdm(monkeypatch)
+
+    op = MagicMock()
+
+    def fake_ensure_async(on_complete=None, on_progress=None):
+        on_complete()
+        return op
+
+    provider = MagicMock()
+    provider.name = "OpenVINOExecutionProvider"
+    provider.version = "1.2.0"
+    provider.package_family_name = "Microsoft.OpenVINOExecutionProvider_8wekyb3d8bbwe"
+    provider.ensure_ready_async.side_effect = fake_ensure_async
+
+    ep_path._ensure_provider_ready(provider)
+
+    err = capsys.readouterr().err
+    assert "OpenVINOExecutionProvider EP installed successfully." in err
+    assert "- Version: 1.2.0" in err
+    assert "- Package Family Name: Microsoft.OpenVINOExecutionProvider_8wekyb3d8bbwe" in err
+
+
+def test_ensure_provider_ready_falls_back_to_path_metadata_when_native_empty(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """When the native handle reports empty version/PFN, recover both from the
+    MSIX install path."""
+    _install_fake_tqdm(monkeypatch)
+
+    op = MagicMock()
+
+    def fake_ensure_async(on_complete=None, on_progress=None):
+        on_complete()
+        return op
+
+    provider = MagicMock()
+    provider.name = "OpenVINOExecutionProvider"
+    provider.version = ""
+    provider.package_family_name = ""
+    provider.library_path = (
+        r"C:\Program Files\WindowsApps"
+        r"\MicrosoftCorporationII.WinML.Intel.OpenVINO.EP.1.8_1.8.79.0_x64__8wekyb3d8bbwe"
+        r"\ExecutionProvider\onnxruntime_providers_openvino_plugin.dll"
+    )
+    provider.ensure_ready_async.side_effect = fake_ensure_async
+
+    ep_path._ensure_provider_ready(provider)
+
+    err = capsys.readouterr().err
+    assert "- Version: 1.8.79.0" in err
+    assert (
+        "- Package Family Name: MicrosoftCorporationII.WinML.Intel.OpenVINO.EP.1.8_8wekyb3d8bbwe"
+        in err
+    )
+
+
+def test_ensure_provider_ready_skips_metadata_lines_when_unavailable(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """If neither the native handle nor the path yields metadata, omit the
+    Version / Package Family Name lines entirely (no blank fields)."""
+    _install_fake_tqdm(monkeypatch)
+
+    op = MagicMock()
+
+    def fake_ensure_async(on_complete=None, on_progress=None):
+        on_complete()
+        return op
+
+    provider = MagicMock()
+    provider.name = "MysteryEP"
+    provider.version = ""
+    provider.package_family_name = ""
+    provider.library_path = r"C:\some\local\path\provider.dll"
+    provider.ensure_ready_async.side_effect = fake_ensure_async
+
+    ep_path._ensure_provider_ready(provider)
+
+    err = capsys.readouterr().err
+    assert "MysteryEP EP installed successfully." in err
+    assert "- Version:" not in err
+    assert "- Package Family Name:" not in err
+
+
+def test_ensure_provider_ready_prints_failure_message_on_timeout(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A timed-out download prints the ❌ failure notice with retry hints,
+    and does NOT emit the 'installed successfully.' line."""
+    _install_fake_tqdm(monkeypatch)
+    monkeypatch.setattr(ep_path, "EP_DOWNLOAD_TIMEOUT_SECONDS", 0.05)
+
+    provider = MagicMock()
+    provider.name = "SlowEP"
+    provider.ensure_ready_async.return_value = MagicMock()
+
+    with pytest.raises(TimeoutError):
+        ep_path._ensure_provider_ready(provider)
+
+    err = capsys.readouterr().err
+    assert "installed successfully" not in err
+    assert "Failed to download SlowEP EP" in err
+    assert "Check your internet connection" in err
+    assert "Troubleshoot:" in err
+    assert "https://aka.ms/winmlcli/ep-errors" in err
+
+
+def test_ensure_provider_ready_prints_failure_message_on_async_launch_error(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A failure at the ensure_ready_async() launch also prints the ❌ block."""
+    _install_fake_tqdm(monkeypatch)
+
+    provider = MagicMock()
+    provider.name = "BadEP"
+    provider.ensure_ready_async.side_effect = OSError("native launch failed")
+
+    with pytest.raises(OSError, match="native launch failed"):
+        ep_path._ensure_provider_ready(provider)
+
+    err = capsys.readouterr().err
+    assert "Failed to download BadEP EP" in err
+    assert "installed successfully" not in err
+
+
+def test_ensure_provider_ready_closes_bar_when_ensure_ready_async_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If ensure_ready_async itself raises, the bar must still be closed
+    (op was never assigned, so op.close() is skipped via the None sentinel)."""
+    fake_bar = _install_fake_tqdm(monkeypatch)
+
+    provider = MagicMock()
+    provider.name = "FakeEP"
+    provider.ensure_ready_async.side_effect = RuntimeError("native init failed")
+
+    with pytest.raises(RuntimeError, match="native init failed"):
+        ep_path._ensure_provider_ready(provider)
+
+    fake_bar.close.assert_called_once_with()
+
+
+def test_ensure_provider_ready_works_without_tqdm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When tqdm (a dev-only optional dep) is missing, the download still
+    completes via the _NoopBar fallback — no ImportError, no progress UI."""
+    # Simulate tqdm being uninstalled: make `from tqdm import tqdm` raise.
+    monkeypatch.setitem(sys.modules, "tqdm", None)
+
+    op = MagicMock()
+
+    def fake_ensure_async(on_complete=None, on_progress=None):
+        # Drive a progress update too — the no-op bar must tolerate bar.n = ...
+        on_progress(0.5)
+        on_complete()
+        return op
+
+    provider = MagicMock()
+    provider.name = "FakeEP"
+    provider.ensure_ready_async.side_effect = fake_ensure_async
+
+    ep_path._ensure_provider_ready(provider)
+
+    op.get_status.assert_called_once_with()
+    op.close.assert_called_once_with()
+
+
+class TestParseEpMetadataFromPath:
+    """`_parse_ep_metadata_from_path` recovers (version, PFN) from install paths."""
+
+    def test_parses_openvino_windowsapps_path(self) -> None:
+        path = (
+            r"C:\Program Files\WindowsApps"
+            r"\MicrosoftCorporationII.WinML.Intel.OpenVINO.EP.1.8_1.8.79.0_x64__8wekyb3d8bbwe"
+            r"\ExecutionProvider\onnxruntime_providers_openvino_plugin.dll"
+        )
+        version, pfn = ep_path._parse_ep_metadata_from_path(path)
+        assert version == "1.8.79.0"
+        assert pfn == "MicrosoftCorporationII.WinML.Intel.OpenVINO.EP.1.8_8wekyb3d8bbwe"
+
+    def test_empty_path_returns_empty(self) -> None:
+        assert ep_path._parse_ep_metadata_from_path("") == ("", "")
+
+    def test_non_windowsapps_path_returns_empty(self) -> None:
+        assert ep_path._parse_ep_metadata_from_path(r"C:\local\ep\provider.dll") == ("", "")
+
+    def test_non_numeric_version_segment_dropped_but_pfn_kept(self) -> None:
+        """A folder that doesn't carry a dotted-numeric version still yields a
+        PFN, but the version is left empty rather than guessed."""
+        path = r"C:\Program Files\WindowsApps\Some.Package_notaversion_x64__pubhash\ep.dll"
+        version, pfn = ep_path._parse_ep_metadata_from_path(path)
+        assert version == ""
+        assert pfn == "Some.Package_pubhash"
+
+
+class TestEpDownloadTimeoutDefault:
+    """`_ep_download_timeout_default` reads ``WINMLCLI_EP_DOWNLOAD_TIMEOUT``."""
+
+    def test_default_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("WINMLCLI_EP_DOWNLOAD_TIMEOUT", raising=False)
+        assert ep_path._ep_download_timeout_default() == 5 * 60
+
+    def test_override_via_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("WINMLCLI_EP_DOWNLOAD_TIMEOUT", "1800")
+        assert ep_path._ep_download_timeout_default() == 1800
+
+    def test_falls_back_to_default_on_invalid_value(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        monkeypatch.setenv("WINMLCLI_EP_DOWNLOAD_TIMEOUT", "not-a-number")
+        with caplog.at_level(logging.WARNING, logger=ep_path.logger.name):
+            assert ep_path._ep_download_timeout_default() == 5 * 60
+        assert any("WINMLCLI_EP_DOWNLOAD_TIMEOUT" in r.getMessage() for r in caplog.records)
+
+    def test_empty_string_uses_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("WINMLCLI_EP_DOWNLOAD_TIMEOUT", "")
+        assert ep_path._ep_download_timeout_default() == 5 * 60

--- a/tests/unit/ep_path/test_winml_catalog_source.py
+++ b/tests/unit/ep_path/test_winml_catalog_source.py
@@ -53,6 +53,24 @@ class _FakeReadyState:
         self.name = name
 
 
+class _FakeReadyOp:
+    """Mimic the async op handle returned by ``ensure_ready_async``."""
+
+    def __init__(self) -> None:
+        self.get_status_calls = 0
+        self.cancel_calls = 0
+        self.close_calls = 0
+
+    def get_status(self) -> None:
+        self.get_status_calls += 1
+
+    def cancel(self) -> None:
+        self.cancel_calls += 1
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
 class _FakeProvider:
     """Mimic a ``windowsml`` execution-provider row."""
 
@@ -63,18 +81,37 @@ class _FakeProvider:
         library_path: str,
         *,
         ensure_ready_raises: Exception | None = None,
+        becomes_ready: bool = True,
+        version: str = "",
+        package_family_name: str = "",
     ) -> None:
         self.name = name
         self.ready_state = _FakeReadyState(ready_state)
         self.library_path = library_path
         self.ensure_ready_calls = 0
         self._ensure_ready_raises = ensure_ready_raises
+        self._becomes_ready = becomes_ready
+        self.version = version
+        self.package_family_name = package_family_name
 
-    def ensure_ready(self) -> None:
+    def ensure_ready_async(
+        self,
+        on_complete: Any = None,
+        on_progress: Any = None,
+    ) -> _FakeReadyOp:
+        # The cold download path: drive a progress callback, (optionally) flip
+        # to Ready, then signal completion — mirroring the real windowsml
+        # async contract that ``_ensure_provider_ready`` consumes.
         self.ensure_ready_calls += 1
         if self._ensure_ready_raises is not None:
             raise self._ensure_ready_raises
-        self.ready_state = _FakeReadyState("Ready")
+        if on_progress is not None:
+            on_progress(1.0)
+        if self._becomes_ready:
+            self.ready_state = _FakeReadyState("Ready")
+        if on_complete is not None:
+            on_complete()
+        return _FakeReadyOp()
 
 
 class _FakeCatalog:
@@ -348,14 +385,24 @@ class TestWithFakeCatalog:
         tmp_path: Path,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        # Provider whose ensure_ready() is called but doesn't become Ready.
+        # Provider whose download completes but never flips to Ready.
         class _StuckProvider:
             name = "VitisAI"
             ready_state = _FakeReadyState("NotReady")
             library_path = str(tmp_path / "v.dll")
+            version = ""
+            package_family_name = ""
 
-            def ensure_ready(self) -> None:
-                pass  # intentionally does NOT update ready_state
+            def ensure_ready_async(
+                self, on_complete: Any = None, on_progress: Any = None
+            ) -> _FakeReadyOp:
+                # Completes the async op but intentionally does NOT update
+                # ready_state, so the caller must warn-and-skip.
+                if on_progress is not None:
+                    on_progress(1.0)
+                if on_complete is not None:
+                    on_complete()
+                return _FakeReadyOp()
 
         catalog = _FakeCatalog([_StuckProvider()])  # type: ignore[list-item]
         _install_windowsml_module(monkeypatch, catalog)
@@ -437,7 +484,7 @@ class TestWithFakeCatalog:
 
 
 # ---------------------------------------------------------------------------
-# Readiness and lifecycle expectations (new synchronous API).
+# Readiness and lifecycle expectations (async progress-driven download API).
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Restores the EP-download progress bar that previously existed in `ep_registry.py` ([PR #788](https://github.com/microsoft/winml-cli/pull/788)) but was dropped during the #1019 EP-discovery refactor, when the `provider.ensure_ready()` call moved into `WinMLCatalogSource._resolve_provider` in `ep_path.py` and lost its progress UX.

## What changed

**`src/winml/modelkit/ep_path.py`** — cherry-picked the progress machinery and wired it into the resolve path:
- `_ep_download_timeout_default()` + `EP_DOWNLOAD_TIMEOUT_SECONDS` — honors `WINMLCLI_EP_DOWNLOAD_TIMEOUT` (default 5 min).
- `_NoopBar` + `_make_progress_bar()` — tqdm bar with a silent fallback when tqdm or `sys.stderr` is unavailable (production installs / spawn workers).
- `_parse_ep_metadata_from_path()` — recovers `(version, package_family_name)` from the MSIX `WindowsApps` install path when the native handle reports them empty.
- `_ensure_provider_ready()` — prints the `[WinML] Installing Execution Provider` notice, drives a live tqdm bar from `ensure_ready_async`'s `on_progress` callback, waits on `on_complete` with a timeout+cancel, and prints success / ❌-failure guidance plus version/PFN.
- `WinMLCatalogSource._resolve_provider` now calls `_ensure_provider_ready(provider)` instead of the silent `provider.ensure_ready()`.

### Note on the sync fast-path
The original helper had a `from windowsml import EpReadyState` sync fast-path for already-`Ready` providers. The current `WinMLCatalogSource` deliberately avoids that coupling (string-based readiness checks) and only invokes this helper on the cold, not-Ready path, so the fast-path was dead code — it's dropped, keeping the helper focused purely on the download+progress flow.

**Tests**
- Added `tests/unit/ep_path/test_ensure_provider_ready.py` — ported the PR #788 coverage (progress bar, stale-callback drop, timeout/cancel, `get_status` error, metadata printing/fallback, failure messages, no-tqdm fallback, timeout-env parsing).
- Updated `tests/unit/ep_path/test_winml_catalog_source.py` fakes to the async download contract.

## Verification
- `ruff check` clean
- `mypy -p winml.modelkit` — no issues (426 files)
- `pytest tests/unit/ep_path/` — 178 passed, 2 skipped (EP-install-gated)