### PR TITLE
Fix QNN detail tracing and compile EP options

### DIFF
--- a/docs/commands/compile.md
+++ b/docs/commands/compile.md
@@ -23,6 +23,7 @@ $ winml compile [options]
 | `--output-dir` | | path | same dir as input | Directory to write compiled output artifacts. |
 | `--device` | `-d` | choice | `auto` | Target device: `auto`, `npu`, `gpu`, or `cpu`. |
 | `--ep` | | `TEXT` | — | Force a specific execution provider, overriding device-to-provider mapping. Accepts full names (e.g., `QNNExecutionProvider`) or aliases (`qnn`, `dml`, `openvino`, `vitisai`, `migraphx`, `cpu`, `nvtensorrtrtx`). |
+| `--ep-options` | | `KEY=VALUE` | — | Execution-provider option for the compilation session. Repeat for multiple options; later duplicate keys win. Explicit CLI values override matching `compile.provider_options` keys from `--config`. |
 | `--validate` / `--no-validate` | | flag | `--validate` | Run a post-compilation validation pass on the target hardware. Enabled by default; pass `--no-validate` to skip when the target hardware or driver is unavailable. |
 | `--compiler` | | choice | `ort` | Compiler backend: `ort` (ONNX Runtime) or `qairt` (Qualcomm AI Runtime Tools). |
 | `--qnn-sdk-root` | | path | `None` | Path to the QNN SDK root directory. |
@@ -71,6 +72,13 @@ winml compile --list --device npu
 ```bash
 # Compile a pre-quantized BERT model for NPU with context embedded inline
 winml compile -m bert-base-uncased_qdq.onnx --embed
+```
+
+```bash
+# Pass provider-specific options to the compilation session
+winml compile -m model.onnx --ep qnn \
+  --ep-options htp_performance_mode=burst \
+  --ep-options soc_model=57
 ```
 
 ```bash

--- a/src/winml/modelkit/commands/compile.py
+++ b/src/winml/modelkit/commands/compile.py
@@ -91,6 +91,10 @@ console = Console()
     help="Force specific EP, optionally pinned to a source (e.g. 'openvino@pypi'). "
     "Overrides device-to-provider mapping.",
 )
+@cli_utils.ep_options_option(
+    optional_message="Applied to the compilation session; overrides matching "
+    "compile.provider_options keys from --config.",
+)
 @click.option(
     "--validate/--no-validate",
     default=True,
@@ -134,6 +138,7 @@ def compile(
     overwrite: bool,
     device: str | None,
     ep: tuple[str, str | None] | None,
+    ep_options: tuple[str, ...],
     validate: bool,
     verbose: int,
     quiet: bool,
@@ -173,6 +178,7 @@ def compile(
     # the raw tuple into user-visible output (T-01 regression pin).
     ep_part, source_part = ep if ep else (None, None)
     ep_name: str | None = ep_part
+    cli_provider_options = cli_utils.parse_ep_options(ep_options)
 
     # Apply build config defaults (CLI explicit options take precedence).
     # Read raw JSON so missing keys are distinguishable from dataclass defaults.
@@ -299,9 +305,12 @@ def compile(
     config.ep_config.compiler = compiler
     config.ep_config.qnn_sdk_root = qnn_sdk_root
     config.ep_config.embed_context = embed
-    # EP provider options supplied via --config (compile.provider_options).
+    # Merge config and CLI provider options, with explicit CLI values winning
+    # for duplicate keys.
     if config_provider_options:
         config.ep_config.provider_options.update(config_provider_options)
+    if cli_provider_options:
+        config.ep_config.provider_options.update(cli_provider_options)
 
     # Show info — device and provider come directly from the resolved EPDeviceTarget.
     console.print(f"[bold blue]Input:[/bold blue] {', '.join(str(m) for m in models)}")

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -1117,11 +1117,9 @@ class PerfBenchmark:
         The EP monitor is integrated into ``session.perf()`` so op-tracing
         observes the user's actual benchmark iterations.
 
-        HWMonitor (system-wide CPU/RAM/NPU metrics) is engaged when available
-        AND either ``--monitor`` was set or HW data is otherwise needed. When
-        HWMonitor is unavailable but op-tracing is still requested, the run
-        proceeds with the EP monitor only — op-tracing is the headline goal
-        and must not be blocked by missing HW telemetry.
+        HWMonitor (system-wide CPU/RAM/NPU metrics) is engaged only when
+        ``--monitor`` was set. Op-tracing still uses the EP monitor required to
+        collect its profiling artifacts, without enabling hardware telemetry.
         """
         from ..session.monitor.hw_monitor import HWMonitor
 
@@ -1142,10 +1140,9 @@ class PerfBenchmark:
             output_dir=output_dir,
         )
 
-        # HWMonitor is best-effort: required only for the live-chart UI on
-        # --monitor. When it's unavailable but op-tracing is requested, run
-        # without HW telemetry rather than degrading op-tracing to a no-op.
-        hw_available = HWMonitor.is_available()
+        # Keep system telemetry under explicit --monitor control. The EP monitor
+        # remains active independently when op-tracing needs profiling data.
+        hw_available = self.config.monitor and HWMonitor.is_available()
         if self.config.monitor and not hw_available:
             Console(stderr=True).print(
                 "[yellow]Warning:[/yellow] HWMonitor unavailable on this system. "
@@ -1191,7 +1188,8 @@ class PerfBenchmark:
             if ep_dict:  # NullEPMonitor returns {}, real monitors return data
                 self._hw_metrics["ep_proof"] = ep_dict
         else:
-            # HW unavailable: run with EP monitor only (op-tracing path).
+            # No --monitor (or HWMonitor unavailable): run with the EP monitor
+            # only so op-tracing and proof-of-execution still work.
             with session.perf(warmup=self.config.warmup, monitor=ep_monitor) as ctx:
                 _run_simple_loop(
                     session,

--- a/src/winml/modelkit/session/ep_registry.py
+++ b/src/winml/modelkit/session/ep_registry.py
@@ -444,6 +444,9 @@ class WinMLEPRegistry:
             # which the caller renders to the console.
             with _suppress_dll_load_dialogs():
                 ort.register_execution_provider_library(arg0, str(entry.dll_path))
+                logger.info(
+                    "Registered EP %r from %r (arg0=%r)", entry.ep_name, entry.dll_path, arg0
+                )
         except Exception as exc:
             raise WinMLEPRegistrationFailed(
                 f"ort.register_execution_provider_library({arg0!r}, "

--- a/src/winml/modelkit/session/monitor/qnn/viewer.py
+++ b/src/winml/modelkit/session/monitor/qnn/viewer.py
@@ -66,11 +66,11 @@ def find_qnn_sdk() -> Path | None:
     for base_path in _COMMON_SDK_PATHS:
         if not base_path.is_dir():
             continue
-        if (base_path / "bin").is_dir():
-            return base_path
         for child in sorted(base_path.iterdir(), reverse=True):
             if child.is_dir() and (child / "bin").is_dir():
                 return child
+        if (base_path / "bin").is_dir():
+            return base_path
 
     return None
 
@@ -104,9 +104,11 @@ def _find_optrace_reader(viewer: Path) -> Path | None:
     """Locate the optrace reader matching the selected viewer architecture."""
     bin_dir = viewer.parent
     if bin_dir.parent.name == "bin":
+        # Architecture-specific layout: bin/<arch> mirrors lib/<arch>.
         sdk_root = bin_dir.parent.parent
         candidate = sdk_root / "lib" / bin_dir.name / _OPTRACE_READER_NAME
     else:
+        # Flat layout: bin/qnn-profile-viewer.exe pairs with lib/<reader>.
         sdk_root = bin_dir.parent
         candidate = sdk_root / "lib" / _OPTRACE_READER_NAME
     return candidate if candidate.is_file() else None

--- a/src/winml/modelkit/session/monitor/qnn/viewer.py
+++ b/src/winml/modelkit/session/monitor/qnn/viewer.py
@@ -46,6 +46,7 @@ _COMMON_SDK_PATHS: list[Path] = [
     Path(r"D:\QC"),
     Path(r"C:\Qualcomm\AIStack\qairt"),
 ]
+_OPTRACE_READER_NAME = "QnnHtpOptraceProfilingReader.dll"
 
 
 def find_qnn_sdk() -> Path | None:
@@ -64,6 +65,8 @@ def find_qnn_sdk() -> Path | None:
     for base_path in _COMMON_SDK_PATHS:
         if not base_path.is_dir():
             continue
+        if (base_path / "bin").is_dir():
+            return base_path
         for child in sorted(base_path.iterdir(), reverse=True):
             if child.is_dir() and (child / "bin").is_dir():
                 return child
@@ -94,6 +97,18 @@ def _find_viewer_exe(sdk_root: Path | None = None) -> Path | None:
         return candidate
 
     return None
+
+
+def _find_optrace_reader(viewer: Path) -> Path | None:
+    """Locate the optrace reader matching the selected viewer architecture."""
+    bin_dir = viewer.parent
+    if bin_dir.parent.name == "bin":
+        sdk_root = bin_dir.parent.parent
+        candidate = sdk_root / "lib" / bin_dir.name / _OPTRACE_READER_NAME
+    else:
+        sdk_root = bin_dir.parent
+        candidate = sdk_root / "lib" / _OPTRACE_READER_NAME
+    return candidate if candidate.is_file() else None
 
 
 def run_basic_viewer(
@@ -163,6 +178,14 @@ def run_qhas_viewer(
             "(falling back to basic CSV)"
         )
         return None
+    reader = _find_optrace_reader(viewer)
+    if reader is None:
+        logger.warning(
+            "%s not found for qnn-profile-viewer at %s; falling back to basic CSV",
+            _OPTRACE_READER_NAME,
+            viewer,
+        )
+        return None
 
     if not schematic.is_file():
         logger.warning("Schematic file not found: %s", schematic)
@@ -180,7 +203,7 @@ def run_qhas_viewer(
         "--output",
         str(output),
         "--reader",
-        "optrace",
+        str(reader),
         "--schematic",
         str(schematic),
         "--config",

--- a/src/winml/modelkit/session/monitor/qnn/viewer.py
+++ b/src/winml/modelkit/session/monitor/qnn/viewer.py
@@ -47,6 +47,7 @@ _COMMON_SDK_PATHS: list[Path] = [
     Path(r"C:\Qualcomm\AIStack\qairt"),
 ]
 _OPTRACE_READER_NAME = "QnnHtpOptraceProfilingReader.dll"
+_QHAS_SUMMARY_SUFFIX = "_qnn_htp_analysis_summary.json"
 
 
 def find_qnn_sdk() -> Path | None:
@@ -161,7 +162,8 @@ def run_qhas_viewer(
     schematic:
         Path to the ``*_schematic.bin`` file.
     output:
-        Path for the resulting QHAS JSON file.
+        Output prefix passed to the viewer. The optrace reader appends its QHAS
+        artifact suffixes to this path.
     config:
         Post-processing features config.  Uses default if ``None``.
     sdk_root:
@@ -169,7 +171,7 @@ def run_qhas_viewer(
 
     Returns:
     -------
-    Path to the generated QHAS JSON, or ``None`` on failure.
+    Path to the generated QNN HTP analysis summary JSON, or ``None`` on failure.
     """
     viewer = _find_viewer_exe(sdk_root)
     if viewer is None:
@@ -220,6 +222,8 @@ def run_qhas_viewer(
         logger.error("qnn-profile-viewer executable not found at %s", viewer)
         return None
 
-    if output.is_file():
-        return output
+    summary_output = output.with_name(f"{output.stem}{_QHAS_SUMMARY_SUFFIX}")
+    if summary_output.is_file():
+        return summary_output
+    logger.warning("QHAS viewer did not produce analysis summary: %s", summary_output)
     return None

--- a/src/winml/modelkit/session/monitor/qnn_monitor.py
+++ b/src/winml/modelkit/session/monitor/qnn_monitor.py
@@ -681,31 +681,31 @@ class QNNMonitor(WinMLEPMonitor):
         if qhas_override is not None:
             # Offline path: caller supplied the QHAS JSON; parse directly.
             if not qhas_override.is_file():
-                logger.debug("QNNMonitor: qhas_override %s is not a file", qhas_override)
+                logger.info("QNNMonitor: qhas_override %s is not a file", qhas_override)
                 return None, None, None
             result_path = qhas_override
         else:
             # Live path: locate inputs and shell out to the QHAS viewer.
             qnn_log = self._select_fresh_qnn_log()
             if qnn_log is None:
-                logger.debug("QNNMonitor: no *_qnn.log found for QHAS")
+                logger.info("QNNMonitor: no *_qnn.log found for QHAS")
                 return None, None, None
 
             # Find the schematic by EPContext partition metadata (never chdir).
             schematic = self._find_schematic()
             if schematic is None:
-                logger.debug("QNNMonitor: no *_schematic.bin found for QHAS")
+                logger.info("QNNMonitor: no *_schematic.bin found for QHAS")
                 return None, None, None
 
             sdk_root = find_qnn_sdk()
             if sdk_root is None:
-                logger.debug("QNNMonitor: QNN SDK not located; skipping QHAS")
+                logger.info("QNNMonitor: QNN SDK not located; skipping QHAS")
                 return None, None, None
 
             qhas_output = self._qhas_output_path()
             viewer_output = run_qhas_viewer(qnn_log, schematic, qhas_output, sdk_root=sdk_root)
             if viewer_output is None or not viewer_output.is_file():
-                logger.debug("QNNMonitor: QHAS viewer produced no output")
+                logger.info("QNNMonitor: QHAS viewer produced no output")
                 return None, None, None
             result_path = viewer_output
 

--- a/src/winml/modelkit/session/monitor/qnn_monitor.py
+++ b/src/winml/modelkit/session/monitor/qnn_monitor.py
@@ -793,7 +793,7 @@ class QNNMonitor(WinMLEPMonitor):
             if not self._csv_path.is_file():
                 return None
         except OSError as exc:
-            logger.debug(
+            logger.info(
                 (
                     "QNNMonitor: unable to read profiling CSV metadata "
                     "for schematic discovery (%s): %s"
@@ -831,7 +831,7 @@ class QNNMonitor(WinMLEPMonitor):
         try:
             return select_main_epcontext_partition_name(self._running_model_path)
         except Exception as exc:
-            logger.debug(
+            logger.info(
                 "QNNMonitor: unable to inspect EPContext partition metadata from %s: %s",
                 self._running_model_path,
                 exc,

--- a/src/winml/modelkit/session/session.py
+++ b/src/winml/modelkit/session/session.py
@@ -757,7 +757,7 @@ class WinMLSession:
         -----------------------
         * If *monitor* contributes provider/session options that differ from
           the active session, the compiled session is torn down first
-          (auto-reset with a WARNING) so the new options take effect.
+          (auto-reset with an INFO diagnostic) so the new options take effect.
         * After the ``with`` block exits, any rebuilt session is restored from
           the saved baseline provider/session-option snapshots.
 

--- a/src/winml/modelkit/session/session.py
+++ b/src/winml/modelkit/session/session.py
@@ -205,6 +205,12 @@ def _build_session_options(
         if provider_options is not None
         else _build_provider_options(ep_device, ep_config, ep_monitor)
     )
+    logger.info(
+        "Building session options for ep=%s device=%s with provider_options=%s",
+        ep_device.ep.arg0,
+        ep_device.device.device_type,
+        options,
+    )
     so.add_provider_for_devices([handle], options)
     return so
 

--- a/src/winml/modelkit/session/session.py
+++ b/src/winml/modelkit/session/session.py
@@ -840,9 +840,7 @@ class WinMLSession:
             or self._session is None
         )
         if had_baseline_session and _session_rebuilt:
-            logger.warning(
-                "auto-resetting compiled session to apply monitor session/provider options"
-            )
+            logger.info("auto-resetting compiled session to apply monitor session/provider options")
             self.reset()
 
         stats = PerfStats(warmup=warmup)

--- a/src/winml/modelkit/session/session.py
+++ b/src/winml/modelkit/session/session.py
@@ -206,11 +206,12 @@ def _build_session_options(
         else _build_provider_options(ep_device, ep_config, ep_monitor)
     )
     logger.info(
-        "Building session options for ep=%s device=%s with provider_options=%s",
+        "Building session options for ep=%s device=%s with provider_option_keys=%s",
         ep_device.ep.arg0,
         ep_device.device.device_type,
-        options,
+        sorted(options),
     )
+    logger.debug("Session provider options: %s", options)
     so.add_provider_for_devices([handle], options)
     return so
 

--- a/src/winml/modelkit/utils/cli.py
+++ b/src/winml/modelkit/utils/cli.py
@@ -458,10 +458,8 @@ def ep_option(
 def ep_options_option(optional_message: str | None = None) -> Callable[[F], F]:
     """Add a repeatable ``--ep-options KEY=VALUE`` option to a Click command.
 
-    Collects runtime EP provider options (e.g. QNN ``htp_performance_mode``)
-    that are forwarded to ``add_provider_for_devices`` when the inference
-    session is created. Distinct from build-time provider options set via
-    ``--config``: these affect the runtime session, not the compiled graph.
+    Collects EP provider options (e.g. QNN ``htp_performance_mode``) that are
+    forwarded when the command creates its execution-provider session.
 
     Use :func:`parse_ep_options` to turn the collected tuple into a dict.
 
@@ -472,8 +470,8 @@ def ep_options_option(optional_message: str | None = None) -> Callable[[F], F]:
         Decorator function.
     """
     help_text = (
-        "Runtime EP provider option as KEY=VALUE (repeatable). Forwarded to the "
-        "inference session's execution provider (e.g. "
+        "EP provider option as KEY=VALUE (repeatable). Forwarded to the command's "
+        "execution-provider session (e.g. "
         "--ep-options htp_performance_mode=burst). Duplicate keys: later "
         "occurrence wins."
     )

--- a/tests/unit/commands/test_compile_cli.py
+++ b/tests/unit/commands/test_compile_cli.py
@@ -120,7 +120,7 @@ def compile_cli_mocks() -> CompileCliMocks:
 
 
 class TestCompileCliHelp:
-    """Verify that --device and --ep appear in --help output."""
+    """Verify compile options appear in --help output."""
 
     def test_device_option_in_help(self, runner: CliRunner) -> None:
         result = runner.invoke(compile, ["--help"])
@@ -131,6 +131,11 @@ class TestCompileCliHelp:
         result = runner.invoke(compile, ["--help"])
         assert result.exit_code == 0
         assert "--ep" in result.output
+
+    def test_ep_options_option_in_help(self, runner: CliRunner) -> None:
+        result = runner.invoke(compile, ["--help"])
+        assert result.exit_code == 0
+        assert "--ep-options" in result.output
 
     def test_device_choices_in_help(self, runner: CliRunner) -> None:
         """Help text must expose the device choices."""
@@ -283,6 +288,78 @@ class TestCompileCliDeviceEpFlags:
         """Unknown EP string is rejected by Click."""
         result = runner.invoke(compile, ["-m", str(fake_onnx), "--ep", "unknown_ep"])
         assert result.exit_code != 0
+
+
+class TestCompileCliEpOptions:
+    """Verify CLI EP options reach the compilation provider configuration."""
+
+    def test_ep_options_forwarded_to_compile_config(
+        self, runner: CliRunner, fake_onnx: Path, compile_cli_mocks: CompileCliMocks
+    ) -> None:
+        result = runner.invoke(
+            compile,
+            [
+                "-m",
+                str(fake_onnx),
+                "--ep-options",
+                "htp_performance_mode=burst",
+                "--ep-options",
+                "soc_model=57",
+            ],
+        )
+
+        _assert_successful_compile_call(result, compile_cli_mocks, fake_onnx)
+        assert compile_cli_mocks.compile_config.ep_config.provider_options == {
+            "htp_performance_mode": "burst",
+            "soc_model": "57",
+        }
+
+    def test_cli_ep_options_override_matching_config_keys(
+        self, runner: CliRunner, fake_onnx: Path, compile_cli_mocks: CompileCliMocks
+    ) -> None:
+        config_path = fake_onnx.parent / "compile.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "compile": {
+                        "provider_options": {
+                            "htp_performance_mode": "sustained_high_performance",
+                            "soc_model": "57",
+                        }
+                    }
+                }
+            )
+        )
+
+        result = runner.invoke(
+            compile,
+            [
+                "-m",
+                str(fake_onnx),
+                "--config",
+                str(config_path),
+                "--ep-options",
+                "htp_performance_mode=burst",
+            ],
+        )
+
+        _assert_successful_compile_call(result, compile_cli_mocks, fake_onnx)
+        assert compile_cli_mocks.compile_config.ep_config.provider_options == {
+            "htp_performance_mode": "burst",
+            "soc_model": "57",
+        }
+
+    def test_invalid_ep_option_is_rejected(
+        self, runner: CliRunner, fake_onnx: Path, compile_cli_mocks: CompileCliMocks
+    ) -> None:
+        result = runner.invoke(
+            compile,
+            ["-m", str(fake_onnx), "--ep-options", "missing-separator"],
+        )
+
+        assert result.exit_code == 2
+        assert "Use KEY=VALUE" in result.output
+        compile_cli_mocks.compile_onnx.assert_not_called()
 
 
 class TestCompileCliConfigPriority:

--- a/tests/unit/commands/test_perf_optracing.py
+++ b/tests/unit/commands/test_perf_optracing.py
@@ -345,6 +345,115 @@ class TestOpTracingIterationsSmartDefault:
         assert captured.get("iterations") == 100
 
 
+class TestOpTracingHardwareMonitor:
+    """--op-tracing must not implicitly enable system hardware monitoring."""
+
+    def test_op_tracing_without_monitor_uses_only_ep_monitor(self):
+        from winml.modelkit.commands.perf import BenchmarkConfig, PerfBenchmark
+
+        config = BenchmarkConfig(
+            model_id="fake/model",
+            device="npu",
+            ep="qnn",
+            iterations=1,
+            warmup=0,
+            monitor=False,
+            op_tracing="detail",
+        )
+        benchmark = PerfBenchmark(config)
+        benchmark._inputs = {}
+
+        ep_monitor = MagicMock()
+        ep_monitor.result = None
+        ep_monitor.to_dict.return_value = {"ep": "qnn"}
+        ctx = MagicMock()
+        ctx.monitor = ep_monitor
+        ctx.stats = MagicMock()
+        session = MagicMock()
+        session.perf.return_value.__enter__.return_value = ctx
+        benchmark._model = SimpleNamespace(
+            _session=session,
+            ep_name="QNNExecutionProvider",
+            device="npu",
+        )
+
+        hw_monitor = MagicMock()
+        with (
+            patch(
+                "winml.modelkit.commands.perf._open_ep_monitor_or_exit",
+                return_value=ep_monitor,
+            ),
+            patch(
+                "winml.modelkit.session.monitor.hw_monitor.HWMonitor",
+                hw_monitor,
+            ),
+            patch("winml.modelkit.commands.perf._run_simple_loop") as simple_loop,
+            patch("winml.modelkit.commands.perf._run_monitored_loop") as monitored_loop,
+        ):
+            result = benchmark._run_benchmark_monitored()
+
+        assert result is ctx.stats
+        hw_monitor.is_available.assert_not_called()
+        hw_monitor.assert_not_called()
+        simple_loop.assert_called_once()
+        monitored_loop.assert_not_called()
+        session.perf.assert_called_once_with(warmup=0, monitor=ep_monitor)
+
+    def test_op_tracing_with_monitor_enables_hardware_monitor(self):
+        from winml.modelkit.commands.perf import BenchmarkConfig, PerfBenchmark
+
+        config = BenchmarkConfig(
+            model_id="fake/model",
+            device="npu",
+            ep="qnn",
+            iterations=1,
+            warmup=0,
+            monitor=True,
+            op_tracing="detail",
+        )
+        benchmark = PerfBenchmark(config)
+        benchmark._inputs = {}
+
+        ep_monitor = MagicMock()
+        ep_monitor.result = None
+        ep_monitor.to_dict.return_value = {"ep": "qnn"}
+        ctx = MagicMock()
+        ctx.monitor = ep_monitor
+        ctx.stats = MagicMock()
+        session = MagicMock()
+        session.perf.return_value.__enter__.return_value = ctx
+        benchmark._model = SimpleNamespace(
+            _session=session,
+            ep_name="QNNExecutionProvider",
+            device="npu",
+        )
+
+        hw = MagicMock()
+        hw.__enter__.return_value = hw
+        hw.to_dict.return_value = {"monitor": "HWMonitor"}
+        hw_monitor = MagicMock(return_value=hw)
+        hw_monitor.is_available.return_value = True
+        with (
+            patch(
+                "winml.modelkit.commands.perf._open_ep_monitor_or_exit",
+                return_value=ep_monitor,
+            ),
+            patch(
+                "winml.modelkit.session.monitor.hw_monitor.HWMonitor",
+                hw_monitor,
+            ),
+            patch("winml.modelkit.commands.perf._run_simple_loop") as simple_loop,
+            patch("winml.modelkit.commands.perf._run_monitored_loop") as monitored_loop,
+        ):
+            result = benchmark._run_benchmark_monitored()
+
+        assert result is ctx.stats
+        hw_monitor.is_available.assert_called_once_with()
+        hw_monitor.assert_called_once()
+        simple_loop.assert_not_called()
+        monitored_loop.assert_called_once()
+
+
 class _ConfigStub:
     """Lightweight stand-in for BenchmarkConfig used by capture tests."""
 

--- a/tests/unit/session/monitor/qnn/test_viewer.py
+++ b/tests/unit/session/monitor/qnn/test_viewer.py
@@ -56,6 +56,18 @@ def test_find_qnn_sdk_accepts_common_path_as_sdk_root(monkeypatch, tmp_path):
     assert find_qnn_sdk() == sdk_root
 
 
+def test_find_qnn_sdk_prefers_versioned_child_over_flat_root(monkeypatch, tmp_path):
+    """A versioned SDK takes priority when a common root also contains bin."""
+    common_root = tmp_path / "qairt"
+    (common_root / "bin").mkdir(parents=True)
+    versioned_root = common_root / "2.30.0"
+    (versioned_root / "bin").mkdir(parents=True)
+    monkeypatch.delenv("QNN_SDK_ROOT", raising=False)
+    monkeypatch.setattr(viewer, "_COMMON_SDK_PATHS", [common_root])
+
+    assert find_qnn_sdk() == versioned_root
+
+
 def test_legacy_viewer_shim_delegates_sdk_discovery_with_one_warning(monkeypatch, tmp_path):
     """The compatibility shim exposes the canonical discovery implementation."""
     from winml.modelkit.optracing.qnn import viewer as legacy_viewer

--- a/tests/unit/session/monitor/qnn/test_viewer.py
+++ b/tests/unit/session/monitor/qnn/test_viewer.py
@@ -46,6 +46,16 @@ def test_find_qnn_sdk_finds_versioned_common_root(monkeypatch, tmp_path):
     assert find_qnn_sdk() == sdk_root
 
 
+def test_find_qnn_sdk_accepts_common_path_as_sdk_root(monkeypatch, tmp_path):
+    """An unversioned common path containing bin is itself the SDK root."""
+    sdk_root = tmp_path / "qairt"
+    (sdk_root / "bin").mkdir(parents=True)
+    monkeypatch.delenv("QNN_SDK_ROOT", raising=False)
+    monkeypatch.setattr(viewer, "_COMMON_SDK_PATHS", [sdk_root])
+
+    assert find_qnn_sdk() == sdk_root
+
+
 def test_legacy_viewer_shim_delegates_sdk_discovery_with_one_warning(monkeypatch, tmp_path):
     """The compatibility shim exposes the canonical discovery implementation."""
     from winml.modelkit.optracing.qnn import viewer as legacy_viewer
@@ -70,6 +80,9 @@ def test_run_qhas_viewer_uses_output_stem_config_per_run(monkeypatch, tmp_path):
     viewer = tmp_path / "sdk" / "bin" / "x64" / "qnn-profile-viewer.exe"
     viewer.parent.mkdir(parents=True)
     viewer.write_text("", encoding="utf-8")
+    reader = tmp_path / "sdk" / "lib" / viewer.parent.name / "QnnHtpOptraceProfilingReader.dll"
+    reader.parent.mkdir(parents=True)
+    reader.write_bytes(b"")
 
     qnn_log_a = tmp_path / "profiling_output_a_qnn.log"
     qnn_log_b = tmp_path / "profiling_output_b_qnn.log"
@@ -94,9 +107,35 @@ def test_run_qhas_viewer_uses_output_stem_config_per_run(monkeypatch, tmp_path):
     assert run_qhas_viewer(qnn_log_b, schematic_b, output_b, sdk_root=tmp_path / "sdk") == output_b
 
     config_paths = [Path(cmd[cmd.index("--config") + 1]) for cmd in commands]
+    assert all(Path(cmd[cmd.index("--reader") + 1]) == reader for cmd in commands)
     assert config_paths == [
         tmp_path / "profiling_output_a_qhas_output_optrace_config.json",
         tmp_path / "profiling_output_b_qhas_output_optrace_config.json",
     ]
     assert config_paths[0] != config_paths[1]
     assert all(path.is_file() for path in config_paths)
+
+
+def test_run_qhas_viewer_requires_matching_optrace_reader(monkeypatch, tmp_path, caplog):
+    from winml.modelkit.session.monitor.qnn.viewer import run_qhas_viewer
+
+    sdk_root = tmp_path / "sdk"
+    viewer_path = sdk_root / "bin" / "x64" / "qnn-profile-viewer.exe"
+    viewer_path.parent.mkdir(parents=True)
+    viewer_path.write_bytes(b"")
+    qnn_log = tmp_path / "profile.log"
+    schematic = tmp_path / "schematic.bin"
+    qnn_log.write_bytes(b"")
+    schematic.write_bytes(b"")
+    monkeypatch.setattr(subprocess, "run", pytest.fail)
+
+    assert (
+        run_qhas_viewer(
+            qnn_log,
+            schematic,
+            tmp_path / "output.json",
+            sdk_root=sdk_root,
+        )
+        is None
+    )
+    assert "QnnHtpOptraceProfilingReader.dll not found" in caplog.text

--- a/tests/unit/session/monitor/qnn/test_viewer.py
+++ b/tests/unit/session/monitor/qnn/test_viewer.py
@@ -98,13 +98,18 @@ def test_run_qhas_viewer_uses_output_stem_config_per_run(monkeypatch, tmp_path):
     def _fake_run(cmd: list[str], **_kwargs):
         commands.append(cmd)
         output = Path(cmd[cmd.index("--output") + 1])
-        output.write_text("{}", encoding="utf-8")
+        summary = output.with_name(f"{output.stem}_qnn_htp_analysis_summary.json")
+        summary.write_text("{}", encoding="utf-8")
         return subprocess.CompletedProcess(cmd, 0, "", "")
 
     monkeypatch.setattr(subprocess, "run", _fake_run)
 
-    assert run_qhas_viewer(qnn_log_a, schematic_a, output_a, sdk_root=tmp_path / "sdk") == output_a
-    assert run_qhas_viewer(qnn_log_b, schematic_b, output_b, sdk_root=tmp_path / "sdk") == output_b
+    assert run_qhas_viewer(
+        qnn_log_a, schematic_a, output_a, sdk_root=tmp_path / "sdk"
+    ) == output_a.with_name(f"{output_a.stem}_qnn_htp_analysis_summary.json")
+    assert run_qhas_viewer(
+        qnn_log_b, schematic_b, output_b, sdk_root=tmp_path / "sdk"
+    ) == output_b.with_name(f"{output_b.stem}_qnn_htp_analysis_summary.json")
 
     config_paths = [Path(cmd[cmd.index("--config") + 1]) for cmd in commands]
     assert all(Path(cmd[cmd.index("--reader") + 1]) == reader for cmd in commands)
@@ -139,3 +144,33 @@ def test_run_qhas_viewer_requires_matching_optrace_reader(monkeypatch, tmp_path,
         is None
     )
     assert "QnnHtpOptraceProfilingReader.dll not found" in caplog.text
+
+
+def test_run_qhas_viewer_rejects_direct_output_without_analysis_summary(
+    monkeypatch, tmp_path, caplog
+):
+    from pathlib import Path
+
+    from winml.modelkit.session.monitor.qnn.viewer import run_qhas_viewer
+
+    sdk_root = tmp_path / "sdk"
+    viewer_path = sdk_root / "bin" / "x64" / "qnn-profile-viewer.exe"
+    viewer_path.parent.mkdir(parents=True)
+    viewer_path.write_bytes(b"")
+    reader = sdk_root / "lib" / viewer_path.parent.name / "QnnHtpOptraceProfilingReader.dll"
+    reader.parent.mkdir(parents=True)
+    reader.write_bytes(b"")
+    qnn_log = tmp_path / "profile.log"
+    schematic = tmp_path / "schematic.bin"
+    output = tmp_path / "qhas_output.json"
+    qnn_log.write_bytes(b"")
+    schematic.write_bytes(b"")
+
+    def _fake_run(cmd: list[str], **_kwargs):
+        Path(cmd[cmd.index("--output") + 1]).write_text("{}", encoding="utf-8")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    assert run_qhas_viewer(qnn_log, schematic, output, sdk_root=sdk_root) is None
+    assert "did not produce analysis summary" in caplog.text

--- a/tests/unit/session/monitor/test_qnn_monitor.py
+++ b/tests/unit/session/monitor/test_qnn_monitor.py
@@ -1094,8 +1094,9 @@ def test_try_qhas_uses_csv_bound_artifacts(tmp_path, monkeypatch):
         seen_logs.append(log)
         seen_schematics.append(selected_schematic)
         seen_outputs.append(output)
-        _write_minimal_qhas(output)
-        return output
+        summary_output = output.with_name(f"{output.stem}_qnn_htp_analysis_summary.json")
+        _write_minimal_qhas(summary_output)
+        return summary_output
 
     monkeypatch.setattr(
         "winml.modelkit.session.monitor.qnn_monitor.find_qnn_sdk",
@@ -1113,7 +1114,7 @@ def test_try_qhas_uses_csv_bound_artifacts(tmp_path, monkeypatch):
     assert seen_outputs == [qhas_output]
     assert summary is not None
     assert operators is not None
-    assert result_path == qhas_output
+    assert result_path == qhas_output.with_name(f"{qhas_output.stem}_qnn_htp_analysis_summary.json")
 
 
 def test_try_qhas_ignores_other_runs_newer_qnn_log(tmp_path, monkeypatch):

--- a/tests/unit/session/test_build_session_options.py
+++ b/tests/unit/session/test_build_session_options.py
@@ -10,6 +10,7 @@ rather than a :class:`EPDeviceTarget`. No internal registry call, no
 handle filtering — the caller pre-selected the device.
 """
 
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -127,6 +128,22 @@ def test_build_session_options_monitor_plumbs_session_options(qnn_npu: WinMLEPDe
     fake_so.add_provider_for_devices.assert_called_once()
     args, _ = fake_so.add_provider_for_devices.call_args
     assert args[1]["profiling_level"] == "detailed"
+
+
+def test_build_session_options_info_log_omits_provider_option_values(
+    qnn_npu: WinMLEPDevice, caplog: pytest.LogCaptureFixture
+) -> None:
+    """INFO diagnostics identify option keys without exposing their values."""
+    fake_so = MagicMock()
+    options = {"remote_auth_token": "secret-value"}
+    with (
+        caplog.at_level(logging.INFO, logger="winml.modelkit.session.session"),
+        patch("winml.modelkit.session.session.ort.SessionOptions", return_value=fake_so),
+    ):
+        _build_session_options(qnn_npu, provider_options=options)
+
+    assert "remote_auth_token" in caplog.text
+    assert "secret-value" not in caplog.text
 
 
 def test_ort_session_options_same_key_overwrites() -> None:

--- a/tests/unit/session/test_perf_auto_reset.py
+++ b/tests/unit/session/test_perf_auto_reset.py
@@ -36,7 +36,7 @@ def _make_cpu_session(model_path):
 
 def test_auto_reset_fires_when_options_contributed(caplog):
     """If session is already compiled AND monitor contributes provider_options,
-    session.perf().__enter__ auto-resets with a WARNING log.
+    session.perf().__enter__ auto-resets with an INFO log.
     """
     from winml.modelkit.session.monitor.ep_monitor import WinMLEPMonitor
     from winml.modelkit.session.session import WinMLSession
@@ -69,15 +69,15 @@ def test_auto_reset_fires_when_options_contributed(caplog):
     assert session._session is not None
     pre_session = session._session
 
-    with caplog.at_level(logging.WARNING), session.perf(monitor=_ContributingMonitor()):
+    with caplog.at_level(logging.INFO), session.perf(monitor=_ContributingMonitor()):
         pass
 
-    # NFR-3: the verbatim phrase MUST appear as a substring of the log.
+    # The diagnostic remains available under -v without warning on a normal path.
     expected = "auto-resetting compiled session to apply monitor session/provider options"
-    warnings = [r.message for r in caplog.records if r.levelname == "WARNING"]
-    assert any(expected in m for m in warnings), (
-        f"NFR-3 verbatim phrase not in WARNING records. expected substring: "
-        f"{expected!r}; got: {warnings}"
+    info_messages = [r.message for r in caplog.records if r.levelname == "INFO"]
+    assert any(expected in message for message in info_messages), (
+        f"Auto-reset phrase not in INFO records. expected substring: "
+        f"{expected!r}; got: {info_messages}"
     )
     # Old session object was dropped
     assert session._session is None or session._session is not pre_session


### PR DESCRIPTION
## Summary

- keep system hardware monitoring behind the explicit `--monitor` flag while allowing EP op tracing to run independently
- add repeatable `--ep-options KEY=VALUE` support to `winml compile`, with CLI values overriding matching config values
- improve QAIRT SDK discovery for direct installation roots
- resolve the architecture-matched QNN optrace reader DLL and pass its path to `qnn-profile-viewer`
- parse the generated QNN HTP analysis summary rather than the viewer output prefix
- add regression coverage and compile command documentation