### PR TITLE
Report memory metadata in winml sys JSON

### DIFF
--- a/docs/commands/sys.md
+++ b/docs/commands/sys.md
@@ -100,8 +100,9 @@ The full JSON report includes a schema version and installed physical memory:
 }
 ```
 
-Memory capacity uses MiB. The value can be `null` when the host does not expose
-the physical memory total.
+Memory capacity uses MiB. If the host does not expose the physical memory total,
+the field is `null` and `winml sys` emits a warning while preserving the rest of
+the system report.
 
 ```bash
 # Only list devices — skip everything else

--- a/docs/commands/sys.md
+++ b/docs/commands/sys.md
@@ -85,7 +85,7 @@ $ winml sys --format json > env.json
 ```
 
 The full JSON report includes a schema version, installed physical memory, and
-device-specific details such as dedicated GPU memory when available:
+dedicated NVIDIA GPU memory when `nvidia-smi` is available:
 
 ```json
 {
@@ -114,7 +114,9 @@ device-specific details such as dedicated GPU memory when available:
 ```
 
 Memory capacities use MiB. A value can be `null` when the host does not expose
-the corresponding capacity.
+the corresponding capacity. NVIDIA GPU capacity comes from `nvidia-smi`; the
+32-bit `Win32_VideoController.AdapterRAM` value is not used. Other GPU vendors
+currently report `null` for `dedicated_memory_mib`.
 
 ```bash
 # Only list devices — skip everything else

--- a/docs/commands/sys.md
+++ b/docs/commands/sys.md
@@ -84,8 +84,7 @@ $ winml sys --format compact
 $ winml sys --format json > env.json
 ```
 
-The full JSON report includes a schema version, installed physical memory, and
-dedicated NVIDIA GPU memory when `nvidia-smi` is available:
+The full JSON report includes a schema version and installed physical memory:
 
 ```json
 {
@@ -97,26 +96,12 @@ dedicated NVIDIA GPU memory when `nvidia-smi` is available:
   },
   "memory": {
     "physical_total_mib": 16384
-  },
-  "devices": [
-    {
-      "priority": 1,
-      "type": "GPU",
-      "name": "Example GPU",
-      "details": {
-        "driver": "32.0.0.0",
-        "manufacturer": "Example Vendor",
-        "dedicated_memory_mib": 8192
-      }
-    }
-  ]
+  }
 }
 ```
 
-Memory capacities use MiB. A value can be `null` when the host does not expose
-the corresponding capacity. NVIDIA GPU capacity comes from `nvidia-smi`; the
-32-bit `Win32_VideoController.AdapterRAM` value is not used. Other GPU vendors
-currently report `null` for `dedicated_memory_mib`.
+Memory capacity uses MiB. The value can be `null` when the host does not expose
+the physical memory total.
 
 ```bash
 # Only list devices — skip everything else

--- a/docs/commands/sys.md
+++ b/docs/commands/sys.md
@@ -84,6 +84,38 @@ $ winml sys --format compact
 $ winml sys --format json > env.json
 ```
 
+The full JSON report includes a schema version, installed physical memory, and
+device-specific details such as dedicated GPU memory when available:
+
+```json
+{
+  "schema_version": 1,
+  "platform": {
+    "system": "Windows",
+    "release": "11",
+    "machine": "ARM64"
+  },
+  "memory": {
+    "physical_total_mib": 16384
+  },
+  "devices": [
+    {
+      "priority": 1,
+      "type": "GPU",
+      "name": "Example GPU",
+      "details": {
+        "driver": "32.0.0.0",
+        "manufacturer": "Example Vendor",
+        "dedicated_memory_mib": 8192
+      }
+    }
+  ]
+}
+```
+
+Memory capacities use MiB. A value can be `null` when the host does not expose
+the corresponding capacity.
+
 ```bash
 # Only list devices — skip everything else
 $ winml sys --list-device

--- a/src/winml/modelkit/commands/sys.py
+++ b/src/winml/modelkit/commands/sys.py
@@ -60,6 +60,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_SYS_JSON_SCHEMA_VERSION = 1
+
 # Rich is imported lazily — Console/Table/Panel only matter at render time,
 # and pulling them at module scope adds ~50 ms to every `winml sys`
 # invocation (including --format json/compact, which never render anything
@@ -201,6 +203,18 @@ def _get_platform_info() -> dict[str, Any]:
     }
 
 
+def _get_memory_info() -> dict[str, int | None]:
+    """Gather installed physical memory without making ``sys`` fail."""
+    try:
+        import psutil
+
+        total_mib = round(psutil.virtual_memory().total / (1024 * 1024))
+    except Exception as exc:
+        logger.warning("Failed to get physical memory details: %s", exc)
+        total_mib = 0
+    return {"physical_total_mib": total_mib or None}
+
+
 def _get_library_versions() -> dict[str, str | None]:
     """Gather versions of key ML libraries."""
     libraries: dict[str, str | None] = {}
@@ -332,8 +346,10 @@ def _gather_system_info(verbose: bool = False) -> dict[str, Any]:
         Dictionary containing all system information
     """
     info = {
+        "schema_version": _SYS_JSON_SCHEMA_VERSION,
         "python": _get_python_info(),
         "platform": _get_platform_info(),
+        "memory": _get_memory_info(),
         "libraries": _get_library_versions(),
         "torch": _get_torch_info(verbose=verbose),
         "backends": {
@@ -586,6 +602,8 @@ def _gather_device_info(
                     "driver": item.driver_version,
                     "manufacturer": item.manufacturer,
                 }
+                if device_label == "GPU":
+                    entry["details"]["dedicated_memory_mib"] = item.vram_mib or None
             elif device_label == "CPU":
                 entry["details"] = {
                     "cores": item.core_count,

--- a/src/winml/modelkit/commands/sys.py
+++ b/src/winml/modelkit/commands/sys.py
@@ -215,6 +215,46 @@ def _get_memory_info() -> dict[str, int | None]:
     return {"physical_total_mib": total_mib or None}
 
 
+def _get_nvidia_memory_by_name() -> dict[str, list[int]]:
+    """Return dedicated memory reported by nvidia-smi, grouped by GPU name."""
+    import csv
+    import shutil
+    import subprocess
+
+    executable = shutil.which("nvidia-smi")
+    if executable is None:
+        return {}
+    try:
+        completed = subprocess.run(  # noqa: S603
+            [
+                executable,
+                "--query-gpu=name,memory.total",
+                "--format=csv,noheader,nounits",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        logger.debug("nvidia-smi memory query failed", exc_info=True)
+        return {}
+
+    memory_by_name: dict[str, list[int]] = {}
+    for row in csv.reader(completed.stdout.splitlines()):
+        if len(row) != 2:
+            continue
+        name = row[0].strip().casefold()
+        try:
+            memory_mib = int(float(row[1].strip()))
+        except ValueError:
+            continue
+        if name and memory_mib > 0:
+            memory_by_name.setdefault(name, []).append(memory_mib)
+    return memory_by_name
+
+
 def _get_library_versions() -> dict[str, str | None]:
     """Gather versions of key ML libraries."""
     libraries: dict[str, str | None] = {}
@@ -345,7 +385,7 @@ def _gather_system_info(verbose: bool = False) -> dict[str, Any]:
     Returns:
         Dictionary containing all system information
     """
-    info = {
+    info: dict[str, Any] = {
         "schema_version": _SYS_JSON_SCHEMA_VERSION,
         "python": _get_python_info(),
         "platform": _get_platform_info(),
@@ -574,6 +614,18 @@ def _gather_device_info(
 
     result: list[dict[str, Any]] = []
     priority = 1
+    gpu_items = next(
+        (
+            items
+            for label, items in ordered_results
+            if label == "GPU" and not isinstance(items, Exception)
+        ),
+        (),
+    )
+    has_nvidia_gpu = any(
+        "nvidia" in f"{item.name} {item.manufacturer}".casefold() for item in gpu_items
+    )
+    nvidia_memory_by_name = _get_nvidia_memory_by_name() if has_nvidia_gpu else {}
     for device_label, items in ordered_results:
         if isinstance(items, Exception):
             logger.warning("Failed to get %s details: %s", device_label, items)
@@ -603,7 +655,11 @@ def _gather_device_info(
                     "manufacturer": item.manufacturer,
                 }
                 if device_label == "GPU":
-                    entry["details"]["dedicated_memory_mib"] = item.vram_mib or None
+                    capacities = nvidia_memory_by_name.get(item.name.strip().casefold(), [])
+                    entry["details"]["dedicated_memory_mib"] = (
+                        capacities.pop(0) if capacities else None
+                    )
+                    # TODO: Add trustworthy 64-bit capacity sources for non-NVIDIA GPUs.
             elif device_label == "CPU":
                 entry["details"] = {
                     "cores": item.core_count,

--- a/src/winml/modelkit/commands/sys.py
+++ b/src/winml/modelkit/commands/sys.py
@@ -209,10 +209,12 @@ def _get_memory_info() -> dict[str, int | None]:
         import psutil
 
         total_mib = round(psutil.virtual_memory().total / (1024 * 1024))
+        if total_mib <= 0:
+            raise ValueError("physical memory total must be greater than zero")
     except Exception as exc:
         logger.warning("Failed to get physical memory details: %s", exc)
-        total_mib = 0
-    return {"physical_total_mib": total_mib or None}
+        return {"physical_total_mib": None}
+    return {"physical_total_mib": total_mib}
 
 
 def _get_library_versions() -> dict[str, str | None]:

--- a/src/winml/modelkit/commands/sys.py
+++ b/src/winml/modelkit/commands/sys.py
@@ -215,46 +215,6 @@ def _get_memory_info() -> dict[str, int | None]:
     return {"physical_total_mib": total_mib or None}
 
 
-def _get_nvidia_memory_by_name() -> dict[str, list[int]]:
-    """Return dedicated memory reported by nvidia-smi, grouped by GPU name."""
-    import csv
-    import shutil
-    import subprocess
-
-    executable = shutil.which("nvidia-smi")
-    if executable is None:
-        return {}
-    try:
-        completed = subprocess.run(  # noqa: S603
-            [
-                executable,
-                "--query-gpu=name,memory.total",
-                "--format=csv,noheader,nounits",
-            ],
-            check=True,
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            timeout=10,
-        )
-    except (OSError, subprocess.SubprocessError):
-        logger.debug("nvidia-smi memory query failed", exc_info=True)
-        return {}
-
-    memory_by_name: dict[str, list[int]] = {}
-    for row in csv.reader(completed.stdout.splitlines()):
-        if len(row) != 2:
-            continue
-        name = row[0].strip().casefold()
-        try:
-            memory_mib = int(float(row[1].strip()))
-        except ValueError:
-            continue
-        if name and memory_mib > 0:
-            memory_by_name.setdefault(name, []).append(memory_mib)
-    return memory_by_name
-
-
 def _get_library_versions() -> dict[str, str | None]:
     """Gather versions of key ML libraries."""
     libraries: dict[str, str | None] = {}
@@ -614,18 +574,6 @@ def _gather_device_info(
 
     result: list[dict[str, Any]] = []
     priority = 1
-    gpu_items = next(
-        (
-            items
-            for label, items in ordered_results
-            if label == "GPU" and not isinstance(items, Exception)
-        ),
-        (),
-    )
-    has_nvidia_gpu = any(
-        "nvidia" in f"{item.name} {item.manufacturer}".casefold() for item in gpu_items
-    )
-    nvidia_memory_by_name = _get_nvidia_memory_by_name() if has_nvidia_gpu else {}
     for device_label, items in ordered_results:
         if isinstance(items, Exception):
             logger.warning("Failed to get %s details: %s", device_label, items)
@@ -654,12 +602,6 @@ def _gather_device_info(
                     "driver": item.driver_version,
                     "manufacturer": item.manufacturer,
                 }
-                if device_label == "GPU":
-                    capacities = nvidia_memory_by_name.get(item.name.strip().casefold(), [])
-                    entry["details"]["dedicated_memory_mib"] = (
-                        capacities.pop(0) if capacities else None
-                    )
-                    # TODO: Add trustworthy 64-bit capacity sources for non-NVIDIA GPUs.
             elif device_label == "CPU":
                 entry["details"] = {
                     "cores": item.core_count,

--- a/tests/e2e/test_sys_e2e.py
+++ b/tests/e2e/test_sys_e2e.py
@@ -174,7 +174,10 @@ class TestSysJsonShape:
     def test_default_json_has_versioned_physical_memory(self):
         data = _run_sys_json()
         assert data["schema_version"] == 1
-        assert data["memory"]["physical_total_mib"] > 0
+        physical_total_mib = data["memory"]["physical_total_mib"]
+        assert physical_total_mib is None or (
+            isinstance(physical_total_mib, int) and physical_total_mib > 0
+        )
 
     def test_default_json_devices_have_sequential_priority(self):
         """Devices come back with sequential 1-based priorities."""

--- a/tests/e2e/test_sys_e2e.py
+++ b/tests/e2e/test_sys_e2e.py
@@ -150,8 +150,10 @@ class TestSysJsonShape:
     """Validate the JSON output shape that downstream scripts depend on."""
 
     REQUIRED_TOP_KEYS: ClassVar[set[str]] = {
+        "schema_version",
         "python",
         "platform",
+        "memory",
         "libraries",
         "torch",
         "backends",
@@ -168,6 +170,11 @@ class TestSysJsonShape:
     def test_default_json_python_version_is_well_formed(self):
         data = _run_sys_json()
         assert re.match(r"^\d+\.\d+\.\d+", data["python"]["version"])
+
+    def test_default_json_has_versioned_physical_memory(self):
+        data = _run_sys_json()
+        assert data["schema_version"] == 1
+        assert data["memory"]["physical_total_mib"] > 0
 
     def test_default_json_devices_have_sequential_priority(self):
         """Devices come back with sequential 1-based priorities."""

--- a/tests/unit/commands/test_sys_device_info.py
+++ b/tests/unit/commands/test_sys_device_info.py
@@ -26,7 +26,12 @@ from unittest.mock import MagicMock, patch
 import click
 import pytest
 
-from winml.modelkit.commands.sys import _gather, _gather_device_info, _get_memory_info
+from winml.modelkit.commands.sys import (
+    _gather,
+    _gather_device_info,
+    _get_memory_info,
+    _get_nvidia_memory_by_name,
+)
 
 
 def _fake_ep_info(
@@ -192,34 +197,73 @@ class TestDeviceInfoEnrichment:
         assert result[0]["details"]["driver"] == "32.0.100"
         assert "architecture" not in result[0]["details"]
 
-    def test_gpu_includes_dedicated_memory(self) -> None:
-        """GPU inventory exposes the dedicated-memory capacity already detected by sysinfo."""
-        gpu_item = MagicMock(
-            driver_version="32.0.15.9000",
-            manufacturer="NVIDIA",
-            vram_mib=8192,
-        )
+    def test_nvidia_gpu_uses_nvidia_smi_memory(self) -> None:
+        """NVIDIA capacity comes from nvidia-smi, not 32-bit WMI AdapterRAM."""
+        gpu_item = MagicMock(driver_version="32.0.15.9000", manufacturer="NVIDIA")
         gpu_item.name = "NVIDIA Test GPU"
 
         with (
             patch("winml.modelkit.sysinfo.NPU.get_all", return_value=[]),
             patch("winml.modelkit.sysinfo.GPU.get_all", return_value=[gpu_item]),
             patch("winml.modelkit.sysinfo.CPU.get_all", return_value=[]),
+            patch(
+                "winml.modelkit.commands.sys._get_nvidia_memory_by_name",
+                return_value={"nvidia test gpu": [24 * 1024]},
+            ),
         ):
             result = _gather_device_info()
 
-        assert result == [
-            {
-                "priority": 1,
-                "type": "GPU",
-                "name": "NVIDIA Test GPU",
-                "details": {
-                    "driver": "32.0.15.9000",
-                    "manufacturer": "NVIDIA",
-                    "dedicated_memory_mib": 8192,
-                },
-            }
-        ]
+        assert result[0]["details"]["dedicated_memory_mib"] == 24 * 1024
+
+    def test_gpu_memory_is_unknown_without_matching_nvidia_smi_device(self) -> None:
+        """A mismatched nvidia-smi row never falls back to 32-bit WMI memory."""
+        gpu_item = MagicMock(driver_version="32.0.15.9000", manufacturer="NVIDIA")
+        gpu_item.name = "NVIDIA Test GPU"
+
+        with (
+            patch("winml.modelkit.sysinfo.NPU.get_all", return_value=[]),
+            patch("winml.modelkit.sysinfo.GPU.get_all", return_value=[gpu_item]),
+            patch("winml.modelkit.sysinfo.CPU.get_all", return_value=[]),
+            patch(
+                "winml.modelkit.commands.sys._get_nvidia_memory_by_name",
+                return_value={"different gpu": [24 * 1024]},
+            ),
+        ):
+            result = _gather_device_info()
+
+        assert result[0]["details"]["dedicated_memory_mib"] is None
+
+    def test_non_nvidia_gpu_does_not_query_nvidia_smi(self) -> None:
+        """Other vendors stay unknown until a trustworthy 64-bit source is added."""
+        gpu_item = MagicMock(driver_version="32.0.100.0000", manufacturer="Intel")
+        gpu_item.name = "Intel Test GPU"
+
+        with (
+            patch("winml.modelkit.sysinfo.NPU.get_all", return_value=[]),
+            patch("winml.modelkit.sysinfo.GPU.get_all", return_value=[gpu_item]),
+            patch("winml.modelkit.sysinfo.CPU.get_all", return_value=[]),
+            patch("winml.modelkit.commands.sys._get_nvidia_memory_by_name") as query,
+        ):
+            result = _gather_device_info()
+
+        query.assert_not_called()
+        assert result[0]["details"]["dedicated_memory_mib"] is None
+
+
+class TestNvidiaGpuMemory:
+    """nvidia-smi is the trusted NVIDIA dedicated-memory source."""
+
+    @patch("shutil.which", return_value="C:/Windows/System32/nvidia-smi.exe")
+    @patch("subprocess.run")
+    def test_parses_multiple_gpu_capacities(self, run: MagicMock, _which: MagicMock) -> None:
+        run.return_value = MagicMock(
+            stdout="NVIDIA RTX 4090, 24564\nNVIDIA RTX 4090, 24564\n"
+        )
+        assert _get_nvidia_memory_by_name() == {"nvidia rtx 4090": [24564, 24564]}
+
+    @patch("shutil.which", return_value=None)
+    def test_missing_nvidia_smi_returns_empty(self, _which: MagicMock) -> None:
+        assert _get_nvidia_memory_by_name() == {}
 
 
 class TestMemoryInfo:

--- a/tests/unit/commands/test_sys_device_info.py
+++ b/tests/unit/commands/test_sys_device_info.py
@@ -26,7 +26,7 @@ from unittest.mock import MagicMock, patch
 import click
 import pytest
 
-from winml.modelkit.commands.sys import _gather, _gather_device_info
+from winml.modelkit.commands.sys import _gather, _gather_device_info, _get_memory_info
 
 
 def _fake_ep_info(
@@ -191,6 +191,48 @@ class TestDeviceInfoEnrichment:
         assert len(result) == 1
         assert result[0]["details"]["driver"] == "32.0.100"
         assert "architecture" not in result[0]["details"]
+
+    def test_gpu_includes_dedicated_memory(self) -> None:
+        """GPU inventory exposes the dedicated-memory capacity already detected by sysinfo."""
+        gpu_item = MagicMock(
+            driver_version="32.0.15.9000",
+            manufacturer="NVIDIA",
+            vram_mib=8192,
+        )
+        gpu_item.name = "NVIDIA Test GPU"
+
+        with (
+            patch("winml.modelkit.sysinfo.NPU.get_all", return_value=[]),
+            patch("winml.modelkit.sysinfo.GPU.get_all", return_value=[gpu_item]),
+            patch("winml.modelkit.sysinfo.CPU.get_all", return_value=[]),
+        ):
+            result = _gather_device_info()
+
+        assert result == [
+            {
+                "priority": 1,
+                "type": "GPU",
+                "name": "NVIDIA Test GPU",
+                "details": {
+                    "driver": "32.0.15.9000",
+                    "manufacturer": "NVIDIA",
+                    "dedicated_memory_mib": 8192,
+                },
+            }
+        ]
+
+
+class TestMemoryInfo:
+    """System memory metadata is fast, explicit, and best-effort."""
+
+    def test_physical_total_is_reported_in_mib(self) -> None:
+        memory = MagicMock(total=24 * 1024 * 1024 * 1024)
+        with patch("psutil.virtual_memory", return_value=memory):
+            assert _get_memory_info() == {"physical_total_mib": 24 * 1024}
+
+    def test_probe_failure_returns_unknown(self) -> None:
+        with patch("psutil.virtual_memory", side_effect=RuntimeError("unavailable")):
+            assert _get_memory_info() == {"physical_total_mib": None}
 
 
 class TestGatherDeviceSectionEnrichment:

--- a/tests/unit/commands/test_sys_device_info.py
+++ b/tests/unit/commands/test_sys_device_info.py
@@ -30,7 +30,6 @@ from winml.modelkit.commands.sys import (
     _gather,
     _gather_device_info,
     _get_memory_info,
-    _get_nvidia_memory_by_name,
 )
 
 
@@ -196,75 +195,6 @@ class TestDeviceInfoEnrichment:
         assert len(result) == 1
         assert result[0]["details"]["driver"] == "32.0.100"
         assert "architecture" not in result[0]["details"]
-
-    def test_nvidia_gpu_uses_nvidia_smi_memory(self) -> None:
-        """NVIDIA capacity comes from nvidia-smi, not 32-bit WMI AdapterRAM."""
-        gpu_item = MagicMock(driver_version="32.0.15.9000", manufacturer="NVIDIA")
-        gpu_item.name = "NVIDIA Test GPU"
-
-        with (
-            patch("winml.modelkit.sysinfo.NPU.get_all", return_value=[]),
-            patch("winml.modelkit.sysinfo.GPU.get_all", return_value=[gpu_item]),
-            patch("winml.modelkit.sysinfo.CPU.get_all", return_value=[]),
-            patch(
-                "winml.modelkit.commands.sys._get_nvidia_memory_by_name",
-                return_value={"nvidia test gpu": [24 * 1024]},
-            ),
-        ):
-            result = _gather_device_info()
-
-        assert result[0]["details"]["dedicated_memory_mib"] == 24 * 1024
-
-    def test_gpu_memory_is_unknown_without_matching_nvidia_smi_device(self) -> None:
-        """A mismatched nvidia-smi row never falls back to 32-bit WMI memory."""
-        gpu_item = MagicMock(driver_version="32.0.15.9000", manufacturer="NVIDIA")
-        gpu_item.name = "NVIDIA Test GPU"
-
-        with (
-            patch("winml.modelkit.sysinfo.NPU.get_all", return_value=[]),
-            patch("winml.modelkit.sysinfo.GPU.get_all", return_value=[gpu_item]),
-            patch("winml.modelkit.sysinfo.CPU.get_all", return_value=[]),
-            patch(
-                "winml.modelkit.commands.sys._get_nvidia_memory_by_name",
-                return_value={"different gpu": [24 * 1024]},
-            ),
-        ):
-            result = _gather_device_info()
-
-        assert result[0]["details"]["dedicated_memory_mib"] is None
-
-    def test_non_nvidia_gpu_does_not_query_nvidia_smi(self) -> None:
-        """Other vendors stay unknown until a trustworthy 64-bit source is added."""
-        gpu_item = MagicMock(driver_version="32.0.100.0000", manufacturer="Intel")
-        gpu_item.name = "Intel Test GPU"
-
-        with (
-            patch("winml.modelkit.sysinfo.NPU.get_all", return_value=[]),
-            patch("winml.modelkit.sysinfo.GPU.get_all", return_value=[gpu_item]),
-            patch("winml.modelkit.sysinfo.CPU.get_all", return_value=[]),
-            patch("winml.modelkit.commands.sys._get_nvidia_memory_by_name") as query,
-        ):
-            result = _gather_device_info()
-
-        query.assert_not_called()
-        assert result[0]["details"]["dedicated_memory_mib"] is None
-
-
-class TestNvidiaGpuMemory:
-    """nvidia-smi is the trusted NVIDIA dedicated-memory source."""
-
-    @patch("shutil.which", return_value="C:/Windows/System32/nvidia-smi.exe")
-    @patch("subprocess.run")
-    def test_parses_multiple_gpu_capacities(self, run: MagicMock, _which: MagicMock) -> None:
-        run.return_value = MagicMock(
-            stdout="NVIDIA RTX 4090, 24564\nNVIDIA RTX 4090, 24564\n"
-        )
-        assert _get_nvidia_memory_by_name() == {"nvidia rtx 4090": [24564, 24564]}
-
-    @patch("shutil.which", return_value=None)
-    def test_missing_nvidia_smi_returns_empty(self, _which: MagicMock) -> None:
-        assert _get_nvidia_memory_by_name() == {}
-
 
 class TestMemoryInfo:
     """System memory metadata is fast, explicit, and best-effort."""

--- a/tests/unit/commands/test_sys_device_info.py
+++ b/tests/unit/commands/test_sys_device_info.py
@@ -20,6 +20,7 @@ the parent's registry.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -204,9 +205,28 @@ class TestMemoryInfo:
         with patch("psutil.virtual_memory", return_value=memory):
             assert _get_memory_info() == {"physical_total_mib": 24 * 1024}
 
-    def test_probe_failure_returns_unknown(self) -> None:
-        with patch("psutil.virtual_memory", side_effect=RuntimeError("unavailable")):
+    def test_probe_failure_returns_unknown_and_warns(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with (
+            patch("psutil.virtual_memory", side_effect=RuntimeError("unavailable")),
+            caplog.at_level(logging.WARNING, logger="winml.modelkit.commands.sys"),
+        ):
             assert _get_memory_info() == {"physical_total_mib": None}
+
+        assert "Failed to get physical memory details: unavailable" in caplog.text
+
+    def test_non_positive_total_returns_unknown_and_warns(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        memory = MagicMock(total=0)
+        with (
+            patch("psutil.virtual_memory", return_value=memory),
+            caplog.at_level(logging.WARNING, logger="winml.modelkit.commands.sys"),
+        ):
+            assert _get_memory_info() == {"physical_total_mib": None}
+
+        assert "physical memory total must be greater than zero" in caplog.text
 
 
 class TestGatherDeviceSectionEnrichment:


### PR DESCRIPTION
## Summary

- add `schema_version: 1` to the full `winml sys --format json` payload
- add installed physical memory as `memory.physical_total_mib`
- keep the memory probe best-effort: failures or non-positive capacities emit a warning, return `null`, and preserve the rest of the `winml sys` report
- document the versioned physical-memory field and cover successful conversion plus warning-backed fallback behavior with unit and hardware-backed E2E tests

GPU memory is intentionally unchanged in this PR. Existing execution-provider inventory already reports available memory through entries such as `DmlExecutionProvider.entries[].devices[].facts`; this change does not add a second GPU-memory field sourced from `Win32_VideoController.AdapterRAM`.

## Validation

- `uv run --no-sync mypy -p winml.modelkit` (435 source files, no issues)
- `uv run --no-sync ruff check src/winml/modelkit/commands/sys.py tests/e2e/test_sys_e2e.py tests/unit/commands/test_sys_device_info.py`
- `uv run --no-sync pytest tests/unit/commands/test_sys_device_info.py -q` (11 passed)
- `uv run --no-sync pytest tests/e2e/test_sys_e2e.py::TestSysJsonShape tests/e2e/test_sys_e2e.py::TestSysFlagVariations -m e2e -q` (12 passed)