### PR TITLE
fix(perf): honor configured input value ranges

### DIFF
--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -538,6 +538,7 @@ def generate_random_inputs(
     symbolic_shapes = io_config.get("input_symbolic_shapes") or [
         [None] * len(s) for s in io_config["input_shapes"]
     ]
+    value_ranges = io_config.get("input_value_ranges") or {}
     overrides = shape_config or {}
 
     specs: dict[str, dict[str, Any]] = {}
@@ -566,6 +567,8 @@ def generate_random_inputs(
             "dtype": gen_dtype,
             "shape": list(resolved_shape),
         }
+        if name in value_ranges:
+            specs[name]["range"] = value_ranges[name]
 
     return generate_dummy_inputs_from_specs(specs)
 

--- a/src/winml/modelkit/session/session.py
+++ b/src/winml/modelkit/session/session.py
@@ -1676,7 +1676,7 @@ class WinMLSession:
             self._io_config["precision"] = self._get_precision(model)
         return self._io_config
 
-    def _load_input_value_ranges(self) -> dict[str, list[int]]:
+    def _load_input_value_ranges(self) -> dict[str, list[float]]:
         """Load input value ranges from the winml_build_config.json.
 
         Searches for the build config file in the same directory as the
@@ -1688,7 +1688,7 @@ class WinMLSession:
         """
         import json
 
-        value_ranges: dict[str, list[int]] = {}
+        value_ranges: dict[str, list[float]] = {}
         model_dir = self._onnx_path.parent
 
         # Try exact name first, then glob for prefixed variants

--- a/tests/unit/commands/test_perf_cli.py
+++ b/tests/unit/commands/test_perf_cli.py
@@ -36,6 +36,7 @@ from winml.modelkit.commands.perf import (
     PerfBenchmark,
     display_console_report,
     generate_output_path,
+    generate_random_inputs,
     perf,
 )
 from winml.modelkit.utils.console import SafeConsole
@@ -253,6 +254,21 @@ class TestPerfOutputPath:
         """Sanity: regardless of input, the file lands under ~/.cache/winml/perf."""
         result = generate_output_path("microsoft/resnet-50")
         assert self._cache_root in result.parents
+
+
+class TestGenerateRandomInputs:
+    def test_uses_persisted_floating_value_range(self) -> None:
+        io_config = {
+            "input_names": ["image"],
+            "input_shapes": [[1, 3, 8, 8]],
+            "input_types": ["float32"],
+            "input_value_ranges": {"image": [-2.1179039478302, 2.640000343322754]},
+        }
+
+        inputs = generate_random_inputs(io_config)
+
+        assert inputs["image"].min() >= io_config["input_value_ranges"]["image"][0]
+        assert inputs["image"].max() < io_config["input_value_ranges"]["image"][1]
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Makes classic `winml perf` honor `input_value_ranges` persisted in `winml_build_config.json` when generating random model inputs.

This generic Perf behavior fix was originally extracted from #1299 because it applies to every model that declares input ranges, not only VitPose. It is now rebased on the merged #1299.

## Changes

- Load persisted input ranges as floating-point bounds in `WinMLSession`.
- Forward per-input ranges into the generic spec-driven random input generator.
- Preserve the existing behavior for models with no declared range.

## Compatibility

There is no public API change. Perf input distributions intentionally change for models whose build config declares a range; their generated inputs now match that contract instead of silently using the default range. Historical Perf measurements for those models may therefore differ.

## Validation

- `tests/unit/commands/test_perf_cli.py`: 122 passed
- Rebased integration suite (`test_perf_cli.py`, `test_perf_genai.py`, `test_winml_session.py`): 288 passed, 6 skipped
- Ruff check: passed
- Ruff format check: passed

Follow-up to merged #1299.