### PR TITLE
Use structured perf results in E2E evaluation

### DIFF
--- a/scripts/e2e_eval/README.md
+++ b/scripts/e2e_eval/README.md
@@ -66,7 +66,7 @@ dropping quantized ones, and a model with no applicable recipe variant builds a
 single `winml config` fallback. EPs evaluated on the unquantized model (VitisAI)
 follow the same non-quantized-only rule on NPU. The runner writes one
 `eval_result.json` per `(model, task, precision)` containing facts only (perf
-output + the winml-eval `metrics`/`dataset`).
+JSON result + the winml-eval `metrics`/`dataset`).
 Delta/verdict grading against the PyTorch baseline is done by the report site.
 
 ```bash
@@ -363,10 +363,12 @@ eval_results/2026-02-25/
     └── ...                     # one dir per (model, task, precision)
 ```
 
-Each `eval_result.json` carries `perf` (latency stdout, pass/fail) and, when
-accuracy ran, `accuracy` (the winml-eval `metrics` + `dataset`). The site reads
-these to render the perf and accuracy reports. Recipe runs produce one directory
-per precision variant; fallback (no recipe) runs omit the `__<precision>` suffix.
+Each `eval_result.json` carries `perf.result` (the structured JSON object written
+by `winml perf --output`) together with pass/fail metadata. Captured stdout and
+stderr are retained only for failure diagnosis. When accuracy ran, `accuracy`
+contains the winml-eval `metrics` + `dataset`. The site reads these to render the
+perf and accuracy reports. Recipe runs produce one directory per precision
+variant; fallback (no recipe) runs omit the `__<precision>` suffix.
 
 ## File Layout
 

--- a/scripts/e2e_eval/run_eval.py
+++ b/scripts/e2e_eval/run_eval.py
@@ -48,6 +48,7 @@ import functools
 import hashlib
 import json
 import logging
+import math
 import os
 import platform
 import re
@@ -1738,6 +1739,71 @@ def _run_build_only(entries: list[ModelEntry], args: argparse.Namespace) -> None
 # ---------------------------------------------------------------------------
 
 
+def _is_finite_number(value: object) -> bool:
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+    )
+
+
+def _validate_single_perf_result(result: dict, context: str = "result") -> str | None:
+    if result.get("schema_version") != 2:
+        return f"{context}.schema_version must be 2"
+
+    for field in ("benchmark_info", "model_info", "latency_ms", "throughput"):
+        if not isinstance(result.get(field), dict):
+            return f"{context}.{field} must be a JSON object"
+
+    latency = result["latency_ms"]
+    for field in ("mean", "min", "max", "p50", "p90", "p95", "p99", "std", "warmup_mean"):
+        if not _is_finite_number(latency.get(field)):
+            return f"{context}.latency_ms.{field} must be a finite number"
+
+    throughput = result["throughput"]
+    for field in ("samples_per_sec", "batches_per_sec"):
+        if not _is_finite_number(throughput.get(field)):
+            return f"{context}.throughput.{field} must be a finite number"
+
+    raw_samples = result.get("raw_samples_ms")
+    if not isinstance(raw_samples, list) or not raw_samples:
+        return f"{context}.raw_samples_ms must be a non-empty array"
+    if any(not _is_finite_number(sample) for sample in raw_samples):
+        return f"{context}.raw_samples_ms must contain only finite numbers"
+    return None
+
+
+def _validate_perf_result(result: dict) -> str | None:
+    """Validate the single-model or native composite ``winml perf`` schema."""
+    if "components" not in result and "component_count" not in result:
+        return _validate_single_perf_result(result)
+
+    components = result.get("components")
+    component_count = result.get("component_count")
+    if not isinstance(component_count, int) or isinstance(component_count, bool):
+        return "result.component_count must be an integer"
+    if not isinstance(components, dict) or not components:
+        return "result.components must be a non-empty JSON object"
+    if component_count != len(components):
+        return "result.component_count must match the number of components"
+
+    for name, component in components.items():
+        if not isinstance(name, str) or not name:
+            return "result.components keys must be non-empty strings"
+        if not isinstance(component, dict):
+            return f"result.components.{name} must be a JSON object"
+        error = _validate_single_perf_result(component, f"result.components.{name}")
+        if error is not None:
+            return error
+    return None
+
+
+def _reject_perf_result(proc: dict, message: str) -> None:
+    proc["stderr"] = "\n".join(filter(None, [proc.get("stderr", ""), message]))
+    proc["exit_code"] = 1
+    proc["error_summary"] = "invalid structured perf output"
+
+
 def _load_perf_result(proc: dict, output_path: Path) -> dict | None:
     """Load the structured JSON report written by ``winml perf --output``."""
     if proc["exit_code"] != 0:
@@ -1746,17 +1812,15 @@ def _load_perf_result(proc: dict, output_path: Path) -> dict | None:
     try:
         result = json.loads(output_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as e:
-        message = f"Failed to load structured winml perf output: {e}"
-        proc["stderr"] = "\n".join(filter(None, [proc.get("stderr", ""), message]))
-        proc["exit_code"] = 1
-        proc["error_summary"] = "invalid structured perf output"
+        _reject_perf_result(proc, f"Failed to load structured winml perf output: {e}")
         return None
 
     if not isinstance(result, dict):
-        message = "Structured winml perf output must be a JSON object"
-        proc["stderr"] = "\n".join(filter(None, [proc.get("stderr", ""), message]))
-        proc["exit_code"] = 1
-        proc["error_summary"] = "invalid structured perf output"
+        _reject_perf_result(proc, "Invalid structured winml perf output: root must be an object")
+        return None
+    validation_error = _validate_perf_result(result)
+    if validation_error is not None:
+        _reject_perf_result(proc, f"Invalid structured winml perf output: {validation_error}")
         return None
     return result
 
@@ -1805,16 +1869,18 @@ def _extract_op_trace_path(text: str) -> Path | None:
     return Path(joined[: end + len(".json")])
 
 
-def _copy_op_trace(proc: dict, model_dir: Path, label: str = "") -> None:
+def _copy_op_trace(proc: dict, output_path: Path, model_dir: Path, label: str = "") -> None:
     """Copy the op-trace JSON produced by winml perf into ``model_dir``.
 
-    The source path is parsed from the perf stdout/stderr. The destination is
-    ``op_trace.json`` (suffixed with the sub-model label for composite models).
-    A missing line is ignored — op-tracing may be unsupported for a given
-    EP/device/level and winml perf then emits nothing.
+    The current perf contract writes the trace beside ``--output`` with an
+    ``_op_trace`` suffix. Console parsing remains as a fallback for older perf
+    versions. The destination is ``op_trace.json`` (suffixed with the sub-model
+    label for composite models).
     """
-    src = _extract_op_trace_path(proc.get("stdout", "") + "\n" + proc.get("stderr", ""))
-    if src is None or not src.exists():
+    src = output_path.with_name(f"{output_path.stem}_op_trace{output_path.suffix}")
+    if not src.exists():
+        src = _extract_op_trace_path(proc.get("stdout", "") + "\n" + proc.get("stderr", ""))
+    if src is None or not src.is_file():
         return
     dest_name = f"op_trace_{label}.json" if label else "op_trace.json"
     dest = model_dir / dest_name
@@ -1843,7 +1909,7 @@ def _run_structured_perf(
         )
         proc["result"] = _load_perf_result(proc, output_path)
         if copy_op_trace and model_dir is not None:
-            _copy_op_trace(proc, model_dir, op_trace_label)
+            _copy_op_trace(proc, output_path, model_dir, op_trace_label)
         return proc
 
 
@@ -1864,9 +1930,8 @@ def run_model(
     summed elapsed). Multi-model structured results are keyed by sub-model label.
 
     When op_tracing is set, ``--op-tracing <level>`` is passed to winml perf. The
-    op-trace path is parsed from perf's output and the file is copied into
-    ``model_dir`` as ``op_trace.json`` (suffixed with the sub-model label for
-    composite models).
+    op-trace JSON beside the structured perf output is copied into ``model_dir``
+    as ``op_trace.json`` (suffixed with the sub-model label for composite models).
     """
     trace = bool(op_tracing) and model_dir is not None
 

--- a/scripts/e2e_eval/run_eval.py
+++ b/scripts/e2e_eval/run_eval.py
@@ -1738,6 +1738,29 @@ def _run_build_only(entries: list[ModelEntry], args: argparse.Namespace) -> None
 # ---------------------------------------------------------------------------
 
 
+def _load_perf_result(proc: dict, output_path: Path) -> dict | None:
+    """Load the structured JSON report written by ``winml perf --output``."""
+    if proc["exit_code"] != 0:
+        return None
+
+    try:
+        result = json.loads(output_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        message = f"Failed to load structured winml perf output: {e}"
+        proc["stderr"] = "\n".join(filter(None, [proc.get("stderr", ""), message]))
+        proc["exit_code"] = 1
+        proc["error_summary"] = "invalid structured perf output"
+        return None
+
+    if not isinstance(result, dict):
+        message = "Structured winml perf output must be a JSON object"
+        proc["stderr"] = "\n".join(filter(None, [proc.get("stderr", ""), message]))
+        proc["exit_code"] = 1
+        proc["error_summary"] = "invalid structured perf output"
+        return None
+    return result
+
+
 def _resolve_op_tracing(
     cli_op_tracing: str | None, entry: ModelEntry, ep: str | None, device: str
 ) -> str | None:
@@ -1802,6 +1825,28 @@ def _copy_op_trace(proc: dict, model_dir: Path, label: str = "") -> None:
         safe_print(f"    op-tracing: failed to copy {src} -> {dest}: {e}")
 
 
+def _run_structured_perf(
+    args: list[str],
+    timeout: int,
+    model_dir: Path | None,
+    copy_op_trace: bool = False,
+    op_trace_label: str = "",
+) -> dict:
+    """Run perf and load its JSON report without parsing console output."""
+    if model_dir is not None:
+        model_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="winml-perf-", dir=model_dir) as temp_dir:
+        output_path = Path(temp_dir) / "result.json"
+        proc = _run_subprocess(
+            [*args, "--output", str(output_path), "--overwrite"],
+            timeout,
+        )
+        proc["result"] = _load_perf_result(proc, output_path)
+        if copy_op_trace and model_dir is not None:
+            _copy_op_trace(proc, model_dir, op_trace_label)
+        return proc
+
+
 def run_model(
     entry: ModelEntry,
     device: str,
@@ -1814,8 +1859,9 @@ def run_model(
     """Execute winml perf for one or more ONNX models. Returns merged result dict.
 
     When onnx_paths is provided, benchmarks each pre-built ONNX directly.
-    Single model is the {"": path} case. Results are merged (worst exit
-    code, concatenated stdout/stderr, summed elapsed).
+    Single model is the {"": path} case. Results are merged (structured perf
+    reports under ``result``, worst exit code, concatenated stdout/stderr,
+    summed elapsed). Multi-model structured results are keyed by sub-model label.
 
     When op_tracing is set, ``--op-tracing <level>`` is passed to winml perf. The
     op-trace path is parsed from perf's output and the file is copied into
@@ -1850,14 +1896,14 @@ def run_model(
             args += ["--op-tracing", op_tracing]
         args += entry.perf_args
 
-        proc = _run_subprocess(args, timeout)
-        if trace:
-            _copy_op_trace(proc, model_dir)
+        proc = _run_structured_perf(args, timeout, model_dir, copy_op_trace=trace)
         proc["device"] = device
         proc["timestamp"] = _utc_now()
         proc["error_summary"] = (
             ""
             if proc["exit_code"] == 0
+            else proc.get("error_summary", "")
+            if proc.get("error_summary")
             else f"timeout ({timeout}s)"
             if proc["timeout"]
             else f"exit code {proc['exit_code']}"
@@ -1871,6 +1917,7 @@ def run_model(
     worst_exit = 0
     any_timeout = False
     commands: list[str] = []
+    perf_results: dict[str, dict] = {}
 
     for label, path in onnx_paths.items():
         if label:
@@ -1884,9 +1931,16 @@ def run_model(
             args += ["--op-tracing", op_tracing]
         args += entry.perf_args
 
-        proc = _run_subprocess(args, timeout)
-        if trace:
-            _copy_op_trace(proc, model_dir, label)
+        proc = _run_structured_perf(
+            args,
+            timeout,
+            model_dir,
+            copy_op_trace=trace,
+            op_trace_label=label,
+        )
+        perf_result = proc["result"]
+        if perf_result is not None:
+            perf_results[label] = perf_result
         if label:
             all_stdout.append(f"=== {label} ===\n{proc['stdout']}")
             all_stderr.append(f"=== {label} ===\n{proc['stderr']}")
@@ -1909,6 +1963,11 @@ def run_model(
         "command": commands[0] if len(commands) == 1 else " | ".join(commands),
         "device": device,
         "timestamp": _utc_now(),
+        "result": (
+            perf_results[""]
+            if len(onnx_paths) == 1 and "" in perf_results
+            else perf_results or None
+        ),
         "error_summary": (
             ""
             if worst_exit == 0

--- a/scripts/e2e_eval/utils/reporter.py
+++ b/scripts/e2e_eval/utils/reporter.py
@@ -45,8 +45,9 @@ def build_eval_result(
 ) -> dict:
     """Build a unified eval_result dict (facts only, no derived fields).
 
-    perf_proc is the raw subprocess result from run_model(), or None when
-    eval_types_run is ["accuracy"] (accuracy-only mode, perf phase skipped).
+    perf_proc is the subprocess result from run_model(), including the
+    structured perf JSON under ``result``, or None when eval_types_run is
+    ["accuracy"] (accuracy-only mode, perf phase skipped).
     accuracy_result is the accuracy sub-section dict (or None if not run).
     ep is the explicit execution provider (e.g., "qnn", "dml"), or None when
     not specified (device-to-provider mapping was used).
@@ -68,6 +69,7 @@ def build_eval_result(
             "passed": passed,
             "elapsed": perf_proc["elapsed"],
             "exit_code": perf_proc["exit_code"],
+            "result": perf_proc.get("result"),
             "stdout_output": stdout,
             "stderr_output": stderr,
             "raw_stdout": raw_stdout,

--- a/tests/unit/eval/test_run_eval_script.py
+++ b/tests/unit/eval/test_run_eval_script.py
@@ -1197,10 +1197,120 @@ def _entry(hf_id="microsoft/resnet-50", task="image-classification"):
     entry = MagicMock()
     entry.hf_id = hf_id
     entry.task = task
+    entry.model_type = "vision"
+    entry.group = "core"
+    entry.priority = "P0"
     entry.precision = None
     entry.perf_args = []
     entry.eval_args = []
     return entry
+
+
+class TestRunModelStructuredPerfResult:
+    def test_single_model_uses_and_loads_json_output(self, run_eval, tmp_path):
+        perf_result = {"latency_ms": {"mean": 1.25}, "throughput_per_second": 800.0}
+
+        def fake_run(args, timeout):
+            output_path = Path(args[args.index("--output") + 1])
+            output_path.write_text(json.dumps(perf_result), encoding="utf-8")
+            assert args[-1] == "--overwrite"
+            assert timeout == 300
+            return {
+                "stdout": "Performance Benchmark Results",
+                "stderr": "",
+                "exit_code": 0,
+                "elapsed": 1.0,
+                "timeout": False,
+                "command": "winml perf",
+            }
+
+        with patch.object(run_eval, "_run_subprocess", side_effect=fake_run):
+            proc = run_eval.run_model(
+                _entry(),
+                "cpu",
+                300,
+                {"": "model.onnx"},
+                model_dir=tmp_path,
+            )
+
+        assert proc["result"] == perf_result
+
+    def test_composite_model_preserves_results_by_label(self, run_eval, tmp_path):
+        perf_results = iter(
+            [
+                {"latency_ms": {"mean": 1.0}},
+                {"latency_ms": {"mean": 2.0}},
+            ]
+        )
+
+        def fake_run(args, timeout):
+            output_path = Path(args[args.index("--output") + 1])
+            output_path.write_text(json.dumps(next(perf_results)), encoding="utf-8")
+            return {
+                "stdout": "Performance Benchmark Results",
+                "stderr": "",
+                "exit_code": 0,
+                "elapsed": 1.0,
+                "timeout": False,
+                "command": "winml perf",
+            }
+
+        with patch.object(run_eval, "_run_subprocess", side_effect=fake_run):
+            proc = run_eval.run_model(
+                _entry(),
+                "cpu",
+                300,
+                {"encoder": "encoder.onnx", "decoder": "decoder.onnx"},
+                model_dir=tmp_path,
+            )
+
+        assert proc["result"] == {
+            "encoder": {"latency_ms": {"mean": 1.0}},
+            "decoder": {"latency_ms": {"mean": 2.0}},
+        }
+
+    def test_missing_structured_output_fails_perf(self, run_eval, tmp_path):
+        proc_result = {
+            "stdout": "Performance Benchmark Results",
+            "stderr": "",
+            "exit_code": 0,
+            "elapsed": 1.0,
+            "timeout": False,
+            "command": "winml perf",
+        }
+
+        with patch.object(run_eval, "_run_subprocess", return_value=proc_result):
+            proc = run_eval.run_model(
+                _entry(),
+                "cpu",
+                300,
+                {"": "model.onnx"},
+                model_dir=tmp_path,
+            )
+
+        assert proc["exit_code"] == 1
+        assert proc["result"] is None
+        assert proc["error_summary"] == "exit code 1"
+        assert "Failed to load structured winml perf output" in proc["stderr"]
+
+    def test_eval_result_contains_structured_perf_result(self, run_eval):
+        perf_result = {"latency_ms": {"mean": 1.25}}
+        result = run_eval.build_eval_result(
+            _entry(),
+            {
+                "stdout": json.dumps(perf_result),
+                "stderr": "",
+                "exit_code": 0,
+                "elapsed": 1.0,
+                "timeout": False,
+                "command": "winml perf --output result.json",
+                "result": perf_result,
+            },
+            "cpu",
+            ["perf"],
+        )
+
+        assert result["perf"]["result"] == perf_result
 
 
 class TestModelResultDirPrecision:

--- a/tests/unit/eval/test_run_eval_script.py
+++ b/tests/unit/eval/test_run_eval_script.py
@@ -1206,9 +1206,42 @@ def _entry(hf_id="microsoft/resnet-50", task="image-classification"):
     return entry
 
 
+def _perf_result(mean=1.25):
+    return {
+        "schema_version": 2,
+        "benchmark_info": {"runtime": "winml", "model_id": "model.onnx"},
+        "model_info": {"input_names": ["input"], "output_names": ["output"]},
+        "latency_ms": {
+            "mean": mean,
+            "min": 1.0,
+            "max": 1.5,
+            "p50": 1.2,
+            "p90": 1.4,
+            "p95": 1.5,
+            "p99": 1.5,
+            "std": 0.1,
+            "warmup_mean": 1.3,
+        },
+        "throughput": {"samples_per_sec": 800.0, "batches_per_sec": 800.0},
+        "raw_samples_ms": [1.0, 1.5],
+    }
+
+
+def _composite_perf_result():
+    return {
+        "model_id": "composite",
+        "task": "zero-shot-image-classification",
+        "component_count": 2,
+        "components": {
+            "text_model": _perf_result(1.0),
+            "vision_model": _perf_result(2.0),
+        },
+    }
+
+
 class TestRunModelStructuredPerfResult:
     def test_single_model_uses_and_loads_json_output(self, run_eval, tmp_path):
-        perf_result = {"latency_ms": {"mean": 1.25}, "throughput_per_second": 800.0}
+        perf_result = _perf_result()
 
         def fake_run(args, timeout):
             output_path = Path(args[args.index("--output") + 1])
@@ -1238,8 +1271,8 @@ class TestRunModelStructuredPerfResult:
     def test_composite_model_preserves_results_by_label(self, run_eval, tmp_path):
         perf_results = iter(
             [
-                {"latency_ms": {"mean": 1.0}},
-                {"latency_ms": {"mean": 2.0}},
+                _perf_result(1.0),
+                _perf_result(2.0),
             ]
         )
 
@@ -1264,10 +1297,105 @@ class TestRunModelStructuredPerfResult:
                 model_dir=tmp_path,
             )
 
-        assert proc["result"] == {
-            "encoder": {"latency_ms": {"mean": 1.0}},
-            "decoder": {"latency_ms": {"mean": 2.0}},
-        }
+        assert proc["result"] == {"encoder": _perf_result(1.0), "decoder": _perf_result(2.0)}
+
+    def test_native_composite_result_is_accepted(self, run_eval, tmp_path):
+        perf_result = _composite_perf_result()
+
+        def fake_run(args, timeout):
+            output_path = Path(args[args.index("--output") + 1])
+            output_path.write_text(json.dumps(perf_result), encoding="utf-8")
+            return {
+                "stdout": "Performance Benchmark Results",
+                "stderr": "",
+                "exit_code": 0,
+                "elapsed": 1.0,
+                "timeout": False,
+                "command": "winml perf",
+            }
+
+        with patch.object(run_eval, "_run_subprocess", side_effect=fake_run):
+            proc = run_eval.run_model(_entry(), "cpu", 300, model_dir=tmp_path)
+
+        assert proc["exit_code"] == 0
+        assert proc["result"] == perf_result
+
+    @pytest.mark.parametrize(
+        "perf_result",
+        [
+            {},
+            {"latency_ms": []},
+            {**_perf_result(), "latency_ms": {**_perf_result()["latency_ms"], "mean": "1.25"}},
+            {**_composite_perf_result(), "component_count": 3},
+            {
+                **_composite_perf_result(),
+                "components": {
+                    **_composite_perf_result()["components"],
+                    "text_model": {
+                        **_perf_result(),
+                        "throughput": {
+                            "samples_per_sec": "800",
+                            "batches_per_sec": 800.0,
+                        },
+                    },
+                },
+            },
+        ],
+    )
+    def test_malformed_structured_output_fails_perf(self, run_eval, tmp_path, perf_result):
+        def fake_run(args, timeout):
+            output_path = Path(args[args.index("--output") + 1])
+            output_path.write_text(json.dumps(perf_result), encoding="utf-8")
+            return {
+                "stdout": "Performance Benchmark Results",
+                "stderr": "",
+                "exit_code": 0,
+                "elapsed": 1.0,
+                "timeout": False,
+                "command": "winml perf",
+            }
+
+        with patch.object(run_eval, "_run_subprocess", side_effect=fake_run):
+            proc = run_eval.run_model(
+                _entry(),
+                "cpu",
+                300,
+                {"": "model.onnx"},
+                model_dir=tmp_path,
+            )
+
+        assert proc["exit_code"] == 1
+        assert proc["result"] is None
+        assert "Invalid structured winml perf output" in proc["stderr"]
+
+    def test_op_trace_sibling_is_copied_before_cleanup(self, run_eval, tmp_path):
+        trace_result = {"status": "ok", "operators": []}
+
+        def fake_run(args, timeout):
+            output_path = Path(args[args.index("--output") + 1])
+            output_path.write_text(json.dumps(_perf_result()), encoding="utf-8")
+            trace_path = output_path.with_name(f"{output_path.stem}_op_trace{output_path.suffix}")
+            trace_path.write_text(json.dumps(trace_result), encoding="utf-8")
+            return {
+                "stdout": f"Op-trace JSON: {trace_path}",
+                "stderr": "",
+                "exit_code": 0,
+                "elapsed": 1.0,
+                "timeout": False,
+                "command": "winml perf",
+            }
+
+        with patch.object(run_eval, "_run_subprocess", side_effect=fake_run):
+            run_eval.run_model(
+                _entry(),
+                "cpu",
+                300,
+                {"": "model.onnx"},
+                op_tracing="basic",
+                model_dir=tmp_path,
+            )
+
+        assert json.loads((tmp_path / "op_trace.json").read_text(encoding="utf-8")) == trace_result
 
     def test_missing_structured_output_fails_perf(self, run_eval, tmp_path):
         proc_result = {
@@ -1294,7 +1422,7 @@ class TestRunModelStructuredPerfResult:
         assert "Failed to load structured winml perf output" in proc["stderr"]
 
     def test_eval_result_contains_structured_perf_result(self, run_eval):
-        perf_result = {"latency_ms": {"mean": 1.25}}
+        perf_result = _perf_result()
         result = run_eval.build_eval_result(
             _entry(),
             {


### PR DESCRIPTION
## Summary
- run `winml perf` with `--output` and persist the structured report under `perf.result`
- preserve structured results per sub-model and fail runs that exit successfully without a valid JSON report
- document the result contract and add focused unit coverage

## Validation
- `uv run --frozen ruff check --fix scripts/e2e_eval/run_eval.py scripts/e2e_eval/utils/reporter.py tests/unit/eval/test_run_eval_script.py`
- `uv run --frozen pytest tests/unit/eval/test_run_eval_script.py -q` (148 passed)
- `run_eval.py --eval-type both` smoke run with `microsoft/resnet-18` on CPU and 5 accuracy samples (perf PASS, accuracy PASS)