### PR TITLE
refactor(cli): centralize cache-control options

### DIFF
--- a/src/winml/modelkit/commands/build.py
+++ b/src/winml/modelkit/commands/build.py
@@ -732,17 +732,10 @@ def _maybe_build_genai_bundle(
     default=None,
     help="Output directory for all build artifacts",
 )
-@click.option(
-    "--use-cache/--no-use-cache",
-    default=False,
-    show_default=True,
-    help="Use WinML CLI global cache (~/.cache/winml/). Mutually exclusive with -o.",
-)
-@click.option(
-    "--rebuild/--no-rebuild",
-    default=False,
-    show_default=True,
-    help="Overwrite existing artifacts and rebuild",
+@cli_utils.cache_options(
+    use_cache_default=False,
+    use_cache_help="Use WinML CLI global cache (~/.cache/winml/). Mutually exclusive with -o.",
+    rebuild_help="Overwrite existing artifacts and rebuild",
 )
 @cli_utils.quant_option()
 @cli_utils.compile_option(

--- a/src/winml/modelkit/utils/cli.py
+++ b/src/winml/modelkit/utils/cli.py
@@ -767,6 +767,58 @@ def skip_build_option(
     )
 
 
+def cache_options(
+    *,
+    use_cache_default: bool = True,
+    use_cache_help: str = "Use the persistent model build cache",
+    rebuild_help: str = "Force rebuild even if cached artifacts exist",
+) -> Callable[[F], F]:
+    """Add the shared cache-control toggles to a Click command.
+
+    The decorated function receives ``use_cache`` and ``rebuild`` parameters.
+    Commands that auto-build models should translate them with
+    :func:`cache_extra_kwargs`. ``build`` uses the same option contract with a
+    command-specific ``use_cache_default=False`` because cache selection is also
+    its artifact-destination choice.
+
+    Args:
+        use_cache_default: Whether persistent caching is enabled by default.
+        use_cache_help: Command-specific help for the cache toggle.
+        rebuild_help: Command-specific help for the rebuild toggle.
+
+    Returns:
+        Decorator function.
+    """
+
+    def decorator(func: F) -> F:
+        func = click.option(
+            "--rebuild/--no-rebuild",
+            default=False,
+            show_default=True,
+            help=rebuild_help,
+        )(func)
+        return click.option(
+            "--use-cache/--no-use-cache",
+            default=use_cache_default,
+            show_default=True,
+            help=use_cache_help,
+        )(func)
+
+    return decorator
+
+
+def cache_extra_kwargs(*, use_cache: bool, rebuild: bool) -> dict[str, bool]:
+    """Translate shared cache controls into ``WinMLAutoModel`` keyword arguments.
+
+    Disabling the persistent cache selects a temporary build directory in the
+    model-loading API, so it must always produce a fresh build.
+    """
+    return {
+        "use_cache": use_cache,
+        "force_rebuild": rebuild or not use_cache,
+    }
+
+
 def trust_remote_code_option(optional_message: str | None = None) -> Callable[[F], F]:
     """Add shared --trust-remote-code option to a Click command.
 

--- a/tests/unit/utils/test_cli.py
+++ b/tests/unit/utils/test_cli.py
@@ -17,6 +17,8 @@ from click.testing import CliRunner
 from winml.modelkit.utils.cli import (
     analyze_option,
     build_pipeline_extra_kwargs,
+    cache_extra_kwargs,
+    cache_options,
     guard_output,
     ignored_build_flags_warning,
     load_export_overrides,
@@ -315,6 +317,68 @@ class TestBuildPipelineExtraKwargs:
     def test_combined_optimize_and_analyze(self) -> None:
         result = build_pipeline_extra_kwargs(optimize=False, analyze=False)
         assert result == {"skip_optimize": True, "hack_max_optim_iterations": 0}
+
+
+class TestCacheOptions:
+    """Tests for the shared cache_options() decorator."""
+
+    @staticmethod
+    def _make_cmd(*, use_cache_default: bool) -> click.Command:
+        @click.command()
+        @cache_options(
+            use_cache_default=use_cache_default,
+            use_cache_help="Cache help",
+            rebuild_help="Rebuild help",
+        )
+        def cmd(use_cache: bool, rebuild: bool) -> None:
+            click.echo(f"{use_cache=},{rebuild=}")
+
+        return cmd
+
+    @pytest.mark.parametrize("use_cache_default", [False, True])
+    def test_configurable_cache_default(self, use_cache_default: bool) -> None:
+        result = CliRunner().invoke(self._make_cmd(use_cache_default=use_cache_default))
+        assert result.exit_code == 0
+        assert result.output.strip() == f"use_cache={use_cache_default},rebuild=False"
+
+    @pytest.mark.parametrize(
+        ("flag", "expected"),
+        [
+            ("--use-cache", "use_cache=True,rebuild=False"),
+            ("--no-use-cache", "use_cache=False,rebuild=False"),
+            ("--rebuild", "use_cache=True,rebuild=True"),
+            ("--no-rebuild", "use_cache=True,rebuild=False"),
+        ],
+    )
+    def test_flag_pairs(self, flag: str, expected: str) -> None:
+        result = CliRunner().invoke(self._make_cmd(use_cache_default=True), [flag])
+        assert result.exit_code == 0
+        assert result.output.strip() == expected
+
+    def test_help_uses_command_specific_text(self) -> None:
+        result = CliRunner().invoke(self._make_cmd(use_cache_default=True), ["--help"])
+        assert result.exit_code == 0
+        assert "Cache help" in result.output
+        assert "Rebuild help" in result.output
+
+
+class TestCacheExtraKwargs:
+    """Tests for the shared cache_extra_kwargs() translator."""
+
+    @pytest.mark.parametrize(
+        ("use_cache", "rebuild", "force_rebuild"),
+        [
+            (True, False, False),
+            (True, True, True),
+            (False, False, True),
+            (False, True, True),
+        ],
+    )
+    def test_mapping(self, use_cache: bool, rebuild: bool, force_rebuild: bool) -> None:
+        assert cache_extra_kwargs(use_cache=use_cache, rebuild=rebuild) == {
+            "use_cache": use_cache,
+            "force_rebuild": force_rebuild,
+        }
 
 
 class TestIgnoredBuildFlagsWarning:


### PR DESCRIPTION
## Summary

- add shared `cache_options()` and `cache_extra_kwargs()` CLI helpers
- migrate `winml build` to the shared option decorator without changing its cache opt-in default, destination validation, or rebuild behavior
- cover cache defaults, flag parsing, help customization, and no-cache rebuild mapping

This is the behavior-preserving foundation for #972. Follow-up PRs will add the shared contract to `eval` and migrate `perf` from its inverse cache flag.