### PR TITLE
Add schema-normalized LLM evaluation runner

### DIFF
--- a/scripts/e2e_eval/README.md
+++ b/scripts/e2e_eval/README.md
@@ -126,6 +126,34 @@ uv run python scripts/e2e_eval/run_eval.py --update-baseline --eval-type accurac
 | `--retry-failed [TYPE ...]` | — | Re-run failed jobs (implies `--continue`) |
 | `--build-only` | off | Build with `--no-compile`, writing each stage's ONNX (no EP needed). Loops the EP matrix when `--ep`/`--device` omitted |
 
+### `run_llm_eval.py` — Run GenAI Context Sweep
+
+Runs an existing ONNX Runtime GenAI bundle through `winml perf --runtime
+winml-genai` at one or more prompt lengths. The runner enables the EPContext
+pre-compilation required by accelerator-backed GenAI stages and generation-window
+hardware monitoring, preserves each raw perf report as `perf_ctx<tokens>.json`, and
+writes a schema-validated `llm_eval_result.json` containing TTFT, decode and prefill
+throughput, total generation time, accelerator utilization, device memory, and
+process CPU/RAM metrics. Use `--compile-timeout` to adjust the per-stage compilation
+limit for larger bundles; compiled stages are cached under the bundle's `_compiled/`
+directory and reused by later runs.
+
+```bash
+uv run python scripts/e2e_eval/run_llm_eval.py \
+  -m out/qwen3-bundle \
+  --model-id Qwen/Qwen3-1.7B \
+  --output-dir eval_results/qwen3-npu \
+  --device npu \
+  --ep qnn \
+  --quantization w8a16 \
+  --context-lengths 256 512 1024
+```
+
+The input directory must contain `genai_config.json` and the bundle tokenizer.
+The result is validated against `schemas/llm_eval_result.schema.json` before it
+is written. If no context point completes, the runner writes
+`llm_eval_failure.json` instead of an invalid empty sweep.
+
 
 #### `--build-only` — Generate per-stage models (no EP required)
 
@@ -344,7 +372,10 @@ per precision variant; fallback (no recipe) runs omit the `__<precision>` suffix
 scripts/e2e_eval/
 ├── build_registry.py          # Step 1: Generate models_all.json
 ├── run_eval.py                # Step 2: Recipe-driven perf + accuracy runner
+├── run_llm_eval.py            # GenAI context-sweep runner
 ├── run_pytorch_baseline.py    # Offline PyTorch baseline (feeds baseline_cache.json)
+├── schemas/
+│   └── llm_eval_result.schema.json
 ├── testsets/
 │   ├── models_all.json        # Full model registry (generated)
 │   ├── models_with_acc.json   # Models with accuracy dataset configs

--- a/scripts/e2e_eval/run_llm_eval.py
+++ b/scripts/e2e_eval/run_llm_eval.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import json
+import math
 import os
 import platform
 import statistics
@@ -50,7 +51,7 @@ def _tail(text: str | None, limit: int = 4000) -> str:
 
 def _write_json(path: Path, data: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    path.write_text(json.dumps(data, indent=2, allow_nan=False), encoding="utf-8")
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -158,6 +159,10 @@ class _ProcessTreeGuard:
             error = ctypes.get_last_error()
             kernel32.CloseHandle(job)
             raise ctypes.WinError(error)
+        status = ctypes.WinDLL("ntdll").NtResumeProcess(process_handle)
+        if status != 0:
+            kernel32.CloseHandle(job)
+            raise OSError(f"NtResumeProcess failed with NTSTATUS 0x{status & 0xFFFFFFFF:08X}")
         return int(job)
 
     def terminate(self) -> None:
@@ -203,7 +208,7 @@ def _run_process(args: list[str], *, timeout: int) -> ProcessResult:
         "env": env,
     }
     if platform.system() == "Windows":
-        kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
+        kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW | 0x00000004  # CREATE_SUSPENDED
     else:
         kwargs["start_new_session"] = True
 
@@ -376,6 +381,7 @@ def _context_point(
     expected_info = {
         "runtime": "winml-genai",
         "device": expected_device,
+        "effective_device": expected_device,
         "compile": True,
         "iterations": expected_iterations,
         "warmup": expected_warmup,
@@ -619,7 +625,9 @@ def main(argv: list[str] | None = None) -> int:
         raise ValueError("--timeout must be positive")
     if args.compile_timeout <= 0:
         raise ValueError("--compile-timeout must be positive")
-    if args.gpu_memory_gb is not None and args.gpu_memory_gb <= 0:
+    if args.gpu_memory_gb is not None and (
+        not math.isfinite(args.gpu_memory_gb) or args.gpu_memory_gb <= 0
+    ):
         raise ValueError("--gpu-memory-gb must be positive")
 
     bundle_dir = args.model.resolve()

--- a/scripts/e2e_eval/run_llm_eval.py
+++ b/scripts/e2e_eval/run_llm_eval.py
@@ -40,6 +40,54 @@ WINML_CLI = [sys.executable, "-m", "winml.modelkit.cli"]
 SCHEMA_PATH = Path(__file__).resolve().parent / "schemas" / "llm_eval_result.schema.json"
 
 
+class _OutputDirectoryLock:
+    """Prevent concurrent runners from sharing mutable result artifacts."""
+
+    def __init__(self, output_dir: Path) -> None:
+        self._output_dir = output_dir
+        self._path = output_dir / ".llm_eval.lock"
+        self._fd: int | None = None
+
+    def __enter__(self) -> _OutputDirectoryLock:
+        fd = os.open(self._path, os.O_RDWR | os.O_CREAT, 0o600)
+        try:
+            if os.fstat(fd).st_size == 0:
+                os.write(fd, b"\0")
+            os.lseek(fd, 0, os.SEEK_SET)
+            if platform.system() == "Windows":
+                import msvcrt
+
+                msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            os.close(fd)
+            raise RuntimeError(
+                f"Output directory is already in use: {self._output_dir}"
+            ) from exc
+        self._fd = fd
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        if self._fd is None:
+            return
+        try:
+            if platform.system() == "Windows":
+                import msvcrt
+
+                os.lseek(self._fd, 0, os.SEEK_SET)
+                msvcrt.locking(self._fd, msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(self._fd, fcntl.LOCK_UN)
+        finally:
+            os.close(self._fd)
+            self._fd = None
+
+
 def _utc_now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -369,6 +417,7 @@ def _context_point(
     target_tokens: int,
     report: dict[str, Any],
     *,
+    expected_bundle_dir: Path,
     expected_device: str,
     expected_ep: str | None,
     expected_max_new_tokens: int,
@@ -378,6 +427,14 @@ def _context_point(
     total_vram_mb: float,
 ) -> dict[str, Any]:
     info = report.get("benchmark_info") or {}
+    reported_bundle_dir = info.get("bundle_dir")
+    if not isinstance(reported_bundle_dir, str) or (
+        Path(reported_bundle_dir).resolve() != expected_bundle_dir.resolve()
+    ):
+        raise ValueError(
+            f"Expected benchmark_info.bundle_dir={str(expected_bundle_dir)!r}, "
+            f"got {reported_bundle_dir!r}"
+        )
     expected_info = {
         "runtime": "winml-genai",
         "device": expected_device,
@@ -632,6 +689,11 @@ def main(argv: list[str] | None = None) -> int:
 
     output_dir = args.output_dir.resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
+    with _OutputDirectoryLock(output_dir):
+        return _run(args, output_dir)
+
+
+def _run(args: argparse.Namespace, output_dir: Path) -> int:
     (output_dir / RESULT_FILENAME).unlink(missing_ok=True)
     (output_dir / FAILURE_FILENAME).unlink(missing_ok=True)
     bundle_dir = args.model.resolve()
@@ -679,6 +741,7 @@ def main(argv: list[str] | None = None) -> int:
             point = _context_point(
                 context_length,
                 report,
+                expected_bundle_dir=bundle_dir,
                 expected_device=args.device,
                 expected_ep=args.ep,
                 expected_max_new_tokens=args.max_new_tokens,

--- a/scripts/e2e_eval/run_llm_eval.py
+++ b/scripts/e2e_eval/run_llm_eval.py
@@ -1,3 +1,8 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
 """Run a schema-normalized ONNX Runtime GenAI context sweep.
 
 The runner consumes an existing GenAI bundle and invokes ``winml perf
@@ -161,7 +166,7 @@ def _perf_args(
     *,
     bundle_dir: Path,
     report_path: Path,
-    prompt: str,
+    prompt_path: Path,
     max_new_tokens: int,
     iterations: int,
     warmup: int,
@@ -178,8 +183,8 @@ def _perf_args(
         "winml-genai",
         "--device",
         device,
-        "--prompt",
-        prompt,
+        "--prompt-file",
+        str(prompt_path),
         "--no-apply-template",
         "--max-new-tokens",
         str(max_new_tokens),
@@ -308,9 +313,9 @@ def _context_point(
         local_memory_mb = float(memory_metrics.get("local_mean_mb") or 0.0)
         shared_memory_mb = float(memory_metrics.get("shared_mean_mb") or 0.0)
         device_memory_mb = local_memory_mb if local_memory_mb > 0 else shared_memory_mb
-        capacity_mb = total_vram_mb if local_memory_mb > 0 and total_vram_mb > 0 else total_ram_mb
+        capacity_mb = total_vram_mb if local_memory_mb > 0 and total_vram_mb > 0 else None
         device_memory_util_pct = (
-            device_memory_mb / capacity_mb * 100 if capacity_mb > 0 else 0.0
+            device_memory_mb / capacity_mb * 100 if capacity_mb is not None else None
         )
 
     prefill_ms = float((report.get("prefill_ms") or {}).get("mean") or 0.0)
@@ -333,7 +338,9 @@ def _context_point(
         "inter_token_latency_ms": _distribution(raw.get("tpot_ms") or []),
         "gpu_util_avg_pct": round(accelerator_util_pct, 4),
         "vram": {
-            "util_avg_pct": round(device_memory_util_pct, 4),
+            "util_avg_pct": (
+                round(device_memory_util_pct, 4) if device_memory_util_pct is not None else None
+            ),
             "used_avg_mb": round(device_memory_mb, 4),
         },
         "process_cpu_util_avg_pct": round(process_cpu_pct, 4),
@@ -348,7 +355,6 @@ def _collect_environment(gpu_memory_gb: float | None = None) -> dict[str, Any]:
     total_ram_mb = psutil.virtual_memory().total / (1024 * 1024)
     gpu_name: str | None = None
     npu_name: str | None = None
-    detected_vram_mb = 0.0
     if platform.system() == "Windows":
         with contextlib.suppress(Exception):
             from winml.modelkit.sysinfo.hardware import GPU, NPU
@@ -357,10 +363,9 @@ def _collect_environment(gpu_memory_gb: float | None = None) -> dict[str, Any]:
             npus = NPU.get_all()
             if gpus:
                 gpu_name = gpus[0].name
-                detected_vram_mb = float(gpus[0].vram_mib)
             if npus:
                 npu_name = npus[0].name
-    total_vram_mb = gpu_memory_gb * 1024 if gpu_memory_gb is not None else detected_vram_mb
+    total_vram_mb = gpu_memory_gb * 1024 if gpu_memory_gb is not None else 0.0
     hardware: dict[str, Any] = {
         "cpu_name": platform.processor() or platform.uname().processor,
         "total_vram_mb": round(total_vram_mb, 1),
@@ -500,13 +505,15 @@ def main(argv: list[str] | None = None) -> int:
     for context_length in args.context_lengths:
         print(f"Benchmarking {args.device.upper()} context={context_length} tokens")
         prompt = _make_prompt(bundle_dir, context_length, args.prompt_filler)
+        prompt_path = output_dir / f"prompt_ctx{context_length}.txt"
+        prompt_path.write_text(prompt, encoding="utf-8")
         report_path = output_dir / f"perf_ctx{context_length}.json"
         report_path.unlink(missing_ok=True)
         process = _run_process(
             _perf_args(
                 bundle_dir=bundle_dir,
                 report_path=report_path,
-                prompt=prompt,
+                prompt_path=prompt_path,
                 max_new_tokens=args.max_new_tokens,
                 iterations=args.iterations,
                 warmup=args.warmup,
@@ -549,6 +556,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if not points:
         failure_path = output_dir / FAILURE_FILENAME
+        (output_dir / RESULT_FILENAME).unlink(missing_ok=True)
         _write_json(
             failure_path,
             {
@@ -585,6 +593,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     result_path = output_dir / RESULT_FILENAME
     _validate_result(result)
+    (output_dir / FAILURE_FILENAME).unlink(missing_ok=True)
     _write_json(result_path, result)
     status = "PASS" if result["run"]["passed"] else "FAIL"
     print(f"[{status}] {result_path}")

--- a/scripts/e2e_eval/run_llm_eval.py
+++ b/scripts/e2e_eval/run_llm_eval.py
@@ -630,10 +630,12 @@ def main(argv: list[str] | None = None) -> int:
     ):
         raise ValueError("--gpu-memory-gb must be positive")
 
-    bundle_dir = args.model.resolve()
-    validate_bundle(bundle_dir)
     output_dir = args.output_dir.resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / RESULT_FILENAME).unlink(missing_ok=True)
+    (output_dir / FAILURE_FILENAME).unlink(missing_ok=True)
+    bundle_dir = args.model.resolve()
+    validate_bundle(bundle_dir)
     started_at = _utc_now()
     started = time.perf_counter()
     environment = _collect_environment(args.gpu_memory_gb)

--- a/scripts/e2e_eval/run_llm_eval.py
+++ b/scripts/e2e_eval/run_llm_eval.py
@@ -1,0 +1,595 @@
+"""Run a schema-normalized ONNX Runtime GenAI context sweep.
+
+The runner consumes an existing GenAI bundle and invokes ``winml perf
+--runtime winml-genai`` for each requested prompt length. Generation timing
+and generation-window resource metrics are normalized into one
+``llm_eval_result.json`` document.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import platform
+import statistics
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import psutil
+
+
+SCHEMA_VERSION = "1.0"
+RUNTIME = "onnxruntime-genai"
+RESULT_FILENAME = "llm_eval_result.json"
+FAILURE_FILENAME = "llm_eval_failure.json"
+DEFAULT_FILLER = "The quick brown fox jumps over the lazy dog. "
+WINML_CLI = [sys.executable, "-m", "winml.modelkit.cli"]
+SCHEMA_PATH = Path(__file__).resolve().parent / "schemas" / "llm_eval_result.schema.json"
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _tail(text: str | None, limit: int = 4000) -> str:
+    value = (text or "").strip()
+    return value if len(value) <= limit else "...(truncated)...\n" + value[-limit:]
+
+
+def _write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise TypeError(f"Expected a JSON object in {path}")
+    return data
+
+
+@dataclass
+class ProcessResult:
+    """Captured subprocess output and timing."""
+
+    args: list[str]
+    exit_code: int
+    elapsed_s: float
+    stdout: str
+    stderr: str
+    timed_out: bool
+
+    @property
+    def command(self) -> str:
+        """Return the subprocess arguments as a reproducible command line."""
+        return subprocess.list2cmdline(self.args)
+
+
+def _kill_process_tree(pid: int) -> None:
+    try:
+        root = psutil.Process(pid)
+    except psutil.Error:
+        return
+    processes = [root]
+    with contextlib.suppress(psutil.Error):
+        processes.extend(root.children(recursive=True))
+    for process in reversed(processes):
+        with contextlib.suppress(psutil.Error):
+            process.kill()
+    with contextlib.suppress(Exception):
+        psutil.wait_procs(processes, timeout=5)
+
+
+def _run_process(args: list[str], *, timeout: int) -> ProcessResult:
+    env = {**os.environ, "PYTHONIOENCODING": "utf-8", "PYTHONUTF8": "1"}
+    kwargs: dict[str, Any] = {
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "text": True,
+        "encoding": "utf-8",
+        "errors": "replace",
+        "env": env,
+    }
+    if platform.system() == "Windows":
+        kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
+    else:
+        kwargs["start_new_session"] = True
+
+    started = time.perf_counter()
+    process = subprocess.Popen(args, **kwargs)  # noqa: S603
+    timed_out = False
+    try:
+        stdout, stderr = process.communicate(timeout=timeout)
+        exit_code = process.returncode
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        _kill_process_tree(process.pid)
+        try:
+            stdout, stderr = process.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            stdout, stderr = process.communicate()
+        exit_code = -1
+    except BaseException:
+        _kill_process_tree(process.pid)
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            process.wait(timeout=5)
+        raise
+
+    return ProcessResult(
+        args=args,
+        exit_code=exit_code,
+        elapsed_s=round(time.perf_counter() - started, 2),
+        stdout=stdout,
+        stderr=stderr,
+        timed_out=timed_out,
+    )
+
+
+def validate_bundle(bundle_dir: Path) -> dict[str, Any]:
+    """Load and minimally validate an ONNX Runtime GenAI bundle."""
+    config_path = bundle_dir / "genai_config.json"
+    if not config_path.is_file():
+        raise ValueError(f"No genai_config.json found under {bundle_dir}")
+    return _load_json(config_path)
+
+
+def _make_prompt(bundle_dir: Path, target_tokens: int, filler: str) -> str:
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(str(bundle_dir), local_files_only=True)
+    repeats = max(16, target_tokens // 4)
+    token_ids: list[int] = []
+    while len(token_ids) < target_tokens:
+        token_ids = tokenizer.encode(filler * repeats, add_special_tokens=False)
+        repeats *= 2
+    return tokenizer.decode(
+        token_ids[:target_tokens],
+        skip_special_tokens=False,
+        clean_up_tokenization_spaces=False,
+    )
+
+
+def _perf_args(
+    *,
+    bundle_dir: Path,
+    report_path: Path,
+    prompt: str,
+    max_new_tokens: int,
+    iterations: int,
+    warmup: int,
+    compile_timeout: int,
+    device: str,
+    ep: str | None,
+) -> list[str]:
+    args = [
+        *WINML_CLI,
+        "perf",
+        "-m",
+        str(bundle_dir),
+        "--runtime",
+        "winml-genai",
+        "--device",
+        device,
+        "--prompt",
+        prompt,
+        "--no-apply-template",
+        "--max-new-tokens",
+        str(max_new_tokens),
+        "--iterations",
+        str(iterations),
+        "--warmup",
+        str(warmup),
+        "--compile",
+        "--compile-timeout",
+        str(compile_timeout),
+        "--monitor",
+        "--no-color",
+        "--quiet",
+        "-o",
+        str(report_path),
+        "--overwrite",
+    ]
+    if ep:
+        args.extend(["--ep", ep])
+    return args
+
+
+def _distribution(values: list[float]) -> dict[str, float] | None:
+    samples = sorted(float(value) for value in values)
+    if not samples:
+        return None
+
+    def percentile(percent: float) -> float:
+        index = min(int(len(samples) * percent / 100), len(samples) - 1)
+        return round(samples[index], 4)
+
+    return {
+        "avg": round(statistics.fmean(samples), 4),
+        "p50": percentile(50),
+        "p90": percentile(90),
+        "p95": percentile(95),
+        "p99": percentile(99),
+        "min": round(samples[0], 4),
+        "max": round(samples[-1], 4),
+        "std": round(statistics.pstdev(samples), 4) if len(samples) > 1 else 0.0,
+    }
+
+
+def _context_label(tokens: int) -> str:
+    return f"{tokens // 1000}k" if tokens >= 1000 and tokens % 1000 == 0 else str(tokens)
+
+
+def _context_point(
+    target_tokens: int,
+    report: dict[str, Any],
+    *,
+    expected_device: str,
+    expected_ep: str | None,
+    expected_max_new_tokens: int,
+    expected_iterations: int,
+    expected_warmup: int,
+    total_ram_mb: float,
+    total_vram_mb: float,
+) -> dict[str, Any]:
+    info = report.get("benchmark_info") or {}
+    expected_info = {
+        "runtime": "winml-genai",
+        "device": expected_device,
+        "compile": True,
+        "iterations": expected_iterations,
+        "warmup": expected_warmup,
+        "max_new_tokens": expected_max_new_tokens,
+        "apply_template": False,
+        "monitor": True,
+    }
+    for key, expected in expected_info.items():
+        if info.get(key) != expected:
+            raise ValueError(f"Expected benchmark_info.{key}={expected!r}, got {info.get(key)!r}")
+
+    reported_ep = str(info.get("ep") or "").lower()
+    if expected_ep:
+        normalized_ep = expected_ep.lower().removesuffix("executionprovider")
+        if reported_ep not in {expected_ep.lower(), normalized_ep}:
+            raise ValueError(f"Expected execution provider {expected_ep!r}, got {info.get('ep')!r}")
+
+    prompt_tokens = int(info.get("prompt_tokens") or 0)
+    if prompt_tokens != target_tokens:
+        raise ValueError(
+            f"Target context was {target_tokens} tokens, but perf measured {prompt_tokens}"
+        )
+    generated_tokens = int(info.get("generated_tokens") or 0)
+    if generated_tokens != expected_max_new_tokens:
+        raise ValueError(
+            f"Expected {expected_max_new_tokens} generated tokens, got {generated_tokens}"
+        )
+
+    raw = report.get("raw") or {}
+    for key in ("ttft_ms", "prefill_ms", "decode_tokens_per_sec", "tpot_ms", "total_ms"):
+        samples = raw.get(key)
+        if not isinstance(samples, list) or len(samples) != expected_iterations:
+            actual = len(samples) if isinstance(samples, list) else None
+            raise ValueError(f"Expected {expected_iterations} raw.{key} samples, got {actual}")
+
+    hw_monitor = report.get("hw_monitor")
+    if not isinstance(hw_monitor, dict):
+        raise TypeError("perf report has no hw_monitor metrics")
+    cpu_metrics = hw_monitor.get("cpu") or {}
+    ram_metrics = hw_monitor.get("ram") or {}
+    process_cpu_pct = float(cpu_metrics.get("process_mean_pct") or 0.0)
+    process_memory_mb = float(ram_metrics.get("mean_mb") or 0.0)
+    if int(cpu_metrics.get("sample_count") or 0) <= 0:
+        raise ValueError("hw_monitor collected no process CPU samples")
+    if process_memory_mb <= 0:
+        raise ValueError("hw_monitor collected no process memory samples")
+
+    if expected_device == "cpu":
+        accelerator_util_pct = 0.0
+        device_memory_mb = 0.0
+        device_memory_util_pct = 0.0
+    else:
+        device_kind = str(hw_monitor.get("device_kind") or "").lower()
+        if device_kind != expected_device:
+            raise ValueError(
+                f"Expected hw_monitor device_kind={expected_device!r}, got {device_kind!r}"
+            )
+        adapter_metrics = hw_monitor.get("adapter") or hw_monitor.get(device_kind) or {}
+        if int(adapter_metrics.get("sample_count") or 0) <= 0:
+            raise ValueError(f"hw_monitor collected no {expected_device} samples")
+        accelerator_util_pct = float(adapter_metrics.get("mean_pct") or 0.0)
+        memory_metrics = hw_monitor.get("device_memory") or {}
+        local_memory_mb = float(memory_metrics.get("local_mean_mb") or 0.0)
+        shared_memory_mb = float(memory_metrics.get("shared_mean_mb") or 0.0)
+        device_memory_mb = local_memory_mb if local_memory_mb > 0 else shared_memory_mb
+        capacity_mb = total_vram_mb if local_memory_mb > 0 and total_vram_mb > 0 else total_ram_mb
+        device_memory_util_pct = (
+            device_memory_mb / capacity_mb * 100 if capacity_mb > 0 else 0.0
+        )
+
+    prefill_ms = float((report.get("prefill_ms") or {}).get("mean") or 0.0)
+    return {
+        "context_length_tokens": target_tokens,
+        "context_length_label": _context_label(target_tokens),
+        "prompt_tokens": prompt_tokens,
+        "generated_tokens": generated_tokens,
+        "tokens_per_second": round(
+            float((report.get("decode") or {}).get("tokens_per_sec") or 0.0), 4
+        ),
+        "prefill_tokens_per_second": (
+            round(prompt_tokens / (prefill_ms / 1000.0), 4) if prefill_ms > 0 else None
+        ),
+        "total_elapsed_s": round(
+            float((report.get("total_generation_ms") or {}).get("mean") or 0.0) / 1000,
+            4,
+        ),
+        "ttft_s": round(float((report.get("ttft_ms") or {}).get("mean") or 0.0) / 1000, 4),
+        "inter_token_latency_ms": _distribution(raw.get("tpot_ms") or []),
+        "gpu_util_avg_pct": round(accelerator_util_pct, 4),
+        "vram": {
+            "util_avg_pct": round(device_memory_util_pct, 4),
+            "used_avg_mb": round(device_memory_mb, 4),
+        },
+        "process_cpu_util_avg_pct": round(process_cpu_pct, 4),
+        "process_mem": {
+            "util_avg_pct": round(process_memory_mb / total_ram_mb * 100, 4),
+            "used_avg_mb": round(process_memory_mb, 4),
+        },
+    }
+
+
+def _collect_environment(gpu_memory_gb: float | None = None) -> dict[str, Any]:
+    total_ram_mb = psutil.virtual_memory().total / (1024 * 1024)
+    gpu_name: str | None = None
+    npu_name: str | None = None
+    detected_vram_mb = 0.0
+    if platform.system() == "Windows":
+        with contextlib.suppress(Exception):
+            from winml.modelkit.sysinfo.hardware import GPU, NPU
+
+            gpus = GPU.get_all()
+            npus = NPU.get_all()
+            if gpus:
+                gpu_name = gpus[0].name
+                detected_vram_mb = float(gpus[0].vram_mib)
+            if npus:
+                npu_name = npus[0].name
+    total_vram_mb = gpu_memory_gb * 1024 if gpu_memory_gb is not None else detected_vram_mb
+    hardware: dict[str, Any] = {
+        "cpu_name": platform.processor() or platform.uname().processor,
+        "total_vram_mb": round(total_vram_mb, 1),
+        "total_ram_mb": round(total_ram_mb, 1),
+        "cpu_logical_cores": psutil.cpu_count(logical=True),
+    }
+    if gpu_name:
+        hardware["gpu_name"] = gpu_name
+    if npu_name:
+        hardware["npu_name"] = npu_name
+    return {
+        "os": platform.system().lower(),
+        "hardware": hardware,
+        "total_ram_mb": round(total_ram_mb, 1),
+        "total_vram_mb": round(total_vram_mb, 1),
+        "gpu_memory_gb": round(total_vram_mb / 1024, 4) if total_vram_mb > 0 else None,
+    }
+
+
+def build_result(
+    *,
+    model: str,
+    model_type: str | None,
+    task: str,
+    quantization: str | None,
+    device: str,
+    ep: str | None,
+    group: str | None,
+    priority: str | None,
+    machine_label: str | None,
+    started_at: str,
+    elapsed_s: float,
+    points: list[dict[str, Any]],
+    errors: list[str],
+    environment: dict[str, Any],
+    command: str | None,
+    timed_out: bool,
+) -> dict[str, Any]:
+    passed = not errors
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "model": model,
+        "model_type": model_type,
+        "task": task,
+        "runtime": RUNTIME,
+        "quantization": quantization,
+        "device": device,
+        "ep": ep,
+        "os": environment["os"],
+        "gpu_memory_gb": environment["gpu_memory_gb"],
+        "machine_label": machine_label,
+        "hardware": environment["hardware"],
+        "group": group,
+        "priority": priority,
+        "eval_types_run": ["perf"],
+        "run_timestamp": started_at,
+        "run": {
+            "passed": passed,
+            "elapsed_s": round(elapsed_s, 2),
+            "exit_code": 0 if passed else 1,
+            "timeout": timed_out,
+            "error": "\n".join(errors) if errors else None,
+            "command": command,
+        },
+        "context_sweep": points,
+    }
+
+
+def _validate_result(result: dict[str, Any]) -> None:
+    from jsonschema import Draft202012Validator, FormatChecker
+
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    Draft202012Validator(schema, format_checker=FormatChecker()).validate(result)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-m", "--model", type=Path, required=True, help="Existing GenAI bundle.")
+    parser.add_argument("--model-id", help="Model identifier recorded in the result.")
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--quantization", help="Artifact quantization label, e.g. w8a16 or fp16.")
+    parser.add_argument("--model-type", default="llm")
+    parser.add_argument("--task", default="text-generation")
+    parser.add_argument("--device", choices=["cpu", "gpu", "npu"], default="npu")
+    parser.add_argument("--ep", help="Execution provider passed to winml perf, e.g. qnn.")
+    parser.add_argument("--group")
+    parser.add_argument("--priority")
+    parser.add_argument("--machine-label")
+    parser.add_argument(
+        "--gpu-memory-gb",
+        type=float,
+        help="Override dedicated GPU memory capacity used for VRAM percentage.",
+    )
+    parser.add_argument("--context-lengths", nargs="+", type=int, default=[256, 512, 1024])
+    parser.add_argument("--max-new-tokens", type=int, default=128)
+    parser.add_argument("--iterations", type=int, default=3)
+    parser.add_argument("--warmup", type=int, default=1)
+    parser.add_argument(
+        "--compile-timeout",
+        type=int,
+        default=1800,
+        help="Maximum seconds to compile each EPContext stage.",
+    )
+    parser.add_argument("--timeout", type=int, default=7200)
+    parser.add_argument("--prompt-filler", default=DEFAULT_FILLER)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if any(length <= 0 for length in args.context_lengths):
+        raise ValueError("--context-lengths values must be positive")
+    if args.iterations <= 0 or args.warmup < 0 or args.max_new_tokens <= 0:
+        raise ValueError("iterations and max-new-tokens must be positive; warmup must be >= 0")
+    if args.timeout <= 0:
+        raise ValueError("--timeout must be positive")
+    if args.compile_timeout <= 0:
+        raise ValueError("--compile-timeout must be positive")
+    if args.gpu_memory_gb is not None and args.gpu_memory_gb <= 0:
+        raise ValueError("--gpu-memory-gb must be positive")
+
+    bundle_dir = args.model.resolve()
+    validate_bundle(bundle_dir)
+    output_dir = args.output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    started_at = _utc_now()
+    started = time.perf_counter()
+    environment = _collect_environment(args.gpu_memory_gb)
+    total_ram_mb = float(environment["total_ram_mb"])
+    total_vram_mb = float(environment["total_vram_mb"])
+    points: list[dict[str, Any]] = []
+    errors: list[str] = []
+    commands: list[str] = []
+    reported_eps: set[str] = set()
+    any_timeout = False
+
+    for context_length in args.context_lengths:
+        print(f"Benchmarking {args.device.upper()} context={context_length} tokens")
+        prompt = _make_prompt(bundle_dir, context_length, args.prompt_filler)
+        report_path = output_dir / f"perf_ctx{context_length}.json"
+        report_path.unlink(missing_ok=True)
+        process = _run_process(
+            _perf_args(
+                bundle_dir=bundle_dir,
+                report_path=report_path,
+                prompt=prompt,
+                max_new_tokens=args.max_new_tokens,
+                iterations=args.iterations,
+                warmup=args.warmup,
+                compile_timeout=args.compile_timeout,
+                device=args.device,
+                ep=args.ep,
+            ),
+            timeout=args.timeout,
+        )
+        commands.append(process.command)
+        any_timeout = any_timeout or process.timed_out
+        if process.exit_code != 0 or not report_path.is_file():
+            reason = "timeout" if process.timed_out else f"exit {process.exit_code}"
+            errors.append(f"context {context_length}: perf {reason}: {_tail(process.stderr)}")
+            continue
+        try:
+            report = _load_json(report_path)
+            point = _context_point(
+                context_length,
+                report,
+                expected_device=args.device,
+                expected_ep=args.ep,
+                expected_max_new_tokens=args.max_new_tokens,
+                expected_iterations=args.iterations,
+                expected_warmup=args.warmup,
+                total_ram_mb=total_ram_mb,
+                total_vram_mb=total_vram_mb,
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            errors.append(f"context {context_length}: invalid perf report: {exc}")
+            continue
+        reported_ep = str((report.get("benchmark_info") or {}).get("ep") or "").lower()
+        if reported_ep and reported_ep != "config":
+            reported_eps.add(reported_ep)
+        points.append(point)
+        print(
+            f"  decode={point['tokens_per_second']:.2f} tok/s "
+            f"ttft={point['ttft_s']:.3f}s total={point['total_elapsed_s']:.3f}s"
+        )
+
+    if not points:
+        failure_path = output_dir / FAILURE_FILENAME
+        _write_json(
+            failure_path,
+            {
+                "model": args.model_id or bundle_dir.name,
+                "device": args.device,
+                "ep": args.ep,
+                "errors": errors or ["No context points completed"],
+                "run_timestamp": started_at,
+            },
+        )
+        print(f"[FAIL] {failure_path}")
+        return 1
+
+    effective_ep = args.ep
+    if effective_ep is None and len(reported_eps) == 1:
+        effective_ep = next(iter(reported_eps))
+    result = build_result(
+        model=args.model_id or bundle_dir.name,
+        model_type=args.model_type,
+        task=args.task,
+        quantization=args.quantization,
+        device=args.device,
+        ep=effective_ep,
+        group=args.group,
+        priority=args.priority,
+        machine_label=args.machine_label,
+        started_at=started_at,
+        elapsed_s=time.perf_counter() - started,
+        points=points,
+        errors=errors,
+        environment=environment,
+        command=" && ".join(commands) if commands else None,
+        timed_out=any_timeout,
+    )
+    result_path = output_dir / RESULT_FILENAME
+    _validate_result(result)
+    _write_json(result_path, result)
+    status = "PASS" if result["run"]["passed"] else "FAIL"
+    print(f"[{status}] {result_path}")
+    return 0 if result["run"]["passed"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/e2e_eval/run_llm_eval.py
+++ b/scripts/e2e_eval/run_llm_eval.py
@@ -209,7 +209,18 @@ def _run_process(args: list[str], *, timeout: int) -> ProcessResult:
 
     started = time.perf_counter()
     process = subprocess.Popen(args, **kwargs)  # noqa: S603
-    tree = _ProcessTreeGuard(process)
+    try:
+        tree = _ProcessTreeGuard(process)
+    except Exception:
+        _kill_process_tree(process.pid)
+        try:
+            process.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            for pipe in (process.stdout, process.stderr):
+                if pipe is not None:
+                    with contextlib.suppress(OSError):
+                        pipe.close()
+        raise
     timed_out = False
     try:
         stdout, stderr = process.communicate(timeout=timeout)
@@ -415,12 +426,16 @@ def _context_point(
     if process_memory_mb <= 0:
         raise ValueError("hw_monitor collected no process memory samples")
 
+    device_kind = str(hw_monitor.get("device_kind") or "").lower()
     if expected_device == "cpu":
+        if device_kind not in ("", "cpu"):
+            raise ValueError(
+                f"Expected CPU-only monitoring, got device_kind={device_kind!r}"
+            )
         accelerator_util_pct = 0.0
         device_memory_mb = 0.0
         device_memory_util_pct = 0.0
     else:
-        device_kind = str(hw_monitor.get("device_kind") or "").lower()
         if device_kind != expected_device:
             raise ValueError(
                 f"Expected hw_monitor device_kind={expected_device!r}, got {device_kind!r}"

--- a/scripts/e2e_eval/run_llm_eval.py
+++ b/scripts/e2e_eval/run_llm_eval.py
@@ -92,6 +92,106 @@ def _kill_process_tree(pid: int) -> None:
         psutil.wait_procs(processes, timeout=5)
 
 
+class _ProcessTreeGuard:
+    """Own a subprocess tree through a Windows Job Object or POSIX process group."""
+
+    def __init__(self, process: subprocess.Popen) -> None:
+        self._process = process
+        self._job: int | None = None
+        if platform.system() == "Windows":
+            self._job = self._create_windows_job(process)
+
+    @staticmethod
+    def _create_windows_job(process: subprocess.Popen) -> int:
+        import ctypes
+        import ctypes.wintypes as wintypes
+
+        class _IoCounters(ctypes.Structure):
+            _fields_ = [(name, ctypes.c_uint64) for name in (
+                "ReadOperationCount",
+                "WriteOperationCount",
+                "OtherOperationCount",
+                "ReadTransferCount",
+                "WriteTransferCount",
+                "OtherTransferCount",
+            )]
+
+        class _BasicLimitInformation(ctypes.Structure):
+            _fields_ = [
+                ("PerProcessUserTimeLimit", ctypes.c_int64),
+                ("PerJobUserTimeLimit", ctypes.c_int64),
+                ("LimitFlags", wintypes.DWORD),
+                ("MinimumWorkingSetSize", ctypes.c_size_t),
+                ("MaximumWorkingSetSize", ctypes.c_size_t),
+                ("ActiveProcessLimit", wintypes.DWORD),
+                ("Affinity", ctypes.c_size_t),
+                ("PriorityClass", wintypes.DWORD),
+                ("SchedulingClass", wintypes.DWORD),
+            ]
+
+        class _ExtendedLimitInformation(ctypes.Structure):
+            _fields_ = [
+                ("BasicLimitInformation", _BasicLimitInformation),
+                ("IoInfo", _IoCounters),
+                ("ProcessMemoryLimit", ctypes.c_size_t),
+                ("JobMemoryLimit", ctypes.c_size_t),
+                ("PeakProcessMemoryUsed", ctypes.c_size_t),
+                ("PeakJobMemoryUsed", ctypes.c_size_t),
+            ]
+
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.CreateJobObjectW.restype = wintypes.HANDLE
+        job = kernel32.CreateJobObjectW(None, None)
+        if not job:
+            raise ctypes.WinError(ctypes.get_last_error())
+
+        info = _ExtendedLimitInformation()
+        info.BasicLimitInformation.LimitFlags = 0x00002000  # KILL_ON_JOB_CLOSE
+        if not kernel32.SetInformationJobObject(
+            job, 9, ctypes.byref(info), ctypes.sizeof(info)
+        ):
+            error = ctypes.get_last_error()
+            kernel32.CloseHandle(job)
+            raise ctypes.WinError(error)
+        process_handle = wintypes.HANDLE(process._handle)
+        if not kernel32.AssignProcessToJobObject(job, process_handle):
+            error = ctypes.get_last_error()
+            kernel32.CloseHandle(job)
+            raise ctypes.WinError(error)
+        return int(job)
+
+    def terminate(self) -> None:
+        if self._job is not None:
+            import ctypes
+            import ctypes.wintypes as wintypes
+
+            kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+            kernel32.TerminateJobObject(wintypes.HANDLE(self._job), 1)
+            return
+        if platform.system() != "Windows":
+            import signal
+
+            with contextlib.suppress(ProcessLookupError):
+                os.killpg(self._process.pid, signal.SIGKILL)
+            return
+        _kill_process_tree(self._process.pid)
+
+    def close(self) -> None:
+        if self._job is None:
+            return
+        import ctypes
+        import ctypes.wintypes as wintypes
+
+        ctypes.WinDLL("kernel32", use_last_error=True).CloseHandle(wintypes.HANDLE(self._job))
+        self._job = None
+
+
+def _timeout_output(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    return value.decode("utf-8", errors="replace") if isinstance(value, bytes) else value
+
+
 def _run_process(args: list[str], *, timeout: int) -> ProcessResult:
     env = {**os.environ, "PYTHONIOENCODING": "utf-8", "PYTHONUTF8": "1"}
     kwargs: dict[str, Any] = {
@@ -109,24 +209,35 @@ def _run_process(args: list[str], *, timeout: int) -> ProcessResult:
 
     started = time.perf_counter()
     process = subprocess.Popen(args, **kwargs)  # noqa: S603
+    tree = _ProcessTreeGuard(process)
     timed_out = False
     try:
         stdout, stderr = process.communicate(timeout=timeout)
         exit_code = process.returncode
-    except subprocess.TimeoutExpired:
+    except subprocess.TimeoutExpired as initial_timeout:
         timed_out = True
-        _kill_process_tree(process.pid)
+        tree.terminate()
         try:
             stdout, stderr = process.communicate(timeout=5)
-        except subprocess.TimeoutExpired:
-            process.kill()
-            stdout, stderr = process.communicate()
+        except subprocess.TimeoutExpired as drain_timeout:
+            stdout = _timeout_output(drain_timeout.output or initial_timeout.output)
+            stderr = _timeout_output(drain_timeout.stderr or initial_timeout.stderr)
+            for pipe in (process.stdout, process.stderr):
+                if pipe is not None:
+                    with contextlib.suppress(OSError):
+                        pipe.close()
+            with contextlib.suppress(OSError):
+                process.kill()
+            with contextlib.suppress(subprocess.TimeoutExpired):
+                process.wait(timeout=5)
         exit_code = -1
     except BaseException:
-        _kill_process_tree(process.pid)
+        tree.terminate()
         with contextlib.suppress(subprocess.TimeoutExpired):
             process.wait(timeout=5)
         raise
+    finally:
+        tree.close()
 
     return ProcessResult(
         args=args,
@@ -150,10 +261,16 @@ def _make_prompt(bundle_dir: Path, target_tokens: int, filler: str) -> str:
     from transformers import AutoTokenizer
 
     tokenizer = AutoTokenizer.from_pretrained(str(bundle_dir), local_files_only=True)
+    if not tokenizer.encode(filler, add_special_tokens=False):
+        raise ValueError("--prompt-filler must tokenize to at least one token")
     repeats = max(16, target_tokens // 4)
     token_ids: list[int] = []
+    previous_count = -1
     while len(token_ids) < target_tokens:
         token_ids = tokenizer.encode(filler * repeats, add_special_tokens=False)
+        if len(token_ids) <= previous_count:
+            raise ValueError("--prompt-filler token count stopped growing")
+        previous_count = len(token_ids)
         repeats *= 2
     return tokenizer.decode(
         token_ids[:target_tokens],
@@ -259,10 +376,13 @@ def _context_point(
         if info.get(key) != expected:
             raise ValueError(f"Expected benchmark_info.{key}={expected!r}, got {info.get(key)!r}")
 
-    reported_ep = str(info.get("ep") or "").lower()
+    reported_ep = str(info.get("ep") or "")
     if expected_ep:
-        normalized_ep = expected_ep.lower().removesuffix("executionprovider")
-        if reported_ep not in {expected_ep.lower(), normalized_ep}:
+        from winml.modelkit.utils.constants import normalize_ep_name
+
+        expected_canonical = normalize_ep_name(expected_ep.split("@", 1)[0])
+        reported_canonical = normalize_ep_name(reported_ep)
+        if reported_canonical != expected_canonical:
             raise ValueError(f"Expected execution provider {expected_ep!r}, got {info.get('ep')!r}")
 
     prompt_tokens = int(info.get("prompt_tokens") or 0)
@@ -271,9 +391,9 @@ def _context_point(
             f"Target context was {target_tokens} tokens, but perf measured {prompt_tokens}"
         )
     generated_tokens = int(info.get("generated_tokens") or 0)
-    if generated_tokens != expected_max_new_tokens:
+    if not 0 < generated_tokens <= expected_max_new_tokens:
         raise ValueError(
-            f"Expected {expected_max_new_tokens} generated tokens, got {generated_tokens}"
+            f"Expected 1..{expected_max_new_tokens} generated tokens, got {generated_tokens}"
         )
 
     raw = report.get("raw") or {}

--- a/scripts/e2e_eval/schemas/llm_eval_result.schema.json
+++ b/scripts/e2e_eval/schemas/llm_eval_result.schema.json
@@ -111,7 +111,7 @@
           "additionalProperties": false,
           "required": ["util_avg_pct", "used_avg_mb"],
           "properties": {
-            "util_avg_pct": { "type": "number", "minimum": 0 },
+            "util_avg_pct": { "type": ["number", "null"], "minimum": 0 },
             "used_avg_mb": { "type": "number", "minimum": 0 }
           }
         },

--- a/scripts/e2e_eval/schemas/llm_eval_result.schema.json
+++ b/scripts/e2e_eval/schemas/llm_eval_result.schema.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/gim-home/ModelKitArtifacts/main/site/e2e_model_coverage_result/llm_eval_result.schema.json",
+  "title": "LLM Evaluation Result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "model",
+    "task",
+    "runtime",
+    "device",
+    "run_timestamp",
+    "context_sweep"
+  ],
+  "properties": {
+    "schema_version": { "type": "string" },
+    "model": { "type": "string" },
+    "model_type": { "type": ["string", "null"] },
+    "task": { "type": "string" },
+    "runtime": { "type": "string" },
+    "quantization": { "type": ["string", "null"] },
+    "device": { "type": "string" },
+    "ep": { "type": ["string", "null"] },
+    "os": { "type": ["string", "null"] },
+    "gpu_memory_gb": { "type": ["number", "null"] },
+    "machine_label": { "type": ["string", "null"] },
+    "hardware": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "gpu_name": { "type": "string" },
+        "cpu_name": { "type": "string" },
+        "total_vram_mb": { "type": "number" },
+        "total_ram_mb": { "type": "number" },
+        "cpu_logical_cores": { "type": "integer" }
+      }
+    },
+    "group": { "type": ["string", "null"] },
+    "priority": { "type": ["string", "null"] },
+    "eval_types_run": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "run_timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "run": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["passed"],
+      "properties": {
+        "passed": { "type": "boolean" },
+        "elapsed_s": { "type": ["number", "null"], "minimum": 0 },
+        "exit_code": { "type": ["integer", "null"] },
+        "timeout": { "type": ["boolean", "null"] },
+        "error": { "type": ["string", "null"] },
+        "command": { "type": ["string", "null"] },
+        "stdout_output": { "type": ["string", "null"] },
+        "stderr_output": { "type": ["string", "null"] }
+      }
+    },
+    "context_sweep": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/contextPoint" }
+    }
+  },
+  "$defs": {
+    "contextPoint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "context_length_tokens",
+        "prompt_tokens",
+        "tokens_per_second",
+        "total_elapsed_s",
+        "ttft_s",
+        "gpu_util_avg_pct",
+        "vram",
+        "process_cpu_util_avg_pct",
+        "process_mem"
+      ],
+      "properties": {
+        "context_length_tokens": { "type": "integer", "minimum": 0 },
+        "context_length_label": { "type": ["string", "null"] },
+        "prompt_tokens": { "type": "integer", "minimum": 0 },
+        "generated_tokens": { "type": ["integer", "null"], "minimum": 0 },
+        "tokens_per_second": { "type": "number", "minimum": 0 },
+        "prefill_tokens_per_second": { "type": ["number", "null"], "minimum": 0 },
+        "total_elapsed_s": { "type": "number", "minimum": 0 },
+        "ttft_s": { "type": "number", "minimum": 0 },
+        "inter_token_latency_ms": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "avg": { "type": "number", "minimum": 0 },
+            "p50": { "type": "number", "minimum": 0 },
+            "p90": { "type": "number", "minimum": 0 },
+            "p95": { "type": "number", "minimum": 0 },
+            "p99": { "type": "number", "minimum": 0 },
+            "min": { "type": "number", "minimum": 0 },
+            "max": { "type": "number", "minimum": 0 },
+            "std": { "type": "number", "minimum": 0 }
+          }
+        },
+        "gpu_util_avg_pct": { "type": "number", "minimum": 0 },
+        "vram": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["util_avg_pct", "used_avg_mb"],
+          "properties": {
+            "util_avg_pct": { "type": "number", "minimum": 0 },
+            "used_avg_mb": { "type": "number", "minimum": 0 }
+          }
+        },
+        "process_cpu_util_avg_pct": { "type": "number", "minimum": 0 },
+        "process_mem": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["util_avg_pct", "used_avg_mb"],
+          "properties": {
+            "util_avg_pct": { "type": "number", "minimum": 0 },
+            "used_avg_mb": { "type": "number", "minimum": 0 }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/winml/modelkit/commands/_perf_genai.py
+++ b/src/winml/modelkit/commands/_perf_genai.py
@@ -40,6 +40,7 @@ from ..session import (
     GenaiSession,
     GenaiSessionError,
     GenerationConfig,
+    HWMonitor,
     short_ep_name,
 )
 from ..utils.constants import (
@@ -62,6 +63,7 @@ logger = logging.getLogger(__name__)
 # =============================================================================
 
 RUNTIME_TYPE = "winml-genai"
+_HW_POLL_INTERVAL_MS = 200
 
 # Built-in benchmark prompt.  Mirrored by the ``--prompt`` CLI default and the
 # ``GenaiPerfConfig.prompt`` field default (a test asserts the two stay in sync).
@@ -171,6 +173,7 @@ class GenaiPerfConfig:
     warmup: int = 2
     compile: bool = False
     compile_timeout: int = 300
+    monitor: bool = False
     context_length: int | None = None
     output_path: Path | None = None
 
@@ -232,10 +235,11 @@ class GenaiBenchmarkResult:
     raw_decode_tokens_per_sec: list[float] = field(default_factory=list)
     raw_tpot_ms: list[float] = field(default_factory=list)
     raw_total_ms: list[float] = field(default_factory=list)
+    hw_monitor: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to a JSON-serializable dictionary."""
-        return {
+        result = {
             "benchmark_info": {
                 "runtime": RUNTIME_TYPE,
                 "bundle_dir": str(self.config.bundle_dir),
@@ -243,6 +247,7 @@ class GenaiBenchmarkResult:
                 "device": self.config.device,
                 "compile": self.config.compile,
                 "compile_timeout": self.config.compile_timeout,
+                "monitor": self.config.monitor,
                 "iterations": self.config.iterations,
                 "warmup": self.config.warmup,
                 "max_new_tokens": self.config.max_new_tokens,
@@ -277,6 +282,9 @@ class GenaiBenchmarkResult:
                 "total_ms": [round(v, 3) for v in self.raw_total_ms],
             },
         }
+        if self.hw_monitor is not None:
+            result["hw_monitor"] = self.hw_monitor
+        return result
 
 
 # =============================================================================
@@ -392,8 +400,34 @@ class GenaiPerfBenchmark:
             self._config.iterations,
             self._config.max_new_tokens,
         )
-        samples = [self._time_one_generation(session, gen_config) for _ in range(total_runs)]
-        return self._aggregate(samples)
+        hw_metrics: dict[str, Any] | None = None
+        if self._config.monitor and HWMonitor.is_available():
+            monitor_device = self._monitor_device()
+            ep_name = normalize_ep_name(self._config.ep) if self._config.ep is not None else None
+            with HWMonitor(
+                poll_interval_ms=_HW_POLL_INTERVAL_MS,
+                device=monitor_device,
+                ep_name=ep_name,
+            ) as hw:
+                samples = [
+                    self._time_one_generation(session, gen_config) for _ in range(total_runs)
+                ]
+            hw_metrics = hw.to_dict()
+        else:
+            if self._config.monitor:
+                logger.warning("HWMonitor is unavailable; generation resource metrics omitted")
+            samples = [self._time_one_generation(session, gen_config) for _ in range(total_runs)]
+
+        result = self._aggregate(samples)
+        result.hw_monitor = hw_metrics
+        return result
+
+    def _monitor_device(self) -> str:
+        """Return the concrete device whose adapter counters should be sampled."""
+        device = (self._config.device or "").lower()
+        if device in ("cpu", "gpu", "npu"):
+            return device
+        return self._session_device() or "auto"
 
     def _time_one_generation(
         self,

--- a/src/winml/modelkit/commands/_perf_genai.py
+++ b/src/winml/modelkit/commands/_perf_genai.py
@@ -424,9 +424,6 @@ class GenaiPerfBenchmark:
 
     def _monitor_device(self) -> str:
         """Return the concrete device whose adapter counters should be sampled."""
-        device = (self._config.device or "").lower()
-        if device in ("cpu", "gpu", "npu"):
-            return device
         effective = getattr(self._session, "effective_device", None)
         return effective if effective in ("cpu", "gpu", "npu") else "cpu"
 

--- a/src/winml/modelkit/commands/_perf_genai.py
+++ b/src/winml/modelkit/commands/_perf_genai.py
@@ -427,7 +427,8 @@ class GenaiPerfBenchmark:
         device = (self._config.device or "").lower()
         if device in ("cpu", "gpu", "npu"):
             return device
-        return self._session_device() or "auto"
+        effective = getattr(self._session, "effective_device", None)
+        return effective if effective in ("cpu", "gpu", "npu") else "cpu"
 
     def _time_one_generation(
         self,

--- a/src/winml/modelkit/commands/_perf_genai.py
+++ b/src/winml/modelkit/commands/_perf_genai.py
@@ -207,6 +207,7 @@ class GenaiBenchmarkResult:
     # override that matched no stage).  Reported instead of the *requested* ep so
     # the report never claims an EP that never applied.
     effective_ep: str | None = None
+    effective_device: str | None = None
 
     # Time to first token (prefill + first decode), milliseconds
     ttft_mean_ms: float = 0.0
@@ -245,6 +246,7 @@ class GenaiBenchmarkResult:
                 "bundle_dir": str(self.config.bundle_dir),
                 "ep": self.effective_ep or "config",
                 "device": self.config.device,
+                "effective_device": self.effective_device,
                 "compile": self.config.compile,
                 "compile_timeout": self.config.compile_timeout,
                 "monitor": self.config.monitor,
@@ -406,7 +408,7 @@ class GenaiPerfBenchmark:
             ep_name = normalize_ep_name(self._config.ep) if self._config.ep is not None else None
             with HWMonitor(
                 poll_interval_ms=_HW_POLL_INTERVAL_MS,
-                device=monitor_device,
+                device=monitor_device or "cpu",
                 ep_name=ep_name,
             ) as hw:
                 samples = [
@@ -422,10 +424,10 @@ class GenaiPerfBenchmark:
         result.hw_monitor = hw_metrics
         return result
 
-    def _monitor_device(self) -> str:
-        """Return the concrete device whose adapter counters should be sampled."""
+    def _monitor_device(self) -> str | None:
+        """Return the proven device to monitor, or ``None`` when unresolved."""
         effective = getattr(self._session, "effective_device", None)
-        return effective if effective in ("cpu", "gpu", "npu") else "cpu"
+        return effective if effective in ("cpu", "gpu", "npu") else None
 
     def _time_one_generation(
         self,
@@ -473,6 +475,7 @@ class GenaiPerfBenchmark:
         return GenaiBenchmarkResult(
             config=self._config,
             effective_ep=getattr(self._session, "effective_ep", None),
+            effective_device=getattr(self._session, "effective_device", None),
             prompt_tokens=len(self._prompt_token_ids),
             generated_tokens=timed[0].n_tokens if timed else 0,
             context_length=self._session.context_length if self._session else None,

--- a/src/winml/modelkit/commands/_perf_genai.py
+++ b/src/winml/modelkit/commands/_perf_genai.py
@@ -405,10 +405,10 @@ class GenaiPerfBenchmark:
         hw_metrics: dict[str, Any] | None = None
         if self._config.monitor and HWMonitor.is_available():
             monitor_device = self._monitor_device()
-            ep_name = normalize_ep_name(self._config.ep) if self._config.ep is not None else None
+            ep_name = self._monitor_ep()
             with HWMonitor(
                 poll_interval_ms=_HW_POLL_INTERVAL_MS,
-                device=monitor_device or "cpu",
+                device=monitor_device if monitor_device and ep_name else "cpu",
                 ep_name=ep_name,
             ) as hw:
                 samples = [
@@ -428,6 +428,10 @@ class GenaiPerfBenchmark:
         """Return the proven device to monitor, or ``None`` when unresolved."""
         effective = getattr(self._session, "effective_device", None)
         return effective if effective in ("cpu", "gpu", "npu") else None
+
+    def _monitor_ep(self) -> EPName | None:
+        """Return the unique EP proven by loaded effective routing."""
+        return getattr(self._session, "effective_hardware_ep", None)
 
     def _time_one_generation(
         self,

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -2123,7 +2123,6 @@ _GENAI_IGNORED_FLAGS: dict[str, str] = {
     "allow_unsupported_nodes": "--allow-unsupported-nodes",
     "batch_size": "--batch-size",
     "duration": "--duration",
-    "monitor": "--monitor",
     "memory": "--memory",
     "op_tracing": "--op-tracing",
 }
@@ -2373,6 +2372,7 @@ def _run_genai_runtime(ctx: click.Context, *, console: Console, json_mode: bool)
             warmup=warmup,
             compile=not p["no_compile"],
             compile_timeout=p["compile_timeout"],
+            monitor=bool(p.get("monitor")),
             output_path=output,
         )
         run_genai_perf(config, console=console, json_mode=json_mode)

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -2368,7 +2368,7 @@ def _run_genai_runtime(ctx: click.Context, *, console: Console, json_mode: bool)
                 raise click.UsageError("--prompt and --prompt-file are mutually exclusive.")
             try:
                 prompt = prompt_file.read_text(encoding="utf-8")
-            except OSError as exc:
+            except (OSError, UnicodeError) as exc:
                 raise click.ClickException(
                     f"Could not read prompt file '{prompt_file}': {exc}"
                 ) from exc

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -2361,11 +2361,23 @@ def _run_genai_runtime(ctx: click.Context, *, console: Console, json_mode: bool)
         else:
             ep = resolve_genai_ep(device)
 
+        prompt = p["prompt"]
+        prompt_file: Path | None = p.get("prompt_file")
+        if prompt_file is not None:
+            if cli_utils.is_cli_provided(ctx, "prompt"):
+                raise click.UsageError("--prompt and --prompt-file are mutually exclusive.")
+            try:
+                prompt = prompt_file.read_text(encoding="utf-8")
+            except OSError as exc:
+                raise click.ClickException(
+                    f"Could not read prompt file '{prompt_file}': {exc}"
+                ) from exc
+
         config = GenaiPerfConfig(
             bundle_dir=bundle_dir,
             ep=ep,
             device=device,
-            prompt=p["prompt"],
+            prompt=prompt,
             apply_template=p["apply_template"],
             max_new_tokens=p["max_new_tokens"],
             iterations=iterations,
@@ -2439,6 +2451,13 @@ def _validate_duration(
     show_default=True,
     help="[winml-genai] Prompt text to generate from. By default it is wrapped in "
     "the bundle's chat template; pass --no-apply-template to benchmark it verbatim.",
+)
+@click.option(
+    "--prompt-file",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help="[winml-genai] Read the prompt from a UTF-8 text file. Mutually exclusive "
+    "with an explicit --prompt; avoids command-line length limits for long contexts.",
 )
 @click.option(
     "--apply-template/--no-apply-template",
@@ -2640,6 +2659,7 @@ def perf(
     model: str | None,
     runtime: RuntimeName,
     prompt: str,
+    prompt_file: Path | None,
     apply_template: bool,
     max_new_tokens: int,
     compile_timeout: int,

--- a/src/winml/modelkit/session/ep_device.py
+++ b/src/winml/modelkit/session/ep_device.py
@@ -356,6 +356,7 @@ class EPDeviceSpec:
     ep: EPName
     device: str
     default_provider_options: Mapping[str, str] = field(default_factory=dict)
+    provider_option_hints: Mapping[str, str] = field(default_factory=dict)
 
 
 EP_DEVICE_SPECS: Final[tuple[EPDeviceSpec, ...]] = (
@@ -379,6 +380,7 @@ EP_DEVICE_SPECS: Final[tuple[EPDeviceSpec, ...]] = (
             "htp_performance_mode": "burst",
             "htp_graph_finalization_optimization_mode": "3",
         },
+        provider_option_hints={"backend_path": "QnnHtp.dll"},
     ),
     EPDeviceSpec(ep="OpenVINOExecutionProvider", device="npu"),
     EPDeviceSpec(ep="VitisAIExecutionProvider", device="npu"),
@@ -388,8 +390,16 @@ EP_DEVICE_SPECS: Final[tuple[EPDeviceSpec, ...]] = (
     EPDeviceSpec(ep="NvTensorRTRTXExecutionProvider", device="gpu"),
     EPDeviceSpec(ep="OpenVINOExecutionProvider", device="cpu"),
     # ---- QNN secondary (Snapdragon boxes without vendor-optimal alternatives) ----
-    EPDeviceSpec(ep="QNNExecutionProvider", device="gpu"),  # TODO: measure
-    EPDeviceSpec(ep="QNNExecutionProvider", device="cpu"),
+    EPDeviceSpec(
+        ep="QNNExecutionProvider",
+        device="gpu",
+        provider_option_hints={"backend_path": "QnnGpu.dll"},
+    ),  # TODO: measure
+    EPDeviceSpec(
+        ep="QNNExecutionProvider",
+        device="cpu",
+        provider_option_hints={"backend_path": "QnnCpu.dll"},
+    ),
     # ---- Built-in fallbacks (last per registry design intent) ----
     EPDeviceSpec(ep="DmlExecutionProvider", device="gpu"),  # cross-vendor GPU fallback
     EPDeviceSpec(ep="CPUExecutionProvider", device="cpu"),  # always-available CPU fallback

--- a/src/winml/modelkit/session/genai_session.py
+++ b/src/winml/modelkit/session/genai_session.py
@@ -420,6 +420,7 @@ class GenaiSession:
         # Resolved at load() time.
         self._context_length: int | None = None
         self._effective_device: str | None = None
+        self._effective_hardware_ep: EPName | None = None
 
         # og.* handles — None until load() is called.
         self._model: Any = None
@@ -496,6 +497,7 @@ class GenaiSession:
         # bundle is visibly reported as "config" rather than silently ignored.
         self._override_effective = self._override_took_effect(effective_cfg)
         self._effective_device = self._resolve_effective_device(effective_cfg)
+        self._effective_hardware_ep = self._hardware_ep_from_config(effective_cfg)
         if self._ep_override is not None and not self._override_effective:
             logger.warning(
                 "EP override %r was requested but did not take effect (flat/empty "
@@ -560,6 +562,7 @@ class GenaiSession:
         self._tokenizer = None
         self._context_length = None
         self._effective_device = None
+        self._effective_hardware_ep = None
         logger.info("GenaiSession unloaded: bundle=%s", self._bundle_dir)
 
     def __enter__(self) -> GenaiSession:
@@ -854,6 +857,11 @@ class GenaiSession:
         accelerator when a config spans or does not identify one device.
         """
         return self._effective_device
+
+    @property
+    def effective_hardware_ep(self) -> EPName | None:
+        """Unique hardware EP in the effective config, or ``None`` if unresolved."""
+        return self._effective_hardware_ep
 
     # ------------------------------------------------------------------
     # Private helpers
@@ -1859,6 +1867,43 @@ class GenaiSession:
             supported = EP_SUPPORTED_DEVICES[self._ep_override]
             return supported[0] if len(supported) == 1 else None
         return None
+
+    @staticmethod
+    def _hardware_ep_from_config(cfg: dict[str, Any]) -> EPName | None:
+        """Return the unique non-CPU EP routed by the effective config."""
+        decoder = cfg.get("model", {}).get("decoder", {})
+        if not isinstance(decoder, dict):
+            return None
+
+        session_options: list[object] = [decoder.get("session_options")]
+        pipeline = decoder.get("pipeline", [])
+        if isinstance(pipeline, list):
+            for stage_entry in pipeline:
+                if isinstance(stage_entry, dict):
+                    session_options.extend(
+                        stage.get("session_options")
+                        for stage in stage_entry.values()
+                        if isinstance(stage, dict)
+                    )
+
+        providers: set[EPName] = set()
+        for options in session_options:
+            if not isinstance(options, dict):
+                continue
+            provider_options = options.get("provider_options", [])
+            if not isinstance(provider_options, list):
+                continue
+            for entry in provider_options:
+                if not isinstance(entry, dict):
+                    continue
+                for name in entry:
+                    canonical = normalize_ep_name(str(name))
+                    if canonical == "CPUExecutionProvider":
+                        continue
+                    if canonical not in EP_NAMES:
+                        return None
+                    providers.add(canonical)
+        return next(iter(providers)) if len(providers) == 1 else None
 
     @staticmethod
     def _device_from_config(cfg: dict[str, Any]) -> str | None:

--- a/src/winml/modelkit/session/genai_session.py
+++ b/src/winml/modelkit/session/genai_session.py
@@ -419,6 +419,7 @@ class GenaiSession:
         self._compile_timeout = compile_timeout
         # Resolved at load() time.
         self._context_length: int | None = None
+        self._effective_device: str | None = None
 
         # og.* handles — None until load() is called.
         self._model: Any = None
@@ -494,6 +495,7 @@ class GenaiSession:
         # when a requested override is a no-op so ``--ep qnn`` on a flat/all-CPU
         # bundle is visibly reported as "config" rather than silently ignored.
         self._override_effective = self._override_took_effect(effective_cfg)
+        self._effective_device = self._resolve_effective_device(effective_cfg)
         if self._ep_override is not None and not self._override_effective:
             logger.warning(
                 "EP override %r was requested but did not take effect (flat/empty "
@@ -557,6 +559,7 @@ class GenaiSession:
         self._model = None
         self._tokenizer = None
         self._context_length = None
+        self._effective_device = None
         logger.info("GenaiSession unloaded: bundle=%s", self._bundle_dir)
 
     def __enter__(self) -> GenaiSession:
@@ -840,6 +843,17 @@ class GenaiSession:
     def context_length(self) -> int | None:
         """Static KV cache length, populated after :meth:`load`."""
         return self._context_length
+
+    @property
+    def effective_device(self) -> str | None:
+        """Uniquely resolved hardware device, or ``None`` when routing is ambiguous.
+
+        An explicit effective override uses its concrete device. Otherwise the
+        value is inferred from the bundle's effective per-stage EP routing.
+        Returning ``None`` prevents monitoring from selecting an unrelated
+        accelerator when a config spans or does not identify one device.
+        """
+        return self._effective_device
 
     # ------------------------------------------------------------------
     # Private helpers
@@ -1833,6 +1847,78 @@ class GenaiSession:
                         for ep in _plugin_eps(stage_cfg.get("session_options")):
                             discovered.setdefault(ep, None)
         return tuple(discovered)
+
+    def _resolve_effective_device(self, cfg: dict[str, Any]) -> str | None:
+        """Resolve the single device targeted by the effective bundle config."""
+        if self._ep_override is not None and self._override_effective:
+            if self._ep_override == "CPUExecutionProvider":
+                return "cpu"
+            if self._device in ("npu", "gpu", "cpu"):
+                return self._device
+            supported = EP_SUPPORTED_DEVICES[self._ep_override]
+            return supported[0] if len(supported) == 1 else None
+        return self._device_from_config(cfg)
+
+    @staticmethod
+    def _device_from_config(cfg: dict[str, Any]) -> str | None:
+        """Infer one hardware device from all decoder provider options.
+
+        Providers tied to exactly one device (for example DML to GPU) resolve
+        directly. A ``device_type`` option narrows multi-device providers. Any
+        ambiguous/unknown provider or a config spanning devices returns
+        ``None``; a config with no hardware provider resolves to CPU.
+        """
+
+        def _provider_lists() -> Iterator[list]:
+            decoder = cfg.get("model", {}).get("decoder", {})
+            if not isinstance(decoder, dict):
+                return
+            session_options = decoder.get("session_options")
+            if isinstance(session_options, dict):
+                options = session_options.get("provider_options")
+                if isinstance(options, list):
+                    yield options
+            pipeline = decoder.get("pipeline", [])
+            if not isinstance(pipeline, list):
+                return
+            for stage_entry in pipeline:
+                if not isinstance(stage_entry, dict):
+                    continue
+                for stage_cfg in stage_entry.values():
+                    if not isinstance(stage_cfg, dict):
+                        continue
+                    session_options = stage_cfg.get("session_options")
+                    if isinstance(session_options, dict):
+                        options = session_options.get("provider_options")
+                        if isinstance(options, list):
+                            yield options
+
+        devices: set[str] = set()
+        for provider_options in _provider_lists():
+            for entry in provider_options:
+                if not isinstance(entry, dict):
+                    continue
+                for name, options in entry.items():
+                    canonical = normalize_ep_name(str(name))
+                    if canonical == "CPUExecutionProvider":
+                        continue
+                    if canonical not in EP_SUPPORTED_DEVICES:
+                        return None
+                    supported = EP_SUPPORTED_DEVICES[cast("EPName", canonical)]
+                    requested = (
+                        str(options.get("device_type", "")).lower()
+                        if isinstance(options, dict)
+                        else ""
+                    )
+                    if requested in supported:
+                        devices.add(requested)
+                    elif len(supported) == 1:
+                        devices.add(supported[0])
+                    else:
+                        return None
+        if not devices:
+            return "cpu"
+        return next(iter(devices)) if len(devices) == 1 else None
 
     @staticmethod
     def _bundle_uses_hardware_ep(cfg: dict[str, Any]) -> str | None:

--- a/src/winml/modelkit/session/genai_session.py
+++ b/src/winml/modelkit/session/genai_session.py
@@ -61,7 +61,7 @@ from ..utils.constants import (
     EP_SUPPORTED_DEVICES,
     normalize_ep_name,
 )
-from .ep_device import VALID_EPS, short_ep_name
+from .ep_device import EP_DEVICE_SPECS, VALID_EPS, short_ep_name
 from .ep_registry import WinMLEPRegistry
 
 
@@ -1850,14 +1850,17 @@ class GenaiSession:
 
     def _resolve_effective_device(self, cfg: dict[str, Any]) -> str | None:
         """Resolve the single device targeted by the effective bundle config."""
+        configured_device = self._device_from_config(cfg)
+        if configured_device is not None:
+            return configured_device
         if self._ep_override is not None and self._override_effective:
             if self._ep_override == "CPUExecutionProvider":
                 return "cpu"
-            if self._device in ("npu", "gpu", "cpu"):
-                return self._device
             supported = EP_SUPPORTED_DEVICES[self._ep_override]
+            if self._device in supported:
+                return self._device
             return supported[0] if len(supported) == 1 else None
-        return self._device_from_config(cfg)
+        return None
 
     @staticmethod
     def _device_from_config(cfg: dict[str, Any]) -> str | None:
@@ -1912,6 +1915,14 @@ class GenaiSession:
                     )
                     if requested in supported:
                         devices.add(requested)
+                    elif isinstance(options, dict):
+                        hinted = GenaiSession._device_from_provider_hints(canonical, options)
+                        if hinted is not None:
+                            devices.add(hinted)
+                        elif len(supported) == 1:
+                            devices.add(supported[0])
+                        else:
+                            return None
                     elif len(supported) == 1:
                         devices.add(supported[0])
                     else:
@@ -1919,6 +1930,20 @@ class GenaiSession:
         if not devices:
             return "cpu"
         return next(iter(devices)) if len(devices) == 1 else None
+
+    @staticmethod
+    def _device_from_provider_hints(ep: EPName, options: dict[str, Any]) -> str | None:
+        """Match provider options against EP/device routing hints in the catalog."""
+        matches: set[str] = set()
+        for spec in EP_DEVICE_SPECS:
+            if spec.ep != ep or not spec.provider_option_hints:
+                continue
+            if all(
+                Path(str(options.get(key, ""))).name.casefold() == expected.casefold()
+                for key, expected in spec.provider_option_hints.items()
+            ):
+                matches.add(spec.device)
+        return next(iter(matches)) if len(matches) == 1 else None
 
     @staticmethod
     def _bundle_uses_hardware_ep(cfg: dict[str, Any]) -> str | None:

--- a/src/winml/modelkit/session/genai_session.py
+++ b/src/winml/modelkit/session/genai_session.py
@@ -1904,7 +1904,7 @@ class GenaiSession:
                         continue
                     if canonical not in EP_SUPPORTED_DEVICES:
                         return None
-                    supported = EP_SUPPORTED_DEVICES[cast("EPName", canonical)]
+                    supported = EP_SUPPORTED_DEVICES[canonical]
                     requested = (
                         str(options.get("device_type", "")).lower()
                         if isinstance(options, dict)

--- a/src/winml/modelkit/session/genai_session.py
+++ b/src/winml/modelkit/session/genai_session.py
@@ -1857,8 +1857,6 @@ class GenaiSession:
             if self._ep_override == "CPUExecutionProvider":
                 return "cpu"
             supported = EP_SUPPORTED_DEVICES[self._ep_override]
-            if self._device in supported:
-                return self._device
             return supported[0] if len(supported) == 1 else None
         return None
 

--- a/src/winml/modelkit/session/monitor/_pdh.py
+++ b/src/winml/modelkit/session/monitor/_pdh.py
@@ -728,6 +728,15 @@ class PdhPoller:
         return max(valid) / (1024 * 1024)
 
     @property
+    def mean_memory_local_mb(self) -> float:
+        """Mean dedicated device memory in MB during polling period."""
+        with self._lock:
+            valid = [s for s in self._memory_local_bytes if s is not None]
+        if not valid:
+            return 0.0
+        return statistics.mean(valid) / (1024 * 1024)
+
+    @property
     def peak_memory_shared_mb(self) -> float:
         """Peak shared system memory used by device in MB during polling period."""
         with self._lock:
@@ -735,6 +744,15 @@ class PdhPoller:
         if not valid:
             return 0.0
         return max(valid) / (1024 * 1024)
+
+    @property
+    def mean_memory_shared_mb(self) -> float:
+        """Mean shared system memory used by device in MB during polling period."""
+        with self._lock:
+            valid = [s for s in self._memory_shared_bytes if s is not None]
+        if not valid:
+            return 0.0
+        return statistics.mean(valid) / (1024 * 1024)
 
     @property
     def peak_memory_mb(self) -> float:
@@ -787,6 +805,11 @@ class PdhPoller:
         return statistics.mean(valid)
 
     @property
+    def mean_process_cpu_pct(self) -> float:
+        """Mean process CPU utilization on a 0..N*100 multicore scale."""
+        return self.mean_cpu_pct * float(os.cpu_count() or 1)
+
+    @property
     def peak_cpu_pct(self) -> float:
         """Peak CPU utilization % during polling period."""
         with self._lock:
@@ -802,6 +825,15 @@ class PdhPoller:
             if not self._ram_used_bytes:
                 return 0.0
             return self._ram_used_bytes[-1] / (1024 * 1024)
+
+    @property
+    def mean_ram_used_mb(self) -> float:
+        """Mean process working-set RAM in MB during polling period."""
+        with self._lock:
+            valid = [s for s in self._ram_used_bytes if s is not None]
+        if not valid:
+            return 0.0
+        return statistics.mean(valid) / (1024 * 1024)
 
     @property
     def peak_ram_used_mb(self) -> float:

--- a/src/winml/modelkit/session/monitor/hw_monitor.py
+++ b/src/winml/modelkit/session/monitor/hw_monitor.py
@@ -129,6 +129,16 @@ class HWMonitor:
         """Peak shared system memory used by device in MB."""
         return self._pdh.peak_memory_shared_mb
 
+    @property
+    def mean_memory_local_mb(self) -> float:
+        """Mean dedicated device memory in MB."""
+        return self._pdh.mean_memory_local_mb
+
+    @property
+    def mean_memory_shared_mb(self) -> float:
+        """Mean shared system memory used by device in MB."""
+        return self._pdh.mean_memory_shared_mb
+
     # --- GPU metrics ---
 
     @property
@@ -153,6 +163,11 @@ class HWMonitor:
         """Peak CPU utilization % during monitoring period."""
         return self._pdh.peak_cpu_pct
 
+    @property
+    def mean_process_cpu_pct(self) -> float:
+        """Mean process CPU utilization on a 0..N*100 multicore scale."""
+        return self._pdh.mean_process_cpu_pct
+
     # --- RAM metrics ---
 
     @property
@@ -164,6 +179,11 @@ class HWMonitor:
     def peak_ram_used_mb(self) -> float:
         """Peak committed RAM in MB during monitoring period."""
         return self._pdh.peak_ram_used_mb
+
+    @property
+    def mean_ram_used_mb(self) -> float:
+        """Mean committed RAM in MB during monitoring period."""
+        return self._pdh.mean_ram_used_mb
 
     # --- Availability ---
 
@@ -198,10 +218,12 @@ class HWMonitor:
             "adapter_luid": self._pdh.adapter_luid,
             "cpu": {
                 "mean_pct": round(self._pdh.mean_cpu_pct, 2),
+                "process_mean_pct": round(self._pdh.mean_process_cpu_pct, 2),
                 "peak_pct": round(self._pdh.peak_cpu_pct, 2),
                 "sample_count": self._pdh.cpu_sample_count,
             },
             "ram": {
+                "mean_mb": round(self._pdh.mean_ram_used_mb, 2),
                 "used_mb": round(self._pdh.ram_used_mb, 2),
                 "peak_mb": round(self._pdh.peak_ram_used_mb, 2),
             },
@@ -212,6 +234,8 @@ class HWMonitor:
                 "luids": self._pdh.gpu_luids,
             },
             "device_memory": {
+                "local_mean_mb": round(self._pdh.mean_memory_local_mb, 2),
+                "shared_mean_mb": round(self._pdh.mean_memory_shared_mb, 2),
                 "local_peak_mb": round(self._pdh.peak_memory_local_mb, 2),
                 "shared_peak_mb": round(self._pdh.peak_memory_shared_mb, 2),
             },

--- a/src/winml/modelkit/sysinfo/pdh_adapters.py
+++ b/src/winml/modelkit/sysinfo/pdh_adapters.py
@@ -272,10 +272,10 @@ def resolve_adapter_luid(
     if kind not in ACCELERATOR_DEVICE_TYPES:
         return None
 
-    luid, ambiguous = _resolve_via_ort(kind, ep_name)
+    luid, block_fallback = _resolve_via_ort(kind, ep_name)
     if luid is not None:
         return luid
-    if ambiguous:
+    if block_fallback:
         return None
 
     # Fallback: PDH-only heuristic discovery.
@@ -287,10 +287,10 @@ def resolve_adapter_luid(
 def _resolve_via_ort(kind: str, ep_name: EPName | None) -> tuple[str | None, bool]:
     r"""Look up the adapter LUID through ORT's autoEP registry.
 
-    Returns None silently on any failure so callers can fall back. ORT-resolved
-    LUIDs are sanity-checked against :func:`enumerate_adapters` because some
-    EPs publish LUIDs that PDH doesn't expose under ``\GPU Engine`` (e.g.
-    drivers that register the adapter only for autoEP); using such a LUID
+    The second return value blocks heuristic fallback when ORT identifies
+    multiple matching adapters or its unique adapter is not monitorable via
+    PDH. ORT-resolved LUIDs are checked against :func:`enumerate_adapters`
+    because using an adapter that PDH doesn't expose under ``\GPU Engine``
     would later raise inside :func:`build_adapter_query`.
     """
     try:
@@ -308,9 +308,6 @@ def _resolve_via_ort(kind: str, ep_name: EPName | None) -> tuple[str | None, boo
     if target_type is None:
         return None, False
 
-    # Lazy PDH enumeration: only probe once, only if ORT yields a candidate.
-    # None = not yet probed; {} = enumeration failed (skip validation).
-    pdh_known: dict[str, AdapterInfo] | None = None
     candidates: set[str] = set()
 
     for ep_dev in ep_devices:
@@ -331,19 +328,6 @@ def _resolve_via_ort(kind: str, ep_name: EPName | None) -> tuple[str | None, boo
         except (TypeError, ValueError):
             logger.debug("Unparseable LUID metadata: %r", decimal_luid)
             continue
-        if pdh_known is None:
-            try:
-                pdh_known = enumerate_adapters()
-            except Exception:
-                logger.debug("enumerate_adapters() failed; skipping LUID validation", exc_info=True)
-                pdh_known = {}
-        if pdh_known and formatted not in pdh_known:
-            logger.debug(
-                "ORT-resolved %s LUID %s not in PDH enumeration; skipping",
-                kind.upper(),
-                formatted,
-            )
-            continue
         logger.debug(
             "Candidate %s LUID via ORT (ep=%s, ep_name=%s): %s",
             kind.upper(),
@@ -353,8 +337,6 @@ def _resolve_via_ort(kind: str, ep_name: EPName | None) -> tuple[str | None, boo
         )
         candidates.add(formatted)
 
-    if len(candidates) == 1:
-        return next(iter(candidates)), False
     if len(candidates) > 1:
         logger.warning(
             "Multiple %s adapters match effective EP %r; accelerator monitoring disabled",
@@ -362,4 +344,20 @@ def _resolve_via_ort(kind: str, ep_name: EPName | None) -> tuple[str | None, boo
             ep_name,
         )
         return None, True
-    return None, False
+    if not candidates:
+        return None, False
+
+    candidate = next(iter(candidates))
+    try:
+        pdh_known = enumerate_adapters()
+    except Exception:
+        logger.debug("enumerate_adapters() failed; adapter is not monitorable", exc_info=True)
+        return None, True
+    if candidate not in pdh_known:
+        logger.debug(
+            "ORT-resolved %s LUID %s not in PDH enumeration; adapter is not monitorable",
+            kind.upper(),
+            candidate,
+        )
+        return None, True
+    return candidate, False

--- a/src/winml/modelkit/sysinfo/pdh_adapters.py
+++ b/src/winml/modelkit/sysinfo/pdh_adapters.py
@@ -272,9 +272,11 @@ def resolve_adapter_luid(
     if kind not in ACCELERATOR_DEVICE_TYPES:
         return None
 
-    luid = _resolve_via_ort(kind, ep_name)
+    luid, ambiguous = _resolve_via_ort(kind, ep_name)
     if luid is not None:
         return luid
+    if ambiguous:
+        return None
 
     # Fallback: PDH-only heuristic discovery.
     if kind == "npu":
@@ -282,7 +284,7 @@ def resolve_adapter_luid(
     return discover_gpu_luid()
 
 
-def _resolve_via_ort(kind: str, ep_name: EPName | None) -> str | None:
+def _resolve_via_ort(kind: str, ep_name: EPName | None) -> tuple[str | None, bool]:
     r"""Look up the adapter LUID through ORT's autoEP registry.
 
     Returns None silently on any failure so callers can fall back. ORT-resolved
@@ -294,21 +296,22 @@ def _resolve_via_ort(kind: str, ep_name: EPName | None) -> str | None:
     try:
         import onnxruntime as ort
     except ImportError:
-        return None
+        return None, False
 
     try:
         ep_devices = ort.get_ep_devices()
     except Exception:
         logger.debug("ort.get_ep_devices() failed", exc_info=True)
-        return None
+        return None, False
 
     target_type = getattr(ort.OrtHardwareDeviceType, "NPU" if kind == "npu" else "GPU", None)
     if target_type is None:
-        return None
+        return None, False
 
     # Lazy PDH enumeration: only probe once, only if ORT yields a candidate.
     # None = not yet probed; {} = enumeration failed (skip validation).
     pdh_known: dict[str, AdapterInfo] | None = None
+    candidates: set[str] = set()
 
     for ep_dev in ep_devices:
         try:
@@ -342,12 +345,21 @@ def _resolve_via_ort(kind: str, ep_name: EPName | None) -> str | None:
             )
             continue
         logger.debug(
-            "Resolved %s LUID via ORT (ep=%s, ep_name=%s): %s",
+            "Candidate %s LUID via ORT (ep=%s, ep_name=%s): %s",
             kind.upper(),
             ep_dev.ep_name,
             ep_name,
             formatted,
         )
-        return formatted
+        candidates.add(formatted)
 
-    return None
+    if len(candidates) == 1:
+        return next(iter(candidates)), False
+    if len(candidates) > 1:
+        logger.warning(
+            "Multiple %s adapters match effective EP %r; accelerator monitoring disabled",
+            kind.upper(),
+            ep_name,
+        )
+        return None, True
+    return None, False

--- a/tests/unit/commands/test_perf_genai.py
+++ b/tests/unit/commands/test_perf_genai.py
@@ -411,6 +411,7 @@ class TestResultToDict:
         assert info["generated_tokens"] == 4
         assert info["compile"] is True
         assert info["compile_timeout"] == 120
+        assert info["monitor"] is False
         assert info["apply_template"] is True
         assert info["prompt"] == "Benchmark this exact prompt"
         assert set(d["ttft_ms"]) == {"mean", "min", "max", "p50", "p90", "p95", "p99"}
@@ -450,6 +451,47 @@ class TestResultToDict:
         info = GenaiPerfBenchmark(cfg, session=session).run().to_dict()["benchmark_info"]
         assert info["ep"] == "config"
         assert info["device"] == "npu"
+
+    def test_to_dict_includes_generation_monitor_metrics(self, monkeypatch) -> None:
+        metrics = {
+            "device_kind": "npu",
+            "npu": {"mean_pct": 42.0, "sample_count": 4},
+            "cpu": {"process_mean_pct": 250.0, "sample_count": 4},
+            "ram": {"mean_mb": 2048.0},
+        }
+
+        class FakeMonitor:
+            @classmethod
+            def is_available(cls) -> bool:
+                return True
+
+            def __init__(self, **_kwargs: object) -> None:
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args: object) -> None:
+                pass
+
+            def to_dict(self) -> dict:
+                return metrics
+
+        monkeypatch.setattr(perf_genai, "HWMonitor", FakeMonitor)
+        cfg = GenaiPerfConfig(
+            bundle_dir=Path("bundle"),
+            ep="qnn",
+            device="npu",
+            iterations=1,
+            warmup=0,
+            monitor=True,
+        )
+        session = _FakeSession([_timing(0.4, 0.6, [0.4])], effective_ep="qnn")
+
+        data = GenaiPerfBenchmark(cfg, session=session).run().to_dict()
+
+        assert data["benchmark_info"]["monitor"] is True
+        assert data["hw_monitor"] == metrics
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/commands/test_perf_genai.py
+++ b/tests/unit/commands/test_perf_genai.py
@@ -77,6 +77,7 @@ class _FakeSession:
         context_length: int = 256,
         chat_template: bool = True,
         effective_ep: str | None = None,
+        effective_device: str | None = None,
     ) -> None:
         self._timings = list(timings)
         self._i = 0
@@ -89,6 +90,7 @@ class _FakeSession:
         # None to mean "config").  Reported by the benchmark instead of the
         # requested ep so a no-op override is not falsely claimed.
         self.effective_ep = effective_ep
+        self.effective_device = effective_device
 
     def encode(self, text: str) -> list[int]:
         self.encoded_text = text
@@ -534,6 +536,16 @@ class TestSessionDevice:
         GenaiPerfBenchmark(cfg)._build_session()
         assert captured == {"ep": "openvino", "device": "npu"}
 
+    def test_monitor_uses_bundle_effective_device_for_config(self) -> None:
+        cfg = GenaiPerfConfig(bundle_dir=Path("bundle"), device="config")
+        session = _FakeSession([], effective_device="gpu")
+        assert GenaiPerfBenchmark(cfg, session=session)._monitor_device() == "gpu"
+
+    def test_monitor_uses_cpu_only_when_bundle_device_is_ambiguous(self) -> None:
+        cfg = GenaiPerfConfig(bundle_dir=Path("bundle"), device="config")
+        session = _FakeSession([], effective_device=None)
+        assert GenaiPerfBenchmark(cfg, session=session)._monitor_device() == "cpu"
+
 
 # ---------------------------------------------------------------------------
 # Reporting helpers
@@ -858,6 +870,53 @@ class TestCliDispatch:
         cfg = capture_run["config"]
         assert cfg.prompt == "hello there"
         assert cfg.max_new_tokens == 64
+
+    def test_prompt_file_is_read_as_utf8(
+        self, runner: CliRunner, tmp_path: Path, capture_run: dict
+    ) -> None:
+        bundle = _make_bundle(tmp_path)
+        prompt_file = tmp_path / "prompt.txt"
+        prompt_file.write_text("hello from a long prompt", encoding="utf-8")
+
+        result = runner.invoke(
+            perf,
+            [
+                "-m",
+                str(bundle),
+                "--runtime",
+                "winml-genai",
+                "--prompt-file",
+                str(prompt_file),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert capture_run["config"].prompt == "hello from a long prompt"
+
+    def test_prompt_and_prompt_file_are_mutually_exclusive(
+        self, runner: CliRunner, tmp_path: Path, capture_run: dict
+    ) -> None:
+        bundle = _make_bundle(tmp_path)
+        prompt_file = tmp_path / "prompt.txt"
+        prompt_file.write_text("file prompt", encoding="utf-8")
+
+        result = runner.invoke(
+            perf,
+            [
+                "-m",
+                str(bundle),
+                "--runtime",
+                "winml-genai",
+                "--prompt",
+                "argv prompt",
+                "--prompt-file",
+                str(prompt_file),
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output
+        assert "config" not in capture_run
 
     def test_default_prompt_used_when_omitted(
         self, runner: CliRunner, tmp_path: Path, capture_run: dict

--- a/tests/unit/commands/test_perf_genai.py
+++ b/tests/unit/commands/test_perf_genai.py
@@ -78,6 +78,7 @@ class _FakeSession:
         chat_template: bool = True,
         effective_ep: str | None = None,
         effective_device: str | None = None,
+        effective_hardware_ep: str | None = None,
     ) -> None:
         self._timings = list(timings)
         self._i = 0
@@ -91,6 +92,7 @@ class _FakeSession:
         # requested ep so a no-op override is not falsely claimed.
         self.effective_ep = effective_ep
         self.effective_device = effective_device
+        self.effective_hardware_ep = effective_hardware_ep
 
     def encode(self, text: str) -> list[int]:
         self.encoded_text = text
@@ -554,6 +556,54 @@ class TestSessionDevice:
         cfg = GenaiPerfConfig(bundle_dir=Path("bundle"), device="npu", ep="qnn")
         session = _FakeSession([], effective_ep=None, effective_device="cpu")
         assert GenaiPerfBenchmark(cfg, session=session)._monitor_device() == "cpu"
+
+    def test_monitor_ep_comes_from_effective_config_not_request(self) -> None:
+        cfg = GenaiPerfConfig(bundle_dir=Path("bundle"), device="gpu", ep="dml")
+        session = _FakeSession(
+            [],
+            effective_ep=None,
+            effective_device="gpu",
+            effective_hardware_ep="OpenVINOExecutionProvider",
+        )
+
+        assert (
+            GenaiPerfBenchmark(cfg, session=session)._monitor_ep()
+            == "OpenVINOExecutionProvider"
+        )
+
+    def test_accelerator_monitor_requires_unique_effective_ep(self, monkeypatch) -> None:
+        captured: dict = {}
+
+        class FakeMonitor:
+            @classmethod
+            def is_available(cls) -> bool:
+                return True
+
+            def __init__(self, **kwargs: object) -> None:
+                captured.update(kwargs)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args: object) -> None:
+                pass
+
+            def to_dict(self) -> dict:
+                return {}
+
+        monkeypatch.setattr(perf_genai, "HWMonitor", FakeMonitor)
+        cfg = GenaiPerfConfig(
+            bundle_dir=Path("bundle"), device="gpu", ep="dml", iterations=1, warmup=0, monitor=True
+        )
+        session = _FakeSession(
+            [_timing(0.4, 0.6, [0.4])],
+            effective_device="gpu",
+            effective_hardware_ep=None,
+        )
+
+        GenaiPerfBenchmark(cfg, session=session).run()
+
+        assert captured == {"poll_interval_ms": 200, "device": "cpu", "ep_name": None}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/commands/test_perf_genai.py
+++ b/tests/unit/commands/test_perf_genai.py
@@ -546,6 +546,11 @@ class TestSessionDevice:
         session = _FakeSession([], effective_device=None)
         assert GenaiPerfBenchmark(cfg, session=session)._monitor_device() == "cpu"
 
+    def test_monitor_uses_session_device_when_override_is_noop(self) -> None:
+        cfg = GenaiPerfConfig(bundle_dir=Path("bundle"), device="npu", ep="qnn")
+        session = _FakeSession([], effective_ep=None, effective_device="cpu")
+        assert GenaiPerfBenchmark(cfg, session=session)._monitor_device() == "cpu"
+
 
 # ---------------------------------------------------------------------------
 # Reporting helpers
@@ -916,6 +921,30 @@ class TestCliDispatch:
 
         assert result.exit_code != 0
         assert "mutually exclusive" in result.output
+        assert "config" not in capture_run
+
+    def test_invalid_utf8_prompt_file_is_a_click_error(
+        self, runner: CliRunner, tmp_path: Path, capture_run: dict
+    ) -> None:
+        bundle = _make_bundle(tmp_path)
+        prompt_file = tmp_path / "prompt.txt"
+        prompt_file.write_bytes(b"\xff\xfe")
+
+        result = runner.invoke(
+            perf,
+            [
+                "-m",
+                str(bundle),
+                "--runtime",
+                "winml-genai",
+                "--prompt-file",
+                str(prompt_file),
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "Could not read prompt file" in result.output
+        assert "Traceback" not in result.output
         assert "config" not in capture_run
 
     def test_default_prompt_used_when_omitted(

--- a/tests/unit/commands/test_perf_genai.py
+++ b/tests/unit/commands/test_perf_genai.py
@@ -388,7 +388,10 @@ class TestResultToDict:
             compile_timeout=120,
         )
         session = _FakeSession(
-            [_timing(0.4, 0.6, [0.4, 0.4, 0.4])], prompt_ids=[1, 2, 3], effective_ep="qnn"
+            [_timing(0.4, 0.6, [0.4, 0.4, 0.4])],
+            prompt_ids=[1, 2, 3],
+            effective_ep="qnn",
+            effective_device="npu",
         )
         bench = GenaiPerfBenchmark(cfg, session=session)
         return bench.run()
@@ -408,6 +411,7 @@ class TestResultToDict:
         assert info["runtime"] == "winml-genai"
         assert info["ep"] == "qnn"
         assert info["device"] == "npu"
+        assert info["effective_device"] == "npu"
         assert info["max_new_tokens"] == 4
         assert info["prompt_tokens"] == 3
         assert info["generated_tokens"] == 4
@@ -544,7 +548,7 @@ class TestSessionDevice:
     def test_monitor_uses_cpu_only_when_bundle_device_is_ambiguous(self) -> None:
         cfg = GenaiPerfConfig(bundle_dir=Path("bundle"), device="config")
         session = _FakeSession([], effective_device=None)
-        assert GenaiPerfBenchmark(cfg, session=session)._monitor_device() == "cpu"
+        assert GenaiPerfBenchmark(cfg, session=session)._monitor_device() is None
 
     def test_monitor_uses_session_device_when_override_is_noop(self) -> None:
         cfg = GenaiPerfConfig(bundle_dir=Path("bundle"), device="npu", ep="qnn")

--- a/tests/unit/eval/test_run_llm_eval_script.py
+++ b/tests/unit/eval/test_run_llm_eval_script.py
@@ -182,6 +182,23 @@ class TestPerfResultMapping:
                 total_vram_mb=4096.0,
             )
 
+    def test_cpu_result_rejects_gpu_monitor(self, runner) -> None:
+        report = _perf_report(device="cpu", ep="dml")
+        report["hw_monitor"]["device_kind"] = "gpu"
+
+        with pytest.raises(ValueError, match="Expected CPU-only monitoring"):
+            runner._context_point(
+                256,
+                report,
+                expected_device="cpu",
+                expected_ep="dml",
+                expected_max_new_tokens=128,
+                expected_iterations=3,
+                expected_warmup=1,
+                total_ram_mb=16384.0,
+                total_vram_mb=4096.0,
+            )
+
     def test_zero_token_prompt_filler_fails_fast(self, runner, monkeypatch, tmp_path) -> None:
         class EmptyTokenizer:
             def encode(self, _text, *, add_special_tokens=False):
@@ -343,6 +360,21 @@ class TestResultContract:
 
 
 class TestProcessLifecycle:
+    def test_guard_setup_failure_cleans_spawned_process(self, runner, monkeypatch) -> None:
+        cleaned: list[int] = []
+
+        class BrokenGuard:
+            def __init__(self, _process) -> None:
+                raise OSError("job assignment failed")
+
+        monkeypatch.setattr(runner, "_ProcessTreeGuard", BrokenGuard)
+        monkeypatch.setattr(runner, "_kill_process_tree", cleaned.append)
+
+        with pytest.raises(OSError, match="job assignment failed"):
+            runner._run_process([sys.executable, "-c", "pass"], timeout=10)
+
+        assert len(cleaned) == 1
+
     def test_timeout_kills_descendant_holding_output_pipe(self, runner) -> None:
         child_code = "import threading; threading.Event().wait(60)"
         parent_code = (

--- a/tests/unit/eval/test_run_llm_eval_script.py
+++ b/tests/unit/eval/test_run_llm_eval_script.py
@@ -359,6 +359,29 @@ class TestResultContract:
         assert not stale_result.exists()
         assert (output_dir / runner.FAILURE_FILENAME).exists()
 
+    def test_run_start_removes_stale_artifacts_before_bundle_validation(
+        self, runner, tmp_path: Path
+    ) -> None:
+        output_dir = tmp_path / "results"
+        output_dir.mkdir()
+        stale_result = output_dir / runner.RESULT_FILENAME
+        stale_failure = output_dir / runner.FAILURE_FILENAME
+        stale_result.write_text("{}", encoding="utf-8")
+        stale_failure.write_text("{}", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="genai_config"):
+            runner.main(
+                [
+                    "-m",
+                    str(tmp_path / "missing-bundle"),
+                    "--output-dir",
+                    str(output_dir),
+                ]
+            )
+
+        assert not stale_result.exists()
+        assert not stale_failure.exists()
+
 
 class TestProcessLifecycle:
     def test_guard_setup_failure_cleans_spawned_process(self, runner, monkeypatch) -> None:

--- a/tests/unit/eval/test_run_llm_eval_script.py
+++ b/tests/unit/eval/test_run_llm_eval_script.py
@@ -19,6 +19,7 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 SCHEMA_PATH = REPO_ROOT / "scripts" / "e2e_eval" / "schemas" / "llm_eval_result.schema.json"
+TEST_BUNDLE_DIR = REPO_ROOT / "test-bundle"
 
 
 def _load_runner():
@@ -42,10 +43,12 @@ def _perf_report(
     device: str = "npu",
     ep: str = "qnn",
     generated_tokens: int = 128,
+    bundle_dir: Path = TEST_BUNDLE_DIR,
 ) -> dict:
     return {
         "benchmark_info": {
             "runtime": "winml-genai",
+            "bundle_dir": str(bundle_dir),
             "ep": ep,
             "device": device,
             "effective_device": device,
@@ -104,6 +107,7 @@ class TestPerfResultMapping:
         point = runner._context_point(
             256,
             _perf_report(),
+            expected_bundle_dir=TEST_BUNDLE_DIR,
             expected_device="npu",
             expected_ep="qnn",
             expected_max_new_tokens=128,
@@ -129,6 +133,7 @@ class TestPerfResultMapping:
             runner._context_point(
                 256,
                 _perf_report(255),
+                expected_bundle_dir=TEST_BUNDLE_DIR,
                 expected_device="npu",
                 expected_ep="qnn",
                 expected_max_new_tokens=128,
@@ -142,6 +147,7 @@ class TestPerfResultMapping:
         point = runner._context_point(
             256,
             _perf_report(ep="nvtensorrtrtx"),
+            expected_bundle_dir=TEST_BUNDLE_DIR,
             expected_device="npu",
             expected_ep="nv_tensorrt_rtx@catalog",
             expected_max_new_tokens=128,
@@ -157,6 +163,7 @@ class TestPerfResultMapping:
         point = runner._context_point(
             256,
             _perf_report(generated_tokens=17),
+            expected_bundle_dir=TEST_BUNDLE_DIR,
             expected_device="npu",
             expected_ep="qnn",
             expected_max_new_tokens=128,
@@ -174,6 +181,7 @@ class TestPerfResultMapping:
             runner._context_point(
                 256,
                 _perf_report(generated_tokens=generated_tokens),
+                expected_bundle_dir=TEST_BUNDLE_DIR,
                 expected_device="npu",
                 expected_ep="qnn",
                 expected_max_new_tokens=128,
@@ -191,8 +199,26 @@ class TestPerfResultMapping:
             runner._context_point(
                 256,
                 report,
+                expected_bundle_dir=TEST_BUNDLE_DIR,
                 expected_device="cpu",
                 expected_ep="dml",
+                expected_max_new_tokens=128,
+                expected_iterations=3,
+                expected_warmup=1,
+                total_ram_mb=16384.0,
+                total_vram_mb=4096.0,
+            )
+
+    def test_bundle_mismatch_fails(self, runner) -> None:
+        report = _perf_report(bundle_dir=TEST_BUNDLE_DIR / "other")
+
+        with pytest.raises(ValueError, match=r"Expected benchmark_info\.bundle_dir"):
+            runner._context_point(
+                256,
+                report,
+                expected_bundle_dir=TEST_BUNDLE_DIR,
+                expected_device="npu",
+                expected_ep="qnn",
                 expected_max_new_tokens=128,
                 expected_iterations=3,
                 expected_warmup=1,
@@ -219,6 +245,7 @@ class TestResultContract:
         point = runner._context_point(
             256,
             _perf_report(),
+            expected_bundle_dir=TEST_BUNDLE_DIR,
             expected_device="npu",
             expected_ep="qnn",
             expected_max_new_tokens=128,
@@ -285,7 +312,11 @@ class TestResultContract:
             assert prompt_path.read_text(encoding="utf-8") == "prompt"
             assert "prompt" not in args
             report_path = Path(args[args.index("-o") + 1])
-            report_path.write_text(json.dumps(_perf_report()), encoding="utf-8")
+            model_arg = args.index("-m", args.index("perf") + 1)
+            bundle_dir = Path(args[model_arg + 1])
+            report_path.write_text(
+                json.dumps(_perf_report(bundle_dir=bundle_dir)), encoding="utf-8"
+            )
             return runner.ProcessResult(args, 0, 1.0, "", "", False)
 
         monkeypatch.setattr(runner, "_run_process", fake_run)
@@ -381,6 +412,29 @@ class TestResultContract:
 
         assert not stale_result.exists()
         assert not stale_failure.exists()
+
+    def test_concurrent_run_rejects_shared_output_directory(
+        self, runner, tmp_path: Path
+    ) -> None:
+        output_dir = tmp_path / "results"
+        output_dir.mkdir()
+        stale_result = output_dir / runner.RESULT_FILENAME
+        stale_result.write_text('{"run": {"passed": true}}', encoding="utf-8")
+
+        with (
+            runner._OutputDirectoryLock(output_dir),
+            pytest.raises(RuntimeError, match="already in use"),
+        ):
+            runner.main(
+                [
+                    "-m",
+                    str(tmp_path / "bundle"),
+                    "--output-dir",
+                    str(output_dir),
+                ]
+            )
+
+        assert stale_result.exists()
 
 
 class TestProcessLifecycle:

--- a/tests/unit/eval/test_run_llm_eval_script.py
+++ b/tests/unit/eval/test_run_llm_eval_script.py
@@ -1,0 +1,226 @@
+"""Tests for ``scripts/e2e_eval/run_llm_eval.py``."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCHEMA_PATH = REPO_ROOT / "scripts" / "e2e_eval" / "schemas" / "llm_eval_result.schema.json"
+
+
+def _load_runner():
+    path = REPO_ROOT / "scripts" / "e2e_eval" / "run_llm_eval.py"
+    spec = importlib.util.spec_from_file_location("_e2e_run_llm_eval", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_e2e_run_llm_eval"] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def runner():
+    return _load_runner()
+
+
+def _perf_report(
+    prompt_tokens: int = 256,
+    *,
+    device: str = "npu",
+    ep: str = "qnn",
+) -> dict:
+    return {
+        "benchmark_info": {
+            "runtime": "winml-genai",
+            "ep": ep,
+            "device": device,
+            "compile": True,
+            "monitor": True,
+            "iterations": 3,
+            "warmup": 1,
+            "max_new_tokens": 128,
+            "apply_template": False,
+            "prompt_tokens": prompt_tokens,
+            "generated_tokens": 128,
+        },
+        "ttft_ms": {"mean": 1000.0},
+        "prefill_ms": {"mean": 900.0},
+        "decode": {"tokens_per_sec": 8.0, "tpot_ms": 125.0},
+        "total_generation_ms": {"mean": 17000.0},
+        "raw": {
+            "ttft_ms": [980.0, 1000.0, 1020.0],
+            "prefill_ms": [880.0, 900.0, 920.0],
+            "decode_tokens_per_sec": [7.9, 8.0, 8.1],
+            "tpot_ms": [126.0, 125.0, 123.5],
+            "total_ms": [17100.0, 17000.0, 16900.0],
+        },
+        "hw_monitor": {
+            "device_kind": device,
+            "adapter": {"mean_pct": 42.5, "sample_count": 40},
+            "cpu": {"process_mean_pct": 350.0, "sample_count": 40},
+            "ram": {"mean_mb": 2048.0},
+            "device_memory": {"local_mean_mb": 0.0, "shared_mean_mb": 512.0},
+        },
+    }
+
+
+class TestPerfResultMapping:
+    def test_perf_args_match_genai_command(self, runner, tmp_path: Path) -> None:
+        args = runner._perf_args(
+            bundle_dir=tmp_path / "bundle",
+            report_path=tmp_path / "report.json",
+            prompt="hello",
+            max_new_tokens=128,
+            iterations=3,
+            warmup=1,
+            compile_timeout=1800,
+            device="npu",
+            ep="qnn",
+        )
+
+        assert args[args.index("--runtime") + 1] == "winml-genai"
+        assert args[args.index("--device") + 1] == "npu"
+        assert args[args.index("--ep") + 1] == "qnn"
+        assert args[args.index("--compile-timeout") + 1] == "1800"
+        assert "--compile" in args
+        assert "--monitor" in args
+
+    def test_context_point_maps_schema_metrics(self, runner) -> None:
+        point = runner._context_point(
+            256,
+            _perf_report(),
+            expected_device="npu",
+            expected_ep="qnn",
+            expected_max_new_tokens=128,
+            expected_iterations=3,
+            expected_warmup=1,
+            total_ram_mb=16384.0,
+            total_vram_mb=4096.0,
+        )
+
+        assert point["context_length_tokens"] == 256
+        assert point["tokens_per_second"] == 8.0
+        assert point["prefill_tokens_per_second"] == pytest.approx(256 / 0.9)
+        assert point["ttft_s"] == 1.0
+        assert point["total_elapsed_s"] == 17.0
+        assert point["inter_token_latency_ms"]["avg"] == pytest.approx(124.8333)
+        assert point["gpu_util_avg_pct"] == 42.5
+        assert point["vram"] == {"util_avg_pct": 3.125, "used_avg_mb": 512.0}
+        assert point["process_cpu_util_avg_pct"] == 350.0
+        assert point["process_mem"] == {"util_avg_pct": 12.5, "used_avg_mb": 2048.0}
+
+    def test_context_length_mismatch_fails(self, runner) -> None:
+        with pytest.raises(ValueError, match="perf measured 255"):
+            runner._context_point(
+                256,
+                _perf_report(255),
+                expected_device="npu",
+                expected_ep="qnn",
+                expected_max_new_tokens=128,
+                expected_iterations=3,
+                expected_warmup=1,
+                total_ram_mb=16384.0,
+                total_vram_mb=4096.0,
+            )
+
+
+class TestResultContract:
+    def test_result_validates_against_schema(self, runner) -> None:
+        point = runner._context_point(
+            256,
+            _perf_report(),
+            expected_device="npu",
+            expected_ep="qnn",
+            expected_max_new_tokens=128,
+            expected_iterations=3,
+            expected_warmup=1,
+            total_ram_mb=16000.0,
+            total_vram_mb=4000.0,
+        )
+        result = runner.build_result(
+            model="Qwen/Qwen3-1.7B",
+            model_type="llm",
+            task="text-generation",
+            quantization="w8a16",
+            device="npu",
+            ep="qnn",
+            group=None,
+            priority="P0",
+            machine_label=None,
+            started_at="2026-08-04T00:00:00+00:00",
+            elapsed_s=60.0,
+            points=[point],
+            errors=[],
+            environment={
+                "os": "windows",
+                "hardware": {"cpu_name": "Test CPU", "cpu_logical_cores": 8},
+                "total_ram_mb": 16000.0,
+                "total_vram_mb": 4000.0,
+                "gpu_memory_gb": 4.0,
+            },
+            command="winml perf -m bundle --runtime winml-genai --device npu",
+            timed_out=False,
+        )
+        schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+        jsonschema.validate(result, schema)
+        assert result["run"]["passed"] is True
+
+    def test_main_writes_schema_valid_result(
+        self, runner, tmp_path: Path, monkeypatch
+    ) -> None:
+        bundle = tmp_path / "qwen3-bundle"
+        bundle.mkdir()
+        (bundle / "genai_config.json").write_text("{}", encoding="utf-8")
+        output_dir = tmp_path / "results"
+
+        monkeypatch.setattr(runner, "_make_prompt", lambda *_args: "prompt")
+        monkeypatch.setattr(
+            runner,
+            "_collect_environment",
+            lambda _gpu_memory_gb: {
+                "os": "windows",
+                "hardware": {"cpu_name": "Test CPU", "cpu_logical_cores": 8},
+                "total_ram_mb": 16384.0,
+                "total_vram_mb": 4096.0,
+                "gpu_memory_gb": 4.0,
+            },
+        )
+
+        def fake_run(args: list[str], *, timeout: int):
+            report_path = Path(args[args.index("-o") + 1])
+            report_path.write_text(json.dumps(_perf_report()), encoding="utf-8")
+            return runner.ProcessResult(args, 0, 1.0, "", "", False)
+
+        monkeypatch.setattr(runner, "_run_process", fake_run)
+
+        exit_code = runner.main(
+            [
+                "-m",
+                str(bundle),
+                "--model-id",
+                "Qwen/Qwen3-1.7B",
+                "--output-dir",
+                str(output_dir),
+                "--device",
+                "npu",
+                "--ep",
+                "qnn",
+                "--context-lengths",
+                "256",
+            ]
+        )
+
+        result = json.loads((output_dir / runner.RESULT_FILENAME).read_text(encoding="utf-8"))
+        runner._validate_result(result)
+        assert exit_code == 0
+        assert result["model"] == "Qwen/Qwen3-1.7B"
+        assert len(result["context_sweep"]) == 1
+        assert "winml.modelkit.cli perf" in result["run"]["command"]

--- a/tests/unit/eval/test_run_llm_eval_script.py
+++ b/tests/unit/eval/test_run_llm_eval_script.py
@@ -48,6 +48,7 @@ def _perf_report(
             "runtime": "winml-genai",
             "ep": ep,
             "device": device,
+            "effective_device": device,
             "compile": True,
             "monitor": True,
             "iterations": 3,
@@ -362,18 +363,44 @@ class TestResultContract:
 class TestProcessLifecycle:
     def test_guard_setup_failure_cleans_spawned_process(self, runner, monkeypatch) -> None:
         cleaned: list[int] = []
+        original_cleanup = runner._kill_process_tree
 
         class BrokenGuard:
             def __init__(self, _process) -> None:
                 raise OSError("job assignment failed")
 
         monkeypatch.setattr(runner, "_ProcessTreeGuard", BrokenGuard)
-        monkeypatch.setattr(runner, "_kill_process_tree", cleaned.append)
+        monkeypatch.setattr(
+            runner,
+            "_kill_process_tree",
+            lambda pid: (cleaned.append(pid), original_cleanup(pid)),
+        )
 
         with pytest.raises(OSError, match="job assignment failed"):
             runner._run_process([sys.executable, "-c", "pass"], timeout=10)
 
         assert len(cleaned) == 1
+
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+    def test_nonfinite_gpu_memory_is_rejected(self, runner, tmp_path, value: float) -> None:
+        bundle = tmp_path / "bundle"
+        bundle.mkdir()
+        (bundle / "genai_config.json").write_text("{}", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="must be positive"):
+            runner.main(
+                [
+                    "-m",
+                    str(bundle),
+                    "--output-dir",
+                    str(tmp_path / "results"),
+                    f"--gpu-memory-gb={value}",
+                ]
+            )
+
+    def test_json_writer_rejects_nonfinite_values(self, runner, tmp_path) -> None:
+        with pytest.raises(ValueError, match="Out of range float values"):
+            runner._write_json(tmp_path / "result.json", {"value": float("nan")})
 
     def test_timeout_kills_descendant_holding_output_pipe(self, runner) -> None:
         child_code = "import threading; threading.Event().wait(60)"

--- a/tests/unit/eval/test_run_llm_eval_script.py
+++ b/tests/unit/eval/test_run_llm_eval_script.py
@@ -1,3 +1,8 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
 """Tests for ``scripts/e2e_eval/run_llm_eval.py``."""
 
 from __future__ import annotations
@@ -76,7 +81,7 @@ class TestPerfResultMapping:
         args = runner._perf_args(
             bundle_dir=tmp_path / "bundle",
             report_path=tmp_path / "report.json",
-            prompt="hello",
+            prompt_path=tmp_path / "prompt.txt",
             max_new_tokens=128,
             iterations=3,
             warmup=1,
@@ -112,7 +117,7 @@ class TestPerfResultMapping:
         assert point["total_elapsed_s"] == 17.0
         assert point["inter_token_latency_ms"]["avg"] == pytest.approx(124.8333)
         assert point["gpu_util_avg_pct"] == 42.5
-        assert point["vram"] == {"util_avg_pct": 3.125, "used_avg_mb": 512.0}
+        assert point["vram"] == {"util_avg_pct": None, "used_avg_mb": 512.0}
         assert point["process_cpu_util_avg_pct"] == 350.0
         assert point["process_mem"] == {"util_avg_pct": 12.5, "used_avg_mb": 2048.0}
 
@@ -180,6 +185,9 @@ class TestResultContract:
         bundle.mkdir()
         (bundle / "genai_config.json").write_text("{}", encoding="utf-8")
         output_dir = tmp_path / "results"
+        output_dir.mkdir()
+        stale_failure = output_dir / runner.FAILURE_FILENAME
+        stale_failure.write_text("{}", encoding="utf-8")
 
         monkeypatch.setattr(runner, "_make_prompt", lambda *_args: "prompt")
         monkeypatch.setattr(
@@ -195,6 +203,9 @@ class TestResultContract:
         )
 
         def fake_run(args: list[str], *, timeout: int):
+            prompt_path = Path(args[args.index("--prompt-file") + 1])
+            assert prompt_path.read_text(encoding="utf-8") == "prompt"
+            assert "prompt" not in args
             report_path = Path(args[args.index("-o") + 1])
             report_path.write_text(json.dumps(_perf_report()), encoding="utf-8")
             return runner.ProcessResult(args, 0, 1.0, "", "", False)
@@ -224,3 +235,48 @@ class TestResultContract:
         assert result["model"] == "Qwen/Qwen3-1.7B"
         assert len(result["context_sweep"]) == 1
         assert "winml.modelkit.cli perf" in result["run"]["command"]
+        assert not stale_failure.exists()
+
+    def test_failed_rerun_removes_stale_result(
+        self, runner, tmp_path: Path, monkeypatch
+    ) -> None:
+        bundle = tmp_path / "qwen3-bundle"
+        bundle.mkdir()
+        (bundle / "genai_config.json").write_text("{}", encoding="utf-8")
+        output_dir = tmp_path / "results"
+        output_dir.mkdir()
+        stale_result = output_dir / runner.RESULT_FILENAME
+        stale_result.write_text('{"run": {"passed": true}}', encoding="utf-8")
+
+        monkeypatch.setattr(runner, "_make_prompt", lambda *_args: "prompt")
+        monkeypatch.setattr(
+            runner,
+            "_collect_environment",
+            lambda _gpu_memory_gb: {
+                "os": "windows",
+                "hardware": {},
+                "total_ram_mb": 16384.0,
+                "total_vram_mb": 0.0,
+                "gpu_memory_gb": None,
+            },
+        )
+        monkeypatch.setattr(
+            runner,
+            "_run_process",
+            lambda args, *, timeout: runner.ProcessResult(args, 1, 1.0, "", "failed", False),
+        )
+
+        exit_code = runner.main(
+            [
+                "-m",
+                str(bundle),
+                "--output-dir",
+                str(output_dir),
+                "--context-lengths",
+                "256",
+            ]
+        )
+
+        assert exit_code == 1
+        assert not stale_result.exists()
+        assert (output_dir / runner.FAILURE_FILENAME).exists()

--- a/tests/unit/eval/test_run_llm_eval_script.py
+++ b/tests/unit/eval/test_run_llm_eval_script.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
+import time
 from pathlib import Path
 
 import jsonschema
@@ -40,6 +41,7 @@ def _perf_report(
     *,
     device: str = "npu",
     ep: str = "qnn",
+    generated_tokens: int = 128,
 ) -> dict:
     return {
         "benchmark_info": {
@@ -53,7 +55,7 @@ def _perf_report(
             "max_new_tokens": 128,
             "apply_template": False,
             "prompt_tokens": prompt_tokens,
-            "generated_tokens": 128,
+            "generated_tokens": generated_tokens,
         },
         "ttft_ms": {"mean": 1000.0},
         "prefill_ms": {"mean": 900.0},
@@ -134,6 +136,64 @@ class TestPerfResultMapping:
                 total_ram_mb=16384.0,
                 total_vram_mb=4096.0,
             )
+
+    def test_canonical_ep_aliases_match(self, runner) -> None:
+        point = runner._context_point(
+            256,
+            _perf_report(ep="nvtensorrtrtx"),
+            expected_device="npu",
+            expected_ep="nv_tensorrt_rtx@catalog",
+            expected_max_new_tokens=128,
+            expected_iterations=3,
+            expected_warmup=1,
+            total_ram_mb=16384.0,
+            total_vram_mb=4096.0,
+        )
+
+        assert point["generated_tokens"] == 128
+
+    def test_early_eos_generated_count_is_accepted(self, runner) -> None:
+        point = runner._context_point(
+            256,
+            _perf_report(generated_tokens=17),
+            expected_device="npu",
+            expected_ep="qnn",
+            expected_max_new_tokens=128,
+            expected_iterations=3,
+            expected_warmup=1,
+            total_ram_mb=16384.0,
+            total_vram_mb=4096.0,
+        )
+
+        assert point["generated_tokens"] == 17
+
+    @pytest.mark.parametrize("generated_tokens", [0, 129])
+    def test_invalid_generated_count_fails(self, runner, generated_tokens: int) -> None:
+        with pytest.raises(ValueError, match=r"Expected 1\.\.128"):
+            runner._context_point(
+                256,
+                _perf_report(generated_tokens=generated_tokens),
+                expected_device="npu",
+                expected_ep="qnn",
+                expected_max_new_tokens=128,
+                expected_iterations=3,
+                expected_warmup=1,
+                total_ram_mb=16384.0,
+                total_vram_mb=4096.0,
+            )
+
+    def test_zero_token_prompt_filler_fails_fast(self, runner, monkeypatch, tmp_path) -> None:
+        class EmptyTokenizer:
+            def encode(self, _text, *, add_special_tokens=False):
+                return []
+
+        monkeypatch.setattr(
+            "transformers.AutoTokenizer.from_pretrained",
+            lambda *_args, **_kwargs: EmptyTokenizer(),
+        )
+
+        with pytest.raises(ValueError, match="tokenize to at least one token"):
+            runner._make_prompt(tmp_path, 256, "")
 
 
 class TestResultContract:
@@ -280,3 +340,19 @@ class TestResultContract:
         assert exit_code == 1
         assert not stale_result.exists()
         assert (output_dir / runner.FAILURE_FILENAME).exists()
+
+
+class TestProcessLifecycle:
+    def test_timeout_kills_descendant_holding_output_pipe(self, runner) -> None:
+        child_code = "import threading; threading.Event().wait(60)"
+        parent_code = (
+            "import subprocess, sys; "
+            f"subprocess.Popen([sys.executable, '-c', {child_code!r}])"
+        )
+        started = time.perf_counter()
+
+        result = runner._run_process([sys.executable, "-c", parent_code], timeout=1)
+
+        assert result.timed_out is True
+        assert result.exit_code == -1
+        assert time.perf_counter() - started < 10

--- a/tests/unit/session/test_ep_monitor.py
+++ b/tests/unit/session/test_ep_monitor.py
@@ -525,6 +525,8 @@ class TestHWMonitor:
         assert isinstance(hw.mean_utilization_pct, float)
         assert isinstance(hw.peak_utilization_pct, float)
         assert isinstance(hw.peak_memory_mb, float)
+        assert isinstance(hw.mean_memory_local_mb, float)
+        assert isinstance(hw.mean_memory_shared_mb, float)
 
     @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only")
     def test_to_dict_structure(self):
@@ -538,10 +540,12 @@ class TestHWMonitor:
         # CPU section
         assert "cpu" in d
         assert "mean_pct" in d["cpu"]
+        assert "process_mean_pct" in d["cpu"]
         assert "peak_pct" in d["cpu"]
         assert "sample_count" in d["cpu"]
         # RAM section
         assert "ram" in d
+        assert "mean_mb" in d["ram"]
         assert "used_mb" in d["ram"]
         assert "peak_mb" in d["ram"]
         # Aggregate GPU telemetry is independent of the selected inference
@@ -563,6 +567,8 @@ class TestHWMonitor:
             assert "npu" not in d
         # Device memory + running time
         assert "device_memory" in d
+        assert "local_mean_mb" in d["device_memory"]
+        assert "shared_mean_mb" in d["device_memory"]
         assert "local_peak_mb" in d["device_memory"]
         assert "shared_peak_mb" in d["device_memory"]
         assert "running_time_ns" in d
@@ -608,6 +614,7 @@ class TestHWMonitor:
             time.sleep(0.2)
 
         assert isinstance(hw.mean_cpu_pct, float)
+        assert isinstance(hw.mean_process_cpu_pct, float)
         assert isinstance(hw.peak_cpu_pct, float)
         assert hw.mean_cpu_pct >= 0.0
 
@@ -620,6 +627,7 @@ class TestHWMonitor:
 
         assert isinstance(hw.ram_used_mb, float)
         assert hw.ram_used_mb > 0.0  # System always uses some RAM
+        assert isinstance(hw.mean_ram_used_mb, float)
         assert isinstance(hw.peak_ram_used_mb, float)
         assert hw.peak_ram_used_mb >= hw.ram_used_mb  # Peak >= current
 
@@ -1207,14 +1215,18 @@ class TestHWMonitorDeviceRouting:
                 "utilization_sample_count": 5,
                 "adapter_luid": "0x0_0xCAFE",
                 "mean_cpu_pct": 12.34,
+                "mean_process_cpu_pct": 98.72,
                 "peak_cpu_pct": 34.56,
                 "cpu_sample_count": 7,
+                "mean_ram_used_mb": 900.12,
                 "ram_used_mb": 1024.56,
                 "peak_ram_used_mb": 2048.78,
                 "mean_gpu_pct": 4.56,
                 "peak_gpu_pct": 7.89,
                 "gpu_sample_count": 11,
                 "gpu_luids": ["0x0_0xBEEF"],
+                "mean_memory_local_mb": 200.12,
+                "mean_memory_shared_mb": 100.34,
                 "peak_memory_local_mb": 256.78,
                 "peak_memory_shared_mb": 128.34,
                 "running_time_delta_ns": 123456789,

--- a/tests/unit/session/test_ep_monitor.py
+++ b/tests/unit/session/test_ep_monitor.py
@@ -839,7 +839,7 @@ class TestResolveAdapterLuid:
 
         assert luid == "0x00000000_0x000000DE"
 
-    def test_multiple_matching_adapters_are_unresolved_without_pdh_fallback(self):
+    def test_multiple_ort_adapters_are_unresolved_when_pdh_exposes_only_one(self):
         from winml.modelkit.sysinfo import pdh_adapters
 
         def fake_device(luid: str):
@@ -866,10 +866,7 @@ class TestResolveAdapterLuid:
                 ),
             },
         )
-        fake_pdh = {
-            "0x00000000_0x0000006F": object(),
-            "0x00000000_0x000000DE": object(),
-        }
+        fake_pdh = {"0x00000000_0x0000006F": object()}
 
         with (
             patch.dict("sys.modules", {"onnxruntime": fake_ort}),
@@ -945,10 +942,8 @@ class TestResolveAdapterLuid:
 
         assert luid == "0x00000000_0x00012C89"
 
-    def test_falls_back_when_ort_luid_not_in_pdh_enumeration(self):
-        """If ORT publishes a LUID PDH doesn't enumerate, the resolver skips
-        it and falls through to the PDH-only fallback. Without this guard,
-        ``build_adapter_query`` would later raise for the unknown LUID."""
+    def test_ort_luid_missing_from_pdh_is_not_monitorable(self):
+        """A unique ORT adapter must not fall back to unrelated PDH telemetry."""
         from winml.modelkit.sysinfo import pdh_adapters
 
         ghost_dev = type(
@@ -973,9 +968,7 @@ class TestResolveAdapterLuid:
             },
         )
 
-        # PDH knows *some* adapters but not the one ORT named. A non-empty
-        # dict triggers validation; the ORT LUID is rejected and we fall
-        # through to discover_npu_luid().
+        # PDH knows some adapters but not the one ORT named.
         fake_pdh = {"0x00000000_0xC0FFEE": object()}
 
         with (
@@ -989,9 +982,10 @@ class TestResolveAdapterLuid:
         ):
             luid = pdh_adapters.resolve_adapter_luid("npu")
 
-        # 22278 == 0x5706 (the failing-test LUID); rejected, fallback wins.
-        assert luid == "0x00000000_0xFA11BACC"
-        mock_pdh.assert_called_once()
+        # 22278 == 0x5706. The ORT adapter cannot be monitored, and choosing
+        # another adapter would silently attribute unrelated telemetry.
+        assert luid is None
+        mock_pdh.assert_not_called()
 
     def test_skips_malformed_ep_device(self):
         """Accessing .device or .metadata may raise on bad ep_devices; the

--- a/tests/unit/session/test_ep_monitor.py
+++ b/tests/unit/session/test_ep_monitor.py
@@ -839,6 +839,50 @@ class TestResolveAdapterLuid:
 
         assert luid == "0x00000000_0x000000DE"
 
+    def test_multiple_matching_adapters_are_unresolved_without_pdh_fallback(self):
+        from winml.modelkit.sysinfo import pdh_adapters
+
+        def fake_device(luid: str):
+            return type(
+                "FakeEpDevice",
+                (),
+                {
+                    "ep_name": "DmlExecutionProvider",
+                    "device": type(
+                        "FakeHwDev",
+                        (),
+                        {"type": "GPU_TYPE", "metadata": {"LUID": luid}},
+                    )(),
+                },
+            )()
+
+        fake_ort = type(
+            "FakeOrt",
+            (),
+            {
+                "get_ep_devices": lambda: [fake_device("111"), fake_device("222")],
+                "OrtHardwareDeviceType": type(
+                    "Types", (), {"NPU": "NPU_TYPE", "GPU": "GPU_TYPE"}
+                ),
+            },
+        )
+        fake_pdh = {
+            "0x00000000_0x0000006F": object(),
+            "0x00000000_0x000000DE": object(),
+        }
+
+        with (
+            patch.dict("sys.modules", {"onnxruntime": fake_ort}),
+            patch.object(pdh_adapters, "enumerate_adapters", return_value=fake_pdh),
+            patch.object(pdh_adapters, "discover_gpu_luid") as fallback,
+        ):
+            luid = pdh_adapters.resolve_adapter_luid(
+                "gpu", ep_name="DmlExecutionProvider"
+            )
+
+        assert luid is None
+        fallback.assert_not_called()
+
     def test_falls_back_to_pdh_when_ort_has_no_luid_metadata(self):
         """Some EPs may register without LUID metadata; PDH is the fallback."""
         from winml.modelkit.sysinfo import pdh_adapters

--- a/tests/unit/session/test_genai_session.py
+++ b/tests/unit/session/test_genai_session.py
@@ -1091,6 +1091,48 @@ class TestEffectiveDevice:
         assert session._resolve_effective_device(cfg) is None
 
 
+class TestEffectiveHardwareEp:
+    def test_unique_configured_ep_is_reported(self) -> None:
+        cfg = {
+            "model": {
+                "decoder": {
+                    "session_options": {
+                        "provider_options": [{"openvino": {"device_type": "GPU"}}]
+                    }
+                }
+            }
+        }
+
+        assert GenaiSession._hardware_ep_from_config(cfg) == "OpenVINOExecutionProvider"
+
+    def test_mixed_hardware_eps_are_unresolved(self) -> None:
+        cfg = {
+            "model": {
+                "decoder": {
+                    "pipeline": [
+                        {
+                            "first": {"session_options": {"provider_options": [{"dml": {}}]}},
+                            "second": {"session_options": {"provider_options": [{"qnn": {}}]}},
+                        }
+                    ]
+                }
+            }
+        }
+
+        assert GenaiSession._hardware_ep_from_config(cfg) is None
+
+    def test_unknown_provider_is_unresolved(self) -> None:
+        cfg = {
+            "model": {
+                "decoder": {
+                    "session_options": {"provider_options": [{"future_ep": {}}]}
+                }
+            }
+        }
+
+        assert GenaiSession._hardware_ep_from_config(cfg) is None
+
+
 # ---------------------------------------------------------------------------
 # Tests: generate / generate_streaming
 # ---------------------------------------------------------------------------

--- a/tests/unit/session/test_genai_session.py
+++ b/tests/unit/session/test_genai_session.py
@@ -1012,6 +1012,63 @@ class TestEffectiveDevice:
 
         assert GenaiSession._device_from_config(cfg) == "gpu"
 
+    def test_provider_hint_resolves_qnn_htp_to_npu(self) -> None:
+        cfg = {
+            "model": {
+                "decoder": {
+                    "pipeline": [
+                        {
+                            "decoder": {
+                                "session_options": {
+                                    "provider_options": [
+                                        {"qnn": {"backend_path": r"C:\QNN\QnnHtp.dll"}}
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+        assert GenaiSession._device_from_config(cfg) == "npu"
+
+    def test_effective_config_precedes_explicit_fallback(self, bundle_dir: Path) -> None:
+        session = GenaiSession(bundle_dir, ep="openvino", device="npu")
+        session._override_effective = True
+        cfg = {
+            "model": {
+                "decoder": {
+                    "session_options": {
+                        "provider_options": [{"openvino": {"device_type": "GPU"}}]
+                    }
+                }
+            }
+        }
+
+        assert session._resolve_effective_device(cfg) == "gpu"
+
+    def test_config_routing_wins_over_contradictory_requested_device(
+        self, bundle_dir: Path
+    ) -> None:
+        session = GenaiSession(bundle_dir, ep="dml", device="npu")
+        session._override_effective = True
+        cfg = {
+            "model": {
+                "decoder": {
+                    "pipeline": [
+                        {
+                            "decoder": {
+                                "session_options": {"provider_options": [{"dml": {}}]}
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+        assert session._resolve_effective_device(cfg) == "gpu"
+
 
 # ---------------------------------------------------------------------------
 # Tests: generate / generate_streaming

--- a/tests/unit/session/test_genai_session.py
+++ b/tests/unit/session/test_genai_session.py
@@ -1069,6 +1069,27 @@ class TestEffectiveDevice:
 
         assert session._resolve_effective_device(cfg) == "gpu"
 
+    def test_unresolved_multidevice_ep_does_not_trust_requested_device(
+        self, bundle_dir: Path
+    ) -> None:
+        session = GenaiSession(bundle_dir, ep="qnn", device="npu")
+        session._override_effective = True
+        cfg = {
+            "model": {
+                "decoder": {
+                    "pipeline": [
+                        {
+                            "decoder": {
+                                "session_options": {"provider_options": [{"qnn": {}}]}
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+        assert session._resolve_effective_device(cfg) is None
+
 
 # ---------------------------------------------------------------------------
 # Tests: generate / generate_streaming

--- a/tests/unit/session/test_genai_session.py
+++ b/tests/unit/session/test_genai_session.py
@@ -964,6 +964,55 @@ class TestEffectiveEp:
         assert session.effective_ep == "qnn"
 
 
+class TestEffectiveDevice:
+    def test_dml_bundle_routes_monitoring_to_gpu(self) -> None:
+        cfg = {
+            "model": {
+                "decoder": {
+                    "pipeline": [
+                        {
+                            "decoder": {
+                                "session_options": {"provider_options": [{"dml": {}}]}
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+        assert GenaiSession._device_from_config(cfg) == "gpu"
+
+    def test_ambiguous_multidevice_provider_omits_adapter(self) -> None:
+        cfg = {
+            "model": {
+                "decoder": {
+                    "pipeline": [
+                        {
+                            "decoder": {
+                                "session_options": {"provider_options": [{"qnn": {}}]}
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+        assert GenaiSession._device_from_config(cfg) is None
+
+    def test_device_type_resolves_multidevice_provider(self) -> None:
+        cfg = {
+            "model": {
+                "decoder": {
+                    "session_options": {
+                        "provider_options": [{"openvino": {"device_type": "GPU"}}]
+                    }
+                }
+            }
+        }
+
+        assert GenaiSession._device_from_config(cfg) == "gpu"
+
+
 # ---------------------------------------------------------------------------
 # Tests: generate / generate_streaming
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a schema-normalized LLM evaluation runner for ONNX Runtime GenAI context sweeps
- collect generation-window accelerator, device-memory, process CPU, and process-memory metrics
- enable cached EPContext pre-compilation for accelerator-backed GenAI bundles
- add the LLM result schema, documentation, and focused unit coverage

## Validation
- `uv run ruff check --fix scripts/e2e_eval/run_llm_eval.py tests/unit/eval/test_run_llm_eval_script.py scripts/e2e_eval/README.md src/winml/modelkit/commands/_perf_genai.py src/winml/modelkit/commands/perf.py src/winml/modelkit/session/monitor/_pdh.py src/winml/modelkit/session/monitor/hw_monitor.py tests/unit/commands/test_perf_genai.py tests/unit/session/test_ep_monitor.py`
- `uv run pytest tests/unit/commands/test_perf_genai.py tests/unit/eval/test_run_llm_eval_script.py tests/unit/session/test_ep_monitor.py::TestHWMonitor tests/unit/session/test_ep_monitor.py::TestHWMonitorDeviceRouting -q --basetemp temp/pytest-llm-eval-final` (85 passed)
- completed a Qwen3-1.7B QNN NPU sweep at 256/512/1024 prompt tokens and validated the result against the supplied Draft 2020-12 schema