### PR TITLE
fix: add VitPose config-driven dummy inputs

### DIFF
--- a/examples/recipes/nielsr_vitpose-base-simple/cpu/cpu/keypoint-detection_fp16_config.json
+++ b/examples/recipes/nielsr_vitpose-base-simple/cpu/cpu/keypoint-detection_fp16_config.json
@@ -1,0 +1,67 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          256,
+          192
+        ],
+        "value_range": [
+          -2.1179039478302,
+          2.640000343322754
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "heatmaps"
+      }
+    ],
+    "compatibility": {
+      "transformers_attention": "eager"
+    }
+  },
+  "optim": {},
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "keypoint-detection",
+    "model_id": "nielsr/vitpose-base-simple",
+    "model_type": "vitpose",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "keypoint-detection",
+    "model_class": "VitPoseForPoseEstimation",
+    "model_type": "vitpose"
+  }
+}

--- a/examples/recipes/nielsr_vitpose-base-simple/cpu/cpu/keypoint-detection_fp32_config.json
+++ b/examples/recipes/nielsr_vitpose-base-simple/cpu/cpu/keypoint-detection_fp32_config.json
@@ -1,0 +1,45 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "pixel_values",
+        "dtype": "float32",
+        "shape": [
+          1,
+          3,
+          256,
+          192
+        ],
+        "value_range": [
+          -2.1179039478302,
+          2.640000343322754
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "heatmaps"
+      }
+    ],
+    "compatibility": {
+      "transformers_attention": "eager"
+    }
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "keypoint-detection",
+    "model_class": "VitPoseForPoseEstimation",
+    "model_type": "vitpose"
+  }
+}

--- a/src/winml/modelkit/models/hf/vitpose.py
+++ b/src/winml/modelkit/models/hf/vitpose.py
@@ -33,7 +33,18 @@ declares mask-generation the same way.
 
 from __future__ import annotations
 
+from optimum.exporters.onnx.model_configs import VitPoseOnnxConfig
+from optimum.utils.input_generators import DummyVisionInputGenerator
 from transformers import VitPoseForPoseEstimation
+
+from ...export import register_onnx_overwrite
+
+
+@register_onnx_overwrite("vitpose", "keypoint-detection", library_name="transformers")
+class VitPoseIOConfig(VitPoseOnnxConfig):  # type: ignore[misc]  # optimum base is untyped
+    """Generate image inputs without reloading a processor from the model ID."""
+
+    DUMMY_INPUT_GENERATOR_CLASSES = (DummyVisionInputGenerator,)
 
 
 # (model_type, task) -> HuggingFace model class

--- a/tests/unit/models/test_vitpose_mapping.py
+++ b/tests/unit/models/test_vitpose_mapping.py
@@ -15,9 +15,13 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+from transformers import VitPoseConfig
+
+from winml.modelkit.export import resolve_io_specs
 from winml.modelkit.loader import resolve_task
 from winml.modelkit.models.hf import MODEL_CLASS_MAPPING
 from winml.modelkit.models.hf.vitpose import MODEL_CLASS_MAPPING as VITPOSE_MAPPING
+from winml.modelkit.models.hf.vitpose import VitPoseIOConfig
 
 
 class TestVitPoseMapping:
@@ -67,3 +71,30 @@ class TestVitPoseMapping:
             is MODEL_CLASS_MAPPING[("vitpose", "keypoint-detection")]
         )
 
+
+class TestVitPoseIOConfig:
+    def test_resolves_dummy_input_without_loading_processor(self):
+        config = VitPoseConfig(
+            backbone_config={
+                "model_type": "vitpose_backbone",
+                "image_size": [256, 192],
+                "num_channels": 3,
+            },
+            num_labels=17,
+            scale_factor=4,
+            use_simple_decoder=True,
+        )
+
+        specs = resolve_io_specs(
+            "vitpose",
+            "keypoint-detection",
+            config,
+            height=256,
+            width=192,
+        )
+
+        assert specs["input_names"] == ["pixel_values"]
+        assert specs["output_names"] == ["heatmaps"]
+        assert specs["input_shapes"] == [(1, 3, 256, 192)]
+        assert specs["input_dtypes"] == ["float32"]
+        assert VitPoseIOConfig.__name__ == "VitPoseIOConfig"


### PR DESCRIPTION
## Summary

Adds CPU fp32/fp16 recipes for `nielsr/vitpose-base-simple` and fixes recipe-free VitPose input generation.

Optimum's `VitPoseDummyInputGenerator` inherits a static Vision generator that reloads preprocessors and indexes the result with `[-1]`. Config-only resolution has no loaded processor, so that path raises `IndexError`. A WinML `VitPoseIOConfig` now preserves Optimum's VitPose I/O declarations and model patcher while replacing only its dummy generator with the config-driven `DummyVisionInputGenerator`.

The workaround is contained in the existing VitPose model adapter. Generic export I/O behavior is unchanged.

The generic Perf range-consumption change was split into #1309. The VitPose evaluator processor fallback was split into #1310.

## Baseline and outcome

Without a recipe, current-main baseline export resolves `VitPoseOnnxConfig` but fails while its static dummy generator loads an empty processor list:

```text
Error: Build failed: list index out of range
```

With this change, recipe-free input resolution produces `pixel_values` `[1, 3, 256, 192]`. The checked-in recipes represent verified CPU fp32/fp16 coverage.

## Validation

- Final head: `5635a06aee12a2dfe3d2f0a4e7c92dc8ac00f8f1`
- Recipe-free CPU fp32 `winml build`: passed; `pixel_values` `[1, 3, 256, 192]` float32 -> `heatmaps`; final `model.onnx` generated
- Checked-in CPU fp32 recipe `winml build`: exit 0; completed in 73.5s; final `model.onnx` generated
- Checked-in CPU fp16 recipe `winml build`: exit 0; completed in 82.7s (Export 38.0s, Optimize 35.3s, FP16 8.8s); final `model.onnx` generated
- `tests/unit/export/test_io.py` + `tests/unit/models/test_vitpose_mapping.py`: 101 passed
- Ruff check: passed
- Ruff format check: passed
- GitHub checks: 9/9 passed
- Recipe README remains unchanged

## Files

- `examples/recipes/nielsr_vitpose-base-simple/cpu/cpu/keypoint-detection_fp32_config.json`
- `examples/recipes/nielsr_vitpose-base-simple/cpu/cpu/keypoint-detection_fp16_config.json`
- `src/winml/modelkit/models/hf/vitpose.py`
- `tests/unit/models/test_vitpose_mapping.py`