### PR TITLE
recipe(owlv2-large-patch14): add CPU zero-shot detection configs

### DIFF
--- a/examples/recipes/google_owlv2-large-patch14/cpu/cpu/zero-shot-object-detection_fp16_config.json
+++ b/examples/recipes/google_owlv2-large-patch14/cpu/cpu/zero-shot-object-detection_fp16_config.json
@@ -1,0 +1,100 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          1008,
+          1008
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          16
+        ],
+        "value_range": [
+          0,
+          49408
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          16
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      },
+      {
+        "name": "pred_boxes"
+      },
+      {
+        "name": "text_embeds"
+      },
+      {
+        "name": "image_embeds"
+      }
+    ],
+    "compatibility": {
+      "transformers_attention": "eager"
+    }
+  },
+  "optim": {},
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "zero-shot-object-detection",
+    "model_id": "google/owlv2-large-patch14",
+    "model_type": "owlv2",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "zero-shot-object-detection",
+    "model_class": "AutoModelForZeroShotObjectDetection",
+    "model_type": "owlv2"
+  }
+}

--- a/examples/recipes/google_owlv2-large-patch14/cpu/cpu/zero-shot-object-detection_fp32_config.json
+++ b/examples/recipes/google_owlv2-large-patch14/cpu/cpu/zero-shot-object-detection_fp32_config.json
@@ -1,0 +1,78 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          1008,
+          1008
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          16
+        ],
+        "value_range": [
+          0,
+          49408
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          16
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      },
+      {
+        "name": "pred_boxes"
+      },
+      {
+        "name": "text_embeds"
+      },
+      {
+        "name": "image_embeds"
+      }
+    ],
+    "compatibility": {
+      "transformers_attention": "eager"
+    }
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "zero-shot-object-detection",
+    "model_class": "AutoModelForZeroShotObjectDetection",
+    "model_type": "owlv2"
+  }
+}


### PR DESCRIPTION
## Summary

Adds config-only CPU fp32 and fp16 recipes for `google/owlv2-large-patch14`, an open-vocabulary object detector for zero-shot localization. The shipped effort and outcome are L0, with full tuple coverage and an independently verified highest Goal verdict of L2 PASS. Dataset-level `winml eval` remains CLI-BLOCKED because zero-shot object detection has no registered eval schema, evaluator, or default dataset; this is tracked by [issue #1147](https://github.com/microsoft/winml-cli/issues/1147).

## Model metadata

### What the model does

OWLv2 Large Patch14 is an open-vocabulary object detector that accepts an image and tokenized text queries, then returns per-image-patch query logits, normalized bounding boxes, and text/image embeddings for zero-shot localization. Evidence: the pinned `google/owlv2-large-patch14@1aabc4ed23010cbcce9b6906e57392fe13622038` model metadata declares `pipeline_tag=zero-shot-object-detection`; its config declares `Owlv2ForObjectDetection` and `model_type=owlv2`; and the concrete Transformers forward path performs image/text embedding followed by class, objectness, and box prediction. Confidence: `verified`.

### Primary user stories

- A user supplies an image plus text descriptions to obtain confidence scores and bounding boxes for objects named by those descriptions, enabling open-vocabulary localization without retraining a fixed class head. Evidence: the pinned checkpoint pipeline metadata and the Transformers `Owlv2ForObjectDetection.forward` example and return type. Confidence: `verified`.

### Supported tasks

- `zero-shot-object-detection` across the checkpoint, Transformers, and WinML support surfaces. Evidence: the pinned checkpoint pipeline tag, the `Owlv2ForObjectDetection` architecture, current WinML inspect/config task resolution, and WinML registration under canonical model type `owlv2`. Confidence: `verified`.

### Model architecture

```text
Owlv2ForObjectDetection
|-- Owlv2Model
|   |-- Vision tower: 1008x1008 input, 14x14 patches, hidden 1024
|   |   |-- Patch + position embeddings (72x72 patches + class token)
|   |   `-- Encoder layers x24 (16-head self-attention, 1024->4096->1024 MLP)
|   `-- Text tower: vocab 49408, sequence 16, hidden 768
|       |-- Token + position embeddings
|       `-- Encoder layers x12 (12-head self-attention, 768->3072->768 MLP)
|-- Patch/class-token fusion + LayerNorm -> image embeddings [B,72,72,1024]
|-- Class prediction head -> query logits and class embeddings
|-- Objectness prediction head -> per-patch objectness logits
`-- Box prediction head + grid bias + sigmoid -> normalized boxes [B,5184,4]
```

- Source/confidence: pinned checkpoint config and concrete Transformers `modeling_owlv2.py` class source (`verified`). A recipe-free HTP trace observed 468 modules, 437,610,760 parameters, 155 traced modules, and 1,526 tagged ONNX nodes.

## Validation and support evidence

### Baseline

- Baseline: `microsoft/winml-cli` main commit `79d7baad10f28cd79e65072f78494e8be758f3df`, WinML `0.3.0`, pinned checkpoint revision `1aabc4ed23010cbcce9b6906e57392fe13622038`.
- Starting auto-config behavior: WinML resolves `zero-shot-object-detection` and model type `owlv2`; the fp32 shipped recipe is semantically identical to current-main auto-config after `_note` removal. The fp16 recipe differs only by the explicit `/quant` precision declaration shown in Delta.
- L0 recipe-free build baseline: `PASS`. The HTP export took 94.89148592948914 seconds for `Owlv2ForObjectDetection` with 437,610,760 parameters, produced a 1658.93 MB opset-17 external-data graph, and tagged 1,987/1,987 ONNX nodes (100%). Final `model.onnx`, `optimized.onnx`, `export_htp_metadata.json`, and `winml_build_config.json` were persisted.
- L1 CPU perf baseline: `PASS` on `CPUExecutionProvider` with pinned semantic named inputs, one warmup, and three measured iterations. Mean was 17321.47 ms, p50 17329.895 ms, throughput 0.06 samples/s, and total RSS delta 2314.86 MB (39.77 MB model-load delta plus 2275.09 MB inference delta); local/shared VRAM deltas were 0.0 MB.
- Eval baseline: `CLI-BLOCKED`. Task-level schema discovery exited 2 and artifact-bound eval exited 1 because `zero-shot-object-detection` has no registered eval support; see [issue #1147](https://github.com/microsoft/winml-cli/issues/1147).
- Goal floor: L1.
- Optimum probe: vendor registration already returned `feature-extraction` and `zero-shot-object-detection`; WinML added no task. Verdict: `VENDOR-ONLY`.

### Goal

- Effort: L0.
- Committed Goal ceiling: L2; no ceiling downgrade occurred. The replacement revision-2 charter re-established the same L2 Goal on current main after reviewer-requested baseline refresh.
- Outcome target: L0 recipe-only support for CPU fp32 and fp16.
- Success definition: fresh exact-SHA L0 build/structure, L1 CPU perf, and L2 pinned named-input PyTorch comparison for fp32 and fp16.

### Outcome

- Shipped tier: L0.
- Highest Goal verdict: `L2 PASS`.
- Coverage: `full`; deferred tuples: none.
- Shipped paths:
  - `examples/recipes/google_owlv2-large-patch14/cpu/cpu/zero-shot-object-detection_fp32_config.json`
  - `examples/recipes/google_owlv2-large-patch14/cpu/cpu/zero-shot-object-detection_fp16_config.json`
- No source code or task-registry path changed.
- `No methodology friction observed`.
- Lane A model knowledge is preserved and deferred to a separate clean skill lane. It is not part of this product diff, and no Lane A branch, commit, or push is claimed here.

### Per-EP/device/precision results - including perf and eval data

#### Goal ladder

| Tier | Verdict | Evidence |
|---|---|---|
| L0 | PASS | Both exact CPU precision tuples freshly built and structurally validated; metadata originals were preserved before payload deletion. |
| L1 | PASS | Deterministic named-input CPU perf completed with one warmup and one measured iteration per tuple. |
| L2 | PASS | Pinned-checkpoint PyTorch vs ONNX comparisons completed for all four expected outputs; numbers are reported as measured. |

#### L0 structure

| EP / Device | Precision | Verdict | Graph | Inputs | Outputs | Initializers | Artifact size |
|---|---|---|---|---|---|---|---|
| CPUExecutionProvider / cpu | fp32 | PASS | IR 8, opset 17; 1,211 nodes | `input_ids` INT32 `[1,16]`; `pixel_values` FLOAT `[1,3,1008,1008]`; `attention_mask` INT32 `[1,16]` | `logits` FLOAT `[1,5184,1]`; `pred_boxes` FLOAT `[1,5184,4]`; `text_embeds` FLOAT `[1,1,768]`; `image_embeds` FLOAT `[1,72,72,1024]` | BOOL 1; FLOAT 611; INT64 20 | 1,739,462,080 bytes |
| CPUExecutionProvider / cpu | fp16 | PASS | IR 8, opset 17; 1,216 nodes | `input_ids` INT32 `[1,16]`; `pixel_values` FLOAT `[1,3,1008,1008]`; `attention_mask` INT32 `[1,16]` | `logits` FLOAT `[1,5184,1]`; `pred_boxes` FLOAT `[1,5184,4]`; `text_embeds` FLOAT `[1,1,768]`; `image_embeds` FLOAT `[1,72,72,1024]` | BOOL 1; FLOAT16 611; INT64 20 | 869,972,428 bytes; 869,489,652 bytes / 49.986123% smaller than fp32 |

External data was co-located as `model.onnx.data` for both tuples. Resolved HTP metadata reports `Owlv2ForObjectDetection`, 468 modules, 437,610,760 parameters, 155 traced modules, and 310 execution steps; export times were 111.80775785446167 seconds for fp32 and 109.25457310676575 seconds for fp16.

#### Perf

These are functional one-iteration measurements with one warmup, not stable benchmark distributions.

| EP / Device | Precision | Verdict | Mean | p50 | Throughput | RSS baseline | Model-load RSS delta | Inference RSS delta | Total RSS delta | Local/shared VRAM total delta |
|---|---|---|---|---|---|---|---|---|---|---|
| CPUExecutionProvider / cpu | fp32 | PASS | 18430.639 ms | 18430.639 ms | 0.05 samples/s | 2031.02 MB | 40.48 MB | 2234.54 MB | 2275.03 MB | 0.0 MB / 0.0 MB |
| CPUExecutionProvider / cpu | fp16 | PASS | 33474.458 ms | 33474.458 ms | 0.03 samples/s | 2205.85 MB | 41.64 MB | 7811.68 MB | 7853.31 MB | 0.0 MB / 0.0 MB |

#### L2 PyTorch comparison

Both tuples used the pinned checkpoint, exact named inputs (`pixel_values` float32 `[1,3,1008,1008]`, `input_ids` int32 `[1,16]`, `attention_mask` int32 `[1,16]`), and a deterministic 1008x1008 blue image with a centered red square plus the text query `a red square`. No random-head warning was detected.

| Precision | Output | Shape | Reference / candidate dtype | Cosine | Max absolute error |
|---|---|---|---|---|---|
| fp32 | logits | `[1,5184,1]` | float32 / float32 | 0.9999999999620212 | 0.0020971298217773438 |
| fp32 | pred_boxes | `[1,5184,4]` | float32 / float32 | 0.9999999999905143 | 4.9367547035217285e-05 |
| fp32 | text_embeds | `[1,1,768]` | float32 / float32 | 0.9999999999995864 | 1.1175870895385742e-07 |
| fp32 | image_embeds | `[1,72,72,1024]` | float32 / float32 | 0.9999999999866064 | 0.0005168914794921875 |
| fp16 | logits | `[1,5184,1]` | float32 / float32 | 0.9999833807139331 | 1.3060321807861328 |
| fp16 | pred_boxes | `[1,5184,4]` | float32 / float32 | 0.9999951356472236 | 0.0638113021850586 |
| fp16 | text_embeds | `[1,1,768]` | float32 / float32 | 0.9999995353306403 | 0.0001304224133491516 |
| fp16 | image_embeds | `[1,72,72,1024]` | float32 / float32 | 0.9999939023018565 | 0.30898094177246094 |

Aggregate fp32: minimum cosine `0.9999999999620212`, maximum max-absolute error `0.0020971298217773438`. Aggregate fp16: minimum cosine `0.9999833807139331`, maximum max-absolute error `1.3060321807861328`.

#### Eval

| EP / Device | Precision | Verdict | Schema exit | Artifact exit | Dataset / revision / subset | Task metric | Blocker |
|---|---|---|---|---|---|---|---|
| CPUExecutionProvider / cpu | fp32 | CLI-BLOCKED | 2 | 1 | none / none / none | none | Task has no eval schema, evaluator, or default dataset; [issue #1147](https://github.com/microsoft/winml-cli/issues/1147). |
| CPUExecutionProvider / cpu | fp16 | CLI-BLOCKED | 2 | 1 | none / none / none | none | Task has no eval schema, evaluator, or default dataset; [issue #1147](https://github.com/microsoft/winml-cli/issues/1147). |

Both artifact-bound attempts resolved `zero-shot-object-detection` and then failed with: `Evaluation failed: Task 'zero-shot-object-detection' is not supported.` The L2 tensor comparison is numeric fidelity evidence, not a dataset-level task metric.

### Delta

- fp32 recipe: semantically identical to current-main auto-config after recursively removing `_note` keys.
- fp16 recipe: exactly one recursive semantic delta after removing `_note` keys.
- JSON pointer: `/quant`.
- Baseline value: `null`.
- Shipped value:

```json
{
  "mode": "fp16",
  "samples": 10,
  "calibration_method": "minmax",
  "weight_type": "uint8",
  "activation_type": "uint8",
  "per_channel": false,
  "symmetric": false,
  "weight_symmetric": null,
  "activation_symmetric": null,
  "save_calibration": false,
  "distribution": "uniform",
  "seed": null,
  "calibration_load_path": null,
  "calibration_save_path": null,
  "op_types_to_quantize": null,
  "nodes_to_exclude": null,
  "task": "zero-shot-object-detection",
  "model_id": "google/owlv2-large-patch14",
  "model_type": "owlv2",
  "fp16_keep_io_types": true,
  "fp16_op_block_list": null
}
```

This is the charter-required fp16 precision declaration, not a model-family architecture repair. There are no code paths, symbols, or class-wide behavior changes. Reducibility is consistent with the charter's per-model recipe resolution. Recipe-free acceptance is `NOT-REQUIRED` for frozen Effort L0 because current-main recipe-free L0/L1 already pass, and the production `examples/recipes/README.md` remains untouched.

### Analyze summary - component level and op level

Static analysis status is `ANALYZE-PARTIAL-SUCCESS`: `winml analyze` exited 1 for each artifact, meaning valid partial support, and emitted complete metadata plus seven requested EP rows. This is static rule compatibility analysis, not runtime execution.

#### Component-level summary

| Artifact | Architecture coverage | Mapping | Actionable EP findings |
|---|---|---|---|
| fp32 | Vision patch/position embeddings; 24x vision encoder; text embeddings; 12x text encoder; class, objectness, and box heads; feature fusion; dual backbone | 1,196 mapped; 15 unmapped; `mapped-with-explicit-gaps` | QNN partial: Add, Div, Erf, Gather, Mul; unsupported: none |
| fp16 | Vision patch/position embeddings; 24x vision encoder; text embeddings; 12x text encoder; class, objectness, and box heads; feature fusion; dual backbone | 1,196 mapped; 20 unmapped; `mapped-with-explicit-gaps` | QNN partial: Add, Div, Erf, Expand, Gather, Mul; unsupported: none |

For both artifacts, functional nodes without exporter scope names remain explicitly unmapped.

#### Op-level summary

| Artifact | Graph | Dominant ops | EP roll-up |
|---|---|---|---|
| fp32 | 1,211 operators / 27 types | Add 315; MatMul 295; Reshape 152; Transpose 145; Mul 117; LayerNormalization 76; Sigmoid 37; Softmax 36 | QNN partial: Add, Div, Erf, Gather, Mul; unsupported: none |
| fp16 | 1,216 operators / 27 types | Add 315; MatMul 295; Reshape 152; Transpose 145; Mul 117; LayerNormalization 76; Sigmoid 37; Softmax 36 | QNN partial: Add, Div, Erf, Expand, Gather, Mul; unsupported: none |

CUDAExecutionProvider, DmlExecutionProvider, MIGraphXExecutionProvider, and TensorrtExecutionProvider were all-unknown with `runtime_support=false` for both artifacts; these are not runtime support or failure claims. QNN classifications are static-rule evidence, not runtime validation.

### Reproduce commands

```powershell
$OUT='temp/owlv2-large-patch14-validation'
$INPUTS="$OUT/named_inputs.npz"
$env:INPUTS=$INPUTS
@'
import os
from pathlib import Path
import numpy as np
from PIL import Image, ImageDraw
from transformers import Owlv2Processor
model_id = "google/owlv2-large-patch14"
revision = "1aabc4ed23010cbcce9b6906e57392fe13622038"
image = Image.new("RGB", (1008, 1008), color=(30, 70, 150))
ImageDraw.Draw(image).rectangle((252, 252, 756, 756), fill=(220, 40, 40))
processor = Owlv2Processor.from_pretrained(model_id, revision=revision)
processed = processor(text=[["a red square"]], images=image, return_tensors="np", padding="max_length", max_length=16, truncation=True)
inputs = {"pixel_values": processed["pixel_values"].astype(np.float32), "input_ids": processed["input_ids"].astype(np.int32), "attention_mask": processed["attention_mask"].astype(np.int32)}
output = Path(os.environ["INPUTS"]); output.parent.mkdir(parents=True, exist_ok=True); np.savez_compressed(output, **inputs)
'@ | python -
winml build -c examples/recipes/google_owlv2-large-patch14/cpu/cpu/zero-shot-object-detection_fp32_config.json -m google/owlv2-large-patch14 -o $OUT/fp32 --ep cpu --device cpu --precision fp32 --no-analyze --no-optimize --no-quant --no-compile --rebuild
winml perf -m $OUT/fp32/model.onnx --device cpu --ep cpu --iterations 1 --warmup 1 --input-data $INPUTS --memory
winml build -c examples/recipes/google_owlv2-large-patch14/cpu/cpu/zero-shot-object-detection_fp16_config.json -m google/owlv2-large-patch14 -o $OUT/fp16 --ep cpu --device cpu --precision fp16 --no-analyze --no-optimize --no-compile --rebuild
winml perf -m $OUT/fp16/model.onnx --device cpu --ep cpu --iterations 1 --warmup 1 --input-data $INPUTS --memory
$env:WINMLCLI_RULES_DIR='<path-to-ModelKitArtifacts>/rules'
winml analyze --model $OUT/fp32/model.onnx --ep all --output $OUT/fp32/analyze.json
winml analyze --model $OUT/fp16/model.onnx --ep all --output $OUT/fp16/analyze.json
winml eval -m $OUT/fp32/model.onnx --model-id google/owlv2-large-patch14 --task zero-shot-object-detection --device cpu --ep cpu --samples 1
winml eval -m $OUT/fp16/model.onnx --model-id google/owlv2-large-patch14 --task zero-shot-object-detection --device cpu --ep cpu --samples 1
```