### PR TITLE
fix(eval): resolve VitPose image processor metadata

### DIFF
--- a/src/winml/modelkit/eval/keypoint_detection_evaluator.py
+++ b/src/winml/modelkit/eval/keypoint_detection_evaluator.py
@@ -86,12 +86,7 @@ class WinMLKeypointDetectionEvaluator(WinMLEvaluator):
         The processor size is forced to the exported ONNX input shape so the
         preprocessed crops match the static model input.
         """
-        from transformers import AutoImageProcessor
-
-        processor = AutoImageProcessor.from_pretrained(
-            self.config.model_id,
-            trust_remote_code=self.config.trust_remote_code,
-        )
+        processor = self._load_image_processor()
 
         io_config = getattr(self.model, "io_config", None) or {}
         input_shapes = io_config.get("input_shapes", [])
@@ -100,6 +95,52 @@ class WinMLKeypointDetectionEvaluator(WinMLEvaluator):
             processor.size = {"height": h, "width": w}
 
         return processor
+
+    def _load_image_processor(self) -> Any:
+        """Resolve image processor with a narrow vitpose-family metadata fallback."""
+        from transformers import AutoImageProcessor, VitPoseImageProcessor
+
+        model_id = self.config.model_id
+        if model_id is None:
+            raise ValueError("model_id is required for keypoint-detection evaluator")
+
+        try:
+            return AutoImageProcessor.from_pretrained(
+                model_id,
+                trust_remote_code=self.config.trust_remote_code,
+            )
+        except ValueError as e:
+            if not self._should_fallback_to_vitpose_image_processor(e):
+                raise
+
+            logger.info(
+                "AutoImageProcessor resolution failed for vitpose metadata; "
+                "retrying with VitPoseImageProcessor"
+            )
+            return VitPoseImageProcessor.from_pretrained(
+                model_id,
+                trust_remote_code=self.config.trust_remote_code,
+            )
+
+    def _should_fallback_to_vitpose_image_processor(self, error: ValueError) -> bool:
+        """Fallback only for known unrecognized-processor failures in vitpose family."""
+        return "Unrecognized image processor" in str(error) and self._is_vitpose_family()
+
+    def _is_vitpose_family(self) -> bool:
+        """Check model metadata for vitpose family without model-id branching."""
+        hf_config = getattr(self.model, "config", None)
+
+        model_type = getattr(hf_config, "model_type", None)
+        if isinstance(model_type, str) and model_type.lower() == "vitpose":
+            return True
+
+        architectures = getattr(hf_config, "architectures", None)
+        if isinstance(architectures, list | tuple):
+            for architecture in architectures:
+                if isinstance(architecture, str) and "vitpose" in architecture.lower():
+                    return True
+
+        return False
 
     def compute(self) -> dict[str, Any]:
         """Run keypoint evaluation over all samples and return COCO AP/AR."""

--- a/tests/unit/eval/test_keypoint_detection_evaluator.py
+++ b/tests/unit/eval/test_keypoint_detection_evaluator.py
@@ -67,7 +67,14 @@ class TestBoxFormat:
             trust_remote_code=True,
         )
 
-    def test_vitpose_alias_mismatch_uses_gated_fallback(self):
+    @pytest.mark.parametrize(
+        ("model_type", "architectures"),
+        [
+            ("vitpose", []),
+            ("custom", ["ViTPoseForPoseEstimation"]),
+        ],
+    )
+    def test_vitpose_alias_mismatch_uses_gated_fallback(self, model_type, architectures):
         ev = _make_evaluator()
         ev.config = WinMLEvaluationConfig(
             model_id="nielsr/vitpose-base-simple",
@@ -77,8 +84,8 @@ class TestBoxFormat:
         ev.model = MagicMock(
             io_config={},
             config=SimpleNamespace(
-                model_type="vitpose",
-                architectures=["ViTPoseForPoseEstimation"],
+                model_type=model_type,
+                architectures=architectures,
             ),
         )
         fallback_processor = MagicMock()
@@ -105,6 +112,36 @@ class TestBoxFormat:
             "nielsr/vitpose-base-simple",
             trust_remote_code=True,
         )
+
+    def test_known_error_for_non_vitpose_model_is_not_swallowed(self):
+        ev = _make_evaluator()
+        ev.config = WinMLEvaluationConfig(
+            model_id="microsoft/resnet-50",
+            task="keypoint-detection",
+            trust_remote_code=False,
+        )
+        ev.model = MagicMock(
+            io_config={},
+            config=SimpleNamespace(
+                model_type="resnet", architectures=["ResNetForImageClassification"]
+            ),
+        )
+
+        with (
+            patch(
+                "transformers.AutoImageProcessor.from_pretrained",
+                side_effect=ValueError("Unrecognized image processor for resnet"),
+            ) as load_auto,
+            patch("transformers.VitPoseImageProcessor.from_pretrained") as load_vitpose,
+            pytest.raises(ValueError, match="Unrecognized image processor"),
+        ):
+            ev.prepare_pipeline()
+
+        load_auto.assert_called_once_with(
+            "microsoft/resnet-50",
+            trust_remote_code=False,
+        )
+        load_vitpose.assert_not_called()
 
     def test_non_vitpose_success_keeps_strict_auto_path(self):
         ev = _make_evaluator()

--- a/tests/unit/eval/test_keypoint_detection_evaluator.py
+++ b/tests/unit/eval/test_keypoint_detection_evaluator.py
@@ -12,6 +12,7 @@ loop wiring with a mocked image processor and model.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -65,6 +66,121 @@ class TestBoxFormat:
             "test/model",
             trust_remote_code=True,
         )
+
+    def test_vitpose_alias_mismatch_uses_gated_fallback(self):
+        ev = _make_evaluator()
+        ev.config = WinMLEvaluationConfig(
+            model_id="nielsr/vitpose-base-simple",
+            task="keypoint-detection",
+            trust_remote_code=True,
+        )
+        ev.model = MagicMock(
+            io_config={},
+            config=SimpleNamespace(
+                model_type="vitpose",
+                architectures=["ViTPoseForPoseEstimation"],
+            ),
+        )
+        fallback_processor = MagicMock()
+
+        with (
+            patch(
+                "transformers.AutoImageProcessor.from_pretrained",
+                side_effect=ValueError(
+                    "Unrecognized image processor in nielsr/vitpose-base-simple"
+                ),
+            ) as load_auto,
+            patch(
+                "transformers.VitPoseImageProcessor.from_pretrained",
+                return_value=fallback_processor,
+            ) as load_vitpose,
+        ):
+            assert ev.prepare_pipeline() is fallback_processor
+
+        load_auto.assert_called_once_with(
+            "nielsr/vitpose-base-simple",
+            trust_remote_code=True,
+        )
+        load_vitpose.assert_called_once_with(
+            "nielsr/vitpose-base-simple",
+            trust_remote_code=True,
+        )
+
+    def test_non_vitpose_success_keeps_strict_auto_path(self):
+        ev = _make_evaluator()
+        ev.config = WinMLEvaluationConfig(
+            model_id="microsoft/resnet-50",
+            task="keypoint-detection",
+            trust_remote_code=False,
+        )
+        ev.model = MagicMock(
+            io_config={},
+            config=SimpleNamespace(
+                model_type="resnet", architectures=["ResNetForImageClassification"]
+            ),
+        )
+        processor = MagicMock()
+
+        with (
+            patch(
+                "transformers.AutoImageProcessor.from_pretrained",
+                return_value=processor,
+            ) as load_auto,
+            patch("transformers.VitPoseImageProcessor.from_pretrained") as load_vitpose,
+        ):
+            assert ev.prepare_pipeline() is processor
+
+        load_auto.assert_called_once_with(
+            "microsoft/resnet-50",
+            trust_remote_code=False,
+        )
+        load_vitpose.assert_not_called()
+
+    def test_unrelated_value_error_is_not_swallowed(self):
+        ev = _make_evaluator()
+        ev.config = WinMLEvaluationConfig(
+            model_id="nielsr/vitpose-base-simple",
+            task="keypoint-detection",
+            trust_remote_code=False,
+        )
+        ev.model = MagicMock(
+            io_config={},
+            config=SimpleNamespace(
+                model_type="vitpose",
+                architectures=["ViTPoseForPoseEstimation"],
+            ),
+        )
+
+        with (
+            patch(
+                "transformers.AutoImageProcessor.from_pretrained",
+                side_effect=ValueError("network timeout while loading processor"),
+            ) as load_auto,
+            patch("transformers.VitPoseImageProcessor.from_pretrained") as load_vitpose,
+            pytest.raises(ValueError, match="network timeout"),
+        ):
+            ev.prepare_pipeline()
+
+        load_auto.assert_called_once_with(
+            "nielsr/vitpose-base-simple",
+            trust_remote_code=False,
+        )
+        load_vitpose.assert_not_called()
+
+    def test_missing_model_id_raises_before_processor_load(self):
+        ev = _make_evaluator()
+        ev.config = WinMLEvaluationConfig(task="keypoint-detection")
+        ev.model = MagicMock(io_config={})
+
+        with (
+            patch("transformers.AutoImageProcessor.from_pretrained") as load_auto,
+            patch("transformers.VitPoseImageProcessor.from_pretrained") as load_vitpose,
+            pytest.raises(ValueError, match="model_id is required"),
+        ):
+            ev.prepare_pipeline()
+
+        load_auto.assert_not_called()
+        load_vitpose.assert_not_called()
 
 
 class TestPredictionFlattening:


### PR DESCRIPTION
## Summary

This L2 contribution enables `nielsr/vitpose-base-simple` keypoint-detection evaluation by resolving the VitPose image-processor metadata alias through a class-wide, metadata-gated fallback. It ships evaluator code and regression tests while the existing CPU fp32/fp16 recipes remain byte-for-byte unchanged. Full CPU fp32/fp16 coverage reached L2, and the committed Goal reached L3 PASS through one bounded fp32 CPU COCO functional smoke.

## Model metadata

### What the model does

`nielsr/vitpose-base-simple` is a top-down human pose model that accepts an RGB image plus person bounding boxes, transforms each person crop into a 256 x 192 tensor, and emits 17 heatmaps whose peaks represent body-keypoint locations.

- Evidence: the pinned checkpoint at revision `2d440ccdd65125f8fdf61110d5b9e2d3ded4a964` declares `pipeline_tag=keypoint-detection`, `model_type=vitpose`, `architectures=[ViTPoseForPoseEstimation]`, `image_size=[256,192]`, and 17 labels; Transformers v5.14.1 `VitPoseImageProcessor` uses COCO-format boxes for affine person crops, and `ViTPoseForPoseEstimation` returns per-keypoint heatmaps. Confidence: `verified`.

### Primary user stories

1. A user supplies an RGB image and one or more detected-person bounding boxes to obtain 17 body-keypoint coordinates and confidence scores for top-down pose estimation. Evidence: Transformers v5.14.1 `VitPoseImageProcessor` preprocessing/postprocessing contracts and the WinML keypoint evaluator's image, bbox, keypoints, and area fields. Confidence: `verified`.
2. An application supplies person detections and uses the resulting keypoints for downstream human-pose analysis. Evidence: the top-down processor and evaluator data flow requires externally supplied person boxes. Confidence: `inferred`.

### Supported tasks

- `keypoint-detection` across checkpoint, Transformers, Optimum ONNX, and WinML surfaces. Evidence: the pinned checkpoint task and architecture; Transformers v5.14.1 `ViTPoseForPoseEstimation` and `VitPoseImageProcessor`; Optimum's `vitpose`/`keypoint-detection` registration to `VitPoseOnnxConfig`; and WinML's `VitPoseIOConfig`, `VitPoseForPoseEstimation`, and merged CPU fp32/fp16 recipes. Confidence: `verified`.

### Model architecture

```text
ViTPoseForPoseEstimation
├── VitPose backbone (256 x 192 RGB; hidden width 768)
│   ├── Patch embedding (16 x 16 patches)
│   ├── Transformer encoder layer x 12
│   │   ├── Multi-head self-attention (12 heads)
│   │   ├── MLP (768 -> 3072 -> 768, GELU)
│   │   └── LayerNorm + residual paths
│   └── Final stage12 feature sequence
├── Token-to-spatial reshape (16 x 12 feature map)
└── VitPoseSimpleDecoder
    ├── ReLU + 4x bilinear upsampling
    └── 3 x 3 convolution -> 17 heatmaps [B,17,64,48]
```

- Source/confidence: pinned checkpoint config and Transformers v5.14.1 `ViTPoseForPoseEstimation`/`VitPoseSimpleDecoder` source (`verified`).

## Validation and support evidence

### Baseline

The current pinned `main` is `2b9ec0e9e57bba8003d25eaff85f8c7c9e30d75a` with WinML 0.3.0; the prior accepted base was `48bfd0f91478a8e281b205b0449222024729f3ea`. Baseline provisioning remains the historical `FAIL-UPSTREAM` measured at `24cccfb23d6e3c3b93ae9bb94399c326cee8ecea`: canonical-lock synchronization failed on TLS transport, offline sync lacked locked torch, and product execution never began. Therefore no fresh current-main baseline config/build/perf/Eval result, build time, node count, latency, or metric is claimed.

No baseline `winml config` command executed and no baseline recipe was generated. Static installed-source evidence identifies the `keypoint-detection` task, `ViTPoseForPoseEstimation`, Optimum's `vitpose`/`keypoint-detection` registration, and WinML's override with `DummyVisionInputGenerator`; these are source-inspection facts, not an executed auto-config selection. No registration was found for `vit-pose` or `vit_pose`. A fresh dynamic probe was blocked by an internally incompatible current lock and is not represented as fresh evidence.

This is a `PARTIAL-RERUN`. Between the prior and current bases, only PR #1312 changed `winml sys` source, documentation, and tests; dependency impact analysis found no reachability into config, build, perf, Eval, analyze, loader/export, model, quantization, or optimization paths. Quality gates reran at shipped head `1207965854b5eeb3dec055a7cfa1f08db30fa6f9`; config/build/perf/parity/Eval/analyze remain reused from original execution SHA `b9f924e3b23bd8caf85339faa3853eeb20df2f17` under no-impact attestation and exact range-diff, stable-patch, owned-blob, and two-file diff equivalence. The current runtime patch commit `88bd424bbf0e415fa05c25c3cf9ad369277a06d5` is exact-equivalent to the originally measured runtime patch.

### Goal

- Effort: L2.
- Committed Goal ceiling: L3.
- Shipped Outcome: L2.
- Goal success definition: CPU fp32/fp16 L0-L2 plus one real, one-row COCO 2017 fp32 CPU functional smoke proving operability only.
- Verdict: L3 PASS. The ceiling was not downgraded or re-issued.

### Outcome

Outcome L2 shipped at head `1207965854b5eeb3dec055a7cfa1f08db30fa6f9`; the highest Goal verdict is L3 PASS. Coverage is full for both required CPU tuples, with no deferred tuples. The product diff contains only `src/winml/modelkit/eval/keypoint_detection_evaluator.py` and `tests/unit/eval/test_keypoint_detection_evaluator.py`; the existing merged fp32/fp16 recipes remain byte-for-byte unchanged, and the production recipe README is untouched.

Fresh exact-head quality evidence passed insert-license, Ruff, and Mypy (436 source files); focused evaluator tests 16 passed; direct `winml sys` unit tests 11 passed; the direct sys-e2e probe reported 20 skipped because `-m e2e` is required and therefore is not executed e2e coverage; the commands partition reported 3618 passed/9 skipped; the remaining partition reported 871 passed/2 skipped/1 deselected. All nine exact-head GitHub checks completed successfully.

No new model finding was produced in this rerun. Prior Lane A entries `vitpose-017` through `vitpose-021` are pushed at commit `a8d9a406bca1efaaf4dd4bace8d990334b5edc97` on remote ref `refs/heads/ssss141414/pr1310-component-mapping-skill`; this run was deduplicated and found no methodology friction. These entries are not claimed to be on `main`, and no Lane A PR URL is asserted.

### Per-EP/device/precision results and Functional smoke Eval

All model-stage rows below are reused from original execution SHA `b9f924e3b23bd8caf85339faa3853eeb20df2f17`; they were not rerun at the shipped head.

| Tier | EP / Device | Precision | Verdict | Mean | p50 | Throughput | RAM Δ | VRAM Δ |
|---|---|---|---|---:|---:|---:|---:|---:|
| L0 | CPUExecutionProvider / cpu | fp32 | PASS | - | - | - | - | - |
| L0 | CPUExecutionProvider / cpu | fp16 | PASS | - | - | - | - | - |
| L1 | CPUExecutionProvider / cpu | fp32 | PASS | 87.770 ms | 85.316 ms | 11.39 samples/s | +41.93 MB | 0.0 MB |
| L1 | CPUExecutionProvider / cpu | fp16 | PASS | 111.774 ms | 111.538 ms | 8.95 samples/s | +44.56 MB | 0.0 MB |

L0 fp32 structure: IR 8, opset 17, input `pixel_values [1,3,256,192]`, output `heatmaps [1,17,64,48]`, 359 nodes, 202 FLOAT initializers, and 343649280 external bytes. L0 fp16 structure: IR 8, opset 17, the same input/output shapes, 361 nodes, 201 FLOAT16 initializers, and 171824640 external bytes; realized fp16 precision was verified.

| Tier | Precision | Verdict | Cosine | Max abs | Mean abs |
|---|---|---|---:|---:|---:|
| L2 | fp32 | PASS | 0.9999999999985615 | 5.066394805908203e-07 | 1.2054166553809864e-08 |
| L2 | fp16 | PASS | 0.999999000534796 | 0.0005256682634353638 | 1.2196907846373506e-05 |

Parity used named input `pixel_values [1,3,256,192]` and output `[1,17,64,48]`.

**Functional smoke Eval (L3 PASS):** CPUExecutionProvider / cpu / fp32 on the official COCO 2017 person-keypoints validation release (`person_keypoints_val2017`, validation), reduced to fixed image 29397 and non-crowd annotation 449985. One image was selected and processed with one person, one affine crop, one model invocation, one prediction, 17 keypoints, and one metric accumulation; schema, label semantics, and prediction semantics were verified. COCO keypoint OKS metrics were AP `0.9999999999999998`, AP50 `0.9999999999999999`, AP75 `0.9999999999999999`, AP_large `0.9999999999999998`, AP_medium `-1.0`, AR `1.0`, AR50 `1.0`, and AR75 `1.0`.

The evaluator capability removed the former `AutoImageProcessor` VitPose alias blocker by using the explicit metadata-gated fallback. This smoke was executed at `b9f924e3b23bd8caf85339faa3853eeb20df2f17` with runtime-equivalent commit `e7c8bd2041ac1aa40329b866362ffa72933f6252`; it was **not rerun** at shipped head `1207965854b5eeb3dec055a7cfa1f08db30fa6f9` and is reused through no-impact and exact-equivalence attestation. It proves end-to-end functional operability only, not representative accuracy or benchmark quality; no fp16 Eval or other-EP accuracy is inferred. PR #1299's historical `mAP=0.8` citation lacks the required command/artifact/revision provenance and is not this accepted smoke result.

### Delta

No baseline recipe was generated because baseline provisioning failed before product execution, so no baseline-generated-recipe or JSON-pointer comparison exists. The existing merged `examples/recipes/nielsr_vitpose-base-simple/cpu/cpu/keypoint-detection_fp32_config.json` and `keypoint-detection_fp16_config.json` files remain byte-for-byte unchanged, and this PR has no recipe delta. Original-execution recipe-free build/Eval evidence at `b9f924e3b23bd8caf85339faa3853eeb20df2f17` verifies the code path independently under the stated no-impact and exact-equivalence reuse attestation. The production `examples/recipes/README.md` remains untouched.

The code delta is `WinMLKeypointDetectionEvaluator.prepare_pipeline` behavior plus its focused unit tests. No product content changed during the rebase: the two commits, resulting evaluator/test blobs, and exact two-file diff are equivalent; only commit and parent identities changed.

**Bug fix explanation:**

1. **Symptom and trigger:** keypoint Eval setup failed before preprocessing/inference when `AutoImageProcessor` raised its exact unrecognized-image-processor `ValueError` for a VitPose-family checkpoint.
2. **Root cause:** the shared evaluator used only the generic loader, while the checkpoint metadata identifies a processor family that the generic alias resolution did not recognize.
3. **Changed symbols and mechanism:** `WinMLKeypointDetectionEvaluator.prepare_pipeline` retains `AutoImageProcessor` as primary, inspects model config only after the known error, and retries through `VitPoseImageProcessor` when `model_type` or `architectures` identifies VitPose; `trust_remote_code` is forwarded to both paths.
4. **General/data-driven rule:** fallback selection is derived case-insensitively from the exact error class/text and model metadata, not from a checkpoint ID.
5. **Compatibility and blast radius:** primary success is unchanged; non-VitPose metadata, unrelated `ValueError`s, non-`ValueError` exceptions, missing model IDs, input-size overrides, crop fanout, box conversion, custom keypoint metadata, dataset indexing, prediction flattening, COCO metrics, and MIGraphX layout behavior remain unchanged. The intentional change is that metadata-identified VitPose checkpoints with this alias mismatch can proceed.
6. **Regression evidence:** all 16 focused evaluator cases pass, covering primary success without fallback, both VitPose metadata gates, non-VitPose propagation, unrelated-error propagation, missing model ID, and `trust_remote_code` forwarding. Recipe-free fp32 build and the bounded COCO smoke establish reducibility and evaluator operability; existing recipes remain unchanged.

### Analyze summary — component level and op level

Status is `ANALYZE-PARTIAL-SUCCESS` (exit code 1): a complete seven-record static rule roll-up was retained while unavailable plugin/rule groups remained explicit. This is static rule analysis, not runtime execution.

#### Component-level summary

| Artifact | Architecture coverage | Mapping | Confidence | Actionable EP findings |
|---|---|---|---|---|
| fp32 | VitPose backbone: 354 nodes; token-to-spatial reshape: 2; simple heatmap decoder: 3 | 359 mapped, 0 partial, 0 unmapped | mapped | Decoder `Resize` unknown on NvTensorRTRTX, OpenVINO, and QNN; no partial or unsupported operators reported. |

#### Op-level summary

| Artifact | Graph | Dominant ops | EP roll-up |
|---|---|---|---|
| fp32 | 359 operators / 12 types | Reshape 122; Gemm 72; Transpose 50; Add 26; LayerNormalization 25 | NvTensorRTRTX/OpenVINO/QNN classify 11 types and leave one decoder `Resize` unknown; the other 358 nodes are covered. |

CUDA, MIGraphX, TensorRT, and DML have no shipped rules, so all operators are unknown for those groups. Every static-analysis row has `runtime_support=false`; no runtime support or compatibility is inferred.

### Reproduce commands

```powershell
$OUT='temp/vitpose-base-simple-validation'
$DATASET='$OUT/coco-one-row-one-person'
winml build -m nielsr/vitpose-base-simple -o $OUT/cpu-fp32-recipe-free --ep cpu --device cpu --no-analyze --no-optimize --no-quant --no-compile --rebuild
winml build -c examples/recipes/nielsr_vitpose-base-simple/cpu/cpu/keypoint-detection_fp32_config.json -m nielsr/vitpose-base-simple -o $OUT/cpu-fp32
winml build -c examples/recipes/nielsr_vitpose-base-simple/cpu/cpu/keypoint-detection_fp16_config.json -m nielsr/vitpose-base-simple -o $OUT/cpu-fp16 --precision fp16
winml perf -m $OUT/cpu-fp32/model.onnx --device cpu --ep cpu --iterations 20 --warmup 5 --memory --output $OUT/perf-fp32.json --overwrite
winml perf -m $OUT/cpu-fp16/model.onnx --device cpu --ep cpu --iterations 20 --warmup 5 --memory --output $OUT/perf-fp16.json --overwrite
winml eval -m $OUT/cpu-fp32-recipe-free/model.onnx --model-id nielsr/vitpose-base-simple --task keypoint-detection --ep cpu --device cpu --dataset $DATASET --samples 1 --no-shuffle --skip-build --output $OUT/eval.json --overwrite
winml analyze --model $OUT/cpu-fp32/model.onnx --ep all --output $OUT/analyze-all.json
```