### PR TITLE
e2e_eval: record the precision the build actually applied

### DIFF
--- a/scripts/e2e_eval/run_eval.py
+++ b/scripts/e2e_eval/run_eval.py
@@ -159,6 +159,47 @@ def _resolve_precision(device: str, explicit: str | None, ep: str | None = None)
     return _DEFAULT_PRECISION_NPU if device == "npu" else None
 
 
+# Quantization type -> bit width, used to rebuild the ``w{x}a{y}`` label from a
+# generated build config's quant section.
+_QUANT_TYPE_BITS = {"uint8": 8, "int8": 8, "uint16": 16, "int16": 16}
+
+
+def _precision_from_build_config(config_path: Path) -> str | None:
+    """Read back the precision ``winml config`` resolved into a build config.
+
+    The harness omits ``--precision`` whenever it has no explicit value (CPU/GPU,
+    ``--device auto``, or a recipe-less model with no pinned precision), and
+    ``winml config`` then resolves ``auto`` against the target device (NPU ->
+    w8a16, CPU/GPU -> fp32). The generated config's ``quant`` section is the only
+    faithful record of that decision, so recording it keeps a quantized build
+    from being written out as "no precision" -- which downstream reports read as
+    "unquantized".
+
+    Returns None when the quant section has an unrecognised shape.
+    """
+    try:
+        cfg = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    quant = cfg.get("quant")
+    if quant is None:
+        # No quant stage and no fp16 conversion: the graph stays fp32.
+        return "fp32"
+    if not isinstance(quant, dict):
+        return None
+    mode = quant.get("mode")
+    if mode == "fp16":
+        return "fp16"
+    if mode == "rtn":
+        bits = quant.get("rtn_bits")
+        return f"int{bits}" if bits else None
+    weight_bits = _QUANT_TYPE_BITS.get(quant.get("weight_type"))
+    activation_bits = _QUANT_TYPE_BITS.get(quant.get("activation_type"))
+    if weight_bits and activation_bits:
+        return f"w{weight_bits}a{activation_bits}"
+    return None
+
+
 def _load_timeout_skip_set() -> set[tuple[str, str]]:
     """Load the timeout skip list as a set of (hf_id, task) tuples."""
     if not TIMEOUT_SKIP_LIST_PATH.exists():
@@ -583,7 +624,10 @@ def _run_build(
     ``precision`` is passed to both ``winml config`` and ``winml build``: since
     we always pass ``--device``, ``winml build -c`` re-resolves quant from
     device+precision and overwrites what the config baked in, so omitting it
-    would let the build revert to its auto default (npu → w8a16).
+    would let the build revert to its auto default (npu → w8a16). The result
+    dict reports that effective precision back under ``precision`` (read from
+    the generated config when the caller passed none), so the recorded
+    eval_result never claims "no precision" for a quantized build.
     """
     composite_onnx = getattr(entry, "composite_onnx", None)
     if isinstance(composite_onnx, dict) and composite_onnx:
@@ -655,6 +699,11 @@ def _run_build(
     if not sub_configs:
         sub_configs = [config_path]
 
+    # Precision actually applied: the flag when the caller pinned one, else what
+    # `winml config` resolved from `auto`. Reported back so the result records
+    # the built precision rather than "none" (see _precision_from_build_config).
+    effective_precision = precision or _precision_from_build_config(sub_configs[0])
+
     # Step 2: build each sub-config
     # Map component label → ONNX path. Single model uses "" as label.
     onnx_paths: dict[str, str] = {}
@@ -703,6 +752,7 @@ def _run_build(
                 "onnx_paths": onnx_paths,
                 "stage": stage,
                 "proc": build_proc,
+                "precision": effective_precision,
             }
 
         if build_only:
@@ -724,6 +774,7 @@ def _run_build(
         "onnx_paths": onnx_paths,
         "stage": "complete",
         "proc": last_proc,
+        "precision": effective_precision,
     }
 
 
@@ -831,6 +882,7 @@ def _run_recipe_build(
                 "stage": stage,
                 "proc": proc,
                 "meta_config": meta_config,
+                "precision": variant.precision,
             }
 
         # Locate the cached artifact from the build output (same mechanism as
@@ -851,6 +903,7 @@ def _run_recipe_build(
                 "stage": stage,
                 "proc": proc,
                 "meta_config": meta_config,
+                "precision": variant.precision,
             }
         onnx_paths[role or ""] = str(onnx)
 
@@ -860,6 +913,7 @@ def _run_recipe_build(
         "stage": "complete",
         "proc": last_proc,
         "meta_config": meta_config,
+        "precision": variant.precision,
     }
 
 
@@ -2891,6 +2945,9 @@ def main() -> None:
     for i, job in enumerate(jobs, 1):
         entry = job.entry
         precision = job.precision
+        # Recorded precision defaults to the declared one and is replaced by what
+        # the build actually applied once the build phase reports it.
+        recorded_precision = precision
         prec_tag = f" [{precision}]" if precision else ""
         base_label = f"{entry.hf_id} / {entry.task}" if entry.task else entry.hf_id
         label = f"{base_label}{prec_tag}"
@@ -2969,6 +3026,11 @@ def main() -> None:
             # for this precision, else the winml-config fallback. Both return
             # {success, onnx_paths, stage, proc}; build is shared by perf + eval.
             build_result, recipe_meta, trust = _build_for_job(job, args, model_dir)
+
+            # A fallback job with no pinned precision still builds at the device
+            # default (NPU -> w8a16), so record what was built, not what the job
+            # declared -- an empty precision reads as "unquantized" downstream.
+            recorded_precision = build_result.get("precision") or precision
 
             onnx_paths = build_result["onnx_paths"] if build_result["success"] else {}
             onnx_size = _compute_onnx_size(onnx_paths)
@@ -3058,6 +3120,10 @@ def main() -> None:
             # build_eval_result would store, so it's spliced in directly.
             result = dict(backfill_existing)
             result["accuracy"] = accuracy_result
+            # The backfill rebuilt the model, so stamp the precision it used —
+            # results written before the build reported it carry none at all.
+            if recorded_precision is not None:
+                result["precision"] = recorded_precision
             etr = result.get("eval_types_run") or []
             if "accuracy" not in etr:
                 result["eval_types_run"] = [*etr, "accuracy"]
@@ -3071,7 +3137,7 @@ def main() -> None:
                 ep=args.ep,
                 onnx_size_bytes=onnx_size,
                 sanitize_fn=None if args.raw_output else _sanitize_output,
-                precision=precision,
+                precision=recorded_precision,
             )
         results.append(result)
 

--- a/scripts/e2e_eval/run_eval.py
+++ b/scripts/e2e_eval/run_eval.py
@@ -634,6 +634,9 @@ def _run_build(
             "success": True,
             "onnx_paths": dict(composite_onnx),
             "stage": "prebuilt",
+            # Nothing is built here: the registry supplies pre-exported ONNX, so
+            # the caller's resolved precision is all that describes them.
+            "precision": precision,
             "proc": {
                 "exit_code": 0,
                 "stdout": "Using pre-built composite ONNX paths from registry.",
@@ -2944,9 +2947,9 @@ def main() -> None:
     for i, job in enumerate(jobs, 1):
         entry = job.entry
         precision = job.precision
-        # Recorded precision defaults to the declared one and is replaced by what
-        # the build actually applied once the build phase reports it.
-        recorded_precision = precision
+        # What the build reports it applied; stays None until the build phase runs
+        # (and for a job whose build applies no precision at all).
+        recorded_precision: str | None = None
         prec_tag = f" [{precision}]" if precision else ""
         base_label = f"{entry.hf_id} / {entry.task}" if entry.task else entry.hf_id
         label = f"{base_label}{prec_tag}"
@@ -3026,10 +3029,11 @@ def main() -> None:
             # {success, onnx_paths, stage, proc}; build is shared by perf + eval.
             build_result, recipe_meta, trust = _build_for_job(job, args, model_dir)
 
-            # A fallback job with no pinned precision still builds at the device
-            # default (NPU -> w8a16), so record what was built, not what the job
-            # declared -- an empty precision reads as "unquantized" downstream.
-            recorded_precision = build_result.get("precision") or precision
+            # Record what the build applied, never what the job declared: a
+            # fallback job with no pinned precision still builds at the device
+            # default (NPU -> w8a16), while a skip-quant EP drops even an explicit
+            # per-model precision. The declared value stays in the dir slug/label.
+            recorded_precision = build_result.get("precision")
 
             onnx_paths = build_result["onnx_paths"] if build_result["success"] else {}
             onnx_size = _compute_onnx_size(onnx_paths)

--- a/scripts/e2e_eval/run_eval.py
+++ b/scripts/e2e_eval/run_eval.py
@@ -169,22 +169,21 @@ def _precision_from_build_config(config_path: Path) -> str | None:
 
     The harness omits ``--precision`` whenever it has no explicit value (CPU/GPU,
     ``--device auto``, or a recipe-less model with no pinned precision), and
-    ``winml config`` then resolves ``auto`` against the target device (NPU ->
-    w8a16, CPU/GPU -> fp32). The generated config's ``quant`` section is the only
-    faithful record of that decision, so recording it keeps a quantized build
-    from being written out as "no precision" -- which downstream reports read as
-    "unquantized".
+    ``winml config`` then resolves ``auto`` against the target device -- on NPU
+    that is w8a16, so the build is quantized even though the job declared no
+    precision. The config's ``quant`` section is the only faithful record of that
+    decision, and reporting it keeps a quantized build from being written out as
+    "no precision" -- which downstream reports read as "unquantized".
 
-    Returns None when the quant section has an unrecognised shape.
+    Only what the config states is returned: a config with no quant stage yields
+    None (nothing was requested, so nothing is claimed), as does a quant section
+    whose shape is unrecognised.
     """
     try:
         cfg = json.loads(config_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
     quant = cfg.get("quant")
-    if quant is None:
-        # No quant stage and no fp16 conversion: the graph stays fp32.
-        return "fp32"
     if not isinstance(quant, dict):
         return None
     mode = quant.get("mode")

--- a/scripts/e2e_eval/run_eval.py
+++ b/scripts/e2e_eval/run_eval.py
@@ -2520,6 +2520,32 @@ def _build_for_job(
     return build_result, recipe_meta, trust
 
 
+def _merge_backfill_result(
+    existing: dict, accuracy_result: dict | None, precision: str | None
+) -> dict:
+    """Splice a freshly-run accuracy into an existing result.
+
+    The recorded perf section is preserved verbatim (it already ran and passed);
+    ``accuracy_result`` has the same shape :func:`build_eval_result` stores, so
+    it is spliced in directly.
+
+    ``precision`` is what the backfill's rebuild reported and always replaces the
+    recorded value -- including when it is None (a skip-quant/unquantized build),
+    since leaving the old value would let a stale declared precision keep
+    claiming an artifact that was never built.
+    """
+    result = dict(existing)
+    result["accuracy"] = accuracy_result
+    if precision is None:
+        result.pop("precision", None)
+    else:
+        result["precision"] = precision
+    eval_types = result.get("eval_types_run") or []
+    if "accuracy" not in eval_types:
+        result["eval_types_run"] = [*eval_types, "accuracy"]
+    return result
+
+
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
@@ -3118,18 +3144,7 @@ def main() -> None:
             break
 
         if backfill_existing is not None:
-            # Merge the freshly-run accuracy into the existing result, preserving
-            # its recorded perf verbatim. accuracy_result has the same shape
-            # build_eval_result would store, so it's spliced in directly.
-            result = dict(backfill_existing)
-            result["accuracy"] = accuracy_result
-            # The backfill rebuilt the model, so stamp the precision it used —
-            # results written before the build reported it carry none at all.
-            if recorded_precision is not None:
-                result["precision"] = recorded_precision
-            etr = result.get("eval_types_run") or []
-            if "accuracy" not in etr:
-                result["eval_types_run"] = [*etr, "accuracy"]
+            result = _merge_backfill_result(backfill_existing, accuracy_result, recorded_precision)
         else:
             result = build_eval_result(
                 entry,

--- a/tests/unit/eval/test_run_eval_script.py
+++ b/tests/unit/eval/test_run_eval_script.py
@@ -604,6 +604,51 @@ class TestBuildForJobPrecision:
         assert build_result["precision"] is None
 
 
+class TestMergeBackfillResult:
+    """``_merge_backfill_result`` splices accuracy into an existing result.
+
+    The backfill rebuilds the model, so the rebuild's precision is authoritative
+    for the merged result -- including when it is None.
+    """
+
+    @staticmethod
+    def _existing(**extra):
+        return {
+            "model": "some/model",
+            "perf": {"passed": True, "elapsed": 3.5},
+            "accuracy": None,
+            "eval_types_run": ["perf"],
+            **extra,
+        }
+
+    def test_stale_precision_cleared_when_rebuild_reports_none(self, run_eval):
+        # A perf-only result written before this fix (VitisAI + declared w8a16)
+        # must not keep claiming that precision once the rebuild -- which runs
+        # with --no-quant -- reports none.
+        existing = self._existing(precision="w8a16")
+        merged = run_eval._merge_backfill_result(existing, {"metrics": {}}, None)
+        assert "precision" not in merged
+
+    def test_rebuild_precision_replaces_recorded_value(self, run_eval):
+        existing = self._existing(precision="w8a16")
+        merged = run_eval._merge_backfill_result(existing, {"metrics": {}}, "w8a8")
+        assert merged["precision"] == "w8a8"
+
+    def test_perf_preserved_and_accuracy_spliced(self, run_eval):
+        existing = self._existing()
+        accuracy = {"metrics": {"top1_accuracy": 1.0}}
+        merged = run_eval._merge_backfill_result(existing, accuracy, "fp16")
+        assert merged["perf"] == existing["perf"]
+        assert merged["accuracy"] is accuracy
+        assert merged["eval_types_run"] == ["perf", "accuracy"]
+        assert existing["accuracy"] is None  # input not mutated
+
+    def test_accuracy_eval_type_not_duplicated(self, run_eval):
+        existing = self._existing(eval_types_run=["perf", "accuracy"])
+        merged = run_eval._merge_backfill_result(existing, {"metrics": {}}, None)
+        assert merged["eval_types_run"] == ["perf", "accuracy"]
+
+
 class TestFeedVersionForCombo:
     """``_feed_version_for`` embeds the EP/device combo after the run-stamp."""
 

--- a/tests/unit/eval/test_run_eval_script.py
+++ b/tests/unit/eval/test_run_eval_script.py
@@ -449,12 +449,13 @@ class TestPrecisionFromBuildConfig:
         path.write_text(json.dumps(cfg), encoding="utf-8")
         return path
 
-    def test_missing_quant_section_is_fp32(self, run_eval, tmp_path):
-        # No quant stage and no fp16 conversion: the graph stays fp32. Both the
-        # explicit null and an omitted key mean the same thing.
-        assert run_eval._precision_from_build_config(self._write(tmp_path, {})) == "fp32"
+    def test_missing_quant_section_is_none(self, run_eval, tmp_path):
+        # Nothing was requested, so nothing is claimed: the config is reported
+        # verbatim rather than inferred as fp32 (the graph's own dtype is not
+        # something the config states).
+        assert run_eval._precision_from_build_config(self._write(tmp_path, {})) is None
         assert (
-            run_eval._precision_from_build_config(self._write(tmp_path, {"quant": None})) == "fp32"
+            run_eval._precision_from_build_config(self._write(tmp_path, {"quant": None})) is None
         )
 
     @pytest.mark.parametrize(
@@ -549,9 +550,9 @@ class TestRunBuildReportsEffectivePrecision:
         result = self._invoke(run_eval, tmp_path, None, quant)
         assert result["precision"] == "w8a16"
 
-    def test_unquantized_config_reports_fp32(self, run_eval, tmp_path):
+    def test_unquantized_config_reports_nothing(self, run_eval, tmp_path):
         result = self._invoke(run_eval, tmp_path, None, None)
-        assert result["precision"] == "fp32"
+        assert result["precision"] is None
 
 
 class TestFeedVersionForCombo:

--- a/tests/unit/eval/test_run_eval_script.py
+++ b/tests/unit/eval/test_run_eval_script.py
@@ -251,6 +251,8 @@ class TestCompositeOnnxRegistry:
         assert result["success"] is True
         assert result["stage"] == "prebuilt"
         assert result["onnx_paths"] == entry.composite_onnx
+        # Nothing is built, so the caller's resolved precision is reported as-is.
+        assert result["precision"] is None
         mock_subprocess.assert_not_called()
 
 
@@ -553,6 +555,53 @@ class TestRunBuildReportsEffectivePrecision:
     def test_unquantized_config_reports_nothing(self, run_eval, tmp_path):
         result = self._invoke(run_eval, tmp_path, None, None)
         assert result["precision"] is None
+
+
+class TestBuildForJobPrecision:
+    """``_build_for_job`` reports the precision the build applied, not the declared one.
+
+    A skip-quant EP (VitisAI) is built with ``--no-quant`` and ``_resolve_precision``
+    drops even an explicit per-model precision, so the job must not report that
+    ignored value -- stamping it would publish an unquantized artifact under a
+    quantized label.
+    """
+
+    def test_skip_quant_ep_drops_explicit_entry_precision(self, run_eval, tmp_path):
+        entry = _entry("some/model", "text-classification")
+        entry.precision = "w8a16"
+        job = run_eval.EvalJob(entry, None)
+        assert job.precision == "w8a16"  # declared: still drives the dir slug
+
+        args = argparse.Namespace(ep="vitisai", device="npu", timeout=300)
+        captured: list[list[str]] = []
+
+        def fake_subprocess(cmd, _timeout):
+            captured.append(list(cmd))
+            if "config" in cmd:
+                # --no-quant makes winml config emit a config with no quant stage.
+                (tmp_path / "build_config.json").write_text(
+                    json.dumps({"quant": None}), encoding="utf-8"
+                )
+                stdout = ""
+            else:
+                stdout = "Build cache: model.onnx"
+            return {
+                "exit_code": 0,
+                "stdout": stdout,
+                "stderr": "",
+                "elapsed": 0.1,
+                "command": " ".join(cmd),
+            }
+
+        with (
+            patch.object(run_eval, "_run_subprocess", side_effect=fake_subprocess),
+            patch.object(run_eval, "_extract_onnx_path", return_value=str(tmp_path / "m.onnx")),
+        ):
+            build_result, _meta, _trust = run_eval._build_for_job(job, args, tmp_path)
+
+        assert all("--no-quant" in cmd for cmd in captured)
+        assert all("--precision" not in cmd for cmd in captured)
+        assert build_result["precision"] is None
 
 
 class TestFeedVersionForCombo:

--- a/tests/unit/eval/test_run_eval_script.py
+++ b/tests/unit/eval/test_run_eval_script.py
@@ -441,6 +441,119 @@ class TestRunBuildPrecisionForwarding:
         assert "--precision" not in build_call, build_call
 
 
+class TestPrecisionFromBuildConfig:
+    """``_precision_from_build_config`` reads back what ``winml config`` resolved."""
+
+    def _write(self, tmp_path, cfg):
+        path = tmp_path / "build_config.json"
+        path.write_text(json.dumps(cfg), encoding="utf-8")
+        return path
+
+    def test_missing_quant_section_is_fp32(self, run_eval, tmp_path):
+        # No quant stage and no fp16 conversion: the graph stays fp32. Both the
+        # explicit null and an omitted key mean the same thing.
+        assert run_eval._precision_from_build_config(self._write(tmp_path, {})) == "fp32"
+        assert (
+            run_eval._precision_from_build_config(self._write(tmp_path, {"quant": None})) == "fp32"
+        )
+
+    @pytest.mark.parametrize(
+        ("weight_type", "activation_type", "expected"),
+        [
+            ("uint8", "uint16", "w8a16"),
+            ("uint8", "uint8", "w8a8"),
+            ("int8", "int16", "w8a16"),
+        ],
+    )
+    def test_qdq_types_map_to_precision(
+        self, run_eval, tmp_path, weight_type, activation_type, expected
+    ):
+        cfg = {
+            "quant": {
+                "mode": "qdq",
+                "weight_type": weight_type,
+                "activation_type": activation_type,
+            }
+        }
+        assert run_eval._precision_from_build_config(self._write(tmp_path, cfg)) == expected
+
+    def test_fp16_mode(self, run_eval, tmp_path):
+        cfg = {"quant": {"mode": "fp16", "weight_type": None, "activation_type": None}}
+        assert run_eval._precision_from_build_config(self._write(tmp_path, cfg)) == "fp16"
+
+    def test_rtn_mode_uses_bits(self, run_eval, tmp_path):
+        cfg = {"quant": {"mode": "rtn", "rtn_bits": 4}}
+        assert run_eval._precision_from_build_config(self._write(tmp_path, cfg)) == "int4"
+
+    def test_unrecognised_quant_shape_is_none(self, run_eval, tmp_path):
+        cfg = {"quant": {"mode": "qdq", "weight_type": "float8", "activation_type": None}}
+        assert run_eval._precision_from_build_config(self._write(tmp_path, cfg)) is None
+
+    def test_unreadable_config_is_none(self, run_eval, tmp_path):
+        missing = tmp_path / "nope.json"
+        assert run_eval._precision_from_build_config(missing) is None
+        broken = tmp_path / "broken.json"
+        broken.write_text("{not json", encoding="utf-8")
+        assert run_eval._precision_from_build_config(broken) is None
+
+
+class TestRunBuildReportsEffectivePrecision:
+    """``_run_build`` reports the precision the build actually applied.
+
+    A fallback job may pin no precision (CPU/GPU, or ``--device auto``), yet
+    ``winml config`` still resolves ``auto`` to a device default -- w8a16 on NPU.
+    Returning None there let the recorded result claim "no precision", which the
+    downstream reports render as an unquantized run.
+    """
+
+    @staticmethod
+    def _make_entry():
+        entry = MagicMock()
+        entry.hf_id = "google-bert/bert-base-uncased"
+        entry.task = "text-classification"
+        entry.perf_args = []
+        return entry
+
+    def _invoke(self, run_eval, tmp_path, precision, quant):
+        def fake_subprocess(args, _timeout):
+            if "config" in args:
+                (tmp_path / "build_config.json").write_text(
+                    json.dumps({"quant": quant}), encoding="utf-8"
+                )
+                stdout = ""
+            else:
+                stdout = "Build cache: model.onnx"
+            return {
+                "exit_code": 0,
+                "stdout": stdout,
+                "stderr": "",
+                "elapsed": 0.1,
+                "command": " ".join(args),
+            }
+
+        with (
+            patch.object(run_eval, "_run_subprocess", side_effect=fake_subprocess),
+            patch.object(run_eval, "_extract_onnx_path", return_value=str(tmp_path / "model.onnx")),
+        ):
+            return run_eval._run_build(
+                self._make_entry(), "npu", precision, 300, tmp_path, ep="qnn"
+            )
+
+    def test_pinned_precision_is_reported(self, run_eval, tmp_path):
+        quant = {"mode": "qdq", "weight_type": "uint8", "activation_type": "uint8"}
+        result = self._invoke(run_eval, tmp_path, "w8a8", quant)
+        assert result["precision"] == "w8a8"
+
+    def test_auto_resolved_precision_is_read_from_config(self, run_eval, tmp_path):
+        quant = {"mode": "qdq", "weight_type": "uint8", "activation_type": "uint16"}
+        result = self._invoke(run_eval, tmp_path, None, quant)
+        assert result["precision"] == "w8a16"
+
+    def test_unquantized_config_reports_fp32(self, run_eval, tmp_path):
+        result = self._invoke(run_eval, tmp_path, None, None)
+        assert result["precision"] == "fp32"
+
+
 class TestFeedVersionForCombo:
     """``_feed_version_for`` embeds the EP/device combo after the run-stamp."""
 
@@ -1069,6 +1182,17 @@ class TestRunRecipeBuild:
             result = run_eval._run_recipe_build(_entry(), variant, 300, tmp_path / "o")
         assert result["success"] is False
         assert result["stage"] == "build"
+
+    def test_reports_variant_precision(self, run_eval, tmp_path):
+        # The authored recipe is the source of truth for its precision, so the
+        # build reports it for the recorded result (same contract as _run_build).
+        variant = self._variant(run_eval, tmp_path, composite=False)
+        with (
+            patch.object(run_eval, "_run_subprocess", side_effect=self._fake_subprocess([])),
+            patch.object(run_eval, "_extract_onnx_path", side_effect=lambda *a: "m.onnx"),
+        ):
+            result = run_eval._run_recipe_build(_entry(), variant, 300, tmp_path / "o")
+        assert result["precision"] == variant.precision == "fp16"
 
 
 class TestRunWinmlEvalRecipePath:


### PR DESCRIPTION
## Problem

`run_eval` wrote `EvalJob.precision` — the **declared** precision — into `eval_result.json`. That value is `None` for any `winml config` fallback job that pins no precision, but such a build is not precision-less: `winml config` resolves `auto` to the device default, which on NPU is `w8a16`.

So a `--device npu` (pre-#1163) or `--device auto --ep <npu ep>` run produced a **w8a16 QDQ model** while the result recorded no precision at all, and the result dir carried no `__<precision>` suffix. The downstream coverage report maps a missing precision to the `unquantized` label, so those quantized runs were published as unquantized baselines — models that never had an unquantized NPU run showed a PASS "unquantized" row.

Verified against the published data: `openai__clip-vit-base-patch32__zero-shot-image-classification` (no suffix, no `precision` field) has `onnx_size_bytes` = 178,466,841 ≈ 2 × the model's w8a16 artifact (89.6 MB), vs 253.9 MB for its fp16 build — i.e. the "unquantized" cell is a quantized run.

## Change

- `_run_build` reports the effective precision back to the caller: the pinned `--precision` flag when there is one, otherwise read from the generated build config's `quant` section (`weight_type`/`activation_type` bit widths -> `w{x}a{y}`, `mode="fp16"` -> `fp16`, `mode="rtn"` -> `int{bits}`). Reading the config back is what `winml config` actually decided, so the harness never has to re-implement the CLI's precision policy.
- Only what the config states is reported: a config with no quant stage yields no precision (unchanged from today), since "winml skipped quantization" is not a claim about the graph's dtype.
- `_run_recipe_build` reports its authored variant precision.
- `main()` writes that effective precision into `eval_result.json` (including the accuracy-backfill merge, which rebuilds the model).

The job's **declared** precision still drives the result-dir slug and the log label, so folder naming, `--continue` resume and the existing data layout are unchanged.

## Verification

Ran the harness on `prajjwal1/bert-tiny` (perf only):

| run | result dir | recorded `precision` | `onnx_size_bytes` |
| --- | --- | --- | --- |
| `--device cpu` | `…__feature-extraction` | *(absent — config has no quant stage)* | 17,507,493 |
| `--device auto --ep openvino` | `…__feature-extraction` | **`w8a16`** | 8,465,338 |
| `--device npu --ep openvino` | `…__feature-extraction__w8a8` | `w8a8` (pinned) | 4,489,977 |
| `--device npu --ep openvino` | `…__feature-extraction__w8a16` | `w8a16` (pinned) | 4,489,977 |

The second row is exactly the previously-broken case: same untagged folder, but the generated config is `weight_type=uint8, activation_type=uint16` and the artifact is half the size. Before this change that file carried no `precision` at all.

Recipe path (`microsoft/resnet-18`, which has `fp16` + `w8a16` recipes) records `fp16` / `w8a16` from the variant, as it already did.

Note the real config uses `quant.mode = "static"`, not `"qdq"`, which is why the mapping keys off the weight/activation bit widths rather than the mode.

`uv run --no-sync pytest tests/unit/eval` -> 540 passed.
