### PR TITLE
feat(export): support static batch size

### DIFF
--- a/docs/commands/export.md
+++ b/docs/commands/export.md
@@ -20,6 +20,7 @@ $ winml export [options]
 |---|---|---|---|---|
 | `--model` | `-m` | string | *(required)* | Hugging Face model name or local path (e.g., `prajjwal1/bert-tiny`). |
 | `--output` | `-o` | path | *(required)* | Output ONNX file path (e.g., `model.onnx`). |
+| `--batch-size` | | integer | `1` | Static batch size for generated model inputs. |
 | `--with-report/--no-with-report` | | flag | `false` | Generate full export reports: Markdown, JSON, and a console tree. |
 | `--hierarchy/--no-hierarchy` | | flag | `true` | Preserve `hierarchy_tag` metadata in ONNX nodes (use `--no-hierarchy` for a clean ONNX file). |
 | `--dynamo/--no-dynamo` | | flag | `false` | Use the legacy TorchScript exporter by default, whose opset-17 op decomposition is the validated path for QNN/NPU compilation today. Pass `--dynamo` to use PyTorch's TorchDynamo ONNX exporter for richer per-node module metadata. |
@@ -63,6 +64,11 @@ Starting HTP export...
   Detected task: image-classification
 
 Success! Model exported to: resnet50.onnx
+```
+
+```bash
+# Export a model with a static batch size of 2
+winml export -m microsoft/resnet-50 -o resnet50_batch2.onnx --batch-size 2
 ```
 
 ```bash

--- a/src/winml/modelkit/commands/export.py
+++ b/src/winml/modelkit/commands/export.py
@@ -93,6 +93,13 @@ def _warn_partial_composite(completed: list[Path]) -> None:
 @cli_utils.output_option("Output ONNX file path (e.g., model.onnx)", required=True)
 @cli_utils.overwrite_option()
 @click.option(
+    "--batch-size",
+    type=click.IntRange(min=1),
+    default=1,
+    show_default=True,
+    help="Static batch size for generated model inputs.",
+)
+@click.option(
     "--with-report/--no-with-report",
     default=False,
     show_default=True,
@@ -164,6 +171,7 @@ def export(
     model: str,
     output: Path,
     overwrite: bool,
+    batch_size: int,
     verbose: int,
     quiet: bool,
     with_report: bool,
@@ -321,6 +329,16 @@ def export(
         dynamic_axes_dict = cli_utils.load_json_object(dynamic_axes, "--dynamic-axes")
         console.print(f"[dim]Dynamic axes: {dynamic_axes_dict}[/dim]")
 
+    effective_batch_size = batch_size
+    if not cli_utils.is_cli_provided(ctx, "batch_size"):
+        effective_batch_size = _build_export_dict.get("batch_size", effective_batch_size)
+        effective_batch_size = export_config_dict.get("batch_size", effective_batch_size)
+    if not isinstance(effective_batch_size, int) or effective_batch_size <= 0:
+        raise click.ClickException(
+            f"Configuration error: batch_size must be a positive integer, got "
+            f"{effective_batch_size!r}"
+        )
+
     # One-time warnings (apply to every sub-model in a composite export).
     if torch_module:
         console.print(
@@ -355,6 +373,7 @@ def export(
             auto_export_cfg, _ = resolve_cfg(
                 model_id=model,
                 task=component_task,
+                batch_size=effective_batch_size,
                 shape_config=shape_overrides,
             )
             if auto_export_cfg.input_tensors:
@@ -424,6 +443,8 @@ def export(
             config_kwargs["verbose"] = bool(verbose)
         if cli_utils.is_cli_provided(ctx, "dynamo"):
             config_kwargs["dynamo"] = dynamo
+        if cli_utils.is_cli_provided(ctx, "batch_size"):
+            config_kwargs["batch_size"] = batch_size
         if dynamic_axes_dict is not None:
             config_kwargs["dynamic_axes"] = dynamic_axes_dict
 

--- a/src/winml/modelkit/export/config.py
+++ b/src/winml/modelkit/export/config.py
@@ -509,6 +509,7 @@ def _resolve_export_config_from_specs(
         output_tensors = [OutputTensorSpec(name=name) for name in io_specs["output_names"]]
 
     return WinMLExportConfig(
+        batch_size=batch_size,
         input_tensors=input_tensors,
         output_tensors=output_tensors,
     )
@@ -520,6 +521,7 @@ def resolve_export_config(
     task: str | None = None,
     model_class: str | None = None,
     model_type: str | None = None,
+    batch_size: int = 1,
     shape_config: dict | None = None,
     library_name: str = "transformers",
     trust_remote_code: bool = False,
@@ -535,6 +537,7 @@ def resolve_export_config(
         task: Task name (auto-detected if None).
         model_class: Explicit model class name.
         model_type: Explicit model type override.
+        batch_size: Batch size for generated input specifications.
         shape_config: Shape overrides (sequence_length, height, width).
         library_name: Source library (default: "transformers").
         trust_remote_code: Whether to trust remote code.
@@ -562,7 +565,7 @@ def resolve_export_config(
         hf_config=hf_config,
         library_name=library_name,
         model_id=model_id,
-        batch_size=WinMLExportConfig().batch_size,
+        batch_size=batch_size,
         **(shape_config or {}),
     )
 

--- a/tests/unit/commands/test_export.py
+++ b/tests/unit/commands/test_export.py
@@ -61,6 +61,7 @@ class TestExportCLIInterface:
         assert "-m" in result.output
         assert "--output" in result.output
         assert "-o" in result.output
+        assert "--batch-size" in result.output
 
         # Optional flags
         assert "--verbose" in result.output
@@ -843,6 +844,58 @@ class TestExportAutoResolveInputTensors:
             call_kwargs = mock_export_onnx.call_args.kwargs
             config = call_kwargs["export_config"]
             assert config.input_tensors is not None
+
+    def test_export_applies_batch_size_to_resolution_and_export_config(
+        self,
+        runner: CliRunner,
+        mock_export_onnx: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """--batch-size controls both generated input shapes and export metadata."""
+        from winml.modelkit.commands.export import export
+        from winml.modelkit.export import InputTensorSpec, WinMLExportConfig
+        from winml.modelkit.loader import WinMLLoaderConfig
+
+        resolved_config = WinMLExportConfig(
+            batch_size=2,
+            input_tensors=[
+                InputTensorSpec(name="pixel_values", dtype="float32", shape=(2, 3, 224, 224)),
+            ],
+        )
+        loader_config = WinMLLoaderConfig(task="image-classification", model_type="resnet")
+
+        with (
+            patch("winml.modelkit.loader.load_hf_model") as mock_load,
+            patch(
+                "winml.modelkit.export.resolve_export_config",
+                return_value=(resolved_config, loader_config),
+            ) as mock_resolve,
+        ):
+            mock_load.return_value = (MagicMock(), None, "image-classification")
+            result = runner.invoke(
+                export,
+                [
+                    "--model",
+                    "microsoft/resnet-50",
+                    "--output",
+                    str(tmp_path / "model.onnx"),
+                    "--batch-size",
+                    "2",
+                ],
+                obj={"debug": False},
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_resolve.assert_called_once_with(
+            model_id="microsoft/resnet-50",
+            task=None,
+            batch_size=2,
+            shape_config=None,
+        )
+        config = mock_export_onnx.call_args.kwargs["export_config"]
+        assert config.batch_size == 2
+        assert config.input_tensors is not None
+        assert config.input_tensors[0].shape == (2, 3, 224, 224)
 
 
 class TestExportTaskValidation:


### PR DESCRIPTION
## Summary
- add a validated `--batch-size` option to `winml export`
- propagate the requested batch size through input-spec resolution and export metadata
- document and test batch-size export behavior

Closes #1072

## Validation
- `uv run pytest tests\unit\commands\test_export.py tests\unit\export\test_config_validation.py tests\unit\export\test_io_specs.py -q` (161 passed)
- exported `microsoft/resnet-50` with batch size 2; input shape was `[2, 3, 224, 224]`
- QNN GPU perf: 18.18 ms average latency, 109.98 samples/sec