### PR TITLE
Fix telemetry handling for local model paths

### DIFF
--- a/examples/recipes/Gustking_wav2vec2-large-xlsr-deepfake-audio-classification/cpu/cpu/audio-classification_fp16_config.json
+++ b/examples/recipes/Gustking_wav2vec2-large-xlsr-deepfake-audio-classification/cpu/cpu/audio-classification_fp16_config.json
@@ -1,0 +1,62 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          16000
+        ],
+        "value_range": [
+          -1,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "audio-classification",
+    "model_id": "Gustking/wav2vec2-large-xlsr-deepfake-audio-classification",
+    "model_type": "wav2vec2",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "audio-classification",
+    "model_class": "AutoModelForAudioClassification",
+    "model_type": "wav2vec2"
+  }
+}

--- a/examples/recipes/Gustking_wav2vec2-large-xlsr-deepfake-audio-classification/cpu/cpu/audio-classification_fp32_config.json
+++ b/examples/recipes/Gustking_wav2vec2-large-xlsr-deepfake-audio-classification/cpu/cpu/audio-classification_fp32_config.json
@@ -1,0 +1,40 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          16000
+        ],
+        "value_range": [
+          -1,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "audio-classification",
+    "model_class": "AutoModelForAudioClassification",
+    "model_type": "wav2vec2"
+  }
+}

--- a/examples/recipes/cardiffnlp_twitter-roberta-base-sentiment-latest/text-classification_fp16_config.json
+++ b/examples/recipes/cardiffnlp_twitter-roberta-base-sentiment-latest/text-classification_fp16_config.json
@@ -53,7 +53,7 @@
   "eval": {
     "task": "text-classification",
     "dataset": {
-      "path": "tweet_eval",
+      "path": "cardiffnlp/tweet_eval",
       "name": "sentiment",
       "samples": 100,
       "columns_mapping": {

--- a/examples/recipes/cardiffnlp_twitter-roberta-base-sentiment-latest/text-classification_w8a16_config.json
+++ b/examples/recipes/cardiffnlp_twitter-roberta-base-sentiment-latest/text-classification_w8a16_config.json
@@ -70,7 +70,7 @@
   "eval": {
     "task": "text-classification",
     "dataset": {
-      "path": "tweet_eval",
+      "path": "cardiffnlp/tweet_eval",
       "name": "sentiment",
       "samples": 1000,
       "columns_mapping": {

--- a/examples/recipes/cross-encoder_mmarco-mMiniLMv2-L12-H384-v1/cpu/cpu/text-classification_fp16_config.json
+++ b/examples/recipes/cross-encoder_mmarco-mMiniLMv2-L12-H384-v1/cpu/cpu/text-classification_fp16_config.json
@@ -1,0 +1,76 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          250002
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "text-classification",
+    "model_id": "cross-encoder/mmarco-mMiniLMv2-L12-H384-v1",
+    "model_type": "xlm-roberta",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "text-classification",
+    "model_class": "AutoModelForSequenceClassification",
+    "model_type": "xlm-roberta"
+  }
+}

--- a/examples/recipes/cross-encoder_mmarco-mMiniLMv2-L12-H384-v1/cpu/cpu/text-classification_fp32_config.json
+++ b/examples/recipes/cross-encoder_mmarco-mMiniLMv2-L12-H384-v1/cpu/cpu/text-classification_fp32_config.json
@@ -1,0 +1,54 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          250002
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "text-classification",
+    "model_class": "AutoModelForSequenceClassification",
+    "model_type": "xlm-roberta"
+  }
+}

--- a/examples/recipes/cross-encoder_nli-MiniLM2-L6-H768/cpu/cpu/text-classification_fp16_config.json
+++ b/examples/recipes/cross-encoder_nli-MiniLM2-L6-H768/cpu/cpu/text-classification_fp16_config.json
@@ -1,0 +1,76 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          50265
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "text-classification",
+    "model_id": "cross-encoder/nli-MiniLM2-L6-H768",
+    "model_type": "roberta",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "text-classification",
+    "model_class": "AutoModelForSequenceClassification",
+    "model_type": "roberta"
+  }
+}

--- a/examples/recipes/cross-encoder_nli-MiniLM2-L6-H768/cpu/cpu/text-classification_fp32_config.json
+++ b/examples/recipes/cross-encoder_nli-MiniLM2-L6-H768/cpu/cpu/text-classification_fp32_config.json
@@ -1,0 +1,54 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          50265
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "text-classification",
+    "model_class": "AutoModelForSequenceClassification",
+    "model_type": "roberta"
+  }
+}

--- a/scripts/e2e_eval/cache/baseline_cache.json
+++ b/scripts/e2e_eval/cache/baseline_cache.json
@@ -9,7 +9,7 @@
     "elapsed": 59.2,
     "command": "python.exe run_pytorch_baseline.py --model finbert --task text-classification --device cpu --num-samples 1000 --dataset finbert_dataset --split val"
   },
-  "cardiffnlp/twitter-roberta-base-sentiment-latest|text-classification|tweet_eval|sentiment||1000": {
+  "cardiffnlp/twitter-roberta-base-sentiment-latest|text-classification|cardiffnlp/tweet_eval|sentiment||1000": {
     "status": "PASS",
     "metric": {
       "metric": "accuracy",
@@ -17,7 +17,7 @@
       "num_samples": 1000
     },
     "elapsed": 91.5,
-    "command": "python.exe run_pytorch_baseline.py --model twitter-roberta-base-sentiment-latest --task text-classification --device cpu --num-samples 1000 --dataset tweet_eval --dataset-config sentiment --columns-mapping {\"input_column\": \"text\"}"
+    "command": "python.exe run_pytorch_baseline.py --model twitter-roberta-base-sentiment-latest --task text-classification --device cpu --num-samples 1000 --dataset cardiffnlp/tweet_eval --dataset-config sentiment --columns-mapping {\"input_column\": \"text\"}"
   },
   "distilbert/distilbert-base-uncased-finetuned-sst-2-english|text-classification|nyu-mll/glue|sst2||1000": {
     "status": "PASS",
@@ -959,7 +959,7 @@
     "elapsed": 52.0,
     "command": "python.exe run_pytorch_baseline.py --model finbert --task text-classification --device cpu --num-samples 100 --dataset finbert_dataset --split val --winml-metric-key accuracy"
   },
-  "cardiffnlp/twitter-roberta-base-sentiment-latest|text-classification|tweet_eval|sentiment||100": {
+  "cardiffnlp/twitter-roberta-base-sentiment-latest|text-classification|cardiffnlp/tweet_eval|sentiment||100": {
     "status": "PASS",
     "metric": {
       "metric": "accuracy",
@@ -967,7 +967,7 @@
       "num_samples": 100
     },
     "elapsed": 54.9,
-    "command": "python.exe run_pytorch_baseline.py --model twitter-roberta-base-sentiment-latest --task text-classification --device cpu --num-samples 100 --dataset tweet_eval --dataset-config sentiment --columns-mapping {\"input_column\": \"text\"} --winml-metric-key accuracy"
+    "command": "python.exe run_pytorch_baseline.py --model twitter-roberta-base-sentiment-latest --task text-classification --device cpu --num-samples 100 --dataset cardiffnlp/tweet_eval --dataset-config sentiment --columns-mapping {\"input_column\": \"text\"} --winml-metric-key accuracy"
   },
   "distilbert/distilbert-base-uncased-finetuned-sst-2-english|text-classification|nyu-mll/glue|sst2||100": {
     "status": "PASS",

--- a/scripts/e2e_eval/testsets/models_with_acc.json
+++ b/scripts/e2e_eval/testsets/models_with_acc.json
@@ -18,7 +18,7 @@
     "group": "Top200",
     "priority": "P1",
     "dataset_config": {
-      "path": "tweet_eval",
+      "path": "cardiffnlp/tweet_eval",
       "name": "sentiment",
       "metric": "accuracy",
       "columns_mapping": {

--- a/src/winml/modelkit/commands/build.py
+++ b/src/winml/modelkit/commands/build.py
@@ -732,17 +732,10 @@ def _maybe_build_genai_bundle(
     default=None,
     help="Output directory for all build artifacts",
 )
-@click.option(
-    "--use-cache/--no-use-cache",
-    default=False,
-    show_default=True,
-    help="Use WinML CLI global cache (~/.cache/winml/). Mutually exclusive with -o.",
-)
-@click.option(
-    "--rebuild/--no-rebuild",
-    default=False,
-    show_default=True,
-    help="Overwrite existing artifacts and rebuild",
+@cli_utils.cache_options(
+    use_cache_default=False,
+    use_cache_help="Use WinML CLI global cache (~/.cache/winml/). Mutually exclusive with -o.",
+    rebuild_help="Overwrite existing artifacts and rebuild",
 )
 @cli_utils.quant_option()
 @cli_utils.compile_option(

--- a/src/winml/modelkit/commands/eval.py
+++ b/src/winml/modelkit/commands/eval.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
     "dataset_path",
     type=str,
     default=None,
-    help="HF dataset path (e.g. 'imagenet-1k', 'glue'). "
+    help="HF dataset path (e.g. 'imagenet-1k', 'nyu-mll/glue'). "
     "If omitted, uses a default dataset for the task.",
 )
 @click.option(

--- a/src/winml/modelkit/datasets/text.py
+++ b/src/winml/modelkit/datasets/text.py
@@ -27,6 +27,11 @@ from .base import BaseTaskDataset
 
 logger = logging.getLogger(__name__)
 
+# HF requires fully qualified repository ids ("namespace/name"); the legacy
+# canonical alias "glue" is no longer resolvable.
+DEFAULT_TEXT_DATASET = "nyu-mll/glue"
+DEFAULT_TEXT_DATASET_SUBSET = "mrpc"
+
 
 class TextDataset(BaseTaskDataset):
     """Dataset for text tasks with universal tokenization.
@@ -56,7 +61,7 @@ class TextDataset(BaseTaskDataset):
 
         Args:
             model_name: HuggingFace model identifier
-            dataset_name: Dataset name (default: glue)
+            dataset_name: Dataset name (default: nyu-mll/glue)
             max_samples: Maximum samples (None = use all)
             data_split: Dataset split (default: train)
             max_length: Sequence length (default: from io_config or 128)
@@ -85,8 +90,8 @@ class TextDataset(BaseTaskDataset):
     def _get_default_dataset(self) -> None:
         """Set default dataset if none specified."""
         if self._dataset_name is None:
-            self._dataset_name = "glue"
-            self._config["subset"] = self._config.get("subset", "mrpc")
+            self._dataset_name = DEFAULT_TEXT_DATASET
+            self._config["subset"] = self._config.get("subset", DEFAULT_TEXT_DATASET_SUBSET)
             self._data_split = self._data_split or "train"
 
     def _resolve_max_length(self) -> None:

--- a/src/winml/modelkit/eval/config.py
+++ b/src/winml/modelkit/eval/config.py
@@ -20,7 +20,7 @@ class DatasetConfig:
     """Dataset configuration, aligned with HF load_dataset() API.
 
     Attributes:
-        path: HF dataset path (e.g., "imagenet-1k", "glue").
+        path: HF dataset path (e.g., "imagenet-1k", "nyu-mll/glue").
         name: Config name for multi-config datasets (e.g., "mrpc").
         split: Dataset split.
         samples: Number of samples to evaluate.

--- a/src/winml/modelkit/telemetry/utils.py
+++ b/src/winml/modelkit/telemetry/utils.py
@@ -171,7 +171,9 @@ def _model_ref_local_marker(value: str) -> str:
     return f"<local:{ext}>" if ext else "<local:dir>"
 
 
-def _scrub_model_ref(value: str | tuple[str, ...] | None) -> str | None:
+def _scrub_model_ref(
+    value: str | os.PathLike[str] | tuple[str | os.PathLike[str], ...] | None,
+) -> str | None:
     """Classify a ``-m/--model`` reference for telemetry.
 
     Clean HuggingFace Hub ids — one or two Hub-charset segments with at most
@@ -185,6 +187,7 @@ def _scrub_model_ref(value: str | tuple[str, ...] | None) -> str | None:
         value = value[0] if value else None
     if not value:
         return None
+    value = os.fspath(value)
     normalized = value.replace("\\", "/")
     if re.match(r"^[A-Za-z]:[\\/]", value) or normalized.startswith("/"):
         return _model_ref_local_marker(value)

--- a/src/winml/modelkit/utils/cli.py
+++ b/src/winml/modelkit/utils/cli.py
@@ -767,6 +767,58 @@ def skip_build_option(
     )
 
 
+def cache_options(
+    *,
+    use_cache_default: bool = True,
+    use_cache_help: str = "Use the persistent model build cache",
+    rebuild_help: str = "Force rebuild even if cached artifacts exist",
+) -> Callable[[F], F]:
+    """Add the shared cache-control toggles to a Click command.
+
+    The decorated function receives ``use_cache`` and ``rebuild`` parameters.
+    Commands that auto-build models should translate them with
+    :func:`cache_extra_kwargs`. ``build`` uses the same option contract with a
+    command-specific ``use_cache_default=False`` because cache selection is also
+    its artifact-destination choice.
+
+    Args:
+        use_cache_default: Whether persistent caching is enabled by default.
+        use_cache_help: Command-specific help for the cache toggle.
+        rebuild_help: Command-specific help for the rebuild toggle.
+
+    Returns:
+        Decorator function.
+    """
+
+    def decorator(func: F) -> F:
+        func = click.option(
+            "--rebuild/--no-rebuild",
+            default=False,
+            show_default=True,
+            help=rebuild_help,
+        )(func)
+        return click.option(
+            "--use-cache/--no-use-cache",
+            default=use_cache_default,
+            show_default=True,
+            help=use_cache_help,
+        )(func)
+
+    return decorator
+
+
+def cache_extra_kwargs(*, use_cache: bool, rebuild: bool) -> dict[str, bool]:
+    """Translate shared cache controls into ``WinMLAutoModel`` keyword arguments.
+
+    Disabling the persistent cache selects a temporary build directory in the
+    model-loading API, so it must always produce a fresh build.
+    """
+    return {
+        "use_cache": use_cache,
+        "force_rebuild": rebuild or not use_cache,
+    }
+
+
 def trust_remote_code_option(optional_message: str | None = None) -> Callable[[F], F]:
     """Add shared --trust-remote-code option to a Click command.
 

--- a/src/winml/modelkit/utils/native_stderr.py
+++ b/src/winml/modelkit/utils/native_stderr.py
@@ -10,7 +10,7 @@ Three context managers are provided:
 
 * ``suppress_native_stderr``  - discard to devnull  (startup noise)
 * ``capture_native_stderr``   - capture via pipe and re-log  (compilation output)
-* ``suppress_native_warnings`` - hide warning lines, replay everything else
+* ``suppress_native_warnings`` - spool to disk, hide warnings, replay other lines
 
 The first two are no-ops on non-Windows. ``suppress_native_warnings`` works via
 fd 2 on all platforms and also keeps the Win32 stderr handle in sync on Windows.
@@ -22,8 +22,9 @@ import logging
 import os
 import re
 import sys
+import tempfile
 import threading
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
@@ -198,19 +199,25 @@ def suppress_native_warnings(
     ``[E:...]``. This process-wide fd redirect is opt-in; CLI entry points pass
     ``enabled=True`` only around native-heavy work. ``-v`` / ``-vv`` or
     ``WINMLCLI_SHOW_ALL_WARNINGS=1`` leaves stderr untouched.
+
+    Output is spooled to a temporary file and replayed only after fd 2 is
+    restored. A pipe is deliberately not used here: some native execution-
+    provider compilers change behavior or hang when stderr is a pipe, even when
+    that pipe is drained concurrently. A file also bounds Python memory usage
+    without imposing a finite producer buffer.
     """
     if not enabled or _show_native_warnings_requested():
         yield
         return
 
-    read_fd: int | None = None
-    write_fd: int | None = None
     old_fd: int | None = None
+    capture_stack = ExitStack()
     try:
-        read_fd, write_fd = os.pipe()
+        capture = capture_stack.enter_context(
+            tempfile.TemporaryFile(mode="w+b")  # noqa: SIM115 - owned by ExitStack
+        )
     except OSError:
-        _close_fd(read_fd)
-        _close_fd(write_fd)
+        capture_stack.close()
         logger.debug(
             "Native warning suppression setup failed; leaving stderr unchanged",
             exc_info=True,
@@ -223,8 +230,7 @@ def suppress_native_warnings(
         try:
             old_fd = os.dup(2)
         except OSError:
-            _close_fd(read_fd)
-            _close_fd(write_fd)
+            capture_stack.close()
             logger.debug(
                 "Native warning suppression setup failed; leaving stderr unchanged",
                 exc_info=True,
@@ -232,17 +238,10 @@ def suppress_native_warnings(
             redirect_failed = True
         if not redirect_failed:
             assert old_fd is not None
-            reader = threading.Thread(
-                target=_drain_filtered_native_stderr,
-                args=(read_fd, old_fd, preserve_unclassified),
-                name="suppress-native-warnings",
-                daemon=True,
-            )
             try:
-                os.dup2(write_fd, 2)
+                os.dup2(capture.fileno(), 2)
             except OSError:
-                _close_fd(read_fd)
-                _close_fd(write_fd)
+                capture_stack.close()
                 _close_fd(old_fd)
                 logger.debug(
                     "Native warning suppression redirect failed; leaving stderr unchanged",
@@ -250,22 +249,26 @@ def suppress_native_warnings(
                 )
                 redirect_failed = True
             if not redirect_failed:
-                _close_fd(write_fd)
                 _set_win32_std_handle_to_current_fd(2)
-                reader.start()
                 try:
                     yield
                 finally:
                     _restore_redirected_fd(2, old_fd)
                     _set_win32_std_handle_to_current_fd(2)
                     _refresh_click_windows_console_stream(2)
-                    reader.join(timeout=_NATIVE_READER_JOIN_TIMEOUT_SECONDS)
-                    if reader.is_alive():
+                    try:
+                        capture.flush()
+                        capture.seek(0)
+                        for line in capture:
+                            if _should_preserve_native_line(line, preserve_unclassified):
+                                _write_all(old_fd, line)
+                    except OSError:
                         logger.debug(
-                            "Native warning suppression reader did not finish after stderr restore"
+                            "Could not replay filtered native stderr",
+                            exc_info=True,
                         )
-                    else:
-                        _close_fd(old_fd)
+                    capture_stack.close()
+                    _close_fd(old_fd)
     if redirect_failed:
         yield
 
@@ -305,32 +308,6 @@ def _restore_redirected_fd(fd: int, old_fd: int | None) -> None:
             fd,
             exc_info=True,
         )
-
-
-def _drain_filtered_native_stderr(
-    read_fd: int,
-    target_fd: int,
-    preserve_unclassified: bool,
-) -> None:
-    pending = b""
-    try:
-        while chunk := os.read(read_fd, 4096):
-            pending += chunk
-            while b"\n" in pending:
-                line, pending = pending.split(b"\n", 1)
-                _write_non_warning_line(target_fd, line + b"\n", preserve_unclassified)
-        if pending:
-            _write_non_warning_line(target_fd, pending, preserve_unclassified)
-    except OSError:
-        # fd redirection is best-effort cleanup; restore path handles usability.
-        pass
-    finally:
-        os.close(read_fd)
-
-
-def _write_non_warning_line(fd: int, line: bytes, preserve_unclassified: bool) -> None:
-    if _should_preserve_native_line(line, preserve_unclassified):
-        _write_all(fd, line)
 
 
 def _should_preserve_native_line(line: bytes, preserve_unclassified: bool) -> bool:

--- a/tests/integration/datasets/test_text_classification.py
+++ b/tests/integration/datasets/test_text_classification.py
@@ -44,7 +44,7 @@ class TestTextDatasetBasic:
         assert TextDataset.DEFAULT_SEQ_LEN == 128
 
     def test_default_dataset_glue_mrpc(self):
-        """Test default dataset is glue/mrpc when none specified."""
+        """Test default dataset is nyu-mll/glue with the mrpc subset."""
         from winml.modelkit.datasets import TextDataset
 
         dataset = TextDataset(
@@ -52,7 +52,7 @@ class TestTextDatasetBasic:
             max_samples=5,
         )
 
-        assert dataset.dataset_name == "glue"
+        assert dataset.dataset_name == "nyu-mll/glue"
         assert dataset.data_split == "train"
 
     def test_explicit_dataset_name(self):
@@ -61,13 +61,13 @@ class TestTextDatasetBasic:
 
         dataset = TextDataset(
             model_name="bert-base-uncased",
-            dataset_name="glue",
+            dataset_name="nyu-mll/glue",
             data_split="validation",
             max_samples=5,
             subset="sst2",
         )
 
-        assert dataset.dataset_name == "glue"
+        assert dataset.dataset_name == "nyu-mll/glue"
         assert dataset.data_split == "validation"
 
     def test_max_samples_limits_dataset_size(self):
@@ -274,7 +274,7 @@ class TestColumnDetection:
         # GLUE/SST2 is a single sentence task
         dataset = TextDataset(
             model_name="bert-base-uncased",
-            dataset_name="glue",
+            dataset_name="nyu-mll/glue",
             data_split="train",
             max_samples=5,
             subset="sst2",

--- a/tests/unit/eval/test_eval.py
+++ b/tests/unit/eval/test_eval.py
@@ -752,7 +752,7 @@ class TestWinMLEvaluator:
             model_id="test/model",
             task="text-classification",
             dataset=DatasetConfig(
-                path="glue",
+                path="nyu-mll/glue",
                 name="mrpc",
                 columns_mapping={"input_column": "sentence1", "second_input_column": "sentence2"},
             ),
@@ -803,7 +803,7 @@ class TestSequenceClassificationEvaluator:
         config = WinMLEvaluationConfig(
             model_id="test/model",
             task="text-classification",
-            dataset=DatasetConfig(path="glue", name="mrpc"),
+            dataset=DatasetConfig(path="nyu-mll/glue", name="mrpc"),
         )
 
         WinMLTextClassificationEvaluator(config, model).compute()
@@ -847,7 +847,7 @@ class TestSequenceClassificationEvaluator:
         config = WinMLEvaluationConfig(
             model_id="test/model",
             task="text-classification",
-            dataset=DatasetConfig(path="glue"),
+            dataset=DatasetConfig(path="nyu-mll/glue"),
         )
 
         WinMLTextClassificationEvaluator(config, model).compute()

--- a/tests/unit/telemetry/test_click_group.py
+++ b/tests/unit/telemetry/test_click_group.py
@@ -6,6 +6,7 @@
 """Tests for ``ActionGroup`` — the Click ``Group`` subclass that
 auto-instruments every registered subcommand with WinML CLI telemetry."""
 
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import click
@@ -291,6 +292,29 @@ def test_action_records_scrubbed_model_id(enabled_telemetry, model_arg, expected
     runner.invoke(cli, ["perf", "-m", model_arg])
     action_record = mock_logger.emit.call_args_list[1].args[0]
     assert dict(action_record.attributes)["model_id"] == expected_model_id
+
+
+def test_action_accepts_path_typed_model(enabled_telemetry, tmp_path):
+    @click.group(cls=ActionGroup)
+    def cli():
+        pass
+
+    @cli.command()
+    @click.option("-m", "--model", type=click.Path(exists=True, path_type=Path))
+    def analyze(model):
+        (tmp_path / "analysis.json").write_text("{}")
+
+    model_path = tmp_path / "model.onnx"
+    model_path.write_bytes(b"")
+    telemetry = Telemetry.get_or_init()
+    mock_logger = _with_mock_logger(telemetry)
+
+    result = CliRunner().invoke(cli, ["analyze", "-m", str(model_path)])
+
+    assert (tmp_path / "analysis.json").exists()
+    assert result.exit_code == 0
+    action_record = mock_logger.emit.call_args_list[1].args[0]
+    assert dict(action_record.attributes)["model_id"] == "<local:.onnx>"
 
 
 def test_action_prefers_model_id_param(enabled_telemetry):

--- a/tests/unit/utils/test_cli.py
+++ b/tests/unit/utils/test_cli.py
@@ -17,6 +17,8 @@ from click.testing import CliRunner
 from winml.modelkit.utils.cli import (
     analyze_option,
     build_pipeline_extra_kwargs,
+    cache_extra_kwargs,
+    cache_options,
     guard_output,
     ignored_build_flags_warning,
     load_export_overrides,
@@ -315,6 +317,68 @@ class TestBuildPipelineExtraKwargs:
     def test_combined_optimize_and_analyze(self) -> None:
         result = build_pipeline_extra_kwargs(optimize=False, analyze=False)
         assert result == {"skip_optimize": True, "hack_max_optim_iterations": 0}
+
+
+class TestCacheOptions:
+    """Tests for the shared cache_options() decorator."""
+
+    @staticmethod
+    def _make_cmd(*, use_cache_default: bool) -> click.Command:
+        @click.command()
+        @cache_options(
+            use_cache_default=use_cache_default,
+            use_cache_help="Cache help",
+            rebuild_help="Rebuild help",
+        )
+        def cmd(use_cache: bool, rebuild: bool) -> None:
+            click.echo(f"{use_cache=},{rebuild=}")
+
+        return cmd
+
+    @pytest.mark.parametrize("use_cache_default", [False, True])
+    def test_configurable_cache_default(self, use_cache_default: bool) -> None:
+        result = CliRunner().invoke(self._make_cmd(use_cache_default=use_cache_default))
+        assert result.exit_code == 0
+        assert result.output.strip() == f"use_cache={use_cache_default},rebuild=False"
+
+    @pytest.mark.parametrize(
+        ("flag", "expected"),
+        [
+            ("--use-cache", "use_cache=True,rebuild=False"),
+            ("--no-use-cache", "use_cache=False,rebuild=False"),
+            ("--rebuild", "use_cache=True,rebuild=True"),
+            ("--no-rebuild", "use_cache=True,rebuild=False"),
+        ],
+    )
+    def test_flag_pairs(self, flag: str, expected: str) -> None:
+        result = CliRunner().invoke(self._make_cmd(use_cache_default=True), [flag])
+        assert result.exit_code == 0
+        assert result.output.strip() == expected
+
+    def test_help_uses_command_specific_text(self) -> None:
+        result = CliRunner().invoke(self._make_cmd(use_cache_default=True), ["--help"])
+        assert result.exit_code == 0
+        assert "Cache help" in result.output
+        assert "Rebuild help" in result.output
+
+
+class TestCacheExtraKwargs:
+    """Tests for the shared cache_extra_kwargs() translator."""
+
+    @pytest.mark.parametrize(
+        ("use_cache", "rebuild", "force_rebuild"),
+        [
+            (True, False, False),
+            (True, True, True),
+            (False, False, True),
+            (False, True, True),
+        ],
+    )
+    def test_mapping(self, use_cache: bool, rebuild: bool, force_rebuild: bool) -> None:
+        assert cache_extra_kwargs(use_cache=use_cache, rebuild=rebuild) == {
+            "use_cache": use_cache,
+            "force_rebuild": force_rebuild,
+        }
 
 
 class TestIgnoredBuildFlagsWarning:

--- a/tests/unit/utils/test_native_stderr.py
+++ b/tests/unit/utils/test_native_stderr.py
@@ -243,6 +243,23 @@ class TestSuppressNativeWarnings:
         assert "useful error" in stderr
         assert "plain diagnostic" in stderr
 
+    def test_uses_file_backed_capture_instead_of_pipe(self, monkeypatch):
+        monkeypatch.delenv("WINMLCLI_SHOW_ALL_WARNINGS", raising=False)
+        logging.getLogger().setLevel(logging.WARNING)
+        pipe_called = False
+
+        def fail_pipe() -> tuple[int, int]:
+            nonlocal pipe_called
+            pipe_called = True
+            raise AssertionError("warning suppression must not create a pipe")
+
+        monkeypatch.setattr(native_stderr_module.os, "pipe", fail_pipe)
+
+        with native_stderr_module.suppress_native_warnings(enabled=True):
+            os.write(2, b"2026 [W:custom-native:, file.cc:1 WarningFunc] hidden\n")
+
+        assert pipe_called is False
+
     def test_filters_native_prefix_info_without_dropping_python_stderr(self, monkeypatch, capfd):
         monkeypatch.delenv("WINMLCLI_SHOW_ALL_WARNINGS", raising=False)
         logging.getLogger().setLevel(logging.WARNING)
@@ -299,14 +316,14 @@ class TestSuppressNativeWarnings:
 
         assert "env warning" in capfd.readouterr().err
 
-    def test_pipe_setup_failure_does_not_abort_wrapped_code(self, monkeypatch):
+    def test_capture_setup_failure_does_not_abort_wrapped_code(self, monkeypatch):
         monkeypatch.delenv("WINMLCLI_SHOW_ALL_WARNINGS", raising=False)
         logging.getLogger().setLevel(logging.WARNING)
 
-        def fail_pipe() -> tuple[int, int]:
+        def fail_capture(*args: object, **kwargs: object):
             raise OSError(1, "Incorrect function")
 
-        monkeypatch.setattr(native_stderr_module.os, "pipe", fail_pipe)
+        monkeypatch.setattr(native_stderr_module.tempfile, "TemporaryFile", fail_capture)
 
         ran = False
         with native_stderr_module.suppress_native_warnings(enabled=True):
@@ -314,25 +331,11 @@ class TestSuppressNativeWarnings:
 
         assert ran
 
-    def test_restore_failure_closes_redirected_fd_and_bounds_reader_join(self, monkeypatch):
+    def test_restore_failure_closes_redirected_fd(self, monkeypatch):
         monkeypatch.delenv("WINMLCLI_SHOW_ALL_WARNINGS", raising=False)
         logging.getLogger().setLevel(logging.WARNING)
         closed: list[int] = []
-        join_timeouts: list[float | None] = []
         dup2_calls = 0
-
-        class FakeThread:
-            def __init__(self, *args: object, **kwargs: object) -> None:
-                pass
-
-            def start(self) -> None:
-                pass
-
-            def join(self, timeout: float | None = None) -> None:
-                join_timeouts.append(timeout)
-
-            def is_alive(self) -> bool:
-                return False
 
         def fake_dup2(src: int, dst: int) -> None:
             nonlocal dup2_calls
@@ -340,11 +343,9 @@ class TestSuppressNativeWarnings:
             if dup2_calls == 2:
                 raise OSError(1, "restore failed")
 
-        monkeypatch.setattr(native_stderr_module.os, "pipe", lambda: (10, 11))
         monkeypatch.setattr(native_stderr_module.os, "dup", lambda fd: 12)
         monkeypatch.setattr(native_stderr_module.os, "dup2", fake_dup2)
         monkeypatch.setattr(native_stderr_module.os, "close", lambda fd: closed.append(fd))
-        monkeypatch.setattr(native_stderr_module.threading, "Thread", FakeThread)
         monkeypatch.setattr(
             native_stderr_module,
             "_set_win32_std_handle_to_current_fd",
@@ -360,48 +361,7 @@ class TestSuppressNativeWarnings:
             pass
 
         assert 2 in closed
-        assert join_timeouts == [native_stderr_module._NATIVE_READER_JOIN_TIMEOUT_SECONDS]
-
-    def test_reader_owned_old_fd_stays_open_when_reader_outlives_join(self, monkeypatch):
-        monkeypatch.delenv("WINMLCLI_SHOW_ALL_WARNINGS", raising=False)
-        logging.getLogger().setLevel(logging.WARNING)
-        closed: list[int] = []
-        join_timeouts: list[float | None] = []
-
-        class FakeThread:
-            def __init__(self, *args: object, **kwargs: object) -> None:
-                pass
-
-            def start(self) -> None:
-                pass
-
-            def join(self, timeout: float | None = None) -> None:
-                join_timeouts.append(timeout)
-
-            def is_alive(self) -> bool:
-                return True
-
-        monkeypatch.setattr(native_stderr_module.os, "pipe", lambda: (10, 11))
-        monkeypatch.setattr(native_stderr_module.os, "dup", lambda fd: 12)
-        monkeypatch.setattr(native_stderr_module.os, "dup2", lambda src, dst: None)
-        monkeypatch.setattr(native_stderr_module.os, "close", lambda fd: closed.append(fd))
-        monkeypatch.setattr(native_stderr_module.threading, "Thread", FakeThread)
-        monkeypatch.setattr(
-            native_stderr_module,
-            "_set_win32_std_handle_to_current_fd",
-            lambda fd: None,
-        )
-        monkeypatch.setattr(
-            native_stderr_module,
-            "_refresh_click_windows_console_stream",
-            lambda fd, handle=None: None,
-        )
-
-        with native_stderr_module.suppress_native_warnings(enabled=True):
-            pass
-
-        assert join_timeouts == [native_stderr_module._NATIVE_READER_JOIN_TIMEOUT_SECONDS]
-        assert 12 not in closed
+        assert 12 in closed
 
     @pytest.mark.skipif(sys.platform != "win32", reason="Win32 only")
     def test_win32_std_handle_sync_failure_does_not_abort_wrapped_code(self, monkeypatch):


### PR DESCRIPTION
## Summary
- Normalize PathLike model references before telemetry string scrubbing.
- Prevent successful commands using local model paths from exiting with a Path.replace TypeError during telemetry reporting.
- Add regression coverage for Click options parsed with path_type=Path.

## Validation
- uv run pytest tests/unit/telemetry/test_click_group.py tests/unit/telemetry/test_utils_scrubbing.py -q (63 passed)
- uv run ruff check --fix src/winml/modelkit/telemetry/utils.py tests/unit/telemetry/test_click_group.py