### PR TITLE
chore+ci: bump version to 0.3.0 and pin official build toolchain

### DIFF
--- a/.pipelines/modelkit-official-build.yml
+++ b/.pipelines/modelkit-official-build.yml
@@ -127,7 +127,14 @@ extends:
                   artifactFeeds: 'windows.ai.toolkit/Modelkit'
                 displayName: 'Authenticate pip with Azure Artifacts'
 
-              - script: python -m pip install --upgrade build twine packaging
+              # PINNED ON PURPOSE — do NOT relax to unpinned/--upgrade.
+              # An unpinned toolchain lets a third-party release break the
+              # release build on publish day. build 1.5.1 did exactly that:
+              # its isolated-env pip invocation fails inside this container
+              # with "FileNotFoundError: [WinError 2]" while resolving the
+              # user cache dir from the registry. These are the versions that
+              # produced the v0.2.0 release. Bump deliberately, never silently.
+              - script: python -m pip install build==1.5.0 twine==6.2.0 packaging==26.2
                 displayName: 'Install build tools'
 
               # Build sdist BEFORE iKey injection so the source archive

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "setuptools>=61", "wheel" ]
 
 [project]
 name = "winml-cli"
-version = "0.2.0"
+version = "0.3.0"
 description = "Accelerate Model Deployment on WinML"
 readme = "README.md"
 keywords = [ "onnx", "winml" ]

--- a/uv.lock
+++ b/uv.lock
@@ -3218,7 +3218,7 @@ wheels = [
 
 [[package]]
 name = "winml-cli"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Release-window changes needed to build a correct v0.3.0 wheel.

### `chore(release): bump version to 0.3.0` (+ uv.lock sync)
Bumps `pyproject.toml` (and `uv.lock`) to `0.3.0`. Version is exposed at runtime via `importlib.metadata`, so `pyproject.toml` is the only source.

### `ci(release): pin official build toolchain versions`
`ModelKit Official Build` installed its toolchain with `pip install --upgrade build twine packaging` — completely unpinned. `build` 1.5.1 (released since v0.2.0) breaks the build inside the OneBranch container:

```
platformdirs\windows.py -> get_win_folder_from_registry
  winreg.QueryValueEx(key, CSIDL_LOCAL_APPDATA)
-> FileNotFoundError: [WinError 2] The system cannot find the file specified
```

The sdist step fails and the wheel step is skipped, so the build produces nothing. Verified on run [153739315](https://dev.azure.com/microsoft/windows.ai.toolkit/_build/results?buildId=153739315) (failed, `build` 1.5.1) vs [150550609](https://dev.azure.com/microsoft/windows.ai.toolkit/_build/results?buildId=150550609) (v0.2.0, succeeded, `build` 1.5.0). `build` 1.5.0 and 1.5.1 have identical `_pip_env()`, so this is environment behavior in 1.5.1, not a change on our side.

Pinning to the versions that produced v0.2.0 restores a green build and, more importantly, stops a third-party release from breaking the release build on publish day.

Validated: official build [153740145](https://dev.azure.com/microsoft/windows.ai.toolkit/_build/results?buildId=153740145) succeeded on this branch — sdist, wheel, iKey verification, and PyPI validation all green.