### PR TITLE
fix(config): skip winml quantization for EPs that quantize internally

### DIFF
--- a/scripts/e2e_eval/run_eval.py
+++ b/scripts/e2e_eval/run_eval.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import functools
 import hashlib
 import json
 import logging
@@ -115,14 +116,49 @@ _NPU_FALLBACK_PRECISIONS: tuple[str, ...] = ("w8a8", "w8a16")
 # ``--no-quant`` cannot override.
 
 
-def _should_skip_winml_quant(ep: str | None) -> bool:
-    """True if the eval harness should run this EP on the unquantized model."""
+@functools.cache
+def _deduce_ep_for_device(device: str) -> str | None:
+    """Canonical EP a concrete device resolves to on this host, or ``None``.
+
+    Mirrors what ``winml config`` / ``winml build`` do internally when ``--ep``
+    is omitted, so harness-side policy decisions see the same EP the product
+    will. ``"auto"`` is deliberately excluded: the product resolves it through
+    its own device detection, and the harness never forces a precision for it,
+    so the product's auto-precision policy already applies.
+    """
+    if not device or device.lower() == "auto":
+        return None
+    # Lazy import: keeps ``scripts/e2e_eval`` cheap to load (winml.modelkit
+    # transitively imports onnxruntime).
+    from winml.modelkit.session import default_ep_for_device
+
+    return default_ep_for_device(device.lower())
+
+
+def _effective_ep(ep: str | None, device: str | None) -> str | None:
+    """Canonical EP this run will actually target: explicit ``--ep``, else deduced."""
+    from winml.modelkit.utils.constants import normalize_ep_name
+
+    if ep:
+        return normalize_ep_name(ep)
+    return _deduce_ep_for_device(device or "auto")
+
+
+def _should_skip_winml_quant(ep: str | None, device: str | None = None) -> bool:
+    """True if the eval harness should run this EP on the unquantized model.
+
+    ``ep`` is ``None`` whenever only ``--device`` was pinned, so the effective EP
+    has to be deduced from the device before deciding. Without that,
+    ``run_eval.py --device npu`` on an AMD-only host would keep expanding
+    quantized jobs and forcing ``--precision w8a16`` on VitisAI -- exactly the
+    QDQ graph this policy exists to avoid.
+    """
     # Lazy import: keeps ``scripts/e2e_eval`` cheap to load (winml.modelkit
     # transitively imports onnxruntime) and matches the existing in-function
     # import pattern used elsewhere in this script.
-    from winml.modelkit.utils.constants import EPS_WITH_INTERNAL_QUANT, normalize_ep_name
+    from winml.modelkit.utils.constants import EPS_WITH_INTERNAL_QUANT
 
-    return normalize_ep_name(ep) in EPS_WITH_INTERNAL_QUANT
+    return _effective_ep(ep, device) in EPS_WITH_INTERNAL_QUANT
 
 
 def _resolve_precision(device: str, explicit: str | None, ep: str | None = None) -> str | None:
@@ -144,11 +180,12 @@ def _resolve_precision(device: str, explicit: str | None, ep: str | None = None)
 
     Otherwise an explicit per-model precision always takes precedence.
     """
-    if _should_skip_winml_quant(ep):
+    if _should_skip_winml_quant(ep, device):
         if explicit:
             safe_print(
-                f"  [precision] Ignoring explicit precision={explicit!r} for EP {ep!r}: "
-                "this EP is run on the unquantized variant (--no-quant)."
+                f"  [precision] Ignoring explicit precision={explicit!r} for EP "
+                f"{_effective_ep(ep, device)!r}: this EP is run on the unquantized "
+                "variant (--no-quant)."
             )
         return None
     if explicit:
@@ -634,7 +671,7 @@ def _run_build(
     # written with quant=None up-front; otherwise on NPU the config command
     # would still apply its default precision (w8a16) and we'd be relying on
     # --no-quant at build time alone to override it.
-    if _should_skip_winml_quant(ep):
+    if _should_skip_winml_quant(ep, device):
         config_args += ["--no-quant"]
 
     config_proc = _run_subprocess(config_args, timeout)
@@ -688,7 +725,7 @@ def _run_build(
         # Mirror the --no-quant passed to winml config above so the build
         # stage also skips QDQ regardless of what the config carries (defence
         # in depth; see _should_skip_winml_quant for the rationale).
-        if _should_skip_winml_quant(ep):
+        if _should_skip_winml_quant(ep, device):
             build_args += ["--no-quant"]
 
         build_proc = _run_subprocess(build_args, timeout)
@@ -1722,7 +1759,7 @@ def run_model(
             args += ["--task", entry.task]
         if ep:
             args += ["--ep", ep]
-        if _should_skip_winml_quant(ep):
+        if _should_skip_winml_quant(ep, device):
             args += ["--no-quant"]
         args += ["--iterations", "10", "--warmup", "2"]
         if trace:
@@ -2398,7 +2435,7 @@ def _build_jobs(
     # would produce duplicate artifacts under distinct precision slugs, and an
     # authored quantized recipe would hand the EP a QDQ graph its compiler is
     # not expected to consume.  Both are suppressed.
-    skip_quant = _should_skip_winml_quant(ep)
+    skip_quant = _should_skip_winml_quant(ep, device)
     expand_npu_quant = npu and not skip_quant
     jobs: list[EvalJob] = []
     for entry in entries:

--- a/scripts/e2e_eval/run_eval.py
+++ b/scripts/e2e_eval/run_eval.py
@@ -14,7 +14,7 @@ and a recipe-less NPU model falls back to ``winml config`` expanded into ``w8a8`
 + ``w8a16`` jobs (an explicit per-model precision overrides this). CPU/GPU build
 only the non-quantized recipe variants (e.g. ``fp16``), or a single ``winml
 config`` fallback when a model has no applicable recipe. EPs that are evaluated
-unquantized (see ``_EPS_SKIP_WINML_QUANT``) follow the same non-quantized-only
+unquantized (see ``_should_skip_winml_quant``) follow the same non-quantized-only
 rule even on NPU.
 
 The runner records facts only (perf output + the winml-eval metrics/dataset).
@@ -104,19 +104,15 @@ _DEFAULT_PRECISION_NPU = "w8a16"
 _NPU_FALLBACK_PRECISIONS: tuple[str, ...] = ("w8a8", "w8a16")
 
 # EPs whose eval track keeps the model unquantized (the "fp" variant)
-# rather than running winml's QDQ pass on top.  This is an eval-setup
-# choice -- e.g. VitisAI / AMD Ryzen AI is benchmarked on the fp32/fp16
-# model -- not a claim about the EP's internal pipeline.  For these EPs
-# the harness passes ``--no-quant`` to both ``winml config`` and
-# ``winml build`` (see :func:`_run_build` and :func:`run_model`) and skips
-# authored quantized recipe variants (see :func:`_build_jobs`), which carry
-# their own ``quant`` section that ``--no-quant`` cannot override.
-#
-# Entries are canonical ``EPName`` values (the ``*ExecutionProvider`` form);
-# user-facing aliases like ``vitisai`` are normalised via
-# ``normalize_ep_name`` in :func:`_should_skip_winml_quant` so each EP only
-# needs to be listed once.
-_EPS_SKIP_WINML_QUANT = frozenset({"VitisAIExecutionProvider"})
+# rather than running winml's QDQ pass on top.  The EP list itself is the
+# product-level policy constant ``EPS_WITH_INTERNAL_QUANT`` -- e.g. VitisAI /
+# AMD Ryzen AI quantizes internally (XINT8) and aborts inside xir when handed a
+# winml-produced QDQ graph.  ``winml config`` / ``winml build`` already fall
+# back to the unquantized track for these EPs on their own; the harness still
+# passes ``--no-quant`` explicitly (see :func:`_run_build` and
+# :func:`run_model`) and additionally skips authored quantized recipe variants
+# (see :func:`_build_jobs`), which carry their own ``quant`` section that
+# ``--no-quant`` cannot override.
 
 
 def _should_skip_winml_quant(ep: str | None) -> bool:
@@ -124,9 +120,9 @@ def _should_skip_winml_quant(ep: str | None) -> bool:
     # Lazy import: keeps ``scripts/e2e_eval`` cheap to load (winml.modelkit
     # transitively imports onnxruntime) and matches the existing in-function
     # import pattern used elsewhere in this script.
-    from winml.modelkit.utils.constants import normalize_ep_name
+    from winml.modelkit.utils.constants import EPS_WITH_INTERNAL_QUANT, normalize_ep_name
 
-    return normalize_ep_name(ep) in _EPS_SKIP_WINML_QUANT
+    return normalize_ep_name(ep) in EPS_WITH_INTERNAL_QUANT
 
 
 def _resolve_precision(device: str, explicit: str | None, ep: str | None = None) -> str | None:
@@ -138,7 +134,8 @@ def _resolve_precision(device: str, explicit: str | None, ep: str | None = None)
     (NHWC layout transformer inserts Conv nodes that QNN GPU's GetCapability
     does not claim).
 
-    For EPs in :data:`_EPS_SKIP_WINML_QUANT` (e.g. VitisAI) the flag is forced
+    For EPs matched by :func:`_should_skip_winml_quant` (e.g. VitisAI) the flag
+    is forced
     off regardless of ``explicit``: the harness pairs these EPs with
     ``--no-quant`` at config/build time, so a non-empty ``--precision`` would
     produce a config that says "quantize to X" while the build says "skip
@@ -632,7 +629,7 @@ def _run_build(
         config_args += ["--task", entry.task]
     if ep:
         config_args += ["--ep", ep]
-    # EPs in _EPS_SKIP_WINML_QUANT are evaluated on the unquantized variant.
+    # Internal-quant EPs are evaluated on the unquantized variant.
     # Pass --no-quant to winml config so the generated build_config.json is
     # written with quant=None up-front; otherwise on NPU the config command
     # would still apply its default precision (w8a16) and we'd be relying on
@@ -690,7 +687,7 @@ def _run_build(
             build_args += ["--ep", ep]
         # Mirror the --no-quant passed to winml config above so the build
         # stage also skips QDQ regardless of what the config carries (defence
-        # in depth; see _EPS_SKIP_WINML_QUANT for the rationale).
+        # in depth; see _should_skip_winml_quant for the rationale).
         if _should_skip_winml_quant(ep):
             build_args += ["--no-quant"]
 

--- a/src/winml/modelkit/config/build.py
+++ b/src/winml/modelkit/config/build.py
@@ -416,7 +416,11 @@ def _apply_target_policy(
 
     # Mutate quant in place so calibration identity fields stamped by
     # _assemble_config survive policy resolution.
-    if policy.weight_type is not None and policy.activation_type is not None:
+    if policy.skip_quantization:
+        # Same operation --no-quant performs. Checked first: the policy carries
+        # no precision choice in this case, so the branches below do not apply.
+        config.quant = None
+    elif policy.weight_type is not None and policy.activation_type is not None:
         if config.quant is None:
             config.quant = WinMLQuantizationConfig()
         config.quant.mode = "static"
@@ -506,7 +510,10 @@ def resolve_quant_compile_config(
 
     # Quant config (weight_type and activation_type are always both-None or both-set)
     quant_config: WinMLQuantizationConfig | None = None
-    if policy.weight_type is not None and policy.activation_type is not None:
+    if policy.skip_quantization:
+        # Same operation --no-quant performs: no quantization stage at all.
+        quant_config = None
+    elif policy.weight_type is not None and policy.activation_type is not None:
         quant_config = WinMLQuantizationConfig()
         quant_config.weight_type = policy.weight_type
         quant_config.activation_type = policy.activation_type

--- a/src/winml/modelkit/config/precision.py
+++ b/src/winml/modelkit/config/precision.py
@@ -23,7 +23,12 @@ from ..session import (
 
 # New session selection stays on EP_DEVICE_SPECS; this legacy build-policy
 # surface intentionally keeps using EP_SUPPORTED_DEVICES for compatibility.
-from ..utils.constants import EP_SUPPORTED_DEVICES, EPNameOrAlias, normalize_ep_name
+from ..utils.constants import (
+    EP_SUPPORTED_DEVICES,
+    EPS_WITH_INTERNAL_QUANT,
+    EPNameOrAlias,
+    normalize_ep_name,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -310,9 +315,15 @@ class PrecisionPolicy:
     Attributes:
         device: Concrete device: "npu", "gpu", or "cpu".
         precision: Resolved precision string (e.g., "int8", "w8a16", "fp16").
+            Stays ``"auto"`` when ``skip_quantization`` is set — winml made no
+            precision choice, the EP decides.
         weight_type: Quantization weight type, or None for fp32/fp16.
         activation_type: Quantization activation type, or None for fp32/fp16.
         compile_provider: Short EP name (e.g. "qnn", "dml") or None for CPU.
+        skip_quantization: True when the build must run no quantization stage at
+            all, i.e. apply exactly what ``--no-quant`` does (``quant = None``).
+            Set for EPs that quantize internally (:data:`EPS_WITH_INTERNAL_QUANT`).
+            Callers must honor this BEFORE inspecting ``precision``.
     """
 
     device: str
@@ -320,6 +331,7 @@ class PrecisionPolicy:
     weight_type: QuantType | None
     activation_type: QuantType | None
     compile_provider: str | None
+    skip_quantization: bool = False
 
 
 def resolve_precision(
@@ -410,16 +422,36 @@ def resolve_precision(
         )
 
     # Resolve "auto" precision for the resolved device
+    skip_quantization = False
     if resolved_precision == "auto":
-        resolved_precision = _AUTO_PRECISION[resolved_device]
-
-        # GPU + LLM: warn about w4a16 recommendation
-        if resolved_device == "gpu" and task in _LLM_TASKS:
+        if ep in EPS_WITH_INTERNAL_QUANT:
+            # This EP applies its own quantization scheme and cannot consume a
+            # winml-produced QDQ graph, so make no precision choice at all and
+            # tell the caller to skip the quantization stage (what --no-quant
+            # does). Leaving precision as "auto" keeps the config honest: winml
+            # picked nothing, the EP decides.
+            skip_quantization = True
             logger.warning(
-                "GPU + LLM task '%s': auto-precision is fp32 (no conversion). "
-                "For better performance, consider w4a16 quantization manually.",
-                task,
+                "EP '%s' quantizes internally, so winml is skipping its own "
+                "quantization stage (equivalent to --no-quant) instead of applying "
+                "the '%s' default for device '%s'. This EP therefore behaves "
+                "differently from the others: the artifact stays unquantized and "
+                "the accelerator applies its own scheme at load time. "
+                "Pass --precision explicitly to force a winml quantization pass.",
+                ep,
+                _AUTO_PRECISION[resolved_device],
+                resolved_device,
             )
+        else:
+            resolved_precision = _AUTO_PRECISION[resolved_device]
+
+            # GPU + LLM: warn about w4a16 recommendation
+            if resolved_device == "gpu" and task in _LLM_TASKS:
+                logger.warning(
+                    "GPU + LLM task '%s': auto-precision is fp32 (no conversion). "
+                    "For better performance, consider w4a16 quantization manually.",
+                    task,
+                )
 
     # EP override takes precedence over device→provider mapping. The policy
     # contract uses short aliases, with CPU represented as no offline compiler.
@@ -446,6 +478,7 @@ def resolve_precision(
         weight_type=weight_type,
         activation_type=activation_type,
         compile_provider=compile_provider,
+        skip_quantization=skip_quantization,
     )
 
 

--- a/src/winml/modelkit/config/precision.py
+++ b/src/winml/modelkit/config/precision.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass
-from typing import Literal, cast
+from typing import TYPE_CHECKING, Literal, cast
 
 from ..session import (
     VALID_DEVICES,
@@ -26,9 +26,14 @@ from ..session import (
 from ..utils.constants import (
     EP_SUPPORTED_DEVICES,
     EPS_WITH_INTERNAL_QUANT,
-    EPNameOrAlias,
     normalize_ep_name,
 )
+
+
+if TYPE_CHECKING:
+    # Referenced only from the quoted ``cast()`` below, so importing it at
+    # runtime would leave an unused import behind.
+    from ..utils.constants import EPNameOrAlias
 
 
 logger = logging.getLogger(__name__)
@@ -421,10 +426,19 @@ def resolve_precision(
             available_devices or ["cpu"],
         )
 
+    # Resolve the EP this build will actually target, BEFORE any policy decision
+    # that depends on it. An explicit --ep wins; otherwise deduce the registered
+    # default for the device. Callers routinely pin only the device
+    # (``--device npu`` with no ``--ep``), and on an AMD-only host that device
+    # still resolves to VitisAI — so the auto-precision decision below must see
+    # the deduced EP, not ``None``. ``compile_provider`` is derived from the same
+    # value so the two can never disagree.
+    effective_ep = ep if ep else default_ep_for_device(resolved_device)
+
     # Resolve "auto" precision for the resolved device
     skip_quantization = False
     if resolved_precision == "auto":
-        if ep in EPS_WITH_INTERNAL_QUANT:
+        if effective_ep in EPS_WITH_INTERNAL_QUANT:
             # This EP applies its own quantization scheme and cannot consume a
             # winml-produced QDQ graph, so make no precision choice at all and
             # tell the caller to skip the quantization stage (what --no-quant
@@ -438,7 +452,7 @@ def resolve_precision(
                 "differently from the others: the artifact stays unquantized and "
                 "the accelerator applies its own scheme at load time. "
                 "Pass --precision explicitly to force a winml quantization pass.",
-                ep,
+                effective_ep,
                 _AUTO_PRECISION[resolved_device],
                 resolved_device,
             )
@@ -453,13 +467,9 @@ def resolve_precision(
                     task,
                 )
 
-    # EP override takes precedence over device→provider mapping. The policy
-    # contract uses short aliases, with CPU represented as no offline compiler.
-    if ep:
-        compile_provider = ep_short_or_none(ep)
-    else:
-        _canonical = default_ep_for_device(resolved_device)
-        compile_provider = ep_short_or_none(_canonical) if _canonical is not None else None
+    # The policy contract uses short aliases, with CPU represented as no
+    # offline compiler.
+    compile_provider = ep_short_or_none(effective_ep) if effective_ep is not None else None
 
     # Resolve weight/activation types — supports named presets and w{x}a{y}.
     # Weight-only precisions (int4, w4a16) use RTN, not QDQ — they have no

--- a/src/winml/modelkit/utils/constants.py
+++ b/src/winml/modelkit/utils/constants.py
@@ -14,6 +14,7 @@ __all__ = [
     "ALL_EP_NAMES",
     "COMPILER_NAMES",
     "DEVICE_PRIORITY",
+    "EPS_WITH_INTERNAL_QUANT",
     "EP_ALIASES",
     "EP_ALIAS_NAMES",
     "EP_NAMES",
@@ -214,6 +215,20 @@ EP_SUPPORTED_DEVICES: dict[EPName, tuple[DeviceType, ...]] = {
     "CPUExecutionProvider": ("cpu",),
     "VitisAIExecutionProvider": ("npu",),
 }
+
+# EPs that run their own internal quantization pipeline and must therefore NOT
+# be handed a winml-produced QDQ graph.
+#
+# VitisAI quantizes to XINT8 inside the EP. Given a winml ``w8a16`` QDQ graph it
+# partitions the QuantizeLinear/DequantizeLinear nodes back to CPU and then
+# aborts inside xir with ``Check failed: attrs_.count(key) > 0 Attrs doesn't
+# contain attribute data``. That abort is a native fail-fast, so the whole
+# process dies (``0xC0000409``) instead of the build reporting an error.
+#
+# Consumed by ``config.precision.resolve_precision`` (auto-precision falls back
+# to the unquantized track for these EPs) and by ``scripts/e2e_eval/run_eval.py``
+# (which additionally drops authored quantized recipe variants).
+EPS_WITH_INTERNAL_QUANT: frozenset[EPName] = frozenset({"VitisAIExecutionProvider"})
 
 
 _COMPAT_CONSTANTS = frozenset(

--- a/tests/e2e/test_eval_e2e.py
+++ b/tests/e2e/test_eval_e2e.py
@@ -189,8 +189,6 @@ class TestEvalPerTask:
     def test_text_classification(self, runner: CliRunner, tmp_path: Path) -> None:
         # Model aligned with CLI default dataset (nyu-mll/glue/mrpc).
         # HF evaluate.evaluator("text-classification") returns `accuracy`.
-        # Skip e2e for VitisAI due to Windows Access violation in model compilation for some models
-        require_not_ep("vitisai")
         out = tmp_path / "result.json"
         _invoke(
             runner,
@@ -213,8 +211,6 @@ class TestEvalPerTask:
             _assert_in_range(data["metrics"], "accuracy", 0.6, 1.0)
 
     def test_token_classification(self, runner: CliRunner, tmp_path: Path) -> None:
-        # Skip e2e for VitisAI due to Windows Access violation in model compilation for some models
-        require_not_ep("vitisai")
         out = tmp_path / "result.json"
         _invoke(
             runner,
@@ -264,8 +260,6 @@ class TestEvalPerTask:
             assert -1.0 <= v <= 1.0, f"{k}={v} outside [-1, 1]"
 
     def test_image_segmentation(self, runner: CliRunner, tmp_path: Path) -> None:
-        # Skip e2e for VitisAI due to Windows Access violation in model compilation for some models
-        require_not_ep("vitisai")
         out = tmp_path / "result.json"
         _invoke(
             runner,
@@ -398,8 +392,6 @@ class TestEvalPerTask:
 
     def test_image_to_text_fp16(self, runner: CliRunner, tmp_path: Path) -> None:
         # Only test that exercises non-auto --precision.
-        # Skip e2e for VitisAI due to Windows Access violation in model compilation for some models
-        require_not_ep("vitisai")
         require_not_ep("migraphx")
         out = tmp_path / "result.json"
         _invoke(
@@ -492,8 +484,6 @@ class TestEvalPerTask:
         runner: CliRunner,
         tmp_path: Path,
     ) -> None:
-        # Skip e2e for VitisAI due to Windows Access violation in model compilation for some models
-        require_not_ep("vitisai")
         out = tmp_path / "result.json"
         _invoke(
             runner,
@@ -575,8 +565,6 @@ class TestEvalModelInputForms:
         runner: CliRunner,
         tmp_path: Path,
     ) -> None:
-        # Skip e2e for VitisAI due to Windows Access violation in model compilation for some models
-        require_not_ep("vitisai")
         hf_id = "openai/clip-vit-base-patch32"
         task = "zero-shot-image-classification"
 
@@ -634,8 +622,6 @@ class TestEvalOutput:
         runner: CliRunner,
         tmp_path: Path,
     ) -> None:
-        # Skip e2e for VitisAI due to Windows Access violation in model compilation for some models
-        require_not_ep("vitisai")
         out = tmp_path / "nested" / "subdir" / "result.json"
         _invoke(
             runner,
@@ -758,8 +744,6 @@ class TestEvalAdditionalOptions:
         runner: CliRunner,
         tmp_path: Path,
     ) -> None:
-        # Skip e2e for VitisAI due to Windows Access violation in model compilation for some models
-        require_not_ep("vitisai")
         out = tmp_path / "result.json"
         _invoke(
             runner,
@@ -792,8 +776,6 @@ class TestEvalAdditionalOptions:
         runner: CliRunner,
         tmp_path: Path,
     ) -> None:
-        # Skip e2e for VitisAI due to Windows Access violation in model compilation for some models
-        require_not_ep("vitisai")
         from pathlib import Path as _Path
 
         label_map = _Path(ADE20K_LABEL_MAP)
@@ -829,8 +811,6 @@ class TestEvalAdditionalOptions:
         runner: CliRunner,
         tmp_path: Path,
     ) -> None:
-        # Skip e2e for VitisAI due to Windows Access violation in model compilation for some models
-        require_not_ep("vitisai")
         # `eval` section provides task + samples.
         cfg = tmp_path / "cfg.json"
         cfg.write_text(
@@ -866,8 +846,6 @@ class TestEvalAdditionalOptions:
         runner: CliRunner,
         tmp_path: Path,
     ) -> None:
-        # Skip e2e for VitisAI due to Windows Access violation in model compilation for some models
-        require_not_ep("vitisai")
         # CLI wins over config file.
         cfg = tmp_path / "cfg.json"
         cfg.write_text(
@@ -905,8 +883,6 @@ class TestEvalAdditionalOptions:
         runner: CliRunner,
         tmp_path: Path,
     ) -> None:
-        # Skip e2e for VitisAI due to Windows Access violation in model compilation for some models
-        require_not_ep("vitisai")
         # No --task flag; CLI infers from HF model.
         out = tmp_path / "result.json"
         _invoke(
@@ -980,8 +956,6 @@ class TestEvalAdditionalOptions:
         tmp_path: Path,
         tiny_textcls_script: Path,
     ) -> None:
-        # Skip e2e for VitisAI due to Windows Access violation in model compilation for some models
-        require_not_ep("vitisai")
         # --dataset-script + --column + --trust-remote-code (happy path).
         ds_path = tmp_path / "tiny_textcls"
         out = tmp_path / "result.json"

--- a/tests/unit/config/test_precision.py
+++ b/tests/unit/config/test_precision.py
@@ -13,6 +13,7 @@ belong in tests/sysinfo/test_device.py.
 from __future__ import annotations
 
 import logging
+from unittest.mock import patch
 
 import pytest
 
@@ -25,6 +26,8 @@ from winml.modelkit.config.precision import (
     resolve_precision,
     resolve_quant_types,
 )
+from winml.modelkit.ep_path import EPCatalog
+from winml.modelkit.session.ep_registry import WinMLEPRegistry
 
 
 # =============================================================================
@@ -351,6 +354,55 @@ class TestInternalQuantEpAutoPrecision:
         assert policy.precision == "w8a16"
         assert policy.weight_type == "uint8"
         assert policy.activation_type == "uint16"
+
+    def test_concrete_device_with_omitted_ep_on_an_amd_only_host(self) -> None:
+        """``--device npu`` with no ``--ep`` must still see the deduced EP.
+
+        ``_resolve_policy_target`` short-circuits for a pinned device and hands
+        ``ep=None`` to this function, so the decision has to deduce the EP the
+        device will actually resolve to. On an AMD-only host that is VitisAI, and
+        without the deduction the build would fall through to ``w8a16`` and hand
+        VitisAI a QDQ graph it cannot consume.
+        """
+        available = frozenset({"VitisAIExecutionProvider", "CPUExecutionProvider"})
+        with (
+            patch.object(WinMLEPRegistry, "available_eps", return_value=available),
+            patch.object(EPCatalog, "is_compatible", return_value=True),
+        ):
+            policy = resolve_precision(device="npu", precision="auto", ep=None)
+
+        assert policy.skip_quantization is True
+        assert policy.precision == "auto"
+        assert policy.weight_type is None
+        assert policy.activation_type is None
+        assert policy.compile_provider == "vitisai"
+
+    def test_concrete_device_with_omitted_ep_on_a_qnn_host(self) -> None:
+        """The same path keeps ``w8a16`` when the deduced NPU EP is not internal-quant."""
+        available = frozenset({"QNNExecutionProvider", "CPUExecutionProvider"})
+        with (
+            patch.object(WinMLEPRegistry, "available_eps", return_value=available),
+            patch.object(EPCatalog, "is_compatible", return_value=True),
+        ):
+            policy = resolve_precision(device="npu", precision="auto", ep=None)
+
+        assert policy.skip_quantization is False
+        assert policy.precision == "w8a16"
+        assert policy.compile_provider == "qnn"
+
+    def test_quant_compile_config_skips_quant_for_deduced_internal_quant_ep(self) -> None:
+        """The build-facing wrapper must produce no quant config on that same path."""
+        from winml.modelkit.config.build import resolve_quant_compile_config
+
+        available = frozenset({"VitisAIExecutionProvider", "CPUExecutionProvider"})
+        with (
+            patch.object(WinMLEPRegistry, "available_eps", return_value=available),
+            patch.object(EPCatalog, "is_compatible", return_value=True),
+        ):
+            quant_config, compile_config = resolve_quant_compile_config(device="npu")
+
+        assert quant_config is None, "VitisAI must get no winml quantization stage"
+        assert compile_config is not None
 
     def test_every_internal_quant_ep_is_covered(self) -> None:
         """Guard the policy table: each listed EP resolves to a skip-quant auto."""

--- a/tests/unit/config/test_precision.py
+++ b/tests/unit/config/test_precision.py
@@ -296,6 +296,77 @@ class TestEpOverride:
 
 
 # =============================================================================
+# TestInternalQuantEpAutoPrecision - EPs that quantize inside the EP
+# =============================================================================
+
+
+class TestInternalQuantEpAutoPrecision:
+    """Auto-precision must not hand a winml QDQ graph to an internal-quant EP.
+
+    VitisAI quantizes to XINT8 itself. Feeding it the NPU default (``w8a16``)
+    makes it partition the QuantizeLinear/DequantizeLinear nodes back to CPU and
+    then abort inside xir, which kills the process instead of failing the build.
+    """
+
+    @pytest.mark.parametrize("ep", ["vitisai", "VitisAIExecutionProvider"])
+    def test_auto_skips_quantization_without_inventing_a_precision(self, ep: str) -> None:
+        """``--precision auto`` requests the ``--no-quant`` behavior, not fp32.
+
+        ``precision`` stays ``"auto"`` because winml makes no precision choice
+        here — the EP does. Claiming a concrete precision would misreport intent.
+        """
+        policy = resolve_precision(device="npu", precision="auto", ep=ep)
+
+        assert policy.skip_quantization is True
+        assert policy.precision == "auto"
+        assert policy.weight_type is None
+        assert policy.activation_type is None
+
+    def test_auto_warns_that_this_ep_differs(self, caplog: pytest.LogCaptureFixture) -> None:
+        """End users must be told the behavior deviates from other EPs."""
+        with caplog.at_level(logging.WARNING, logger="winml.modelkit.config.precision"):
+            resolve_precision(device="npu", precision="auto", ep="vitisai")
+
+        warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+        assert warnings, "expected a user-visible warning"
+        message = warnings[0]
+        assert "quantizes internally" in message
+        assert "--no-quant" in message
+        assert "differently" in message
+
+    def test_other_npu_eps_keep_the_quantized_default(self) -> None:
+        """QNN (no internal quantization) still gets the NPU ``w8a16`` default."""
+        policy = resolve_precision(device="npu", precision="auto", ep="qnn")
+
+        assert policy.skip_quantization is False
+        assert policy.precision == "w8a16"
+        assert policy.weight_type == "uint8"
+        assert policy.activation_type == "uint16"
+
+    def test_explicit_precision_still_wins(self) -> None:
+        """The fallback only applies to ``auto`` — an explicit request is honored."""
+        policy = resolve_precision(device="npu", precision="w8a16", ep="vitisai")
+
+        assert policy.skip_quantization is False
+        assert policy.precision == "w8a16"
+        assert policy.weight_type == "uint8"
+        assert policy.activation_type == "uint16"
+
+    def test_every_internal_quant_ep_is_covered(self) -> None:
+        """Guard the policy table: each listed EP resolves to a skip-quant auto."""
+        from winml.modelkit.session import short_ep_name
+        from winml.modelkit.utils.constants import EPS_WITH_INTERNAL_QUANT
+
+        assert EPS_WITH_INTERNAL_QUANT, "policy table must not be empty"
+        for ep_name in EPS_WITH_INTERNAL_QUANT:
+            policy = resolve_precision(precision="auto", ep=ep_name)
+            assert policy.skip_quantization is True, ep_name
+            assert policy.weight_type is None, ep_name
+            assert policy.activation_type is None, ep_name
+            assert policy.compile_provider == short_ep_name(ep_name)
+
+
+# =============================================================================
 # TestRegistrationAwareCompileProvider - spec §6.4 in 3_design_ep.md
 # =============================================================================
 

--- a/tests/unit/eval/test_run_eval_script.py
+++ b/tests/unit/eval/test_run_eval_script.py
@@ -57,6 +57,25 @@ def run_eval():
     return _load_run_eval()
 
 
+@pytest.fixture(autouse=True)
+def _deterministic_ep_deduction(run_eval):
+    """Pin the device->EP deduction so these tests do not depend on the host.
+
+    ``_should_skip_winml_quant`` deduces the EP from the device when ``--ep`` is
+    omitted, so without this the expectations below would flip on an AMD box
+    (where ``npu`` resolves to VitisAI). Default to QNN — not an internal-quant
+    EP — which keeps the historical NPU behavior; tests that exercise the
+    deduction patch it themselves.
+    """
+    run_eval._deduce_ep_for_device.cache_clear()
+    with patch(
+        "winml.modelkit.session.default_ep_for_device",
+        return_value="QNNExecutionProvider",
+    ):
+        yield
+    run_eval._deduce_ep_for_device.cache_clear()
+
+
 class TestShouldSkipWinmlQuant:
     """Membership test for ``_should_skip_winml_quant``.
 
@@ -77,6 +96,77 @@ class TestShouldSkipWinmlQuant:
     )
     def test_other_eps_do_not_skip(self, run_eval, ep):
         assert run_eval._should_skip_winml_quant(ep) is False
+
+
+class TestDeducedEpForPinnedDevice:
+    """``--device npu`` with ``--ep`` omitted must still see the effective EP.
+
+    The harness forwards its own ``--precision`` to ``winml config``/``build``,
+    which suppresses the product-side auto-precision policy. So when only the
+    device is pinned, the harness has to deduce the EP itself — otherwise a run
+    on an AMD-only host expands quantized jobs and forces ``w8a16`` onto VitisAI.
+    """
+
+    @staticmethod
+    def _with_deduced_ep(run_eval, ep_name):
+        """Patch the device->EP deduction and reset its cache first."""
+        run_eval._deduce_ep_for_device.cache_clear()
+        return patch(
+            "winml.modelkit.session.default_ep_for_device",
+            return_value=ep_name,
+        )
+
+    @staticmethod
+    def _entry(run_eval):
+        return run_eval.ModelEntry(
+            hf_id="acme/model",
+            task="image-classification",
+            model_type="vit",
+            priority="P0",
+            group="Benchmark",
+        )
+
+    def test_skips_quant_when_device_deduces_to_vitisai(self, run_eval):
+        with self._with_deduced_ep(run_eval, "VitisAIExecutionProvider"):
+            assert run_eval._should_skip_winml_quant(None, "npu") is True
+        run_eval._deduce_ep_for_device.cache_clear()
+
+    def test_keeps_quant_when_device_deduces_to_qnn(self, run_eval):
+        with self._with_deduced_ep(run_eval, "QNNExecutionProvider"):
+            assert run_eval._should_skip_winml_quant(None, "npu") is False
+        run_eval._deduce_ep_for_device.cache_clear()
+
+    def test_resolve_precision_drops_w8a16_for_deduced_vitisai(self, run_eval):
+        with self._with_deduced_ep(run_eval, "VitisAIExecutionProvider"):
+            assert run_eval._resolve_precision("npu", None) is None
+        run_eval._deduce_ep_for_device.cache_clear()
+
+    def test_build_jobs_drops_quantized_fanout_for_deduced_vitisai(self, run_eval):
+        """No ``--ep``: the NPU quantized fan-out collapses to one unquantized job."""
+        with self._with_deduced_ep(run_eval, "VitisAIExecutionProvider"):
+            jobs = run_eval._build_jobs([self._entry(run_eval)], None, "npu", ep=None)
+        run_eval._deduce_ep_for_device.cache_clear()
+
+        assert len(jobs) == 1
+        assert jobs[0].fallback_precision is None
+
+    def test_build_jobs_still_expands_for_deduced_qnn(self, run_eval):
+        """The same path keeps the w8a8 + w8a16 fan-out on a QNN host."""
+        with self._with_deduced_ep(run_eval, "QNNExecutionProvider"):
+            jobs = run_eval._build_jobs([self._entry(run_eval)], None, "npu", ep=None)
+        run_eval._deduce_ep_for_device.cache_clear()
+
+        assert [j.fallback_precision for j in jobs] == list(run_eval._NPU_FALLBACK_PRECISIONS)
+
+    def test_auto_device_defers_to_the_product(self, run_eval):
+        """``--device auto`` must not deduce.
+
+        The product resolves that itself and applies its own auto-precision
+        policy; the harness forces no precision, so there is nothing to gate.
+        """
+        run_eval._deduce_ep_for_device.cache_clear()
+        assert run_eval._deduce_ep_for_device("auto") is None
+        assert run_eval._should_skip_winml_quant(None, "auto") is False
 
 
 class TestResolvePrecision:
@@ -104,9 +194,10 @@ class TestResolvePrecision:
         captured = capsys.readouterr()
         # Warning must mention the dropped value and the EP so the override
         # is visible in the log when an explicit per-model precision is set
-        # for an EP that runs on the unquantized variant.
+        # for an EP that runs on the unquantized variant. The EP is reported in
+        # its canonical form, which also covers the deduced-EP case.
         assert "w8a8" in captured.out
-        assert "vitisai" in captured.out
+        assert "vitisai" in captured.out.lower()
 
 
 class TestResolveOpTracing:

--- a/tests/unit/eval/test_run_eval_script.py
+++ b/tests/unit/eval/test_run_eval_script.py
@@ -256,7 +256,7 @@ class TestCompositeOnnxRegistry:
 
 class TestRunBuildNoQuantInjection:
     """``_run_build`` must append ``--no-quant`` to both winml config and
-    winml build invocations when the EP is in ``_EPS_SKIP_WINML_QUANT``.
+    winml build invocations when the EP quantizes internally (``EPS_WITH_INTERNAL_QUANT``).
     """
 
     @staticmethod


### PR DESCRIPTION
## Problem

`tests/e2e/test_eval_e2e.py` does not fail on an AMD Ryzen AI host — it **kills the pytest process on its very first test**, so none of its 46 cases run:

```
$ pytest tests/e2e/test_eval_e2e.py::TestEvalPerTask::test_image_classification -m e2e
collected 1 item
tests/e2e/test_eval_e2e.py::TestEvalPerTask::test_image_classification
EXIT=-1073740791          # 0xC0000409, native fail-fast
```

The same reproduces straight from the CLI, with no test harness involved:

```powershell
winml eval -m google/vit-base-patch16-224 --task image-classification --streaming --samples 10
```

```
[W PartitionPass.cpp] xir::Op{... type = dequantize-linear} is partitioned to CPU as :
    doesn't supported by target [AMD_AIE2P_4x8_CMC_Overlay].
[W PartitionPass.cpp] xir::Op{... type = :IsNaN} is partitioned to CPU as : ...
[F attrs_imp.cpp:38] Check failed: attrs_.count(key) > 0 Attrs doesn't contain attribute data
*** Check failure stack trace: ***
```

## Root cause

`_AUTO_PRECISION` in `config/precision.py` is keyed on the **device only**:

```python
_AUTO_PRECISION: dict[str, str] = {
    "npu": "w8a16",
    "gpu": "fp32",
    "cpu": "fp32",
}
```

On an AMD host the auto-selected NPU EP is VitisAI, so `--precision auto` produces a winml `w8a16` QDQ graph. VitisAI quantizes to XINT8 **inside the EP** and is not meant to consume that graph: it partitions the quantize/dequantize and `IsNaN` nodes back to CPU, then aborts inside xir. The abort is a native fail-fast, so the process dies rather than the build reporting an error.

This policy was already established — but only inside the eval harness. `scripts/e2e_eval/run_eval.py` carried its own `_EPS_SKIP_WINML_QUANT` and worked around the problem by passing `--no-quant` to `winml config` / `winml build` (see #1226). The product itself still handed every AMD NPU user a `w8a16` graph.

Verification that the unquantized track is the fix, same model and host:

| precision | result |
| --- | --- |
| `w8a16` (the auto default) | xir abort, `0xC0000409` |
| unquantized | `accuracy 1.0`, results written |

## Change

- `utils/constants.py`: add `EPS_WITH_INTERNAL_QUANT` as the single source of truth for "this EP runs its own quantization pipeline". `run_eval.py` now consumes it instead of defining its own copy.
- `config/precision.py`: `resolve_precision` sets `PrecisionPolicy.skip_quantization` when the resolved EP matches, and leaves `precision` at `"auto"` — winml makes no precision choice here, the EP does. No fake precision value is invented.
- `config/build.py`: both policy consumers (`_apply_device_precision_policy`, `resolve_quant_compile_config`) honor the flag first and apply exactly what `--no-quant` does (`quant = None`).
- Warn at `WARNING` level so the deviation is visible to end users:

  ```
  [WARNING winml.modelkit.config.precision] EP 'VitisAIExecutionProvider' quantizes
  internally, so winml is skipping its own quantization stage (equivalent to
  --no-quant) instead of applying the 'w8a16' default for device 'npu'. This EP
  therefore behaves differently from the others: the artifact stays unquantized and
  the accelerator applies its own scheme at load time. Pass --precision explicitly
  to force a winml quantization pass.
  ```

- `tests/e2e/test_eval_e2e.py`: drop the 13 per-test `require_not_ep("vitisai")` guards. They had been added one at a time as individual models hit the abort; `test_image_classification` was never guarded, so the module took the whole process down on AMD regardless. These tests now run for real.

An explicit `--precision` is unaffected — only `auto` is redirected.

| EP | `--precision auto` | change |
| --- | --- | --- |
| VitisAI | skip quantization | was `w8a16` |
| QNN | `w8a16` | unchanged |
| no `--ep` on a QNN host | `w8a16` | unchanged |
| VitisAI + explicit `--precision w8a16` | `w8a16` | user override still honored |

## Verification

On an AMD Ryzen AI NPU host:

- `pytest tests/e2e/test_eval_e2e.py -m e2e` → **41 passed, 5 skipped, 0 failed** (was: process killed on test 1, 0 cases completed). Zero VitisAI-related skips; the 5 remaining are `require_ep("qnn")` ×3 and `require_not_ep("migraphx")` ×2.
- `pytest tests/unit` → 7897 passed, 77 skipped, 3 xfailed.
- `winml config -m microsoft/resnet-50 --device npu --ep vitisai` → warning shown, generated config has `"quant": null`.
- `ruff check` / `ruff format --check` clean.

## Notes for follow-up (not in this PR)

- Switching VitisAI to the float graph makes its `vaip-ort-api.cpp` emit one `E ... Invalid NodeIndex` line **per graph node, twice** (808 lines for a 404-node ViT; 98.6% of the full e2e log). Inference is correct and the tests pass — it is pure log noise from the EP, but it buries real test output. Worth an upstream report to AMD.
- The e2e run still exits non-zero: after `41 passed, 5 skipped` is printed, the process hits `0xC0000005` in `Microsoft.Windows.AI.MachineLearning.dll` teardown. That is #1233, reproduces on Intel CPU EP too, and is unrelated to this change.
