### PR TITLE
fix(pipeline): use GitHub App for releases

### DIFF
--- a/.pipelines/modelkit-release-github.yml
+++ b/.pipelines/modelkit-release-github.yml
@@ -156,7 +156,8 @@ extends:
         - task: GitHubRelease@1
           displayName: 'Create GitHub Release'
           inputs:
-            gitHubConnection: 'ModelKit'
+            # GitHub App-backed connection; avoids expiring and SAML-bound PAT credentials.
+            gitHubConnection: 'microsoft'
             repositoryName: 'microsoft/winml-cli'
             action: create
             target: '$(Build.SourceVersion)'


### PR DESCRIPTION
Switches `GitHubRelease@1` from the PAT-backed `ModelKit` service connection to the GitHub App-backed `microsoft` connection.

The previous PAT expired and then required separate Microsoft organization SAML authorization during the v0.3.0 release. The replacement connection uses an installation token and has been authorized for pipeline `191404`.