### PR TITLE
Fix telemetry handling for local model paths

### DIFF
--- a/src/winml/modelkit/telemetry/utils.py
+++ b/src/winml/modelkit/telemetry/utils.py
@@ -171,7 +171,9 @@ def _model_ref_local_marker(value: str) -> str:
     return f"<local:{ext}>" if ext else "<local:dir>"
 
 
-def _scrub_model_ref(value: str | tuple[str, ...] | None) -> str | None:
+def _scrub_model_ref(
+    value: str | os.PathLike[str] | tuple[str | os.PathLike[str], ...] | None,
+) -> str | None:
     """Classify a ``-m/--model`` reference for telemetry.
 
     Clean HuggingFace Hub ids — one or two Hub-charset segments with at most
@@ -185,6 +187,7 @@ def _scrub_model_ref(value: str | tuple[str, ...] | None) -> str | None:
         value = value[0] if value else None
     if not value:
         return None
+    value = os.fspath(value)
     normalized = value.replace("\\", "/")
     if re.match(r"^[A-Za-z]:[\\/]", value) or normalized.startswith("/"):
         return _model_ref_local_marker(value)

--- a/tests/unit/telemetry/test_click_group.py
+++ b/tests/unit/telemetry/test_click_group.py
@@ -6,6 +6,7 @@
 """Tests for ``ActionGroup`` — the Click ``Group`` subclass that
 auto-instruments every registered subcommand with WinML CLI telemetry."""
 
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import click
@@ -291,6 +292,29 @@ def test_action_records_scrubbed_model_id(enabled_telemetry, model_arg, expected
     runner.invoke(cli, ["perf", "-m", model_arg])
     action_record = mock_logger.emit.call_args_list[1].args[0]
     assert dict(action_record.attributes)["model_id"] == expected_model_id
+
+
+def test_action_accepts_path_typed_model(enabled_telemetry, tmp_path):
+    @click.group(cls=ActionGroup)
+    def cli():
+        pass
+
+    @cli.command()
+    @click.option("-m", "--model", type=click.Path(exists=True, path_type=Path))
+    def analyze(model):
+        (tmp_path / "analysis.json").write_text("{}")
+
+    model_path = tmp_path / "model.onnx"
+    model_path.write_bytes(b"")
+    telemetry = Telemetry.get_or_init()
+    mock_logger = _with_mock_logger(telemetry)
+
+    result = CliRunner().invoke(cli, ["analyze", "-m", str(model_path)])
+
+    assert (tmp_path / "analysis.json").exists()
+    assert result.exit_code == 0
+    action_record = mock_logger.emit.call_args_list[1].args[0]
+    assert dict(action_record.attributes)["model_id"] == "<local:.onnx>"
 
 
 def test_action_prefers_model_id_param(enabled_telemetry):


### PR DESCRIPTION
## Summary
- Normalize PathLike model references before telemetry string scrubbing.
- Prevent successful commands using local model paths from exiting with a Path.replace TypeError during telemetry reporting.
- Add regression coverage for Click options parsed with path_type=Path.
- Cherry-picked as a single focused commit onto release/v0.3.0.

## Validation
- uv run pytest tests/unit/telemetry/test_click_group.py tests/unit/telemetry/test_utils_scrubbing.py -q (63 passed)
- uv run ruff check src/winml/modelkit/telemetry/utils.py tests/unit/telemetry/test_click_group.py