### PR TITLE
Support ACPI NVDA PNP parsing for GPU detection

### DIFF
--- a/src/winml/modelkit/sysinfo/hardware.py
+++ b/src/winml/modelkit/sysinfo/hardware.py
@@ -50,6 +50,14 @@ def get_vendor_id_device_id_from_pnp_id(pnp_id: str) -> tuple[int, int]:
         device_id = int.from_bytes(id_segment[4:].encode("ascii"), byteorder="little")
         return vendor_id, device_id
 
+    # Some NVIDIA GPUs are exposed via ACPI IDs without VEN_/DEV_ tokens
+    # (e.g., "ACPI\\NVDA200A\\0"). Parse the NVDA tag directly.
+    acpi_nvda_match = re.search(r"^ACPI\\NVDA([0-9A-Fa-f]{4})(?:\\|$)", pnp_id)
+    if acpi_nvda_match is not None:
+        vendor_id = 0x10DE
+        device_id = int(acpi_nvda_match.group(1), 16)
+        return vendor_id, device_id
+
     vendor_id_str_groups = re.search(r"VEN_([0-9A-Za-z]+)", pnp_id)
     if vendor_id_str_groups is None:
         raise ValueError(f"Invalid PNPDeviceID format: {pnp_id}")

--- a/tests/unit/sysinfo/test_hardware.py
+++ b/tests/unit/sysinfo/test_hardware.py
@@ -207,6 +207,11 @@ class TestGetVendorIdDeviceIdFromPnpId:
         vendor_id, device_id = get_vendor_id_device_id_from_pnp_id("PCI\\VEN_QCOM&DEV_5C40")
         assert (vendor_id, device_id) == (0x4D4F4351, 0x30344335)
 
+    def test_nvidia_acpi_quirk(self) -> None:
+        """``ACPI\\NVDA####`` should map to NVIDIA vendor id + hex device id."""
+        vendor_id, device_id = get_vendor_id_device_id_from_pnp_id("ACPI\\NVDA200A\\0")
+        assert (vendor_id, device_id) == (0x10DE, 0x200A)
+
     def test_missing_vendor_raises(self) -> None:
         with pytest.raises(ValueError, match="Invalid PNPDeviceID"):
             get_vendor_id_device_id_from_pnp_id("PCI\\DEV_2204")


### PR DESCRIPTION
- Summary
  add support for ACPI\NVDA#### style PNP IDs in hardware detection
  map ACPI NVDA IDs to NVIDIA vendor id 0x10DE and parse the 4-digit device id as hex
  keep existing PCI VEN_/DEV_ and Qualcomm parsing branches unchanged
  add unit test coverage for ACPI\NVDA200A\0 parsing

- Why

  Some ARM devices expose NVIDIA adapters through ACPI IDs instead of PCI VEN_/DEV_ tokens. Without this handling, device parsing can fail and downstream provider compatibility may be marked incorrectly.

- Validation

  python -m pytest tests/unit/sysinfo/test_hardware.py -q
  result: 25 passed