### PR TITLE
Add MGP-STR image-to-text support

### DIFF
--- a/examples/recipes/alibaba-damo_mgp-str-base/cpu/cpu/image-to-text_fp16_config.json
+++ b/examples/recipes/alibaba-damo_mgp-str-base/cpu/cpu/image-to-text_fp16_config.json
@@ -1,0 +1,73 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          32,
+          128
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "char_logits"
+      },
+      {
+        "name": "bpe_logits"
+      },
+      {
+        "name": "wp_logits"
+      }
+    ],
+    "compatibility": {
+      "transformers_attention": "eager"
+    }
+  },
+  "optim": {},
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "image-to-text",
+    "model_id": "alibaba-damo/mgp-str-base",
+    "model_type": "mgp-str",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "image-to-text",
+    "model_class": "MgpstrForSceneTextRecognition",
+    "model_type": "mgp-str"
+  }
+}

--- a/examples/recipes/alibaba-damo_mgp-str-base/cpu/cpu/image-to-text_fp32_config.json
+++ b/examples/recipes/alibaba-damo_mgp-str-base/cpu/cpu/image-to-text_fp32_config.json
@@ -1,0 +1,51 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          32,
+          128
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "char_logits"
+      },
+      {
+        "name": "bpe_logits"
+      },
+      {
+        "name": "wp_logits"
+      }
+    ],
+    "compatibility": {
+      "transformers_attention": "eager"
+    }
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "image-to-text",
+    "model_class": "MgpstrForSceneTextRecognition",
+    "model_type": "mgp-str"
+  }
+}

--- a/src/winml/modelkit/inference/pipeline.py
+++ b/src/winml/modelkit/inference/pipeline.py
@@ -36,6 +36,10 @@ _HF_PIPELINE_TASK_MAP: dict[str, str] = {
     "sentence-similarity": "feature-extraction",
 }
 
+_SPECIALIZED_PIPELINE_REGISTRY: dict[tuple[str, str], str] = {
+    ("mgp-str", "image-to-text"): "MgpstrImageToTextPipeline",
+}
+
 _PIPELINE_COMPONENT_FLAGS = (
     ("tokenizer", "_load_tokenizer"),
     ("feature_extractor", "_load_feature_extractor"),
@@ -550,6 +554,25 @@ def create_pipeline(
     Returns:
         A configured task callable ready for inference.
     """
+    pipe: Any
+    model_type = getattr(getattr(model, "config", None), "model_type", None)
+    model_type = model_type.lower().replace("_", "-") if isinstance(model_type, str) else ""
+    specialized = _SPECIALIZED_PIPELINE_REGISTRY.get((model_type, task))
+    if specialized is not None:
+        if model_id is None:
+            raise ValueError(f"{specialized} requires a model ID to load its processor.")
+        from ..models.winml.image_to_text import MgpstrImageToTextPipeline
+
+        pipe = MgpstrImageToTextPipeline(
+            model,
+            model_id,
+            device=device,
+            trust_remote_code=trust_remote_code,
+        )
+        _adapt_image_processor_size(pipe, task, model)
+        logger.info("Created specialized pipeline: task=%s model=%s", task, model_id)
+        return pipe
+
     from transformers import pipeline
 
     hf_task = _HF_PIPELINE_TASK_MAP.get(task, task)

--- a/src/winml/modelkit/models/hf/__init__.py
+++ b/src/winml/modelkit/models/hf/__init__.py
@@ -55,6 +55,8 @@ from .marian import MARIAN_CONFIG
 from .marian import MODEL_CLASS_MAPPING as _MARIAN_CLASS_MAPPING
 from .marian import MarianDecoderIOConfig as _MarianDecoderIOConfig  # triggers registration
 from .marian import MarianEncoderIOConfig as _MarianEncoderIOConfig  # triggers registration
+from .mgp_str import MODEL_CLASS_MAPPING as _MGP_STR_CLASS_MAPPING
+from .mgp_str import MgpstrImageToTextIOConfig as _MgpstrImageToTextIOConfig
 from .mu2 import MODEL_CLASS_MAPPING as _MU2_CLASS_MAPPING
 from .mu2 import MU2_CONFIG
 from .mu2 import Mu2DecoderIOConfig as _Mu2DecoderIOConfig  # triggers registration
@@ -129,6 +131,7 @@ MODEL_CLASS_MAPPING: dict[tuple[str, str | None], type] = {
         _BLIP_CLASS_MAPPING,
         _CLIP_CLASS_MAPPING,
         _MARIAN_CLASS_MAPPING,
+        _MGP_STR_CLASS_MAPPING,
         _MU2_CLASS_MAPPING,
         _QWEN_CLASS_MAPPING,
         _QWEN_TO_CLASS_MAPPING,

--- a/src/winml/modelkit/models/hf/mgp_str.py
+++ b/src/winml/modelkit/models/hf/mgp_str.py
@@ -1,0 +1,23 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""MGP-STR image-to-text export and model-class registration."""
+
+from __future__ import annotations
+
+from optimum.exporters.onnx.model_configs import MgpstrOnnxConfig
+from transformers import MgpstrForSceneTextRecognition
+
+from ...export import register_onnx_overwrite
+
+
+@register_onnx_overwrite("mgp-str", "image-to-text", library_name="transformers")
+class MgpstrImageToTextIOConfig(MgpstrOnnxConfig):  # type: ignore[misc]
+    """Register the vendor MGP-STR image-to-text ONNX contract."""
+
+
+MODEL_CLASS_MAPPING: dict[tuple[str, str | None], type] = {
+    ("mgp-str", "image-to-text"): MgpstrForSceneTextRecognition,
+    ("mgp-str", None): MgpstrForSceneTextRecognition,
+}

--- a/src/winml/modelkit/models/winml/__init__.py
+++ b/src/winml/modelkit/models/winml/__init__.py
@@ -59,6 +59,7 @@ WINML_MODEL_CLASS_MAPPING: dict[tuple[str, str], str] = {
     # - Specific OPSET requirements
     # - Input remapping (non-standard tensor names)
     # - Custom pre/post-processing
+    ("mgp-str", "image-to-text"): "WinMLModelForMgpstrSceneTextRecognition",
 }
 
 
@@ -82,6 +83,7 @@ def _import_winml_class(class_name: str) -> type[WinMLPreTrainedModel]:
         WinMLModelForImageSegmentation,
         WinMLModelForSemanticSegmentation,
     )
+    from .image_to_text import WinMLModelForMgpstrSceneTextRecognition
     from .object_detection import WinMLModelForObjectDetection
     from .question_answering import WinMLModelForQuestionAnswering
     from .sequence_classification import WinMLModelForSequenceClassification
@@ -91,6 +93,7 @@ def _import_winml_class(class_name: str) -> type[WinMLPreTrainedModel]:
         "WinMLModelForDepthEstimation": WinMLModelForDepthEstimation,
         "WinMLModelForFeatureExtraction": WinMLModelForFeatureExtraction,
         "WinMLModelForImageClassification": WinMLModelForImageClassification,
+        "WinMLModelForMgpstrSceneTextRecognition": WinMLModelForMgpstrSceneTextRecognition,
         "WinMLModelForImageSegmentation": WinMLModelForImageSegmentation,
         "WinMLModelForObjectDetection": WinMLModelForObjectDetection,
         "WinMLModelForQuestionAnswering": WinMLModelForQuestionAnswering,
@@ -205,6 +208,7 @@ from .image_segmentation import (
     WinMLModelForImageSegmentation,
     WinMLModelForSemanticSegmentation,
 )
+from .image_to_text import MgpstrImageToTextPipeline, WinMLModelForMgpstrSceneTextRecognition
 from .kv_cache import (
     WinMLCache,
     WinMLSlidingWindowCache,
@@ -226,6 +230,7 @@ __all__ = [
     "GenaiTransformerSpec",
     "HFCausalLM",
     "ImageSegmentationOutput",
+    "MgpstrImageToTextPipeline",
     "WinMLCache",
     "WinMLCompositeModel",
     "WinMLDecoderOnlyModel",
@@ -236,6 +241,7 @@ __all__ = [
     "WinMLModelForGenericTask",
     "WinMLModelForImageClassification",
     "WinMLModelForImageSegmentation",
+    "WinMLModelForMgpstrSceneTextRecognition",
     "WinMLModelForObjectDetection",
     "WinMLModelForSemanticSegmentation",
     "WinMLModelForSequenceClassification",

--- a/src/winml/modelkit/models/winml/image_to_text.py
+++ b/src/winml/modelkit/models/winml/image_to_text.py
@@ -1,0 +1,125 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Specialized image-to-text inference support."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, cast
+
+import numpy as np
+import torch
+from PIL import Image
+
+from .base import WinMLPreTrainedModel
+
+
+def _convert_images_to_rgb(images: Any) -> Any:
+    """Normalize supported image inputs to RGB before processor conversion."""
+    from transformers.image_transforms import to_pil_image
+    from transformers.image_utils import load_image
+
+    if isinstance(images, list | tuple):
+        return [_convert_images_to_rgb(image) for image in images]
+    if isinstance(images, np.ndarray | torch.Tensor) and images.ndim == 4:
+        return [_convert_images_to_rgb(image) for image in images]
+    if isinstance(images, str):
+        try:
+            return load_image(images).convert("RGB")
+        except ValueError:
+            return images
+    if isinstance(images, Image.Image):
+        return images.convert("RGB")
+    if isinstance(images, np.ndarray):
+        if images.ndim == 2:
+            return Image.fromarray(images).convert("RGB")
+        return to_pil_image(images).convert("RGB")
+    if isinstance(images, torch.Tensor):
+        if images.ndim == 2:
+            images = images.unsqueeze(0)
+        return to_pil_image(images).convert("RGB")
+    return images
+
+
+class WinMLModelForMgpstrSceneTextRecognition(WinMLPreTrainedModel):
+    """Expose MGP-STR's ordered ONNX heads in its Transformers output contract."""
+
+    main_input_name = "pixel_values"
+
+    def forward(self, **kwargs: Any) -> Any:
+        """Run the graph and return character, BPE, then WordPiece logits."""
+        from transformers.models.mgp_str.modeling_mgp_str import MgpstrModelOutput
+
+        try:
+            pixel_values = kwargs.pop("pixel_values")
+        except KeyError as exc:
+            raise ValueError("MGP-STR inference requires 'pixel_values'.") from exc
+
+        outputs = self._run_inference(self._format_inputs(pixel_values=pixel_values))
+        return MgpstrModelOutput(
+            logits=cast(
+                "Any",
+                (
+                    outputs["char_logits"],
+                    outputs["bpe_logits"],
+                    outputs["wp_logits"],
+                ),
+            )
+        )
+
+
+class MgpstrImageToTextPipeline:
+    """Preprocess and decode MGP-STR's character, BPE, and WordPiece heads."""
+
+    def __init__(
+        self,
+        model: WinMLPreTrainedModel,
+        model_id: str,
+        *,
+        device: str = "cpu",
+        trust_remote_code: bool = False,
+    ) -> None:
+        from transformers import AutoProcessor
+
+        processor_kwargs = {"trust_remote_code": True} if trust_remote_code else {}
+        self.model = model
+        self.processor = AutoProcessor.from_pretrained(model_id, **processor_kwargs)
+        self.image_processor = self.processor.image_processor
+        self.tokenizer = getattr(self.processor, "char_tokenizer", None)
+        self.device = device
+        self._preprocess_params: dict[str, Any] = {}
+
+    def _sanitize_parameters(self, **_kwargs: Any) -> tuple[dict, dict, dict]:
+        """Expose the pipeline parameter-introspection contract."""
+        return {}, {}, {}
+
+    def __call__(self, images: Any, *, prompt: str | None = None, **_kwargs: Any) -> Any:
+        """Recognize text in one image or a batch of images."""
+        if prompt is not None:
+            raise ValueError("MGP-STR scene text recognition does not accept a text prompt.")
+
+        model_inputs = self.processor(
+            images=_convert_images_to_rgb(images),
+            return_tensors="pt",
+        )
+        outputs = self.model(**model_inputs)
+        if isinstance(outputs, Mapping) and all(
+            name in outputs for name in ("char_logits", "bpe_logits", "wp_logits")
+        ):
+            logits = tuple(outputs[name] for name in ("char_logits", "bpe_logits", "wp_logits"))
+        elif isinstance(outputs, Mapping):
+            logits = outputs["logits"]
+        else:
+            logits = outputs.logits
+        decoded = self.processor.batch_decode(logits)
+
+        records = []
+        for index, text in enumerate(decoded["generated_text"]):
+            record: dict[str, Any] = {"generated_text": text}
+            if "scores" in decoded:
+                score = decoded["scores"][index]
+                record["score"] = float(score.item() if hasattr(score, "item") else score)
+            records.append(record)
+        return records

--- a/tests/unit/export/test_mgp_str_onnx_config.py
+++ b/tests/unit/export/test_mgp_str_onnx_config.py
@@ -1,0 +1,42 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Tests for MGP-STR image-to-text registration and export I/O."""
+
+from optimum.exporters.tasks import TasksManager
+from transformers import MgpstrConfig, MgpstrForSceneTextRecognition
+
+import winml.modelkit.models.hf  # noqa: F401
+from winml.modelkit.export import resolve_io_specs
+from winml.modelkit.loader.resolution import TaskSource, resolve_task
+
+
+def test_stale_architecture_resolves_to_scene_text_recognition() -> None:
+    config = MgpstrConfig()
+    config.architectures = ["MGPSTRModel"]
+
+    resolved = resolve_task(config)
+
+    assert resolved.task == "image-to-text"
+    assert resolved.optimum_task == "image-to-text"
+    assert resolved.model_class is MgpstrForSceneTextRecognition
+    assert resolved.source == TaskSource.SENTINEL_DEFAULT
+
+
+def test_image_to_text_onnx_config_is_registered() -> None:
+    constructor = TasksManager.get_exporter_config_constructor(
+        exporter="onnx",
+        model_type="mgp-str",
+        task="image-to-text",
+        library_name="transformers",
+    )
+
+    assert constructor.func.__name__ == "MgpstrImageToTextIOConfig"
+
+
+def test_image_to_text_io_preserves_three_head_order() -> None:
+    specs = resolve_io_specs("mgp-str", "image-to-text", MgpstrConfig())
+
+    assert specs["input_names"] == ["pixel_values"]
+    assert specs["output_names"] == ["char_logits", "bpe_logits", "wp_logits"]

--- a/tests/unit/inference/test_pipeline.py
+++ b/tests/unit/inference/test_pipeline.py
@@ -189,6 +189,64 @@ class TestPipelineComponentKwargs:
 
 
 class TestCreatePipeline:
+    def test_creates_mgpstr_pipeline_with_device_and_trust(self) -> None:
+        model = MagicMock()
+        model.config.model_type = "mgp-str"
+        model.io_config = {"input_shapes": [[1, 3, 32, 128]]}
+        specialized = MagicMock()
+        specialized.image_processor.size = {"height": 32, "width": 128}
+
+        with patch(
+            "winml.modelkit.models.winml.image_to_text.MgpstrImageToTextPipeline",
+            return_value=specialized,
+        ) as factory:
+            result = create_pipeline(
+                "image-to-text",
+                model,
+                "org/model",
+                device="cuda",
+                trust_remote_code=True,
+            )
+
+        assert result is specialized
+        factory.assert_called_once_with(
+            model,
+            "org/model",
+            device="cuda",
+            trust_remote_code=True,
+        )
+
+    def test_non_mgp_image_to_text_keeps_generic_pipeline(self) -> None:
+        model = MagicMock()
+        model.config.model_type = "vision-encoder-decoder"
+        pipe = MagicMock()
+        pipe.tokenizer = None
+        pipe.image_processor = None
+
+        with (
+            patch(
+                "winml.modelkit.inference.pipeline._pipeline_component_kwargs",
+                return_value={"processor": "org/model"},
+            ),
+            patch("transformers.pipeline", return_value=pipe) as pipeline,
+        ):
+            result = create_pipeline(
+                "image-to-text",
+                model,
+                "org/model",
+                device="cuda",
+                trust_remote_code=True,
+            )
+
+        assert result is pipe
+        pipeline.assert_called_once_with(
+            "image-text-to-text",
+            model=model,
+            device="cuda",
+            processor="org/model",
+            trust_remote_code=True,
+        )
+
     def test_threads_trust_remote_code_to_pipeline(self) -> None:
         model = MagicMock()
         pipe = MagicMock()

--- a/tests/unit/models/winml/test_image_to_text.py
+++ b/tests/unit/models/winml/test_image_to_text.py
@@ -1,0 +1,108 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Tests for specialized MGP-STR image-to-text inference."""
+
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+from winml.modelkit.models.winml import get_winml_class
+from winml.modelkit.models.winml.image_to_text import (
+    MgpstrImageToTextPipeline,
+    WinMLModelForMgpstrSceneTextRecognition,
+    _convert_images_to_rgb,
+)
+
+
+def test_specialized_wrapper_is_registered() -> None:
+    assert (
+        get_winml_class("mgp_str", "image-to-text")
+        is WinMLModelForMgpstrSceneTextRecognition
+    )
+
+
+def test_wrapper_forward_signature_and_missing_input() -> None:
+    signature = inspect.signature(WinMLModelForMgpstrSceneTextRecognition.forward)
+    assert list(signature.parameters) == ["self", "kwargs"]
+    assert signature.parameters["kwargs"].kind == inspect.Parameter.VAR_KEYWORD
+
+    model = object.__new__(WinMLModelForMgpstrSceneTextRecognition)
+    with pytest.raises(ValueError, match="requires 'pixel_values'"):
+        model.forward()
+
+
+def test_wrapper_preserves_three_head_order() -> None:
+    model = object.__new__(WinMLModelForMgpstrSceneTextRecognition)
+    model._format_inputs = MagicMock(return_value={"pixel_values": np.zeros((1, 3, 32, 128))})
+    expected = {
+        "char_logits": torch.tensor([1]),
+        "bpe_logits": torch.tensor([2]),
+        "wp_logits": torch.tensor([3]),
+    }
+    model._run_inference = MagicMock(return_value=expected)
+
+    output = model.forward(pixel_values=torch.zeros(1, 3, 32, 128))
+
+    assert output.logits == (
+        expected["char_logits"],
+        expected["bpe_logits"],
+        expected["wp_logits"],
+    )
+
+
+@pytest.mark.parametrize(
+    "image",
+    [
+        Image.new("L", (128, 32)),
+        np.zeros((32, 128), dtype=np.uint8),
+        torch.zeros(1, 32, 128),
+    ],
+    ids=["grayscale-pil", "2d-numpy", "single-channel-torch"],
+)
+def test_supported_grayscale_inputs_normalize_to_rgb(image) -> None:
+    converted = _convert_images_to_rgb(image)
+
+    assert isinstance(converted, Image.Image)
+    assert converted.mode == "RGB"
+    assert converted.size == (128, 32)
+
+
+@pytest.mark.parametrize(
+    "outputs",
+    [
+        {
+            "char_logits": torch.tensor([1]),
+            "bpe_logits": torch.tensor([2]),
+            "wp_logits": torch.tensor([3]),
+        },
+        {"logits": (torch.tensor([1]), torch.tensor([2]), torch.tensor([3]))},
+    ],
+    ids=["raw-named-heads", "mapping-backed-logits"],
+)
+def test_pipeline_decodes_heads_in_order(outputs) -> None:
+    model = MagicMock(return_value=outputs)
+    processor = MagicMock()
+    processor.image_processor = SimpleNamespace(size={"height": 32, "width": 128})
+    processor.char_tokenizer = MagicMock()
+    processor.return_value = {"pixel_values": torch.zeros(1, 3, 32, 128)}
+    processor.batch_decode.return_value = {"generated_text": ["word"]}
+
+    with patch("transformers.AutoProcessor.from_pretrained", return_value=processor):
+        pipeline = MgpstrImageToTextPipeline(model, "org/model")
+
+    result = pipeline(Image.new("L", (128, 32)))
+
+    assert result == [{"generated_text": "word"}]
+    assert processor.call_args.kwargs["images"].mode == "RGB"
+    assert processor.return_value["pixel_values"].shape == (1, 3, 32, 128)
+    decoded = processor.batch_decode.call_args.args[0]
+    assert tuple(int(item.item()) for item in decoded) == (1, 2, 3)


### PR DESCRIPTION
# Summary

This adds first-class WinML support for `alibaba-damo/mgp-str-base`, an image-to-text scene-text recognition model that fuses character, BPE, and WordPiece predictions. The contribution ships at Effort/Outcome L2 with CPU fp32 and fp16 recipes, class-wide export/runtime support, and focused regression coverage. The highest Goal verdict reached is L3 PASS through one bounded final-candidate fp32 CPU functional smoke Eval; that Eval proves operability only and is not a benchmark-quality accuracy claim.

# Model metadata

## What the model does

MGP-STR recognizes scene text from a fixed 32 x 128 RGB image with a vision transformer and three vocabulary heads whose predictions are fused into text by `MgpstrProcessor` (`verified`; pinned Hub metadata/config and Transformers v5.14.1 MGP-STR source).

## Primary user stories

- A user supplies an image containing a word or text line to obtain its transcription for OCR (`verified`; pinned model card and image-to-text tag).

## Supported tasks

- `image-to-text` on the checkpoint, Transformers, and WinML surfaces (`verified`; Hub pipeline tag, model class, and PR #1253 evidence).
- `feature-extraction` on the Transformers and Optimum-ONNX surfaces (`verified`; Optimum-ONNX v0.1.0 task registration).

## Model architecture

```text
MgpstrForSceneTextRecognition
|-- MgpstrModel
|   |-- patch embedding (32x128 RGB / 4x4 patches / width 768)
|   `-- encoder layer x 12 (12-head attention + 3072-wide MLP)
|-- character A^3 + linear head (38 labels)
|-- BPE A^3 + linear head (50,257 labels)
|-- WordPiece A^3 + linear head (30,522 labels)
`-- runtime MgpstrProcessor.batch_decode
```

- Source/confidence: Transformers v5.14.1 source and the pinned `alibaba-damo/mgp-str-base` revision `5d06493b6b2a8c4c023d2c030175c03be30f4202` config (`verified`). Score fusion is processor-side runtime behavior.

# Validation and support evidence

## Baseline

- Baseline: `main` commit `24cccfb23d6e3c3b93ae9bb94399c326cee8ecea`, WinML 0.3.0. The baseline was fully rerun because the prior candidate base and current runtime/config dependency surfaces had moved; only the frozen model profile was reused.
- Build: **FAIL**. Auto resolution selected unsupported `text-classification`; explicit `image-to-text` also exited 2 because that task was unregistered. Neither path created an ONNX artifact, so baseline perf, numeric parity, and ONNX Analyze were unreachable.
- Inspect/config: legacy `architectures=MGPSTRModel` resolved to `next-sentence-prediction` with no ONNX config. Explicit `image-to-text` found `MgpstrForSceneTextRecognition`, but no exporter existed and WinML fell back to `WinMLModelForGenericTask`. Neither auto nor explicit config emitted a current-main recipe.
- Eval floor: a pinned one-row PyTorch diagnostic completed, but the generic image-to-text pipeline failed on `decoder_input_ids`, skipped 1/1 row, and emitted `cer=null`, `cider=null`, `n_samples=0`. This was diagnostic only, not L3 evidence.
- Optimum probe: **VENDOR-ONLY**. Optimum-ONNX exposed `feature-extraction` for `mgp-str`; WinML added no task registration.

## Goal

- Committed Effort: **L2**. Goal ceiling: **L3**. Shipped Outcome: **L2**. Charter revision 6 re-issued the current-main reconstruction and full-rerun requirement after detecting that the historical candidate was not patch-equivalent to current `main`.
- L0 success required both CPU/cpu fp32 and fp16 recipes to build valid ONNX artifacts. L1 required measured CPU perf for both tuples. L2 required named-input PyTorch/ONNX comparison of the character, BPE, and WordPiece heads. L3 required exactly one final-candidate CPU fp32 Eval to process at least 1 of at most 2 pinned real IIIT5K rows, emit non-null CER, preserve requested/processed/skipped counts, and exercise RGB preprocessing plus ordered three-head fusion, with no accuracy threshold or broad benchmark.

## Outcome

- Shipped tier: **L2**. Highest Goal verdict: **L3 PASS**. Coverage: **full**. Deferred tuples: **none**.
- Shipped recipes: `examples/recipes/alibaba-damo_mgp-str-base/cpu/cpu/image-to-text_fp32_config.json` and `examples/recipes/alibaba-damo_mgp-str-base/cpu/cpu/image-to-text_fp16_config.json`.
- Shipped class-wide support: `src/winml/modelkit/models/hf/mgp_str.py`, aggregate HF registration, the specialized WinML image-to-text wrapper and registration, and specialized pipeline dispatch.
- Model findings: fp32 CPU measured 120.877/126.897 ms mean/p50, 8.27 samples/s, and +45.39 MB RAM; fp16 measured 144.137/150.128 ms, 6.94 samples/s, and +57.68 MB RAM. FP16 was 18.3% slower at p50 on this host. FP16 external data was 295,904,534 bytes versus 591,809,068 bytes for fp32 while retaining float32 public I/O. All 374 fp32 and 378 fp16 graph nodes were component-mapped.
- Methodology findings: complete static Analyze JSON with nonzero exits remains `ANALYZE-PARTIAL-SUCCESS`; twelve bounded static scans used explicit provider/device pairs and `--no-check-optim` without installing providers or inferring accelerator runtime support.

## Per-EP/device/precision results and Functional smoke Eval

| Tier | EP / Device | Precision | Verdict | Evidence |
|---|---|---|---|---|
| L0 | CPUExecutionProvider / cpu | fp32 | PASS | ONNX load PASS; 374 nodes; input `pixel_values` `[1,3,32,128]`; outputs `char_logits` `[1,27,38]`, `bpe_logits` `[1,27,50257]`, `wp_logits` `[1,27,30522]` |
| L0 | CPUExecutionProvider / cpu | fp16 | PASS | ONNX load PASS; 378 nodes; input `pixel_values` `[1,3,32,128]`; the same three output names and shapes |
| L1 | CPUExecutionProvider / cpu | fp32 | PASS | mean 120.877 ms; p50 126.897 ms; 8.27 samples/s; RAM +45.39 MB; local/shared VRAM +0.0/+0.0 MB |
| L1 | CPUExecutionProvider / cpu | fp16 | PASS | mean 144.137 ms; p50 150.128 ms; 6.94 samples/s; RAM +57.68 MB; local/shared VRAM +0.0/+0.0 MB |
| L2 | CPUExecutionProvider / cpu | fp32 | PASS | named `pixel_values` PyTorch/ONNX comparison passed for all three ordered heads |
| L2 | CPUExecutionProvider / cpu | fp16 | PASS | named `pixel_values` PyTorch/ONNX comparison passed for all three ordered heads |
| L3 | CPUExecutionProvider / cpu | fp32 | PASS | exactly one bounded final-candidate functional smoke Eval processed 2/2 rows and emitted non-null CER/CIDEr |

### Full CPU perf

| EP / Device | Precision | Verdict | Mean | p50 | Throughput | RAM delta | Local VRAM delta | Shared VRAM delta |
|---|---|---|---:|---:|---:|---:|---:|---:|
| CPUExecutionProvider / cpu | fp32 | PASS | 120.877 ms | 126.897 ms | 8.27 samples/s | +45.39 MB | +0.0 MB | +0.0 MB |
| CPUExecutionProvider / cpu | fp16 | PASS | 144.137 ms | 150.128 ms | 6.94 samples/s | +57.68 MB | +0.0 MB | +0.0 MB |

### L2 named-input parity

The comparison used identical float32 `pixel_values` input with shape `[1,3,32,128]`, PyTorch as reference, CPUExecutionProvider for the final ONNX artifacts, and head order `char_logits`, `bpe_logits`, `wp_logits`.

| Precision | Head | Cosine | Max absolute error | Mean absolute error |
|---|---|---:|---:|---:|
| fp32 | `char_logits` | 0.9999999999999072 | 5.340576171875e-05 | 1.4122931348417702e-05 |
| fp32 | `bpe_logits` | 0.9999999999998808 | 0.0002288818359375 | 5.44793679042825e-05 |
| fp32 | `wp_logits` | 0.9999999999996452 | 0.00014495849609375 | 2.5079136153019223e-05 |
| fp16 | `char_logits` | 0.9999999556679489 | 0.054443359375 | 0.010301827919645849 |
| fp16 | `bpe_logits` | 0.999999911178238 | 0.16356658935546875 | 0.04750968691862811 |
| fp16 | `wp_logits` | 0.9999974815042161 | 0.20363616943359375 | 0.07969268049442278 |

### Functional smoke Eval

Exactly one tester-owned Eval ran on final candidate `b7fdd1d1fe1f65610f56c229e02db853dc2c7529`, CPUExecutionProvider/cpu, fp32. It used `MiXaiLL76/IIIT5K_OCR` revision `d0a25a5bd51d121ae00ac59bfbabdc15381bd9f5`, config `default`, split `test`, first two rows with no shuffle and selection seed 42. It selected 2 and processed 2 samples; schema, label semantics, and prediction semantics were verified.

| Row scope | Processed | CER | CIDEr | n_samples |
|---|---:|---:|---:|---:|
| IIIT5K test row 1 | 1 | included in aggregate | included in aggregate | included in aggregate |
| IIIT5K test row 2 | 1 | included in aggregate | included in aggregate | included in aggregate |
| **Aggregate** | **2/2** | **1.0** | **0.0** | **2** |

Fan-out caps were 0 candidate labels/prompts, 1 beam, 1 frame/crop, sequence/generation length 27, 3 processor heads, and 2 dataset rows. The former generic pipeline blocker was missing MGP-STR prediction decoding; the specialized path now normalizes supported image inputs to RGB, preserves character/BPE/WordPiece output order, and decodes through `MgpstrProcessor.batch_decode`. **This is end-to-end functional operability evidence only; it is not representative accuracy or benchmark quality.** No other precision or EP was evaluated for accuracy.

## Delta

- Recipe comparison: **CHANGED** relative to the recipe-free current-main starting config. The fp32 recipe is **IDENTICAL**, with no JSON-pointer changes. The fp16 recipe has exactly one change: `/quant` changes from absent (`null`) to the following value:

```json
{
	"mode": "fp16",
	"samples": 10,
	"calibration_method": "minmax",
	"weight_type": "uint8",
	"activation_type": "uint8",
	"per_channel": false,
	"symmetric": false,
	"weight_symmetric": null,
	"activation_symmetric": null,
	"save_calibration": false,
	"distribution": "uniform",
	"seed": null,
	"calibration_load_path": null,
	"calibration_save_path": null,
	"op_types_to_quantize": null,
	"nodes_to_exclude": null,
	"task": "image-to-text",
	"model_id": "alibaba-damo/mgp-str-base",
	"model_type": "mgp-str",
	"fp16_keep_io_types": true,
	"fp16_op_block_list": null
}
```

- Recipe-free inspect, config, and build acceptance all passed. Inspect resolved `image-to-text`, sentinel-default `MgpstrForSceneTextRecognition`, `MgpstrImageToTextIOConfig`, and `WinMLModelForMgpstrSceneTextRecognition`; config exposed `pixel_values [1,3,32,128]` and `char_logits`, `bpe_logits`, `wp_logits`. Reducibility is consistent with the charter.
- The production recipe README remains untouched.

### Bug fix explanation

1. **Symptom and trigger:** an MGP-STR image-to-text checkpoint could not build through auto resolution, and explicit image-to-text lacked an exporter; the generic Eval path failed on `decoder_input_ids` and processed 0/1 rows.
2. **Root cause:** WinML had no data-driven `mgp-str` image-to-text task/export registration, specialized runtime wrapper, RGB normalization, or ordered three-head processor decode. The old path therefore selected an unrelated default task or generic image-to-text behavior.
3. **Changed symbols and mechanism:** `MgpstrImageToTextIOConfig` and `MODEL_CLASS_MAPPING` register export and the concrete model class; `_convert_images_to_rgb`, `WinMLModelForMgpstrSceneTextRecognition`, and `MgpstrImageToTextPipeline` normalize images, validate `pixel_values`, preserve ordered heads, and decode with the processor; `_SPECIALIZED_PIPELINE_REGISTRY` and `create_pipeline` dispatch the specialization while preserving generic flow; aggregate HF/WinML mappings expose the classes.
4. **General rule:** dispatch is derived from `model_type=mgp-str` plus image-to-text checkpoint/task metadata. Source contains 0 hardcoded checkpoint IDs.
5. **Compatibility and blast radius:** non-MGP image-to-text continues to use the generic Transformers image-text-to-text path; device and `trust_remote_code` propagation, compatibility factories, generic fallbacks, aggregate mappings, and existing evaluator behavior remain intact. Intentional change: MGP-STR image-to-text is now class-wide first-class WinML support.
6. **Regression evidence:** focused producer coverage passed 177 tests; independent final-candidate quality gates passed license insertion, Ruff, mypy over 437 source files, and the workflow-aligned test groups: 1526 passed/45 skipped; 1535 passed/6 skipped/2 xfailed; 714 passed/16 skipped/1 xfailed; 3605 passed/9 skipped/1 warning; and 870 passed/2 skipped/1 deselected/1 warning. Compatibility-plan verification passed.

## Analyze summary — component level and op level

`ANALYZE-PARTIAL-SUCCESS`: all 12 static JSON classifications completed, while CLI exit 1 retained partial/unknown findings. This is static rule analysis, not runtime execution, and it does not establish accelerator runtime support.

### Component-level summary

| Artifact | Architecture coverage | Mapping | Actionable static findings |
|---|---|---|---|
| fp32 | patch embedding; 12x vision encoder; character/BPE/WordPiece A^3 heads; runtime-only `batch_decode` | 374 mapped, 0 partial, 0 unmapped; mapped and mapped-with-graph-adjacency confidence, with decode runtime-only | exact-signature `Reshape` and three A^3 `Einsum` sites remain unknown in the bounded scans |
| fp16 | patch embedding; 12x vision encoder; character/BPE/WordPiece A^3 heads; runtime-only `batch_decode` | 378 mapped, 0 partial, 0 unmapped; mapped-with-graph-adjacency confidence, with decode runtime-only | exact-signature `Reshape` and three A^3 `Einsum` sites remain unknown in the bounded scans |

### Op-level summary

| Artifact | Graph | Dominant operators | Static EP roll-up |
|---|---|---|---|
| fp32 | 374 operators / 14 types | Reshape 109; Gemm 51; Transpose 43; Gather 36; LayerNormalization 30; Add 25 | NvTensorRTRTX GPU, OpenVINO CPU/GPU/NPU, and QNN GPU/NPU scans completed with exit 1; `Einsum` and exact-signature `Reshape` remain unknown |
| fp16 | 378 operators / 15 types | Reshape 109; Gemm 51; Transpose 43; Gather 36; LayerNormalization 30; Add 25 | NvTensorRTRTX GPU, OpenVINO CPU/GPU/NPU, and QNN GPU/NPU scans completed with exit 1; `Einsum` and exact-signature `Reshape` remain unknown |

DML and VitisAI had no local rule directories and receive no fabricated static classification. CPU runtime support is established only by the CPU Goal ladder above; no accelerator runtime support is claimed from Analyze.

## Reproduce commands

```powershell
$OUT='temp/mgp-str-support-repro'
winml build -c examples/recipes/alibaba-damo_mgp-str-base/cpu/cpu/image-to-text_fp32_config.json -m alibaba-damo/mgp-str-base -o $OUT/fp32
winml build -c examples/recipes/alibaba-damo_mgp-str-base/cpu/cpu/image-to-text_fp16_config.json -m alibaba-damo/mgp-str-base -o $OUT/fp16 --precision fp16
winml perf -m $OUT/fp32/model.onnx --ep cpu --device cpu --precision fp32 --memory
winml perf -m $OUT/fp16/model.onnx --ep cpu --device cpu --precision fp16 --memory
$env:WINMLCLI_RULES_DIR='<rules-root>'
winml analyze -m $OUT/fp32/model.onnx --ep qnn --device npu --no-run-unknown-op --no-check-optim
winml eval -m $OUT/fp32/model.onnx --model-id alibaba-damo/mgp-str-base --task image-to-text --dataset MiXaiLL76/IIIT5K_OCR --split test --samples 2 --no-shuffle --ep cpu --device cpu
```