### PR TITLE
Fix deepset/roberta-large-squad2 fp16 recipe missing quant config

### DIFF
--- a/examples/recipes/deepset_roberta-large-squad2/cpu/cpu/question-answering_fp16_config.json
+++ b/examples/recipes/deepset_roberta-large-squad2/cpu/cpu/question-answering_fp16_config.json
@@ -47,7 +47,29 @@
   "optim": {
     "clamp_constant_values": true
   },
-  "quant": null,
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "question-answering",
+    "model_id": "deepset/roberta-large-squad2",
+    "model_type": "roberta",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
   "loader": {
     "task": "question-answering",
     "model_class": "AutoModelForQuestionAnswering",


### PR DESCRIPTION
## Summary

This L0 recipe-only contribution makes the CPU FP16 recipe for `deepset/roberta-large-squad2` authoritative by adding the generated FP16 quantization policy instead of relying on an external precision override. The model performs English extractive question answering, including SQuAD 2.0 no-answer cases. Independent exact-head testing reached Goal L3 PASS with full planned CPU FP32/FP16 coverage; the only shipped winml-cli change is the FP16 recipe.

## Model metadata

### What the model does

This English RoBERTa-large checkpoint performs extractive question answering: a user supplies a question and a context passage, and the model emits start and end logits over passage tokens so an answer span, including a no-answer outcome for SQuAD 2.0 questions, can be selected.

- Evidence/confidence: the [pinned model card and checkpoint](https://huggingface.co/deepset/roberta-large-squad2/tree/78fb38a59ea3cb6902e04d96da93efc87aeeff76) identify English extractive QA trained on SQuAD 2.0, including unanswerable questions; `config.json` names `RobertaForQuestionAnswering`; its concrete forward path returns `start_logits` and `end_logits` (`verified`).

### Primary user stories

- A user supplies a natural-language question and a document passage to obtain the most likely answer span for document reading or retrieval-assisted question answering. Evidence/confidence: pinned model-card pipeline and Haystack `ExtractiveReader` usage (`verified`).
- A user supplies a question whose answer may be absent from the passage to obtain either an extracted span or a no-answer decision. Evidence/confidence: the pinned model card states that training included unanswerable SQuAD 2.0 questions (`verified`).

### Supported tasks

- `question-answering` across the checkpoint, Transformers, Optimum ONNX, and WinML surfaces. Evidence/confidence: Hub `pipeline_tag`, pinned `RobertaForQuestionAnswering` architecture, Optimum's `roberta/question-answering` registration, and current-main `winml inspect` resolving `WinMLModelForQuestionAnswering` (`verified`).

### Model architecture

```text
RobertaForQuestionAnswering
|-- RobertaModel encoder backbone
|   |-- Embeddings (token vocab 50,265 + absolute position, hidden 1,024)
|   `-- Encoder layer x 24
|       |-- Self-attention (16 heads; Q/K/V 1,024 -> 1,024)
|       |-- Attention output + residual + LayerNorm
|       |-- Feed-forward (1,024 -> 4,096 -> 1,024, GELU)
|       `-- Residual + LayerNorm
`-- QA span head (Linear 1,024 -> 2)
    |-- start_logits [batch, sequence]
    `-- end_logits [batch, sequence]
```

- Source/confidence: dimensions come from the pinned checkpoint; structure and outputs come from the concrete Transformers 5.14.1 `RobertaModel` and `RobertaForQuestionAnswering` sources (`verified`).

## Validation and support evidence

### Baseline

The baseline was fully rerun on current `main` commit and evidence commit `c45e9513964bc0bc55ad9cdd612537e96349c8a3` with WinML CLI 0.2.0. The previous validated main was `904c20109ab31d737c5132c3686ab404236edd57`; although it remained an ancestor, the intervening range included the exact target recipe surfaces and the complete dependency impact could not be proven narrow, so the fail-closed decision was **FULL-RERUN** rather than relabeling older measurements. The rebased contribution patch remained equivalent to the original one-commit recipe change.

- Config: PASS. Current main generated a `RobertaForQuestionAnswering` question-answering config. The starting FP32/FP16 auto-config comparison is retained under Delta.
- Build: PASS. Recipe-free FP32 build completed in 129.6 s; the final artifact passed ONNX checker with IR 8, ONNX opset 17, and 844 nodes. The command requested `--no-optimize`, but the current HF path still optimized because stage intent was dropped before the optimize sink; this pre-existing shared CLI defect is separate from the recipe change.
- Perf: PASS over 20 iterations after 5 warmups: mean 640.146 ms, p50 636.068 ms, throughput 1.56 samples/s, RSS inference delta 134.14 MB, RSS total delta 134.47 MB.
- Eval: PASS for a deterministic two-row SQuAD v2 functional smoke: exact match 100.0, F1 100.0, 1.460407 samples/s, 0.68474045 s/sample. This is operability evidence, not representative accuracy.
- Optimum probe: `roberta` already exposed `feature-extraction`, `fill-mask`, `multiple-choice`, `question-answering`, `text-classification`, and `token-classification`; WinML added no task registration (`VENDOR-ONLY`).

The exact normalized baseline commands appear once under Reproduce commands.

### Goal

- **Effort L0:** one checkpoint-specific recipe repair, with no source or test changes.
- **Goal ceiling L3:** march both CPU precision tuples through build, perf, and numeric parity, then run one bounded final-SHA FP32 CPU task smoke. Success requires authoritative recipe builds, structurally realized precision, retained perf/memory, parity within tester thresholds with the same decoded span, semantically valid smoke metrics, and component/op analysis.
- **Outcome L0:** ship the verified recipe-only change and record reusable knowledge separately. No charter reissue or ceiling downgrade occurred.

### Outcome

Tester verdict: **PASS**. Shipped tier: **L0 recipe-only**. Highest Goal verdict: **L3 PASS**. Coverage is **full** for the planned `CPUExecutionProvider / cpu / {fp32, fp16}` matrix; deferred tuples: `[]`.

- Shipped winml-cli path: [`examples/recipes/deepset_roberta-large-squad2/cpu/cpu/question-answering_fp16_config.json`](https://github.com/microsoft/winml-cli/blob/fdf697a741909c34932354f4af2560eea6efbc71/examples/recipes/deepset_roberta-large-squad2/cpu/cpu/question-answering_fp16_config.json).
- Existing FP32 evidence recipe: [`examples/recipes/deepset_roberta-large-squad2/cpu/cpu/question-answering_fp32_config.json`](https://github.com/microsoft/winml-cli/blob/fdf697a741909c34932354f4af2560eea6efbc71/examples/recipes/deepset_roberta-large-squad2/cpu/cpu/question-answering_fp32_config.json).
- Separate Lane A model-knowledge evidence: [ModelKitArtifacts PR #210](https://github.com/gim-home/ModelKitArtifacts/pull/210), Draft at head `1a56006897219e19323365f870dbc99759f7190f`, records `roberta-002` and `roberta-003`. It is not part of this winml-cli diff. No new methodology finding was added; the observed `--no-optimize` propagation issue is already covered by `_meta-096`.

#### Quality gates

- Recipe JSON and build-config consumption: PASS; both recipes produced fresh successful builds.
- Static checks: `insert-license` PASS; Ruff PASS; mypy PASS with no issues in 435 source files.
- Local tests: **8,043 passed** across the workflow partitions: analyze 1,526 passed / 45 skipped; models 1,523 passed / 6 skipped / 2 xfailed; optim 570 passed / 16 skipped / 1 xfailed; commands 3,555 passed / 9 skipped; remaining 869 passed / 2 skipped / 1 deselected. All five partitions exited 0.
- Exact-head GitHub checks: **9/9 SUCCESS**: `license/cla`, `CodeQL`, `Analyze (Python)`, `lint`, `test (analyze)`, `test (models)`, `test (optim)`, `test (commands)`, and `test (remaining)`.

### Per-EP/device/precision results and Functional smoke Eval

| Tier | EP / device | Precision | Verdict | Build / structure | Mean | p50 | Throughput | RSS inference / total |
|---|---|---:|---|---|---:|---:|---:|---:|
| L0/L1 | CPUExecutionProvider / cpu | fp32 | PASS | Checker PASS; IR 8; opset 17; 749 nodes; 394 FLOAT initializers; 1,417,256,976 external bytes; FLOAT start/end logits | 629.132 ms | 625.715 ms | 1.59 samples/s | 134.21 / 134.54 MB |
| L0/L1 | CPUExecutionProvider / cpu | fp16 | PASS | Checker PASS; IR 8; opset 17; 751 nodes; 394 FLOAT16 initializers; 708,632,592 external bytes; FLOAT start/end logits | 750.687 ms | 746.023 ms | 1.33 samples/s | 163.11 / 163.42 MB |

The FP16 external-data size is 0.5000028957 of FP32, materially realizing FP16 weights while preserving floating-point QA outputs.

| L2 parity | Start logits: max abs / cosine | End logits: max abs / cosine | Decoded reference and ONNX span | Verdict |
|---|---:|---:|---|---|
| fp32 CPU | 2.014636993408203e-05 / 0.9999999999999316 | 3.0994415283203125e-05 / 0.9999999999998967 | `France` / `France` | PASS |
| fp16 CPU | 0.011583268642425537 / 0.9999999707472499 | 0.014380931854248047 / 0.999999942941659 | `France` / `France` | PASS |

**Functional smoke Eval:** exactly one final-candidate (`fdf697a741909c34932354f4af2560eea6efbc71`) FP32 CPU run used [`rajpurkar/squad_v2`](https://huggingface.co/datasets/rajpurkar/squad_v2) revision `3ffb306f725f7d2ce8394bc1873b24868140c412`, validation split, license CC BY-SA 4.0. Selection was the deterministic first 2 rows with no shuffle: 2 requested, 2 processed, 2 tokenized features, 2 model inferences, and 2 decoded predictions. Fan-out was capped at sequence length 512, one feature/inference/prediction per row. The evaluator consumed `question`, `context`, and `id`; targets were `answers.text` plus zero-based `answers.answer_start`; all selected target offsets were verified, and decoded predictions had the intended extractive-span semantics. Exact match was 100.0 and F1 was 100.0. This proves end-to-end functional operability only; it is explicitly **not benchmark accuracy or representative model quality**. FP16 Eval was not run by contract.

### Delta

The sole winml-cli diff changes `/quant` in the FP16 recipe from `null` to the exact current auto-config FP16 policy: `mode=fp16`, `task=question-answering`, `model_id=deepset/roberta-large-squad2`, `model_type=roberta`, and `fp16_keep_io_types=true`. This makes deployment precision recipe-owned rather than dependent on a semantic CLI override.

- Recipe versus auto-config, FP32: `/quant` is identical (`null`); the checked-in recipe alone carries `/eval`; auto-config alone emits `/compile=null` and `/export/compatibility/transformers_attention=eager`. The existing recipe retains `AutoModelForQuestionAnswering`, while baseline config explicitly requested `RobertaForQuestionAnswering`; no new semantic field was fabricated.
- Recipe versus auto-config, FP16: `/quant` and loader metadata are identical; the checked-in recipe alone carries `/eval`; auto-config alone emits `/compile=null` and `/export/compatibility/transformers_attention=eager`.
- The resolved class-wide CPU policy remains `transformers_attention=eager`; absent compile versus `null` is default-none. The FP16 tuple intent is checkpoint/deployment-specific and not derivable safely as a RoBERTa-wide default, so recipe resolution is consistent with the L0 charter and recipe-free acceptance is not required.
- No source, tests, or `examples/recipes/README.md` changed.

### Analyze summary - component level and op level

Both artifacts returned **ANALYZE-PARTIAL-SUCCESS** with complete structured output for all seven requested EPs. Exit code 1 reflects unavailable or unclassified provider rules; this is static rule analysis, not runtime execution.

#### Component-level summary

| Artifact | Architecture mapping and ranges | Coverage / confidence | Actionable EP findings |
|---|---|---|---|
| fp32 | Embeddings `0-16`; 24-layer encoder attention/FFN/residual across `17-743`; QA head `744-748` | 749/749 mapped: 497 direct-scope + 252 execution-adjacency inferred optimizer nodes; 0 unmapped; mapped with inferred optimizer nodes | QNN partial `Gather`/`GatherElements` in embedding/indexing regions; `Gather` also occurs in attention indexing |
| fp16 | Embeddings `0-16`; 24-layer encoder attention/FFN/residual across `17-743`; QA head `744-750` | 751/751 mapped: 497 direct-scope + 254 execution-adjacency inferred optimizer nodes; 0 unmapped; mapped with inferred optimizer nodes | QNN partial `Gather`/`GatherElements` in embedding/indexing regions; `Gather` also occurs in attention indexing |

The mapping follows the source architecture from Embeddings through the repeated 24-layer Encoder to the QA span head. The only mapping caveat is that optimizer-generated reshape nodes lack direct module paths and are assigned to the nearest scoped execution neighbor.

#### Op-level summary

| Artifact | Graph | Dominant operators | Grouped EP results |
|---|---|---|---|
| fp32 | 749 operators / 21 unique types | `Reshape` 243; `Gemm` 145; `Transpose` 96; `Add` 75; `LayerNormalization` 49; `MatMul` 48 | NvTensorRTRTX + OpenVINO: 20 supported, 1 unknown (`Where`); QNN: 19 supported, 2 partial (`Gather`, `GatherElements`), 1 unknown (`Where`) |
| fp16 | 751 operators / 21 unique types | `Reshape` 243; `Gemm` 145; `Transpose` 96; `Add` 75; `LayerNormalization` 49; `MatMul` 48 | NvTensorRTRTX + OpenVINO: 20 supported, 1 unknown (`Where`); QNN: 19 supported, 2 partial (`Gather`, `GatherElements`), 1 unknown (`Where`) |

CUDA, MIGraphX, TensorRT, and DML have no shipped rule classifications. These unknown/partial static results are limitations, not claims of runtime support; only CPU was runtime-tested. Exhaustive node lists, full histograms, local artifacts, and hashes remain internal review evidence.

### Reproduce commands

Baseline commands below are normalized only by replacing the planner's machine-specific Python and output paths with `python`, `$BASE_CONFIG`, `$BASE_BUILD`, and `$BASE_PERF`; arguments and measured stages are unchanged.

```powershell
$BASE_CONFIG='temp/roberta-large-squad2-baseline-config'
$BASE_BUILD='temp/roberta-large-squad2-baseline-build'
$BASE_PERF='temp/roberta-large-squad2-baseline-perf.json'
python -m winml.modelkit.cli config -m deepset/roberta-large-squad2 -t question-answering --model-class RobertaForQuestionAnswering -o $BASE_CONFIG
python -m winml.modelkit.cli build -m deepset/roberta-large-squad2 -o $BASE_BUILD --ep cpu --device cpu --no-analyze --no-optimize --no-quant --no-compile --rebuild
python -m winml.modelkit.cli perf -m $BASE_BUILD/model.onnx --ep cpu --device cpu --iterations 20 --warmup 5 --memory -f json -o $BASE_PERF
python -m winml.modelkit.cli eval -m $BASE_BUILD/model.onnx --model-id deepset/roberta-large-squad2 --task question-answering --dataset rajpurkar/squad_v2 --dataset-revision 3ffb306f725f7d2ce8394bc1873b24868140c412 --split validation --samples 2 --no-shuffle --ep cpu --device cpu -f json -o temp/roberta-large-squad2-baseline-eval.json
```

The exact tester-supplied public candidate commands are:

```powershell
$OUT='temp/roberta-large-squad2-test'
python -m winml.modelkit.cli build -c examples/recipes/deepset_roberta-large-squad2/cpu/cpu/question-answering_fp32_config.json -m deepset/roberta-large-squad2 -o $OUT/fp32 --ep cpu --device cpu -p fp32
python -m winml.modelkit.cli build -c examples/recipes/deepset_roberta-large-squad2/cpu/cpu/question-answering_fp16_config.json -m deepset/roberta-large-squad2 -o $OUT/fp16 --ep cpu --device cpu -p fp16
python -m winml.modelkit.cli perf -m $OUT/fp32/model.onnx --ep cpu --device cpu --iterations 20 --warmup 5 --memory
python -m winml.modelkit.cli perf -m $OUT/fp16/model.onnx --ep cpu --device cpu --iterations 20 --warmup 5 --memory
python -m winml.modelkit.cli analyze --model $OUT/fp32/model.onnx --ep all --output $OUT/fp32-analyze.json
python -m winml.modelkit.cli analyze --model $OUT/fp16/model.onnx --ep all --output $OUT/fp16-analyze.json
python -m winml.modelkit.cli eval -m $OUT/fp32/model.onnx --model-id deepset/roberta-large-squad2 --task question-answering --dataset rajpurkar/squad_v2 --dataset-revision 3ffb306f725f7d2ce8394bc1873b24868140c412 --split validation --samples 2 --no-shuffle --ep cpu --device cpu
```

Limitations: measurements are Windows CPU-only and hardware-specific; FP16 is not faster on this CPU; accelerator runtime support and FP16 task accuracy were not measured; the two-row Eval is only a bounded functional smoke; static EP rule analysis contains the partial/unknown classifications above; and the current HF `--no-optimize` propagation defect remains outside this recipe-only diff.