### PR TITLE
Hide EP installation status from sys JSON output

### DIFF
--- a/src/winml/modelkit/commands/sys.py
+++ b/src/winml/modelkit/commands/sys.py
@@ -44,6 +44,7 @@ from ..ep_path import (
     NuGetSource,
     PyPISource,
     WinMLCatalogSource,
+    _suppress_ep_install_status,
 )
 from ..session import WinMLEPRegistry
 from ..sysinfo import OS
@@ -671,9 +672,7 @@ def _output_device_text(devices: list[dict[str, Any]]) -> None:
     console.print("\n[bold blue]Available Devices (priority order)[/bold blue]")
     for dev in devices:
         name = escape(dev["name"])
-        console.print(
-            f"  [bold]#{dev['priority']}[/bold]  [cyan]{dev['type']:5s}[/cyan] {name}"
-        )
+        console.print(f"  [bold]#{dev['priority']}[/bold]  [cyan]{dev['type']:5s}[/cyan] {name}")
         details = dev.get("details", {})
         if "error" in details:
             console.print(f"             [red]Error: {escape(details['error'])}[/red]")
@@ -827,8 +826,7 @@ def isolated_ep_register(
             "",
         )
         raise WinMLEPRegistrationFailed(
-            f"isolated register of {dll_path} exited {proc.returncode}: "
-            f"{stderr_tail[-500:]}",
+            f"isolated register of {dll_path} exited {proc.returncode}: {stderr_tail[-500:]}",
             dll_path=dll_path,
             raw_error=last_line,
         )
@@ -918,9 +916,7 @@ def _gather_ep_info() -> dict[str, dict[str, Any]]:
 
     ep_records: dict[
         str,
-        list[
-            tuple[EPEntry, dict[str, Any] | None, WinMLEPRegistrationFailed | None, bool | None]
-        ],
+        list[tuple[EPEntry, dict[str, Any] | None, WinMLEPRegistrationFailed | None, bool | None]],
     ] = {}
     for entry in all_entries:
         row = next(fs_iter) if not entry.is_built_in() else _process(entry)
@@ -1267,26 +1263,28 @@ def sysinfo(
     configure_logging(verbosity=verbose, quiet=quiet)
 
     fmt = output_format.lower()
-    if list_device or list_ep:
-        # Explicit-section mode: raise on per-section error so the
-        # user knows their pin didn't produce a result.
-        info = _gather(
-            devices=list_device,
-            eps=list_ep,
-            verbose=bool(verbose),
-            tolerant=False,
-        )
-    else:
-        # Default mode: always include system info; sections only
-        # for non-compact formats (compact is a sysinfo overview by
-        # convention); tolerant so a broken section doesn't blank
-        # the whole report.
-        include_sections = fmt != "compact"
-        info = _gather(
-            system=True,
-            devices=include_sections,
-            eps=include_sections,
-            verbose=bool(verbose),
-            tolerant=True,
-        )
+    status_context = _suppress_ep_install_status() if fmt == "json" else contextlib.nullcontext()
+    with status_context:
+        if list_device or list_ep:
+            # Explicit-section mode: raise on per-section error so the
+            # user knows their pin didn't produce a result.
+            info = _gather(
+                devices=list_device,
+                eps=list_ep,
+                verbose=bool(verbose),
+                tolerant=False,
+            )
+        else:
+            # Default mode: always include system info; sections only
+            # for non-compact formats (compact is a sysinfo overview by
+            # convention); tolerant so a broken section doesn't blank
+            # the whole report.
+            include_sections = fmt != "compact"
+            info = _gather(
+                system=True,
+                devices=include_sections,
+                eps=include_sections,
+                verbose=bool(verbose),
+                tolerant=True,
+            )
     _RENDERERS[fmt](info, bool(verbose))

--- a/src/winml/modelkit/ep_path.py
+++ b/src/winml/modelkit/ep_path.py
@@ -41,6 +41,7 @@ Public API:
 from __future__ import annotations
 
 import atexit
+import contextlib
 import dataclasses
 import functools
 import logging
@@ -49,6 +50,7 @@ import platform
 import sys
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable, Iterator, Mapping
+from contextvars import ContextVar
 from dataclasses import dataclass
 from importlib import metadata
 from pathlib import Path
@@ -59,6 +61,20 @@ from packaging.version import InvalidVersion, Version
 
 
 logger = logging.getLogger(__name__)
+_EP_INSTALL_STATUS_ENABLED: ContextVar[bool] = ContextVar(
+    "_EP_INSTALL_STATUS_ENABLED",
+    default=True,
+)
+
+
+@contextlib.contextmanager
+def _suppress_ep_install_status() -> Iterator[None]:
+    """Temporarily hide EP installation notices and download progress."""
+    token = _EP_INSTALL_STATUS_ENABLED.set(False)
+    try:
+        yield
+    finally:
+        _EP_INSTALL_STATUS_ENABLED.reset(token)
 
 
 # Canonical EPSource origin tags accepted by ``--ep <name>@<source>`` and
@@ -891,6 +907,8 @@ def _make_progress_bar() -> Any:
 
     Format: ``Downloading... ████████████░░░░░░ 62%``
     """
+    if not _EP_INSTALL_STATUS_ENABLED.get():
+        return _NoopBar()
     if sys.stderr is None or not hasattr(sys.stderr, "write"):
         logger.debug("stderr is unavailable; using no-op progress bar.")
         return _NoopBar()
@@ -968,6 +986,8 @@ def _safe_console_print(console: Any, *args: Any, **kwargs: Any) -> None:
     mirroring :class:`_SafeProgressBar` — failures are logged at debug and
     otherwise ignored.
     """
+    if not _EP_INSTALL_STATUS_ENABLED.get():
+        return
     try:
         console.print(*args, **kwargs)
     except Exception as e:

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -231,6 +231,31 @@ class TestSysCommand:
         assert "python" in data
         assert "libraries" in data
 
+    def test_sys_json_suppresses_ep_install_status(self, runner: CliRunner) -> None:
+        """JSON gathering runs with EP installation status disabled."""
+        from winml.modelkit import ep_path
+
+        mock_eps = {
+            "CPUExecutionProvider": {
+                "entries": [
+                    {"status": "primary", "source_kind": "BuiltinSource", "dll_path": None}
+                ],
+            }
+        }
+
+        def gather_ep_info():
+            assert ep_path._EP_INSTALL_STATUS_ENABLED.get() is False
+            return mock_eps
+
+        with patch(
+            "winml.modelkit.commands.sys._gather_ep_info",
+            side_effect=gather_ep_info,
+        ):
+            result = runner.invoke(main, ["sys", "--format", "json"])
+
+        assert result.exit_code == 0
+        assert "[WinML] Installing Execution Provider" not in result.output
+
     def test_sys_compact_format(self, runner: CliRunner) -> None:
         """Test sys with compact format."""
         result = runner.invoke(main, ["sys", "--format", "compact"])

--- a/tests/unit/ep_path/test_ensure_provider_ready.py
+++ b/tests/unit/ep_path/test_ensure_provider_ready.py
@@ -119,6 +119,37 @@ def test_ensure_provider_ready_warns_before_download(
     assert "FakeEP" in err
 
 
+def test_ensure_provider_ready_suppresses_status_and_progress(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Structured-output callers can hide all installation status."""
+    fake_tqdm = MagicMock()
+    tqdm_mod = types.ModuleType("tqdm")
+    tqdm_mod.tqdm = fake_tqdm  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "tqdm", tqdm_mod)
+
+    op = MagicMock()
+
+    def fake_ensure_async(on_complete=None, on_progress=None):
+        on_progress(0.5)
+        on_complete()
+        return op
+
+    provider = MagicMock()
+    provider.name = "FakeEP"
+    provider.version = "1.0.0"
+    provider.package_family_name = "FakeEP_123"
+    provider.ensure_ready_async.side_effect = fake_ensure_async
+
+    with ep_path._suppress_ep_install_status():
+        ep_path._ensure_provider_ready(provider)
+
+    assert capsys.readouterr().err == ""
+    fake_tqdm.assert_not_called()
+    op.get_status.assert_called_once_with()
+    op.close.assert_called_once_with()
+
+
 def test_ensure_provider_ready_forces_bar_to_100_on_success_without_progress(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- suppress EP installation notices and download progress while `winml sys` gathers JSON output
- preserve existing installation status for human-readable formats
- add regression coverage for CLI JSON mode and provider readiness