### PR TITLE
test(perf): relax TensorRT RTX PDH assertion

### DIFF
--- a/tests/e2e/test_perf_e2e.py
+++ b/tests/e2e/test_perf_e2e.py
@@ -626,12 +626,12 @@ class _PerfBenchmarkSuite:
 
         assert output_file.exists()
         data = json.loads(output_file.read_text())
-        # TODO openvino gpu could not emit valid pdh counter
+        # TODO OpenVINO GPU and TensorRT RTX do not emit reliable PDH utilization counters.
         _assert_monitor_result(
             data,
             device="gpu",
             ep=EP_ALIASES[ep],
-            require_utilization=ep != "openvino",
+            require_utilization=ep not in ("nv_tensorrt_rtx", "openvino"),
         )
 
     @pytest.mark.parametrize("ep", NPU_EPS)
@@ -886,8 +886,12 @@ class TestPerfHuggingFace:
         assert output_file.exists()
         data = json.loads(output_file.read_text())
         assert data["benchmark_info"]["ep"] == EP_ALIASES[ep]
-        # TODO openvino gpu could not emit valid pdh counter
-        _assert_monitor_result(data, device="gpu", require_utilization=ep != "openvino")
+        # TODO OpenVINO GPU and TensorRT RTX do not emit reliable PDH utilization counters.
+        _assert_monitor_result(
+            data,
+            device="gpu",
+            require_utilization=ep not in ("nv_tensorrt_rtx", "openvino"),
+        )
 
     @pytest.mark.parametrize("ep", NPU_EPS)
     def test_benchmark_ep_npu(self, ep: str, tmp_path: Path, model_arg: str):


### PR DESCRIPTION
## Summary

- Treat TensorRT RTX like OpenVINO when validating Windows PDH GPU utilization.
- Keep the benchmark, execution provider, device, adapter LUID, latency, and monitor structure assertions intact.
- Document the unreliable PDH utilization behavior with a TODO in both ONNX-direct and Hugging Face GPU cases.

## Validation

- `uv run --no-sync pytest -m e2e -q "tests/e2e/test_perf_e2e.py::TestPerfONNXDirect::test_benchmark_ep_device_gpu[nv_tensorrt_rtx]" "tests/e2e/test_perf_e2e.py::TestPerfHuggingFace::test_benchmark_ep_gpu[nv_tensorrt_rtx]" --basetemp=temp/pytest_tmp/release-v030-trtrtx-monitor-fix` (2 passed)
- `uv run --no-sync ruff check --fix tests/e2e/test_perf_e2e.py`