### PR TITLE
Consolidate development dependencies

### DIFF
--- a/.pipelines/templates/e2e-test-jobs.yml
+++ b/.pipelines/templates/e2e-test-jobs.yml
@@ -157,14 +157,11 @@ jobs:
         displayName: 'Authenticate pip with Azure Artifacts'
 
       # NOTE: This is the single source of truth for installing project deps
-      # into the venv. Every later step uses `uv run --no-sync` to *skip*
-      # uv's lockfile sync and rely on what was installed here. Do NOT remove
-      # this step assuming `uv run` will install on demand -- it won't, with
-      # `--no-sync` -- and do NOT drop `--no-sync` below assuming it's a
-      # no-op: without it, `uv run` would re-resolve from uv.lock and may
-      # silently replace this editable install.
+      # into the venv. Every later step uses `uv run --no-sync` and relies on
+      # the environment created here. Do not remove this step while those
+      # commands use `--no-sync`.
       - script: |
-          uv pip install -e .[dev]
+          uv pip install -e . --group dev
         workingDirectory: $(Build.SourcesDirectory)
         displayName: 'Install dependencies'
 

--- a/.pipelines/templates/eval-report-jobs.yml
+++ b/.pipelines/templates/eval-report-jobs.yml
@@ -109,14 +109,11 @@ jobs:
         displayName: 'Authenticate pip with Azure Artifacts'
 
       # NOTE: This is the single source of truth for installing project deps
-      # into the venv. Every later step uses `uv run --no-sync` to *skip*
-      # uv's lockfile sync and rely on what was installed here. Do NOT remove
-      # this step assuming `uv run` will install on demand -- it won't, with
-      # `--no-sync` -- and do NOT drop `--no-sync` below assuming it's a
-      # no-op: without it, `uv run` would re-resolve from uv.lock and may
-      # silently replace this editable install.
+      # into the venv. Every later step uses `uv run --no-sync` and relies on
+      # the environment created here. Do not remove this step while those
+      # commands use `--no-sync`.
       - script: |
-          uv pip install -e .[dev]
+          uv pip install -e . --group dev
         workingDirectory: $(Build.SourcesDirectory)
         displayName: 'Install dependencies'
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ See the [README](./README.md#getting-started) for prerequisites and installation
 ```bash
 git clone https://github.com/microsoft/winml-cli.git
 cd winml-cli
-uv sync --extra dev
+uv sync --locked
 uv run pre-commit install
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ This folder hosts the source for the [winml-cli](https://github.com/microsoft/wi
 
 | Task | Command |
 |---|---|
-| Install dev deps | `uv sync --extra dev` |
+| Install dev deps | `uv sync --locked` |
 | Live preview | `uv run mkdocs serve` |
 | Build for CI | `uv run mkdocs build --strict` |
 | Publish (one-shot from laptop) | `uv run mkdocs gh-deploy --force` |
@@ -48,7 +48,7 @@ Python 3.10+ and [uv](https://github.com/astral-sh/uv).
 
 ```bash
 # from the repo root
-uv sync --extra dev
+uv sync --locked
 uv run mkdocs serve
 ```
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -8,7 +8,7 @@ For the full contributing guide — development setup, coding conventions, testi
 # Clone and set up
 git clone https://github.com/microsoft/winml-cli.git
 cd winml-cli
-uv sync --extra dev
+uv sync --locked
 uv run pre-commit install
 
 # Download runtime check rules (required for `winml analyze`)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -27,7 +27,7 @@ uv pip install winml-cli
 
     ```powershell
     uv python install cpython-3.11-windows-x86_64-none
-    uv sync --extra dev --python cpython-3.11-windows-x86_64-none
+    uv sync --locked --python cpython-3.11-windows-x86_64-none
     ```
 
     The x64 interpreter runs under Windows emulation on Arm64 hardware; `winml sys` still reports the Arm64 machine, and the NPU/GPU/CPU providers work normally.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,25 +84,6 @@ dependencies = [
   "windowsml==2.0.300 ; sys_platform == 'win32'",
 ]
 
-optional-dependencies.dev = [
-  "ipykernel>=6.30.1",
-  "ipywidgets>=8.1.7",
-  "jupyter>=1.1.1",
-  "markdown-it-py>=3",
-  "matplotlib>=3.10",
-  "mkdocs-jupyter>=0.25",
-  "mkdocs-material>=9.5",
-  "mypy>=1.18",
-  "nbconvert>=7.16",
-  "pymdown-extensions>=10.7",
-  "pytest>=8.4",
-  "pytest-cov>=7",
-  "pytest-timeout>=2.3",
-  "ruff>=0.15",
-  "seaborn>=0.13",
-  "timm>=1.0.20",
-  "types-colorama>=0.4.15.20250801",
-]
 optional-dependencies.audio = [ "soundfile>=0.13" ]
 optional-dependencies.openvino = [ "openvino>=2023" ]
 optional-dependencies.qnn = [
@@ -167,12 +148,25 @@ torchvision = [
 
 [dependency-groups]
 dev = [
+  "ipykernel>=6.30.1",
+  "ipywidgets>=8.1.7",
   "jupyter>=1.1.1",
+  "markdown-it-py>=3",
+  "matplotlib>=3.10",
+  "mkdocs-jupyter>=0.25",
+  "mkdocs-material>=9.5",
+  "mypy>=1.18",
+  "nbconvert>=7.16",
   "pandas-stubs>=3.0.0.260204",
   "pre-commit>=4.5.1",
+  "pymdown-extensions>=10.7",
+  "pytest>=8.4",
   "pytest-cov>=7",
   "pytest-timeout>=2.4.0",
+  "ruff>=0.15",
   "scipy-stubs>=1.17.1.5",
+  "seaborn>=0.13",
+  "types-colorama>=0.4.15.20250801",
   "types-jsonschema>=4.26.0.20260518",
   "types-protobuf>=7.34.1.20260518",
   "types-psutil>=7.2.2.20260518",

--- a/uv.lock
+++ b/uv.lock
@@ -3273,6 +3273,14 @@ dependencies = [
 audio = [
     { name = "soundfile" },
 ]
+openvino = [
+    { name = "openvino" },
+]
+qnn = [
+    { name = "onnxruntime-qnn" },
+]
+
+[package.dev-dependencies]
 dev = [
     { name = "ipykernel" },
     { name = "ipywidgets" },
@@ -3283,30 +3291,16 @@ dev = [
     { name = "mkdocs-material" },
     { name = "mypy" },
     { name = "nbconvert" },
+    { name = "pandas-stubs" },
+    { name = "pre-commit" },
     { name = "pymdown-extensions" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-timeout" },
     { name = "ruff" },
-    { name = "seaborn" },
-    { name = "timm" },
-    { name = "types-colorama" },
-]
-openvino = [
-    { name = "openvino" },
-]
-qnn = [
-    { name = "onnxruntime-qnn" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "jupyter" },
-    { name = "pandas-stubs" },
-    { name = "pre-commit" },
-    { name = "pytest-cov" },
-    { name = "pytest-timeout" },
     { name = "scipy-stubs" },
+    { name = "seaborn" },
+    { name = "types-colorama" },
     { name = "types-jsonschema" },
     { name = "types-protobuf" },
     { name = "types-psutil" },
@@ -3330,18 +3324,9 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.135.3" },
     { name = "hf-xet", specifier = ">=1.1.10" },
     { name = "httpx", specifier = ">=0.24.0" },
-    { name = "ipykernel", marker = "extra == 'dev'", specifier = ">=6.30.1" },
-    { name = "ipywidgets", marker = "extra == 'dev'", specifier = ">=8.1.7" },
     { name = "jsonschema", specifier = ">=4.23" },
-    { name = "jupyter", marker = "extra == 'dev'", specifier = ">=1.1.1" },
-    { name = "markdown-it-py", marker = "extra == 'dev'", specifier = ">=3" },
-    { name = "matplotlib", marker = "extra == 'dev'", specifier = ">=3.10" },
     { name = "mcp", specifier = ">=0.1.0" },
-    { name = "mkdocs-jupyter", marker = "extra == 'dev'", specifier = ">=0.25" },
-    { name = "mkdocs-material", marker = "extra == 'dev'", specifier = ">=9.5" },
     { name = "ml-dtypes", specifier = ">=0.5.3" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.18" },
-    { name = "nbconvert", marker = "extra == 'dev'", specifier = ">=7.16" },
     { name = "numpy", specifier = ">=2.2,<2.3" },
     { name = "onnx", specifier = "==1.18" },
     { name = "onnx-ir", specifier = ">=0.1" },
@@ -3358,24 +3343,17 @@ requires-dist = [
     { name = "psutil", specifier = ">=7" },
     { name = "pyarrow", specifier = "==23.0.1" },
     { name = "pydantic", specifier = ">=2" },
-    { name = "pymdown-extensions", marker = "extra == 'dev'", specifier = ">=10.7" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7" },
-    { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3" },
     { name = "python-multipart", specifier = ">=0.0.22" },
     { name = "rapidfuzz", specifier = ">=3.9" },
     { name = "requests", specifier = ">=2.32.5" },
     { name = "rich", specifier = ">=14" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15" },
     { name = "scikit-learn", specifier = ">=1.7" },
     { name = "scipy", specifier = ">=1.15,<1.16" },
-    { name = "seaborn", marker = "extra == 'dev'", specifier = ">=0.13" },
     { name = "sentencepiece", specifier = ">=0.2.1" },
     { name = "seqeval", specifier = ">=1.2.2" },
     { name = "snakemd", specifier = ">=2" },
     { name = "soundfile", marker = "extra == 'audio'", specifier = ">=0.13" },
     { name = "timm", specifier = ">=1.0.22" },
-    { name = "timm", marker = "extra == 'dev'", specifier = ">=1.0.20" },
     { name = "tokenizers", specifier = ">=0.22" },
     { name = "torch", marker = "platform_machine != 'x86_64' or sys_platform != 'linux'", specifier = ">=2.9" },
     { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", specifier = ">=2.9", index = "https://download.pytorch.org/whl/cpu" },
@@ -3385,20 +3363,32 @@ requires-dist = [
     { name = "torchvision", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", specifier = ">=0.24", index = "https://download.pytorch.org/whl/cpu" },
     { name = "tqdm", specifier = ">=4.67" },
     { name = "transformers", specifier = ">=4.57" },
-    { name = "types-colorama", marker = "extra == 'dev'", specifier = ">=0.4.15.20250801" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.42.0" },
     { name = "windowsml", marker = "sys_platform == 'win32'", specifier = "==2.0.300" },
 ]
-provides-extras = ["dev", "audio", "openvino", "qnn"]
+provides-extras = ["audio", "openvino", "qnn"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "ipykernel", specifier = ">=6.30.1" },
+    { name = "ipywidgets", specifier = ">=8.1.7" },
     { name = "jupyter", specifier = ">=1.1.1" },
+    { name = "markdown-it-py", specifier = ">=3" },
+    { name = "matplotlib", specifier = ">=3.10" },
+    { name = "mkdocs-jupyter", specifier = ">=0.25" },
+    { name = "mkdocs-material", specifier = ">=9.5" },
+    { name = "mypy", specifier = ">=1.18" },
+    { name = "nbconvert", specifier = ">=7.16" },
     { name = "pandas-stubs", specifier = ">=3.0.0.260204" },
     { name = "pre-commit", specifier = ">=4.5.1" },
+    { name = "pymdown-extensions", specifier = ">=10.7" },
+    { name = "pytest", specifier = ">=8.4" },
     { name = "pytest-cov", specifier = ">=7" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
+    { name = "ruff", specifier = ">=0.15" },
     { name = "scipy-stubs", specifier = ">=1.17.1.5" },
+    { name = "seaborn", specifier = ">=0.13" },
+    { name = "types-colorama", specifier = ">=0.4.15.20250801" },
     { name = "types-jsonschema", specifier = ">=4.26.0.20260518" },
     { name = "types-protobuf", specifier = ">=7.34.1.20260518" },
     { name = "types-psutil", specifier = ">=7.2.2.20260518" },


### PR DESCRIPTION
## Summary

- merge the legacy `dev` optional extra into the default `dev` dependency group
- update development setup documentation to use locked synchronization
- update Azure pipeline editable installs to consume the dependency group
- keep the lockfile metadata aligned without unrelated package churn