### PR TITLE
feat(optim): preserve fast QNN grouped-conv regions

### DIFF
--- a/src/winml/modelkit/onnx/__init__.py
+++ b/src/winml/modelkit/onnx/__init__.py
@@ -28,7 +28,13 @@ from .io import (
 from .metadata import capture_metadata, restore_metadata
 from .persistence import ONNXSaveError, cleanup_onnx, load_onnx, save_onnx
 from .shape import infer_onnx_shapes, infer_shapes
-from .utils import EXTERNAL_DATA_THRESHOLD, check_onnx_model, get_model_size, strip_node_attrs
+from .utils import (
+    EXTERNAL_DATA_THRESHOLD,
+    check_onnx_model,
+    get_captured_tensor_names,
+    get_model_size,
+    strip_node_attrs,
+)
 
 
 __all__ = [
@@ -44,6 +50,7 @@ __all__ = [
     "cleanup_onnx",
     "copy_onnx_model",
     "generate_inputs_from_onnx",
+    "get_captured_tensor_names",
     "get_external_data_files",
     "get_io_config",
     "get_model_size",
@@ -64,7 +71,6 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "is_compiled_onnx": (".detection", "is_compiled_onnx"),
     "is_quantized_onnx": (".detection", "is_quantized_onnx"),
 }
-
 
 
 def __getattr__(name: str) -> Any:

--- a/src/winml/modelkit/onnx/utils.py
+++ b/src/winml/modelkit/onnx/utils.py
@@ -13,6 +13,23 @@ from onnx.external_data_helper import _get_all_tensors
 EXTERNAL_DATA_THRESHOLD = 100 * 1024 * 1024  # 100 MiB
 
 
+def get_captured_tensor_names(graph: onnx.GraphProto) -> set[str]:
+    """Return tensor names that *graph* resolves from an enclosing scope."""
+    locally_defined = {value.name for value in graph.input if value.name}
+    locally_defined.update(initializer.name for initializer in graph.initializer)
+    locally_defined.update(output for node in graph.node for output in node.output if output)
+    referenced = {input_name for node in graph.node for input_name in node.input if input_name}
+    referenced.update(output.name for output in graph.output if output.name)
+    for node in graph.node:
+        for attribute in node.attribute:
+            if attribute.type == onnx.AttributeProto.GRAPH:
+                referenced.update(get_captured_tensor_names(attribute.g))
+            elif attribute.type == onnx.AttributeProto.GRAPHS:
+                for nested_graph in attribute.graphs:
+                    referenced.update(get_captured_tensor_names(nested_graph))
+    return referenced - locally_defined
+
+
 def strip_node_attrs(
     model: onnx.ModelProto,
     op_type: str,

--- a/src/winml/modelkit/optim/capabilities/surgery.py
+++ b/src/winml/modelkit/optim/capabilities/surgery.py
@@ -54,3 +54,14 @@ UNTIE_CONSTANT_BATCHED_MATMUL = BoolCapability(
     category=CapabilityCategory.SURGERY,
     default=False,
 )
+
+TRIM_SPLIT_GROUPED_CONV = BoolCapability(
+    name="trim-split-grouped-conv",
+    ort_name=None,
+    description=(
+        "Trim unreachable grouped Conv kernel taps and split the groups into "
+        "two quantization-aware branches"
+    ),
+    category=CapabilityCategory.SURGERY,
+    default=False,
+)

--- a/src/winml/modelkit/optim/grouped_conv.py
+++ b/src/winml/modelkit/optim/grouped_conv.py
@@ -132,6 +132,7 @@ def _match_plan(
     *,
     consumers: dict[str, list[NodeProto]],
     graph_outputs: set[str],
+    graph_inputs: set[str],
     initializers: dict[str, TensorProto],
     shapes: dict[str, tuple[int | None, ...]],
     used_names: set[str],
@@ -150,6 +151,8 @@ def _match_plan(
     if tail_slice.op_type != "Slice" or tail_slice.domain not in ("", "ai.onnx"):
         return None
     if len(tail_slice.input) != 5 or len(tail_slice.output) != 1:
+        return None
+    if graph_inputs.intersection((*conv.input[1:], *tail_slice.input[1:])):
         return None
 
     conv_attributes = {attribute.name: attribute for attribute in conv.attribute}
@@ -363,6 +366,7 @@ def trim_split_grouped_convs(
     initializers = {initializer.name: initializer for initializer in graph.initializer}
     consumers = _consumer_nodes(graph)
     graph_outputs = {value.name for value in graph.output}
+    graph_inputs = {value.name for value in graph.input}
     shapes = _static_shapes(model)
     used_names = {
         name for node in graph.node for name in (*node.input, *node.output, node.name) if name
@@ -378,6 +382,7 @@ def trim_split_grouped_convs(
                 node,
                 consumers=consumers,
                 graph_outputs=graph_outputs,
+                graph_inputs=graph_inputs,
                 initializers=initializers,
                 shapes=shapes,
                 used_names=used_names,

--- a/src/winml/modelkit/optim/grouped_conv.py
+++ b/src/winml/modelkit/optim/grouped_conv.py
@@ -12,8 +12,8 @@ from dataclasses import dataclass
 
 import numpy as np
 import onnx
-from onnx import helper, numpy_helper
 
+from ..onnx import get_captured_tensor_names
 from ..quant.hints import (
     QUANTIZATION_REGION_HINT_KEY,
     STANDARD_ONNX_DOMAINS,
@@ -35,6 +35,7 @@ class _RewritePlan:
     kernel_end: int
     pad_begin: int
     pad_end: int
+    group: int
     branch_names: tuple[str, str]
     split_name: str
     concat_name: str
@@ -44,10 +45,6 @@ class _RewritePlan:
     bias_names: tuple[str, str] | None
 
 
-def _attributes(node: onnx.NodeProto) -> dict[str, object]:
-    return {attribute.name: helper.get_attribute_value(attribute) for attribute in node.attribute}
-
-
 def _constant_vector(
     name: str,
     initializers: dict[str, onnx.TensorProto],
@@ -55,7 +52,7 @@ def _constant_vector(
     initializer = initializers.get(name)
     if initializer is None:
         return None
-    values = np.asarray(numpy_helper.to_array(initializer))
+    values = np.asarray(onnx.numpy_helper.to_array(initializer))
     if values.ndim != 1:
         return None
     return [int(value) for value in values]
@@ -89,7 +86,7 @@ def _replace_attribute(node: onnx.NodeProto, name: str, value: object) -> None:
     attributes = [
         copy.deepcopy(attribute) for attribute in node.attribute if attribute.name != name
     ]
-    attributes.append(helper.make_attribute(name, value))
+    attributes.append(onnx.helper.make_attribute(name, value))
     del node.attribute[:]
     node.attribute.extend(attributes)
 
@@ -105,6 +102,21 @@ def _referenced_tensor_names(graph: onnx.GraphProto) -> set[str]:
                 for subgraph in attribute.graphs:
                     names.update(_referenced_tensor_names(subgraph))
     return names
+
+
+def _consumer_nodes(graph: onnx.GraphProto) -> dict[str, list[onnx.NodeProto]]:
+    consumers: dict[str, list[onnx.NodeProto]] = {}
+    for node in graph.node:
+        consumed_names = {input_name for input_name in node.input if input_name}
+        for attribute in node.attribute:
+            if attribute.type == onnx.AttributeProto.GRAPH:
+                consumed_names.update(get_captured_tensor_names(attribute.g))
+            elif attribute.type == onnx.AttributeProto.GRAPHS:
+                for nested_graph in attribute.graphs:
+                    consumed_names.update(get_captured_tensor_names(nested_graph))
+        for input_name in consumed_names:
+            consumers.setdefault(input_name, []).append(node)
+    return consumers
 
 
 def _match_plan(
@@ -132,15 +144,34 @@ def _match_plan(
     if len(tail_slice.input) != 5 or len(tail_slice.output) != 1:
         return None
 
-    conv_attributes = _attributes(conv)
-    if conv_attributes.get("auto_pad", b"NOTSET") != b"NOTSET":
+    conv_attributes = {attribute.name: attribute for attribute in conv.attribute}
+    auto_pad = conv_attributes.get("auto_pad")
+    if auto_pad is not None and (
+        auto_pad.type != onnx.AttributeProto.STRING or auto_pad.s != b"NOTSET"
+    ):
         return None
-    if "pads" not in conv_attributes:
+    pads_attribute = conv_attributes.get("pads")
+    if pads_attribute is None or pads_attribute.type != onnx.AttributeProto.INTS:
         return None
-    pads = [int(value) for value in conv_attributes["pads"]]
-    strides = [int(value) for value in conv_attributes.get("strides", [1])]
-    dilations = [int(value) for value in conv_attributes.get("dilations", [1])]
-    group = int(conv_attributes.get("group", 1))
+    pads = [int(value) for value in pads_attribute.ints]
+    strides_attribute = conv_attributes.get("strides")
+    if strides_attribute is not None and strides_attribute.type != onnx.AttributeProto.INTS:
+        return None
+    strides = (
+        [int(value) for value in strides_attribute.ints] if strides_attribute is not None else [1]
+    )
+    dilations_attribute = conv_attributes.get("dilations")
+    if dilations_attribute is not None and dilations_attribute.type != onnx.AttributeProto.INTS:
+        return None
+    dilations = (
+        [int(value) for value in dilations_attribute.ints]
+        if dilations_attribute is not None
+        else [1]
+    )
+    group_attribute = conv_attributes.get("group")
+    if group_attribute is not None and group_attribute.type != onnx.AttributeProto.INT:
+        return None
+    group = int(group_attribute.i) if group_attribute is not None else 1
     if len(pads) != 2 or strides != [1] or dilations != [1] or group < 2 or group % 2:
         return None
 
@@ -154,7 +185,7 @@ def _match_plan(
     weight_initializer = initializers.get(conv.input[1])
     if weight_initializer is None:
         return None
-    weights = np.asarray(numpy_helper.to_array(weight_initializer))
+    weights = np.asarray(onnx.numpy_helper.to_array(weight_initializer))
     if weights.ndim != 3:
         return None
     output_channels, channels_per_group, kernel_size = weights.shape
@@ -165,7 +196,17 @@ def _match_plan(
         or kernel_size <= 1
     ):
         return None
-    kernel_shape = [int(value) for value in conv_attributes.get("kernel_shape", [kernel_size])]
+    kernel_shape_attribute = conv_attributes.get("kernel_shape")
+    if (
+        kernel_shape_attribute is not None
+        and kernel_shape_attribute.type != onnx.AttributeProto.INTS
+    ):
+        return None
+    kernel_shape = (
+        [int(value) for value in kernel_shape_attribute.ints]
+        if kernel_shape_attribute is not None
+        else [kernel_size]
+    )
     if kernel_shape != [kernel_size]:
         return None
 
@@ -174,7 +215,7 @@ def _match_plan(
         bias_initializer = initializers.get(conv.input[2])
         if bias_initializer is None:
             return None
-        bias = np.asarray(numpy_helper.to_array(bias_initializer))
+        bias = np.asarray(onnx.numpy_helper.to_array(bias_initializer))
         if bias.shape != (output_channels,):
             return None
 
@@ -237,6 +278,7 @@ def _match_plan(
         kernel_end=kernel_end,
         pad_begin=pad_begin,
         pad_end=pad_end,
+        group=group,
         branch_names=branch_names,
         split_name=split_name,
         concat_name=concat_name,
@@ -253,11 +295,9 @@ def _validated_existing_regions(model: onnx.ModelProto) -> tuple[QuantizationReg
         return ()
 
     nodes_by_name: dict[str, list[onnx.NodeProto]] = {}
-    consumers: dict[str, list[onnx.NodeProto]] = {}
     for node in model.graph.node:
         nodes_by_name.setdefault(node.name, []).append(node)
-        for input_name in node.input:
-            consumers.setdefault(input_name, []).append(node)
+    consumers = _consumer_nodes(model.graph)
     graph_outputs = {value.name for value in model.graph.output}
     for region in regions:
         concat_nodes = nodes_by_name.get(region.concat, [])
@@ -318,10 +358,7 @@ def trim_split_grouped_convs(
     existing_regions = _validated_existing_regions(model)
     graph = model.graph
     initializers = {initializer.name: initializer for initializer in graph.initializer}
-    consumers: dict[str, list[onnx.NodeProto]] = {}
-    for node in graph.node:
-        for input_name in node.input:
-            consumers.setdefault(input_name, []).append(node)
+    consumers = _consumer_nodes(graph)
     graph_outputs = {value.name for value in graph.output}
     shapes = _static_shapes(model)
     used_names = {
@@ -354,23 +391,28 @@ def trim_split_grouped_convs(
     regions: list[QuantizationRegion] = []
     removable_initializers: set[str] = set()
     for plan in plans:
-        conv_attributes = _attributes(plan.conv)
-        weights = np.asarray(numpy_helper.to_array(initializers[plan.conv.input[1]]))
+        weights = np.asarray(onnx.numpy_helper.to_array(initializers[plan.conv.input[1]]))
         output_midpoint = weights.shape[0] // 2
         trimmed_weights = weights[:, :, plan.kernel_start : plan.kernel_end + 1]
         for index, values in enumerate(np.split(trimmed_weights, [output_midpoint], axis=0)):
             new_initializers.append(
-                numpy_helper.from_array(np.ascontiguousarray(values), plan.weight_names[index])
+                onnx.numpy_helper.from_array(
+                    np.ascontiguousarray(values),
+                    plan.weight_names[index],
+                )
             )
 
         if plan.bias_names is not None:
-            bias = np.asarray(numpy_helper.to_array(initializers[plan.conv.input[2]]))
+            bias = np.asarray(onnx.numpy_helper.to_array(initializers[plan.conv.input[2]]))
             for index, values in enumerate(np.split(bias, [output_midpoint], axis=0)):
                 new_initializers.append(
-                    numpy_helper.from_array(np.ascontiguousarray(values), plan.bias_names[index])
+                    onnx.numpy_helper.from_array(
+                        np.ascontiguousarray(values),
+                        plan.bias_names[index],
+                    )
                 )
 
-        split = helper.make_node(
+        split = onnx.helper.make_node(
             "Split",
             [plan.conv.input[0]],
             list(plan.split_outputs),
@@ -387,11 +429,11 @@ def trim_split_grouped_convs(
                 branch.input.append(plan.bias_names[index])
             del branch.output[:]
             branch.output.append(plan.branch_outputs[index])
-            _replace_attribute(branch, "group", int(conv_attributes["group"]) // 2)
+            _replace_attribute(branch, "group", plan.group // 2)
             _replace_attribute(branch, "kernel_shape", [plan.kernel_end - plan.kernel_start + 1])
             _replace_attribute(branch, "pads", [plan.pad_begin, plan.pad_end])
             branches.append(branch)
-        concat = helper.make_node(
+        concat = onnx.helper.make_node(
             "Concat",
             list(plan.branch_outputs),
             list(plan.tail_slice.output),
@@ -414,9 +456,9 @@ def trim_split_grouped_convs(
                 plan.conv.name,
                 plan.kernel_start,
                 plan.kernel_end + 1,
-                int(conv_attributes["group"]),
-                int(conv_attributes["group"]) // 2,
-                int(conv_attributes["group"]) // 2,
+                plan.group,
+                plan.group // 2,
+                plan.group // 2,
             )
 
     rebuilt: list[onnx.NodeProto] = []

--- a/src/winml/modelkit/optim/grouped_conv.py
+++ b/src/winml/modelkit/optim/grouped_conv.py
@@ -11,7 +11,15 @@ import logging
 from dataclasses import dataclass
 
 import numpy as np
-import onnx
+from onnx import (
+    AttributeProto,
+    GraphProto,
+    ModelProto,
+    NodeProto,
+    TensorProto,
+    helper,
+    numpy_helper,
+)
 
 from ..onnx import get_captured_tensor_names
 from ..quant.hints import (
@@ -29,8 +37,8 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class _RewritePlan:
-    conv: onnx.NodeProto
-    tail_slice: onnx.NodeProto
+    conv: NodeProto
+    tail_slice: NodeProto
     kernel_start: int
     kernel_end: int
     pad_begin: int
@@ -47,18 +55,18 @@ class _RewritePlan:
 
 def _constant_vector(
     name: str,
-    initializers: dict[str, onnx.TensorProto],
+    initializers: dict[str, TensorProto],
 ) -> list[int] | None:
     initializer = initializers.get(name)
     if initializer is None:
         return None
-    values = np.asarray(onnx.numpy_helper.to_array(initializer))
+    values = np.asarray(numpy_helper.to_array(initializer))
     if values.ndim != 1:
         return None
     return [int(value) for value in values]
 
 
-def _static_shapes(model: onnx.ModelProto) -> dict[str, tuple[int | None, ...]]:
+def _static_shapes(model: ModelProto) -> dict[str, tuple[int | None, ...]]:
     shapes: dict[str, tuple[int | None, ...]] = {}
     for value_info in (*model.graph.input, *model.graph.value_info, *model.graph.output):
         tensor_type = value_info.type.tensor_type
@@ -82,36 +90,36 @@ def _unique_name(base: str, used_names: set[str]) -> str:
     return candidate
 
 
-def _replace_attribute(node: onnx.NodeProto, name: str, value: object) -> None:
+def _replace_attribute(node: NodeProto, name: str, value: object) -> None:
     attributes = [
         copy.deepcopy(attribute) for attribute in node.attribute if attribute.name != name
     ]
-    attributes.append(onnx.helper.make_attribute(name, value))
+    attributes.append(helper.make_attribute(name, value))
     del node.attribute[:]
     node.attribute.extend(attributes)
 
 
-def _referenced_tensor_names(graph: onnx.GraphProto) -> set[str]:
+def _referenced_tensor_names(graph: GraphProto) -> set[str]:
     names = {value.name for value in (*graph.input, *graph.output)}
     for node in graph.node:
         names.update(input_name for input_name in node.input if input_name)
         for attribute in node.attribute:
-            if attribute.type == onnx.AttributeProto.GRAPH:
+            if attribute.type == AttributeProto.GRAPH:
                 names.update(_referenced_tensor_names(attribute.g))
-            elif attribute.type == onnx.AttributeProto.GRAPHS:
+            elif attribute.type == AttributeProto.GRAPHS:
                 for subgraph in attribute.graphs:
                     names.update(_referenced_tensor_names(subgraph))
     return names
 
 
-def _consumer_nodes(graph: onnx.GraphProto) -> dict[str, list[onnx.NodeProto]]:
-    consumers: dict[str, list[onnx.NodeProto]] = {}
+def _consumer_nodes(graph: GraphProto) -> dict[str, list[NodeProto]]:
+    consumers: dict[str, list[NodeProto]] = {}
     for node in graph.node:
         consumed_names = {input_name for input_name in node.input if input_name}
         for attribute in node.attribute:
-            if attribute.type == onnx.AttributeProto.GRAPH:
+            if attribute.type == AttributeProto.GRAPH:
                 consumed_names.update(get_captured_tensor_names(attribute.g))
-            elif attribute.type == onnx.AttributeProto.GRAPHS:
+            elif attribute.type == AttributeProto.GRAPHS:
                 for nested_graph in attribute.graphs:
                     consumed_names.update(get_captured_tensor_names(nested_graph))
         for input_name in consumed_names:
@@ -120,11 +128,11 @@ def _consumer_nodes(graph: onnx.GraphProto) -> dict[str, list[onnx.NodeProto]]:
 
 
 def _match_plan(
-    conv: onnx.NodeProto,
+    conv: NodeProto,
     *,
-    consumers: dict[str, list[onnx.NodeProto]],
+    consumers: dict[str, list[NodeProto]],
     graph_outputs: set[str],
-    initializers: dict[str, onnx.TensorProto],
+    initializers: dict[str, TensorProto],
     shapes: dict[str, tuple[int | None, ...]],
     used_names: set[str],
 ) -> _RewritePlan | None:
@@ -146,22 +154,20 @@ def _match_plan(
 
     conv_attributes = {attribute.name: attribute for attribute in conv.attribute}
     auto_pad = conv_attributes.get("auto_pad")
-    if auto_pad is not None and (
-        auto_pad.type != onnx.AttributeProto.STRING or auto_pad.s != b"NOTSET"
-    ):
+    if auto_pad is not None and (auto_pad.type != AttributeProto.STRING or auto_pad.s != b"NOTSET"):
         return None
     pads_attribute = conv_attributes.get("pads")
-    if pads_attribute is None or pads_attribute.type != onnx.AttributeProto.INTS:
+    if pads_attribute is None or pads_attribute.type != AttributeProto.INTS:
         return None
     pads = [int(value) for value in pads_attribute.ints]
     strides_attribute = conv_attributes.get("strides")
-    if strides_attribute is not None and strides_attribute.type != onnx.AttributeProto.INTS:
+    if strides_attribute is not None and strides_attribute.type != AttributeProto.INTS:
         return None
     strides = (
         [int(value) for value in strides_attribute.ints] if strides_attribute is not None else [1]
     )
     dilations_attribute = conv_attributes.get("dilations")
-    if dilations_attribute is not None and dilations_attribute.type != onnx.AttributeProto.INTS:
+    if dilations_attribute is not None and dilations_attribute.type != AttributeProto.INTS:
         return None
     dilations = (
         [int(value) for value in dilations_attribute.ints]
@@ -169,7 +175,7 @@ def _match_plan(
         else [1]
     )
     group_attribute = conv_attributes.get("group")
-    if group_attribute is not None and group_attribute.type != onnx.AttributeProto.INT:
+    if group_attribute is not None and group_attribute.type != AttributeProto.INT:
         return None
     group = int(group_attribute.i) if group_attribute is not None else 1
     if len(pads) != 2 or strides != [1] or dilations != [1] or group < 2 or group % 2:
@@ -185,7 +191,7 @@ def _match_plan(
     weight_initializer = initializers.get(conv.input[1])
     if weight_initializer is None:
         return None
-    weights = np.asarray(onnx.numpy_helper.to_array(weight_initializer))
+    weights = np.asarray(numpy_helper.to_array(weight_initializer))
     if weights.ndim != 3:
         return None
     output_channels, channels_per_group, kernel_size = weights.shape
@@ -197,10 +203,7 @@ def _match_plan(
     ):
         return None
     kernel_shape_attribute = conv_attributes.get("kernel_shape")
-    if (
-        kernel_shape_attribute is not None
-        and kernel_shape_attribute.type != onnx.AttributeProto.INTS
-    ):
+    if kernel_shape_attribute is not None and kernel_shape_attribute.type != AttributeProto.INTS:
         return None
     kernel_shape = (
         [int(value) for value in kernel_shape_attribute.ints]
@@ -215,7 +218,7 @@ def _match_plan(
         bias_initializer = initializers.get(conv.input[2])
         if bias_initializer is None:
             return None
-        bias = np.asarray(onnx.numpy_helper.to_array(bias_initializer))
+        bias = np.asarray(numpy_helper.to_array(bias_initializer))
         if bias.shape != (output_channels,):
             return None
 
@@ -289,12 +292,12 @@ def _match_plan(
     )
 
 
-def _validated_existing_regions(model: onnx.ModelProto) -> tuple[QuantizationRegion, ...]:
+def _validated_existing_regions(model: ModelProto) -> tuple[QuantizationRegion, ...]:
     regions = parse_quantization_region_hints(model) or ()
     if not regions:
         return ()
 
-    nodes_by_name: dict[str, list[onnx.NodeProto]] = {}
+    nodes_by_name: dict[str, list[NodeProto]] = {}
     for node in model.graph.node:
         nodes_by_name.setdefault(node.name, []).append(node)
     consumers = _consumer_nodes(model.graph)
@@ -336,7 +339,7 @@ def _validated_existing_regions(model: onnx.ModelProto) -> tuple[QuantizationReg
 
 
 def _set_region_hints(
-    model: onnx.ModelProto,
+    model: ModelProto,
     regions: tuple[QuantizationRegion, ...],
 ) -> None:
     entry = next(
@@ -350,10 +353,10 @@ def _set_region_hints(
 
 
 def trim_split_grouped_convs(
-    model: onnx.ModelProto,
+    model: ModelProto,
     *,
     verbose: bool = False,
-) -> onnx.ModelProto:
+) -> ModelProto:
     """Trim unreachable 1D kernels and split even grouped Conv regions."""
     existing_regions = _validated_existing_regions(model)
     graph = model.graph
@@ -385,41 +388,41 @@ def trim_split_grouped_convs(
     if not plans:
         return model
 
-    replacements: dict[int, list[onnx.NodeProto]] = {}
+    replacements: dict[int, list[NodeProto]] = {}
     removed_node_ids: set[int] = set()
-    new_initializers: list[onnx.TensorProto] = []
+    new_initializers: list[TensorProto] = []
     regions: list[QuantizationRegion] = []
     removable_initializers: set[str] = set()
     for plan in plans:
-        weights = np.asarray(onnx.numpy_helper.to_array(initializers[plan.conv.input[1]]))
+        weights = np.asarray(numpy_helper.to_array(initializers[plan.conv.input[1]]))
         output_midpoint = weights.shape[0] // 2
         trimmed_weights = weights[:, :, plan.kernel_start : plan.kernel_end + 1]
         for index, values in enumerate(np.split(trimmed_weights, [output_midpoint], axis=0)):
             new_initializers.append(
-                onnx.numpy_helper.from_array(
+                numpy_helper.from_array(
                     np.ascontiguousarray(values),
                     plan.weight_names[index],
                 )
             )
 
         if plan.bias_names is not None:
-            bias = np.asarray(onnx.numpy_helper.to_array(initializers[plan.conv.input[2]]))
+            bias = np.asarray(numpy_helper.to_array(initializers[plan.conv.input[2]]))
             for index, values in enumerate(np.split(bias, [output_midpoint], axis=0)):
                 new_initializers.append(
-                    onnx.numpy_helper.from_array(
+                    numpy_helper.from_array(
                         np.ascontiguousarray(values),
                         plan.bias_names[index],
                     )
                 )
 
-        split = onnx.helper.make_node(
+        split = helper.make_node(
             "Split",
             [plan.conv.input[0]],
             list(plan.split_outputs),
             name=plan.split_name,
             axis=1,
         )
-        branches: list[onnx.NodeProto] = []
+        branches: list[NodeProto] = []
         for index in range(2):
             branch = copy.deepcopy(plan.conv)
             branch.name = plan.branch_names[index]
@@ -433,7 +436,7 @@ def trim_split_grouped_convs(
             _replace_attribute(branch, "kernel_shape", [plan.kernel_end - plan.kernel_start + 1])
             _replace_attribute(branch, "pads", [plan.pad_begin, plan.pad_end])
             branches.append(branch)
-        concat = onnx.helper.make_node(
+        concat = helper.make_node(
             "Concat",
             list(plan.branch_outputs),
             list(plan.tail_slice.output),
@@ -461,7 +464,7 @@ def trim_split_grouped_convs(
                 plan.group // 2,
             )
 
-    rebuilt: list[onnx.NodeProto] = []
+    rebuilt: list[NodeProto] = []
     for node in graph.node:
         if id(node) in replacements:
             rebuilt.extend(replacements[id(node)])

--- a/src/winml/modelkit/optim/grouped_conv.py
+++ b/src/winml/modelkit/optim/grouped_conv.py
@@ -355,12 +355,22 @@ def _set_region_hints(
     entry.value = serialize_quantization_region_hints(regions)
 
 
+def _standard_opset_version(model: ModelProto) -> int | None:
+    versions = [
+        int(opset.version) for opset in model.opset_import if opset.domain in STANDARD_ONNX_DOMAINS
+    ]
+    return versions[0] if len(versions) == 1 else None
+
+
 def trim_split_grouped_convs(
     model: ModelProto,
     *,
     verbose: bool = False,
 ) -> ModelProto:
     """Trim unreachable 1D kernels and split even grouped Conv regions."""
+    opset_version = _standard_opset_version(model)
+    if opset_version is None:
+        return model
     existing_regions = _validated_existing_regions(model)
     graph = model.graph
     initializers = {initializer.name: initializer for initializer in graph.initializer}
@@ -427,6 +437,8 @@ def trim_split_grouped_convs(
             name=plan.split_name,
             axis=1,
         )
+        if opset_version >= 18:
+            _replace_attribute(split, "num_outputs", len(plan.split_outputs))
         branches: list[NodeProto] = []
         for index in range(2):
             branch = copy.deepcopy(plan.conv)

--- a/src/winml/modelkit/optim/grouped_conv.py
+++ b/src/winml/modelkit/optim/grouped_conv.py
@@ -1,0 +1,447 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Conservative static grouped-Conv graph surgery."""
+
+from __future__ import annotations
+
+import copy
+import logging
+from dataclasses import dataclass
+
+import numpy as np
+import onnx
+from onnx import helper, numpy_helper
+
+from ..quant.hints import (
+    QUANTIZATION_REGION_HINT_KEY,
+    STANDARD_ONNX_DOMAINS,
+    QuantizationHintError,
+    QuantizationRegion,
+    parse_quantization_region_hints,
+    serialize_quantization_region_hints,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _RewritePlan:
+    conv: onnx.NodeProto
+    tail_slice: onnx.NodeProto
+    kernel_start: int
+    kernel_end: int
+    pad_begin: int
+    pad_end: int
+    branch_names: tuple[str, str]
+    split_name: str
+    concat_name: str
+    split_outputs: tuple[str, str]
+    branch_outputs: tuple[str, str]
+    weight_names: tuple[str, str]
+    bias_names: tuple[str, str] | None
+
+
+def _attributes(node: onnx.NodeProto) -> dict[str, object]:
+    return {attribute.name: helper.get_attribute_value(attribute) for attribute in node.attribute}
+
+
+def _constant_vector(
+    name: str,
+    initializers: dict[str, onnx.TensorProto],
+) -> list[int] | None:
+    initializer = initializers.get(name)
+    if initializer is None:
+        return None
+    values = np.asarray(numpy_helper.to_array(initializer))
+    if values.ndim != 1:
+        return None
+    return [int(value) for value in values]
+
+
+def _static_shapes(model: onnx.ModelProto) -> dict[str, tuple[int | None, ...]]:
+    shapes: dict[str, tuple[int | None, ...]] = {}
+    for value_info in (*model.graph.input, *model.graph.value_info, *model.graph.output):
+        tensor_type = value_info.type.tensor_type
+        if not tensor_type.HasField("shape"):
+            continue
+        dimensions = [
+            dimension.dim_value if dimension.HasField("dim_value") else None
+            for dimension in tensor_type.shape.dim
+        ]
+        shapes[value_info.name] = tuple(dimensions)
+    return shapes
+
+
+def _unique_name(base: str, used_names: set[str]) -> str:
+    candidate = base
+    suffix = 1
+    while candidate in used_names:
+        candidate = f"{base}_{suffix}"
+        suffix += 1
+    used_names.add(candidate)
+    return candidate
+
+
+def _replace_attribute(node: onnx.NodeProto, name: str, value: object) -> None:
+    attributes = [
+        copy.deepcopy(attribute) for attribute in node.attribute if attribute.name != name
+    ]
+    attributes.append(helper.make_attribute(name, value))
+    del node.attribute[:]
+    node.attribute.extend(attributes)
+
+
+def _referenced_tensor_names(graph: onnx.GraphProto) -> set[str]:
+    names = {value.name for value in (*graph.input, *graph.output)}
+    for node in graph.node:
+        names.update(input_name for input_name in node.input if input_name)
+        for attribute in node.attribute:
+            if attribute.type == onnx.AttributeProto.GRAPH:
+                names.update(_referenced_tensor_names(attribute.g))
+            elif attribute.type == onnx.AttributeProto.GRAPHS:
+                for subgraph in attribute.graphs:
+                    names.update(_referenced_tensor_names(subgraph))
+    return names
+
+
+def _match_plan(
+    conv: onnx.NodeProto,
+    *,
+    consumers: dict[str, list[onnx.NodeProto]],
+    graph_outputs: set[str],
+    initializers: dict[str, onnx.TensorProto],
+    shapes: dict[str, tuple[int | None, ...]],
+    used_names: set[str],
+) -> _RewritePlan | None:
+    if conv.op_type != "Conv" or conv.domain not in ("", "ai.onnx"):
+        return None
+    if len(conv.input) not in (2, 3) or len(conv.output) != 1:
+        return None
+    if conv.output[0] in graph_outputs:
+        return None
+
+    output_consumers = consumers.get(conv.output[0], [])
+    if len(output_consumers) != 1:
+        return None
+    tail_slice = output_consumers[0]
+    if tail_slice.op_type != "Slice" or tail_slice.domain not in ("", "ai.onnx"):
+        return None
+    if len(tail_slice.input) != 5 or len(tail_slice.output) != 1:
+        return None
+
+    conv_attributes = _attributes(conv)
+    if conv_attributes.get("auto_pad", b"NOTSET") != b"NOTSET":
+        return None
+    if "pads" not in conv_attributes:
+        return None
+    pads = [int(value) for value in conv_attributes["pads"]]
+    strides = [int(value) for value in conv_attributes.get("strides", [1])]
+    dilations = [int(value) for value in conv_attributes.get("dilations", [1])]
+    group = int(conv_attributes.get("group", 1))
+    if len(pads) != 2 or strides != [1] or dilations != [1] or group < 2 or group % 2:
+        return None
+
+    input_shape = shapes.get(conv.input[0])
+    if input_shape is None or len(input_shape) != 3:
+        return None
+    input_channels, input_length = input_shape[1:]
+    if input_channels is None or input_length is None or input_channels <= 0 or input_length <= 0:
+        return None
+
+    weight_initializer = initializers.get(conv.input[1])
+    if weight_initializer is None:
+        return None
+    weights = np.asarray(numpy_helper.to_array(weight_initializer))
+    if weights.ndim != 3:
+        return None
+    output_channels, channels_per_group, kernel_size = weights.shape
+    if (
+        output_channels <= 0
+        or output_channels % group
+        or input_channels != channels_per_group * group
+        or kernel_size <= 1
+    ):
+        return None
+    kernel_shape = [int(value) for value in conv_attributes.get("kernel_shape", [kernel_size])]
+    if kernel_shape != [kernel_size]:
+        return None
+
+    bias_names: tuple[str, str] | None = None
+    if len(conv.input) == 3:
+        bias_initializer = initializers.get(conv.input[2])
+        if bias_initializer is None:
+            return None
+        bias = np.asarray(numpy_helper.to_array(bias_initializer))
+        if bias.shape != (output_channels,):
+            return None
+
+    starts = _constant_vector(tail_slice.input[1], initializers)
+    ends = _constant_vector(tail_slice.input[2], initializers)
+    axes = _constant_vector(tail_slice.input[3], initializers)
+    steps = _constant_vector(tail_slice.input[4], initializers)
+    if starts != [0] or axes not in ([2], [-1]) or steps != [1] or ends is None or len(ends) != 1:
+        return None
+
+    output_length = input_length + pads[0] + pads[1] - kernel_size + 1
+    if output_length <= 1:
+        return None
+    retained_length = ends[0] + output_length if ends[0] < 0 else ends[0]
+    retained_length = min(max(retained_length, 0), output_length)
+    if retained_length <= 0 or retained_length >= output_length:
+        return None
+
+    kernel_start = max(0, pads[0] - (retained_length - 1))
+    kernel_end = min(kernel_size - 1, pads[0] + input_length - 1)
+    if kernel_start > kernel_end or (kernel_start == 0 and kernel_end == kernel_size - 1):
+        return None
+    trimmed_kernel = kernel_end - kernel_start + 1
+    pad_begin = pads[0] - kernel_start
+    pad_end = retained_length - input_length - pad_begin + trimmed_kernel - 1
+    if pad_begin < 0 or pad_end < 0:
+        return None
+    if input_length + pad_begin + pad_end - trimmed_kernel + 1 != retained_length:
+        return None
+
+    base_name = conv.name or conv.output[0] or "grouped_conv"
+    split_name = _unique_name(f"{base_name}__winml_split", used_names)
+    branch_names = (
+        _unique_name(f"{base_name}__winml_part0", used_names),
+        _unique_name(f"{base_name}__winml_part1", used_names),
+    )
+    concat_name = _unique_name(f"{base_name}__winml_concat", used_names)
+    split_outputs = (
+        _unique_name(f"{split_name}_output0", used_names),
+        _unique_name(f"{split_name}_output1", used_names),
+    )
+    branch_outputs = (
+        _unique_name(f"{branch_names[0]}_output", used_names),
+        _unique_name(f"{branch_names[1]}_output", used_names),
+    )
+    weight_names = (
+        _unique_name(f"{conv.input[1]}__winml_part0", used_names),
+        _unique_name(f"{conv.input[1]}__winml_part1", used_names),
+    )
+    if len(conv.input) == 3:
+        bias_names = (
+            _unique_name(f"{conv.input[2]}__winml_part0", used_names),
+            _unique_name(f"{conv.input[2]}__winml_part1", used_names),
+        )
+
+    return _RewritePlan(
+        conv=conv,
+        tail_slice=tail_slice,
+        kernel_start=kernel_start,
+        kernel_end=kernel_end,
+        pad_begin=pad_begin,
+        pad_end=pad_end,
+        branch_names=branch_names,
+        split_name=split_name,
+        concat_name=concat_name,
+        split_outputs=split_outputs,
+        branch_outputs=branch_outputs,
+        weight_names=weight_names,
+        bias_names=bias_names,
+    )
+
+
+def _validated_existing_regions(model: onnx.ModelProto) -> tuple[QuantizationRegion, ...]:
+    regions = parse_quantization_region_hints(model) or ()
+    if not regions:
+        return ()
+
+    nodes_by_name: dict[str, list[onnx.NodeProto]] = {}
+    consumers: dict[str, list[onnx.NodeProto]] = {}
+    for node in model.graph.node:
+        nodes_by_name.setdefault(node.name, []).append(node)
+        for input_name in node.input:
+            consumers.setdefault(input_name, []).append(node)
+    graph_outputs = {value.name for value in model.graph.output}
+    for region in regions:
+        concat_nodes = nodes_by_name.get(region.concat, [])
+        if (
+            len(concat_nodes) != 1
+            or concat_nodes[0].op_type != "Concat"
+            or concat_nodes[0].domain not in STANDARD_ONNX_DOMAINS
+        ):
+            raise QuantizationHintError(
+                f"Existing hinted Concat {region.concat!r} does not identify one Concat node"
+            )
+        branch_outputs: list[str] = []
+        for branch_name in region.branches:
+            branch_nodes = nodes_by_name.get(branch_name, [])
+            if (
+                len(branch_nodes) != 1
+                or branch_nodes[0].op_type != "Conv"
+                or branch_nodes[0].domain not in STANDARD_ONNX_DOMAINS
+                or len(branch_nodes[0].output) != 1
+                or not branch_nodes[0].output[0]
+            ):
+                raise QuantizationHintError(
+                    f"Existing hinted branch {branch_name!r} does not identify one Conv node"
+                )
+            branch_output = branch_nodes[0].output[0]
+            if branch_output in graph_outputs or consumers.get(branch_output) != concat_nodes:
+                raise QuantizationHintError(
+                    f"Existing hinted branch {branch_name!r} does not exclusively feed its Concat"
+                )
+            branch_outputs.append(branch_output)
+        if list(concat_nodes[0].input) != branch_outputs:
+            raise QuantizationHintError(
+                f"Existing hinted Concat {region.concat!r} does not consume its branches directly"
+            )
+    return regions
+
+
+def _set_region_hints(
+    model: onnx.ModelProto,
+    regions: tuple[QuantizationRegion, ...],
+) -> None:
+    entry = next(
+        (item for item in model.metadata_props if item.key == QUANTIZATION_REGION_HINT_KEY),
+        None,
+    )
+    if entry is None:
+        entry = model.metadata_props.add()
+        entry.key = QUANTIZATION_REGION_HINT_KEY
+    entry.value = serialize_quantization_region_hints(regions)
+
+
+def trim_split_grouped_convs(
+    model: onnx.ModelProto,
+    *,
+    verbose: bool = False,
+) -> onnx.ModelProto:
+    """Trim unreachable 1D kernels and split even grouped Conv regions."""
+    existing_regions = _validated_existing_regions(model)
+    graph = model.graph
+    initializers = {initializer.name: initializer for initializer in graph.initializer}
+    consumers: dict[str, list[onnx.NodeProto]] = {}
+    for node in graph.node:
+        for input_name in node.input:
+            consumers.setdefault(input_name, []).append(node)
+    graph_outputs = {value.name for value in graph.output}
+    shapes = _static_shapes(model)
+    used_names = {
+        name for node in graph.node for name in (*node.input, *node.output, node.name) if name
+    }
+    used_names.update(initializer.name for initializer in graph.initializer)
+    used_names.update(value.name for value in (*graph.input, *graph.value_info, *graph.output))
+
+    plans = [
+        plan
+        for node in graph.node
+        if (
+            plan := _match_plan(
+                node,
+                consumers=consumers,
+                graph_outputs=graph_outputs,
+                initializers=initializers,
+                shapes=shapes,
+                used_names=used_names,
+            )
+        )
+        is not None
+    ]
+    if not plans:
+        return model
+
+    replacements: dict[int, list[onnx.NodeProto]] = {}
+    removed_node_ids: set[int] = set()
+    new_initializers: list[onnx.TensorProto] = []
+    regions: list[QuantizationRegion] = []
+    removable_initializers: set[str] = set()
+    for plan in plans:
+        conv_attributes = _attributes(plan.conv)
+        weights = np.asarray(numpy_helper.to_array(initializers[plan.conv.input[1]]))
+        output_midpoint = weights.shape[0] // 2
+        trimmed_weights = weights[:, :, plan.kernel_start : plan.kernel_end + 1]
+        for index, values in enumerate(np.split(trimmed_weights, [output_midpoint], axis=0)):
+            new_initializers.append(
+                numpy_helper.from_array(np.ascontiguousarray(values), plan.weight_names[index])
+            )
+
+        if plan.bias_names is not None:
+            bias = np.asarray(numpy_helper.to_array(initializers[plan.conv.input[2]]))
+            for index, values in enumerate(np.split(bias, [output_midpoint], axis=0)):
+                new_initializers.append(
+                    numpy_helper.from_array(np.ascontiguousarray(values), plan.bias_names[index])
+                )
+
+        split = helper.make_node(
+            "Split",
+            [plan.conv.input[0]],
+            list(plan.split_outputs),
+            name=plan.split_name,
+            axis=1,
+        )
+        branches: list[onnx.NodeProto] = []
+        for index in range(2):
+            branch = copy.deepcopy(plan.conv)
+            branch.name = plan.branch_names[index]
+            del branch.input[:]
+            branch.input.extend([plan.split_outputs[index], plan.weight_names[index]])
+            if plan.bias_names is not None:
+                branch.input.append(plan.bias_names[index])
+            del branch.output[:]
+            branch.output.append(plan.branch_outputs[index])
+            _replace_attribute(branch, "group", int(conv_attributes["group"]) // 2)
+            _replace_attribute(branch, "kernel_shape", [plan.kernel_end - plan.kernel_start + 1])
+            _replace_attribute(branch, "pads", [plan.pad_begin, plan.pad_end])
+            branches.append(branch)
+        concat = helper.make_node(
+            "Concat",
+            list(plan.branch_outputs),
+            list(plan.tail_slice.output),
+            name=plan.concat_name,
+            axis=1,
+        )
+        replacements[id(plan.conv)] = [split, *branches, concat]
+        removed_node_ids.update((id(plan.conv), id(plan.tail_slice)))
+        removable_initializers.update(plan.conv.input[1:])
+        removable_initializers.update(plan.tail_slice.input[1:])
+        regions.append(
+            QuantizationRegion(
+                branches=plan.branch_names,
+                concat=plan.concat_name,
+            )
+        )
+        if verbose:
+            logger.info(
+                "trim-split-grouped-conv: %s kernel [%d:%d], groups %d -> %d + %d",
+                plan.conv.name,
+                plan.kernel_start,
+                plan.kernel_end + 1,
+                int(conv_attributes["group"]),
+                int(conv_attributes["group"]) // 2,
+                int(conv_attributes["group"]) // 2,
+            )
+
+    rebuilt: list[onnx.NodeProto] = []
+    for node in graph.node:
+        if id(node) in replacements:
+            rebuilt.extend(replacements[id(node)])
+        elif id(node) not in removed_node_ids:
+            rebuilt.append(node)
+    del graph.node[:]
+    graph.node.extend(rebuilt)
+    graph.initializer.extend(new_initializers)
+    referenced_tensors = _referenced_tensor_names(graph)
+    kept_initializers = [
+        initializer
+        for initializer in graph.initializer
+        if initializer.name not in removable_initializers or initializer.name in referenced_tensors
+    ]
+    del graph.initializer[:]
+    graph.initializer.extend(kept_initializers)
+    _set_region_hints(model, (*existing_regions, *regions))
+    logger.info("SurgeryPipe: trim-split-grouped-conv: rewrote %d region(s)", len(plans))
+    return model
+
+
+__all__ = [
+    "QUANTIZATION_REGION_HINT_KEY",
+    "trim_split_grouped_convs",
+]

--- a/src/winml/modelkit/optim/pipes/algebraic.py
+++ b/src/winml/modelkit/optim/pipes/algebraic.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 import numpy as np
 import onnx
 
+from ...onnx import get_captured_tensor_names
 from ..capabilities import algebraic, misc
 from .base import BasePipe, PipeConfig, caps_dict
 
@@ -82,10 +83,10 @@ class _GraphIndex:
             consumed_names = {input_name for input_name in node.input if input_name}
             for attribute in node.attribute:
                 if attribute.type == onnx.AttributeProto.GRAPH:
-                    consumed_names.update(_captured_tensor_names(attribute.g))
+                    consumed_names.update(get_captured_tensor_names(attribute.g))
                 elif attribute.type == onnx.AttributeProto.GRAPHS:
                     for nested_graph in attribute.graphs:
-                        consumed_names.update(_captured_tensor_names(nested_graph))
+                        consumed_names.update(get_captured_tensor_names(nested_graph))
             for input_name in consumed_names:
                 consumers.setdefault(input_name, []).append(node)
 
@@ -369,23 +370,6 @@ def _remove_nodes(model: onnx.ModelProto, nodes: set[int]) -> None:
     remaining = [node for node in model.graph.node if id(node) not in nodes]
     del model.graph.node[:]
     model.graph.node.extend(remaining)
-
-
-def _captured_tensor_names(graph: onnx.GraphProto) -> set[str]:
-    """Return names a nested graph resolves from an enclosing scope."""
-    locally_defined = {value.name for value in graph.input if value.name}
-    locally_defined.update(initializer.name for initializer in graph.initializer)
-    locally_defined.update(output for node in graph.node for output in node.output if output)
-    referenced = {input_name for node in graph.node for input_name in node.input if input_name}
-    referenced.update(output.name for output in graph.output if output.name)
-    for node in graph.node:
-        for attribute in node.attribute:
-            if attribute.type == onnx.AttributeProto.GRAPH:
-                referenced.update(_captured_tensor_names(attribute.g))
-            elif attribute.type == onnx.AttributeProto.GRAPHS:
-                for nested_graph in attribute.graphs:
-                    referenced.update(_captured_tensor_names(nested_graph))
-    return referenced - locally_defined
 
 
 def _referenced_tensor_names(graph: onnx.GraphProto) -> set[str]:

--- a/src/winml/modelkit/optim/pipes/surgery.py
+++ b/src/winml/modelkit/optim/pipes/surgery.py
@@ -39,6 +39,7 @@ SURGERY_CAPABILITIES: dict[str, Any] = caps_dict(
     surgery.CLAMP_CONSTANT_VALUES,
     surgery.REMOVE_ISNAN_IN_ATTENTION_MASK,
     surgery.UNTIE_CONSTANT_BATCHED_MATMUL,
+    surgery.TRIM_SPLIT_GROUPED_CONV,
 )
 
 
@@ -68,6 +69,7 @@ class SurgeryPipeConfig(PipeConfig):
     clamp_max: float = 1e3
     remove_isnan_in_attention_mask: bool = False
     untie_constant_batched_matmul: bool = False
+    trim_split_grouped_conv: bool = False
     verbose: bool = False
 
 
@@ -111,6 +113,7 @@ class SurgeryPipe(BasePipe[SurgeryPipeConfig]):
             clamp_max=kwargs.get("clamp_max", 1e3),
             remove_isnan_in_attention_mask=kwargs.get("remove_isnan_in_attention_mask", False),
             untie_constant_batched_matmul=kwargs.get("untie_constant_batched_matmul", False),
+            trim_split_grouped_conv=kwargs.get("trim_split_grouped_conv", False),
             verbose=kwargs.get("verbose", False),
         )
 
@@ -128,6 +131,7 @@ class SurgeryPipe(BasePipe[SurgeryPipeConfig]):
             config.clamp_constant_values
             or config.remove_isnan_in_attention_mask
             or config.untie_constant_batched_matmul
+            or config.trim_split_grouped_conv
         )
 
     def process(self, model: onnx.ModelProto, config: SurgeryPipeConfig) -> onnx.ModelProto:
@@ -160,6 +164,11 @@ class SurgeryPipe(BasePipe[SurgeryPipeConfig]):
 
         if config.untie_constant_batched_matmul:
             model_copy = self._untie_constant_batched_matmul(model_copy, config.verbose)
+
+        if config.trim_split_grouped_conv:
+            from ..grouped_conv import trim_split_grouped_convs
+
+            model_copy = trim_split_grouped_convs(model_copy, verbose=config.verbose)
 
         return model_copy
 

--- a/src/winml/modelkit/quant/hints.py
+++ b/src/winml/modelkit/quant/hints.py
@@ -179,7 +179,7 @@ def canonicalize_quantization_region_hints(model: ModelProto) -> ModelProto:
                 f"Hinted Concat {region.concat!r} has unsupported domain {concat.domain!r}"
             )
 
-        region_dq_outputs: list[str] = []
+        region_inputs: list[str] = []
         region_rewrites: dict[str, str] = {}
         for branch_name in region.branches:
             branch_index = _one_node_index(indexes_by_name, branch_name, role="branch")
@@ -196,11 +196,17 @@ def canonicalize_quantization_region_hints(model: ModelProto) -> ModelProto:
                     f"Hinted branch {branch_name!r} output is a graph output"
                 )
 
-            q_index = _one_consumer(
+            branch_consumer_index = _one_consumer(
                 consumers,
                 branch_output,
                 context=f"Hinted branch {branch_name!r} output",
             )
+            if branch_consumer_index == concat_index:
+                region_inputs.append(branch_output)
+                region_rewrites[branch_output] = branch_output
+                continue
+
+            q_index = branch_consumer_index
             q_node = nodes[q_index]
             if q_node.op_type != "QuantizeLinear":
                 raise QuantizationHintError(
@@ -267,10 +273,10 @@ def canonicalize_quantization_region_hints(model: ModelProto) -> ModelProto:
                     f"Quantization nodes are shared by branch {branch_name!r}"
                 )
             remove_indexes.update((q_index, dq_index))
-            region_dq_outputs.append(dq_output)
+            region_inputs.append(dq_output)
             region_rewrites[dq_output] = branch_output
 
-        if list(concat.input) != region_dq_outputs:
+        if list(concat.input) != region_inputs:
             raise QuantizationHintError(
                 f"Hinted Concat {region.concat!r} inputs do not exactly match its branches"
             )

--- a/src/winml/modelkit/quant/hints.py
+++ b/src/winml/modelkit/quant/hints.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass
 
 import onnx
 
+from ..onnx import get_captured_tensor_names
+
 
 QUANTIZATION_REGION_HINT_KEY = "winml.quantization.region_hints"
 STANDARD_ONNX_DOMAINS = frozenset(("", "ai.onnx"))
@@ -154,7 +156,14 @@ def canonicalize_quantization_region_hints(model: onnx.ModelProto) -> onnx.Model
     consumers: dict[str, list[int]] = {}
     for index, node in enumerate(nodes):
         indexes_by_name.setdefault(node.name, []).append(index)
-        for input_name in node.input:
+        consumed_names = {input_name for input_name in node.input if input_name}
+        for attribute in node.attribute:
+            if attribute.type == onnx.AttributeProto.GRAPH:
+                consumed_names.update(get_captured_tensor_names(attribute.g))
+            elif attribute.type == onnx.AttributeProto.GRAPHS:
+                for nested_graph in attribute.graphs:
+                    consumed_names.update(get_captured_tensor_names(nested_graph))
+        for input_name in consumed_names:
             consumers.setdefault(input_name, []).append(index)
     graph_outputs = {value.name for value in model.graph.output}
 

--- a/src/winml/modelkit/quant/hints.py
+++ b/src/winml/modelkit/quant/hints.py
@@ -10,7 +10,7 @@ import copy
 import json
 from dataclasses import dataclass
 
-import onnx
+from onnx import AttributeProto, ModelProto, NodeProto
 
 from ..onnx import get_captured_tensor_names
 
@@ -77,7 +77,7 @@ def _parse_payload(payload: object) -> tuple[QuantizationRegion, ...]:
 
 
 def parse_quantization_region_hints(
-    model: onnx.ModelProto,
+    model: ModelProto,
 ) -> tuple[QuantizationRegion, ...] | None:
     """Parse and strictly validate model-level quantization region hints."""
     entries = [item for item in model.metadata_props if item.key == QUANTIZATION_REGION_HINT_KEY]
@@ -125,7 +125,7 @@ def _one_node_index(
     return indexes[0]
 
 
-def _one_output(node: onnx.NodeProto, *, context: str) -> str:
+def _one_output(node: NodeProto, *, context: str) -> str:
     if len(node.output) != 1 or not node.output[0]:
         raise QuantizationHintError(f"{context} must have exactly one output")
     return node.output[0]
@@ -145,7 +145,7 @@ def _one_consumer(
     return indexes[0]
 
 
-def canonicalize_quantization_region_hints(model: onnx.ModelProto) -> onnx.ModelProto:
+def canonicalize_quantization_region_hints(model: ModelProto) -> ModelProto:
     """Remove exact hinted branch-output QDQ pairs from a copy of *model*."""
     regions = parse_quantization_region_hints(model)
     if regions is None:
@@ -158,9 +158,9 @@ def canonicalize_quantization_region_hints(model: onnx.ModelProto) -> onnx.Model
         indexes_by_name.setdefault(node.name, []).append(index)
         consumed_names = {input_name for input_name in node.input if input_name}
         for attribute in node.attribute:
-            if attribute.type == onnx.AttributeProto.GRAPH:
+            if attribute.type == AttributeProto.GRAPH:
                 consumed_names.update(get_captured_tensor_names(attribute.g))
-            elif attribute.type == onnx.AttributeProto.GRAPHS:
+            elif attribute.type == AttributeProto.GRAPHS:
                 for nested_graph in attribute.graphs:
                     consumed_names.update(get_captured_tensor_names(nested_graph))
         for input_name in consumed_names:
@@ -276,7 +276,7 @@ def canonicalize_quantization_region_hints(model: onnx.ModelProto) -> onnx.Model
             )
         rewrites_by_concat[concat_index] = region_rewrites
 
-    result = onnx.ModelProto()
+    result = ModelProto()
     result.CopyFrom(model)
     for concat_index, rewrites in rewrites_by_concat.items():
         concat = result.graph.node[concat_index]

--- a/src/winml/modelkit/quant/hints.py
+++ b/src/winml/modelkit/quant/hints.py
@@ -1,0 +1,301 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Consume optimizer-authored quantization region hints."""
+
+from __future__ import annotations
+
+import copy
+import json
+from dataclasses import dataclass
+
+import onnx
+
+
+QUANTIZATION_REGION_HINT_KEY = "winml.quantization.region_hints"
+STANDARD_ONNX_DOMAINS = frozenset(("", "ai.onnx"))
+QDQ_ONNX_DOMAINS = STANDARD_ONNX_DOMAINS | {"com.microsoft"}
+
+
+@dataclass(frozen=True)
+class QuantizationRegion:
+    """One optimizer-authored Conv-to-Concat quantization region."""
+
+    branches: tuple[str, str]
+    concat: str
+
+
+class QuantizationHintError(ValueError):
+    """A quantization region hint is malformed or does not match the graph."""
+
+
+def _parse_payload(payload: object) -> tuple[QuantizationRegion, ...]:
+    if not isinstance(payload, dict) or set(payload) != {"version", "regions"}:
+        raise QuantizationHintError(f"Invalid {QUANTIZATION_REGION_HINT_KEY} schema")
+    if type(payload["version"]) is not int or payload["version"] != 1:
+        raise QuantizationHintError(
+            f"Unsupported {QUANTIZATION_REGION_HINT_KEY} version: {payload['version']!r}"
+        )
+    raw_regions = payload["regions"]
+    if not isinstance(raw_regions, list) or not raw_regions:
+        raise QuantizationHintError(f"Invalid {QUANTIZATION_REGION_HINT_KEY} regions")
+
+    regions: list[QuantizationRegion] = []
+    branch_names: set[str] = set()
+    concat_names: set[str] = set()
+    for index, value in enumerate(raw_regions):
+        if not isinstance(value, dict) or set(value) != {"kind", "branches", "concat"}:
+            raise QuantizationHintError(f"Invalid quantization region {index}")
+        if value["kind"] != "conv_concat":
+            raise QuantizationHintError(f"Unsupported quantization region kind: {value['kind']!r}")
+        raw_branches = value["branches"]
+        concat = value["concat"]
+        if (
+            not isinstance(raw_branches, list)
+            or len(raw_branches) != 2
+            or any(not isinstance(name, str) or not name for name in raw_branches)
+            or len(set(raw_branches)) != 2
+            or not isinstance(concat, str)
+            or not concat
+        ):
+            raise QuantizationHintError(f"Invalid conv_concat region {index}")
+        if branch_names.intersection(raw_branches) or concat in concat_names:
+            raise QuantizationHintError(f"Duplicate node name in quantization region {index}")
+        if concat in raw_branches:
+            raise QuantizationHintError(f"Concat is also a branch in quantization region {index}")
+        branch_names.update(raw_branches)
+        concat_names.add(concat)
+        regions.append(
+            QuantizationRegion(branches=(raw_branches[0], raw_branches[1]), concat=concat)
+        )
+    if branch_names.intersection(concat_names):
+        raise QuantizationHintError("A hinted node has both branch and Concat roles")
+    return tuple(regions)
+
+
+def parse_quantization_region_hints(
+    model: onnx.ModelProto,
+) -> tuple[QuantizationRegion, ...] | None:
+    """Parse and strictly validate model-level quantization region hints."""
+    entries = [item for item in model.metadata_props if item.key == QUANTIZATION_REGION_HINT_KEY]
+    if not entries:
+        return None
+    if len(entries) != 1:
+        raise QuantizationHintError(f"Duplicate {QUANTIZATION_REGION_HINT_KEY} metadata")
+    try:
+        payload = json.loads(entries[0].value)
+    except (json.JSONDecodeError, TypeError) as error:
+        raise QuantizationHintError(f"Invalid {QUANTIZATION_REGION_HINT_KEY} JSON") from error
+    return _parse_payload(payload)
+
+
+def serialize_quantization_region_hints(
+    regions: tuple[QuantizationRegion, ...],
+) -> str:
+    """Validate and serialize quantization regions in the versioned schema."""
+    payload = {
+        "version": 1,
+        "regions": [
+            {
+                "kind": "conv_concat",
+                "branches": list(region.branches),
+                "concat": region.concat,
+            }
+            for region in regions
+        ],
+    }
+    _parse_payload(payload)
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True)
+
+
+def _one_node_index(
+    indexes_by_name: dict[str, list[int]],
+    name: str,
+    *,
+    role: str,
+) -> int:
+    indexes = indexes_by_name.get(name, [])
+    if len(indexes) != 1:
+        raise QuantizationHintError(
+            f"Hinted {role} {name!r} must identify exactly one node; found {len(indexes)}"
+        )
+    return indexes[0]
+
+
+def _one_output(node: onnx.NodeProto, *, context: str) -> str:
+    if len(node.output) != 1 or not node.output[0]:
+        raise QuantizationHintError(f"{context} must have exactly one output")
+    return node.output[0]
+
+
+def _one_consumer(
+    consumers: dict[str, list[int]],
+    output_name: str,
+    *,
+    context: str,
+) -> int:
+    indexes = consumers.get(output_name, [])
+    if len(indexes) != 1:
+        raise QuantizationHintError(
+            f"{context} must have exactly one consumer; found {len(indexes)}"
+        )
+    return indexes[0]
+
+
+def canonicalize_quantization_region_hints(model: onnx.ModelProto) -> onnx.ModelProto:
+    """Remove exact hinted branch-output QDQ pairs from a copy of *model*."""
+    regions = parse_quantization_region_hints(model)
+    if regions is None:
+        return model
+
+    nodes = list(model.graph.node)
+    indexes_by_name: dict[str, list[int]] = {}
+    consumers: dict[str, list[int]] = {}
+    for index, node in enumerate(nodes):
+        indexes_by_name.setdefault(node.name, []).append(index)
+        for input_name in node.input:
+            consumers.setdefault(input_name, []).append(index)
+    graph_outputs = {value.name for value in model.graph.output}
+
+    remove_indexes: set[int] = set()
+    rewrites_by_concat: dict[int, dict[str, str]] = {}
+    for region in regions:
+        concat_index = _one_node_index(indexes_by_name, region.concat, role="Concat")
+        concat = nodes[concat_index]
+        if concat.op_type != "Concat":
+            raise QuantizationHintError(f"Hinted Concat {region.concat!r} is {concat.op_type}")
+        if concat.domain not in STANDARD_ONNX_DOMAINS:
+            raise QuantizationHintError(
+                f"Hinted Concat {region.concat!r} has unsupported domain {concat.domain!r}"
+            )
+
+        region_dq_outputs: list[str] = []
+        region_rewrites: dict[str, str] = {}
+        for branch_name in region.branches:
+            branch_index = _one_node_index(indexes_by_name, branch_name, role="branch")
+            branch = nodes[branch_index]
+            if branch.op_type != "Conv":
+                raise QuantizationHintError(f"Hinted branch {branch_name!r} is {branch.op_type}")
+            if branch.domain not in STANDARD_ONNX_DOMAINS:
+                raise QuantizationHintError(
+                    f"Hinted branch {branch_name!r} has unsupported domain {branch.domain!r}"
+                )
+            branch_output = _one_output(branch, context=f"Hinted branch {branch_name!r}")
+            if branch_output in graph_outputs:
+                raise QuantizationHintError(
+                    f"Hinted branch {branch_name!r} output is a graph output"
+                )
+
+            q_index = _one_consumer(
+                consumers,
+                branch_output,
+                context=f"Hinted branch {branch_name!r} output",
+            )
+            q_node = nodes[q_index]
+            if q_node.op_type != "QuantizeLinear":
+                raise QuantizationHintError(
+                    f"Hinted branch {branch_name!r} output consumer is {q_node.op_type}"
+                )
+            if q_node.domain not in QDQ_ONNX_DOMAINS:
+                raise QuantizationHintError(
+                    f"Branch {branch_name!r} QuantizeLinear has unsupported "
+                    f"domain {q_node.domain!r}"
+                )
+            if not q_node.input or q_node.input[0] != branch_output:
+                raise QuantizationHintError(
+                    f"Hinted branch {branch_name!r} output is not the QuantizeLinear data input"
+                )
+            q_output = _one_output(q_node, context=f"Branch {branch_name!r} QuantizeLinear")
+            if q_output in graph_outputs:
+                raise QuantizationHintError(
+                    f"Branch {branch_name!r} QuantizeLinear output is a graph output"
+                )
+
+            dq_index = _one_consumer(
+                consumers,
+                q_output,
+                context=f"Branch {branch_name!r} QuantizeLinear output",
+            )
+            dq_node = nodes[dq_index]
+            if dq_node.op_type != "DequantizeLinear":
+                raise QuantizationHintError(
+                    f"Branch {branch_name!r} QuantizeLinear consumer is {dq_node.op_type}"
+                )
+            if dq_node.domain not in QDQ_ONNX_DOMAINS:
+                raise QuantizationHintError(
+                    f"Branch {branch_name!r} DequantizeLinear has unsupported "
+                    f"domain {dq_node.domain!r}"
+                )
+            if dq_node.domain != q_node.domain:
+                raise QuantizationHintError(
+                    f"Branch {branch_name!r} Q/DQ nodes use different domains"
+                )
+            if not dq_node.input or dq_node.input[0] != q_output:
+                raise QuantizationHintError(
+                    f"Branch {branch_name!r} QuantizeLinear output is not the "
+                    "DequantizeLinear data input"
+                )
+            dq_output = _one_output(
+                dq_node,
+                context=f"Branch {branch_name!r} DequantizeLinear",
+            )
+            if dq_output in graph_outputs:
+                raise QuantizationHintError(
+                    f"Branch {branch_name!r} DequantizeLinear output is a graph output"
+                )
+            downstream_index = _one_consumer(
+                consumers,
+                dq_output,
+                context=f"Branch {branch_name!r} DequantizeLinear output",
+            )
+            if downstream_index != concat_index:
+                raise QuantizationHintError(
+                    f"Branch {branch_name!r} does not feed hinted Concat {region.concat!r}"
+                )
+            if q_index in remove_indexes or dq_index in remove_indexes:
+                raise QuantizationHintError(
+                    f"Quantization nodes are shared by branch {branch_name!r}"
+                )
+            remove_indexes.update((q_index, dq_index))
+            region_dq_outputs.append(dq_output)
+            region_rewrites[dq_output] = branch_output
+
+        if list(concat.input) != region_dq_outputs:
+            raise QuantizationHintError(
+                f"Hinted Concat {region.concat!r} inputs do not exactly match its branches"
+            )
+        rewrites_by_concat[concat_index] = region_rewrites
+
+    result = onnx.ModelProto()
+    result.CopyFrom(model)
+    for concat_index, rewrites in rewrites_by_concat.items():
+        concat = result.graph.node[concat_index]
+        for input_index, input_name in enumerate(concat.input):
+            concat.input[input_index] = rewrites[input_name]
+    kept_nodes = [
+        node for index, node in enumerate(result.graph.node) if index not in remove_indexes
+    ]
+    del result.graph.node[:]
+    result.graph.node.extend(kept_nodes)
+
+    kept_metadata = [
+        copy.deepcopy(item)
+        for item in result.metadata_props
+        if item.key != QUANTIZATION_REGION_HINT_KEY
+    ]
+    del result.metadata_props[:]
+    result.metadata_props.extend(kept_metadata)
+    return result
+
+
+__all__ = [
+    "QDQ_ONNX_DOMAINS",
+    "QUANTIZATION_REGION_HINT_KEY",
+    "STANDARD_ONNX_DOMAINS",
+    "QuantizationHintError",
+    "QuantizationRegion",
+    "canonicalize_quantization_region_hints",
+    "parse_quantization_region_hints",
+    "serialize_quantization_region_hints",
+]

--- a/src/winml/modelkit/quant/passes/static.py
+++ b/src/winml/modelkit/quant/passes/static.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING
 
+from onnx import checker as onnx_checker
+
 from .base import BaseQuantPass
 
 
@@ -31,7 +33,6 @@ def _publish_staged_model(staged_path: Path, output_path: Path) -> None:
     backup_sidecar = staged_path.parent / "previous-output.onnx.data"
     backed_up_model = False
     backed_up_sidecar = False
-    published_model = False
     published_sidecar = False
     try:
         if output_path.exists():
@@ -44,10 +45,7 @@ def _publish_staged_model(staged_path: Path, output_path: Path) -> None:
             staged_sidecar.replace(output_sidecar)
             published_sidecar = True
         staged_path.replace(output_path)
-        published_model = True
     except BaseException:
-        if published_model:
-            output_path.unlink(missing_ok=True)
         if published_sidecar:
             output_sidecar.unlink(missing_ok=True)
         if backed_up_sidecar:
@@ -229,9 +227,7 @@ class StaticPass(BaseQuantPass):
             )
             save_onnx(quantized_model, staged_output, use_external_data=use_external_data)
 
-            import onnx
-
-            onnx.checker.check_model(str(staged_output), full_check=True)
+            onnx_checker.check_model(str(staged_output), full_check=True)
             _publish_staged_model(staged_output, output_path)
             postproc_time = time.perf_counter() - postproc_start
 

--- a/src/winml/modelkit/quant/passes/static.py
+++ b/src/winml/modelkit/quant/passes/static.py
@@ -186,7 +186,7 @@ class StaticPass(BaseQuantPass):
             prefix=f".{output_path.stem}-",
             dir=output_path.parent,
         ) as staging_directory:
-            staged_output = Path(staging_directory) / output_path.name
+            staged_output = (Path(staging_directory) / output_path.name).resolve()
             original_cwd = Path.cwd()
             try:
                 os.chdir(staged_output.parent)

--- a/src/winml/modelkit/quant/passes/static.py
+++ b/src/winml/modelkit/quant/passes/static.py
@@ -29,30 +29,35 @@ def _publish_staged_model(staged_path: Path, output_path: Path) -> None:
     """Publish a validated staged ONNX model while preserving prior output on failure."""
     staged_sidecar = staged_path.parent / f"{staged_path.name}.data"
     output_sidecar = output_path.parent / f"{output_path.name}.data"
-    backup_model = staged_path.parent / "previous-output.onnx"
-    backup_sidecar = staged_path.parent / "previous-output.onnx.data"
-    backed_up_model = False
-    backed_up_sidecar = False
-    published_sidecar = False
-    try:
-        if output_path.exists():
-            output_path.replace(backup_model)
-            backed_up_model = True
-        if output_sidecar.exists():
-            output_sidecar.replace(backup_sidecar)
-            backed_up_sidecar = True
-        if staged_sidecar.exists():
-            staged_sidecar.replace(output_sidecar)
-            published_sidecar = True
-        staged_path.replace(output_path)
-    except BaseException:
-        if published_sidecar:
-            output_sidecar.unlink(missing_ok=True)
-        if backed_up_sidecar:
-            backup_sidecar.replace(output_sidecar)
-        if backed_up_model:
-            backup_model.replace(output_path)
-        raise
+    for label, path in (("Output path", output_path), ("Output sidecar path", output_sidecar)):
+        if os.path.lexists(path) and not path.is_file():
+            raise ValueError(f"{label} exists but is not a file: {path}")
+
+    with TemporaryDirectory(prefix=".publish-backup-", dir=staged_path.parent) as backup_directory:
+        backup_model = Path(backup_directory) / "model"
+        backup_sidecar = Path(backup_directory) / "sidecar"
+        backed_up_model = False
+        backed_up_sidecar = False
+        published_sidecar = False
+        try:
+            if output_path.exists():
+                output_path.replace(backup_model)
+                backed_up_model = True
+            if output_sidecar.exists():
+                output_sidecar.replace(backup_sidecar)
+                backed_up_sidecar = True
+            if staged_sidecar.exists():
+                staged_sidecar.replace(output_sidecar)
+                published_sidecar = True
+            staged_path.replace(output_path)
+        except BaseException:
+            if published_sidecar:
+                output_sidecar.unlink(missing_ok=True)
+            if backed_up_sidecar:
+                backup_sidecar.replace(output_sidecar)
+            if backed_up_model:
+                backup_model.replace(output_path)
+            raise
 
 
 class StaticPass(BaseQuantPass):

--- a/src/winml/modelkit/quant/passes/static.py
+++ b/src/winml/modelkit/quant/passes/static.py
@@ -10,6 +10,7 @@ import logging
 import os
 import time
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING
 
 from .base import BaseQuantPass
@@ -20,6 +21,40 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+
+def _publish_staged_model(staged_path: Path, output_path: Path) -> None:
+    """Publish a validated staged ONNX model while preserving prior output on failure."""
+    staged_sidecar = staged_path.parent / f"{staged_path.name}.data"
+    output_sidecar = output_path.parent / f"{output_path.name}.data"
+    backup_model = staged_path.parent / "previous-output.onnx"
+    backup_sidecar = staged_path.parent / "previous-output.onnx.data"
+    backed_up_model = False
+    backed_up_sidecar = False
+    published_model = False
+    published_sidecar = False
+    try:
+        if output_path.exists():
+            output_path.replace(backup_model)
+            backed_up_model = True
+        if output_sidecar.exists():
+            output_sidecar.replace(backup_sidecar)
+            backed_up_sidecar = True
+        if staged_sidecar.exists():
+            staged_sidecar.replace(output_sidecar)
+            published_sidecar = True
+        staged_path.replace(output_path)
+        published_model = True
+    except BaseException:
+        if published_model:
+            output_path.unlink(missing_ok=True)
+        if published_sidecar:
+            output_sidecar.unlink(missing_ok=True)
+        if backed_up_sidecar:
+            backup_sidecar.replace(output_sidecar)
+        if backed_up_model:
+            backup_model.replace(output_path)
+        raise
 
 
 class StaticPass(BaseQuantPass):
@@ -148,52 +183,57 @@ class StaticPass(BaseQuantPass):
         if use_external_data:
             qdq_config.use_external_data_format = True
         logger.info("Applying quantization...")
-        abs_model_output = str(Path(output_path).resolve())
-        if output_path.exists():
-            output_path.unlink()
-        stale_sidecar = output_path.parent / f"{output_path.name}.data"
-        if stale_sidecar.exists():
-            stale_sidecar.unlink()
-        original_cwd = Path.cwd()
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            os.chdir(output_path.parent)
-            quantize(
-                model_input=input_model,
-                model_output=abs_model_output,
-                quant_config=qdq_config,
+        with TemporaryDirectory(
+            prefix=f".{output_path.stem}-",
+            dir=output_path.parent,
+        ) as staging_directory:
+            staged_output = Path(staging_directory) / output_path.name
+            original_cwd = Path.cwd()
+            try:
+                os.chdir(staged_output.parent)
+                quantize(
+                    model_input=input_model,
+                    model_output=str(staged_output.resolve()),
+                    quant_config=qdq_config,
+                )
+            finally:
+                os.chdir(original_cwd)
+
+            qdq_time = time.perf_counter() - qdq_start
+            postproc_start = time.perf_counter()
+            quantized_model = load_onnx(staged_output, validate=False)
+
+            logger.info("Fixing QDQ node dtype info...")
+            fix_result = fix_qdq_dtype_info(quantized_model)
+            warnings.extend(fix_result.warnings)
+
+            from ...onnx import infer_shapes
+
+            logger.info("Running shape inference on quantized model...")
+            quantized_model = infer_shapes(quantized_model)
+
+            if metadata_snapshot.model_prop_count > 0 or metadata_snapshot.node_count > 0:
+                logger.info("Restoring metadata from pre-quantization model...")
+                restore_metadata(quantized_model, metadata_snapshot)
+
+            from ..hints import canonicalize_quantization_region_hints
+
+            logger.info("Applying optimizer quantization-region hints...")
+            quantized_model = canonicalize_quantization_region_hints(quantized_model)
+
+            from ...compiler import QDQ_OP_TYPES
+
+            nodes_quantized = sum(
+                1 for node in quantized_model.graph.node if node.op_type in QDQ_OP_TYPES
             )
-        finally:
-            os.chdir(original_cwd)
+            save_onnx(quantized_model, staged_output, use_external_data=use_external_data)
 
-        qdq_time = time.perf_counter() - qdq_start
+            import onnx
 
-        postproc_start = time.perf_counter()
-
-        quantized_model = load_onnx(output_path, validate=False)
-
-        logger.info("Fixing QDQ node dtype info...")
-        fix_result = fix_qdq_dtype_info(quantized_model)
-        warnings.extend(fix_result.warnings)
-
-        from ...onnx import infer_shapes
-
-        logger.info("Running shape inference on quantized model...")
-        quantized_model = infer_shapes(quantized_model)
-
-        if metadata_snapshot.node_count > 0:
-            logger.info("Restoring metadata from pre-quantization model...")
-            restore_metadata(quantized_model, metadata_snapshot)
-
-        postproc_time = time.perf_counter() - postproc_start
-
-        from ...compiler import QDQ_OP_TYPES
-
-        nodes_quantized = sum(
-            1 for node in quantized_model.graph.node if node.op_type in QDQ_OP_TYPES
-        )
-
-        save_onnx(quantized_model, output_path, use_external_data=use_external_data)
+            onnx.checker.check_model(str(staged_output), full_check=True)
+            _publish_staged_model(staged_output, output_path)
+            postproc_time = time.perf_counter() - postproc_start
 
         total_time = time.perf_counter() - start_time
 

--- a/tests/unit/config/test_build.py
+++ b/tests/unit/config/test_build.py
@@ -463,6 +463,19 @@ class TestExportCompatibilityBuildConfig:
 
         assert default_config.generate_cache_key() != eager_config.generate_cache_key()
 
+    def test_trim_split_grouped_conv_round_trips_and_changes_cache_key(self) -> None:
+        default_config = WinMLBuildConfig()
+        enabled_config = WinMLBuildConfig(
+            optim=WinMLOptimizationConfig(trim_split_grouped_conv=True)
+        )
+
+        serialized = enabled_config.to_dict()
+        restored = WinMLBuildConfig.from_dict(serialized)
+
+        assert serialized["optim"] == {"trim_split_grouped_conv": True}
+        assert restored.optim["trim_split_grouped_conv"] is True
+        assert default_config.generate_cache_key() != enabled_config.generate_cache_key()
+
     def test_registered_export_merge_preserves_override_compatibility(self) -> None:
         from winml.modelkit.config.build import _merge_export_config
 

--- a/tests/unit/optim/pipes/test_pipe_surgery.py
+++ b/tests/unit/optim/pipes/test_pipe_surgery.py
@@ -512,6 +512,7 @@ def _make_grouped_conv_tail_slice_model(
     input_length: int = 3,
     pads: tuple[int, int] = (4, 4),
     slice_end: int = -1,
+    opset_version: int = 17,
 ) -> onnx.ModelProto:
     """Build a grouped 1D Conv whose final output is removed by Slice."""
     from onnx import TensorProto, helper
@@ -547,7 +548,7 @@ def _make_grouped_conv_tail_slice_model(
         [helper.make_tensor_value_info("output", TensorProto.FLOAT, [1, 32, 3])],
         initializer=[weights, bias, starts, ends, axes, steps],
     )
-    return helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+    return helper.make_model(graph, opset_imports=[helper.make_opsetid("", opset_version)])
 
 
 class TestTrimSplitGroupedConvCapability:
@@ -627,16 +628,26 @@ class TestTrimSplitGroupedConvProcess:
             ],
         }
 
-    def test_preserves_cpu_outputs_and_is_idempotent(self) -> None:
+    @pytest.mark.parametrize("opset_version", [17, 18])
+    def test_preserves_cpu_outputs_and_is_idempotent(self, opset_version: int) -> None:
         import onnxruntime as ort
 
-        model = _make_grouped_conv_tail_slice_model()
+        model = _make_grouped_conv_tail_slice_model(opset_version=opset_version)
         pipe = SurgeryPipe()
         config = SurgeryPipeConfig(trim_split_grouped_conv=True)
         transformed = pipe.process(model, config)
         second_pass = pipe.process(transformed, config)
         feed = {"input": np.random.RandomState(7).randn(1, 32, 3).astype(np.float32)}
+        split = next(node for node in transformed.graph.node if node.op_type == "Split")
+        split_attributes = {
+            attribute.name: onnx.helper.get_attribute_value(attribute)
+            for attribute in split.attribute
+        }
 
+        onnx.checker.check_model(transformed, full_check=True)
+        assert split_attributes == (
+            {"axis": 1} if opset_version < 18 else {"axis": 1, "num_outputs": 2}
+        )
         expected = ort.InferenceSession(
             model.SerializeToString(), providers=["CPUExecutionProvider"]
         ).run(None, feed)[0]

--- a/tests/unit/optim/pipes/test_pipe_surgery.py
+++ b/tests/unit/optim/pipes/test_pipe_surgery.py
@@ -722,6 +722,57 @@ class TestTrimSplitGroupedConvProcess:
 
         self._assert_no_rewrite(model)
 
+    def test_conv_output_captured_by_subgraph_is_unchanged(self) -> None:
+        from onnx import TensorProto
+
+        model = _make_grouped_conv_tail_slice_model()
+        model.graph.initializer.append(
+            numpy_helper.from_array(np.array(True, dtype=np.bool_), "condition")
+        )
+
+        def branch_graph(name: str) -> onnx.GraphProto:
+            output_name = f"{name}_output"
+            return onnx.helper.make_graph(
+                [
+                    onnx.helper.make_node(
+                        "Identity",
+                        ["conv_output"],
+                        [output_name],
+                        name=f"{name}_identity",
+                    )
+                ],
+                name,
+                [],
+                [
+                    onnx.helper.make_tensor_value_info(
+                        output_name,
+                        TensorProto.FLOAT,
+                        [1, 32, 4],
+                    )
+                ],
+            )
+
+        model.graph.node.append(
+            onnx.helper.make_node(
+                "If",
+                ["condition"],
+                ["captured_conv_output"],
+                name="capture_conv_output",
+                then_branch=branch_graph("then_branch"),
+                else_branch=branch_graph("else_branch"),
+            )
+        )
+        model.graph.output.append(
+            onnx.helper.make_tensor_value_info(
+                "captured_conv_output",
+                TensorProto.FLOAT,
+                [1, 32, 4],
+            )
+        )
+        onnx.checker.check_model(model, full_check=True)
+
+        self._assert_no_rewrite(model)
+
     def test_nonunit_stride_is_unchanged(self) -> None:
         model = _make_grouped_conv_tail_slice_model()
         conv = next(node for node in model.graph.node if node.op_type == "Conv")
@@ -867,6 +918,73 @@ class TestTrimSplitGroupedConvProcess:
 
         onnx.checker.check_model(result, full_check=True)
         assert "weights" in {initializer.name for initializer in result.graph.initializer}
+
+    def test_existing_hint_with_nested_capture_fails_without_mutating_input(self) -> None:
+        from onnx import TensorProto
+
+        config = SurgeryPipeConfig(trim_split_grouped_conv=True)
+        model = SurgeryPipe().process(_make_grouped_conv_tail_slice_model(), config)
+        hint = json.loads(
+            next(
+                item.value
+                for item in model.metadata_props
+                if item.key == "winml.quantization.region_hints"
+            )
+        )
+        branch_name = hint["regions"][0]["branches"][0]
+        branch_output = next(
+            node.output[0] for node in model.graph.node if node.name == branch_name
+        )
+        model.graph.initializer.append(
+            numpy_helper.from_array(np.array(True, dtype=np.bool_), "condition")
+        )
+
+        def branch_graph(name: str) -> onnx.GraphProto:
+            output_name = f"{name}_output"
+            return onnx.helper.make_graph(
+                [
+                    onnx.helper.make_node(
+                        "Identity",
+                        [branch_output],
+                        [output_name],
+                        name=f"{name}_identity",
+                    )
+                ],
+                name,
+                [],
+                [
+                    onnx.helper.make_tensor_value_info(
+                        output_name,
+                        TensorProto.FLOAT,
+                        [1, 16, 3],
+                    )
+                ],
+            )
+
+        model.graph.node.append(
+            onnx.helper.make_node(
+                "If",
+                ["condition"],
+                ["captured_branch_output"],
+                name="capture_branch_output",
+                then_branch=branch_graph("then_branch"),
+                else_branch=branch_graph("else_branch"),
+            )
+        )
+        model.graph.output.append(
+            onnx.helper.make_tensor_value_info(
+                "captured_branch_output",
+                TensorProto.FLOAT,
+                [1, 16, 3],
+            )
+        )
+        onnx.checker.check_model(model, full_check=True)
+        original = model.SerializeToString()
+
+        with pytest.raises(QuantizationHintError, match="exclusively feed"):
+            SurgeryPipe().process(model, config)
+
+        assert model.SerializeToString() == original
 
     @pytest.mark.parametrize(
         "metadata_values",

--- a/tests/unit/optim/pipes/test_pipe_surgery.py
+++ b/tests/unit/optim/pipes/test_pipe_surgery.py
@@ -807,6 +807,39 @@ class TestTrimSplitGroupedConvProcess:
 
         self._assert_no_rewrite(model)
 
+    @pytest.mark.parametrize(
+        "initializer_name",
+        ["weights", "bias", "starts", "ends", "axes", "steps"],
+    )
+    def test_overridable_initializer_is_unchanged(self, initializer_name: str) -> None:
+        model = _make_grouped_conv_tail_slice_model()
+        initializer = next(
+            value for value in model.graph.initializer if value.name == initializer_name
+        )
+        model.graph.input.append(
+            onnx.helper.make_tensor_value_info(
+                initializer.name,
+                initializer.data_type,
+                list(initializer.dims),
+            )
+        )
+
+        self._assert_no_rewrite(model)
+
+    def test_legacy_ir_initializer_inputs_are_unchanged(self) -> None:
+        model = _make_grouped_conv_tail_slice_model()
+        model.ir_version = 3
+        for initializer in model.graph.initializer:
+            model.graph.input.append(
+                onnx.helper.make_tensor_value_info(
+                    initializer.name,
+                    initializer.data_type,
+                    list(initializer.dims),
+                )
+            )
+
+        self._assert_no_rewrite(model)
+
     def test_generated_names_do_not_collide(self) -> None:
         model = _make_grouped_conv_tail_slice_model()
         model.graph.node.append(

--- a/tests/unit/optim/pipes/test_pipe_surgery.py
+++ b/tests/unit/optim/pipes/test_pipe_surgery.py
@@ -18,6 +18,8 @@ Fixtures used from conftest.py:
 
 from __future__ import annotations
 
+import json
+
 import numpy as np
 import onnx
 import pytest
@@ -28,6 +30,7 @@ from winml.modelkit.optim.pipes import (
     SurgeryPipe,
     SurgeryPipeConfig,
 )
+from winml.modelkit.quant.hints import QuantizationHintError
 
 
 # =============================================================================
@@ -497,3 +500,447 @@ class TestUntieConstantBatchedMatmulProcess:
             result.SerializeToString(), providers=["CPUExecutionProvider"]
         ).run(None, feed)[0]
         np.testing.assert_array_equal(ref, got)
+
+
+# =============================================================================
+# TRIM-SPLIT-GROUPED-CONV TESTS
+# =============================================================================
+
+
+def _make_grouped_conv_tail_slice_model(
+    *,
+    input_length: int = 3,
+    pads: tuple[int, int] = (4, 4),
+    slice_end: int = -1,
+) -> onnx.ModelProto:
+    """Build a grouped 1D Conv whose final output is removed by Slice."""
+    from onnx import TensorProto, helper
+
+    rng = np.random.RandomState(0)
+    weights = numpy_helper.from_array(rng.randn(32, 2, 8).astype(np.float32), "weights")
+    bias = numpy_helper.from_array(rng.randn(32).astype(np.float32), "bias")
+    starts = numpy_helper.from_array(np.array([0], dtype=np.int64), "starts")
+    ends = numpy_helper.from_array(np.array([slice_end], dtype=np.int64), "ends")
+    axes = numpy_helper.from_array(np.array([2], dtype=np.int64), "axes")
+    steps = numpy_helper.from_array(np.array([1], dtype=np.int64), "steps")
+    conv = helper.make_node(
+        "Conv",
+        ["input", "weights", "bias"],
+        ["conv_output"],
+        name="grouped_conv",
+        group=16,
+        kernel_shape=[8],
+        pads=list(pads),
+        strides=[1],
+        dilations=[1],
+    )
+    tail_slice = helper.make_node(
+        "Slice",
+        ["conv_output", "starts", "ends", "axes", "steps"],
+        ["output"],
+        name="tail_slice",
+    )
+    graph = helper.make_graph(
+        [conv, tail_slice],
+        "grouped_conv_tail_slice",
+        [helper.make_tensor_value_info("input", TensorProto.FLOAT, [1, 32, input_length])],
+        [helper.make_tensor_value_info("output", TensorProto.FLOAT, [1, 32, 3])],
+        initializer=[weights, bias, starts, ends, axes, steps],
+    )
+    return helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+
+
+class TestTrimSplitGroupedConvCapability:
+    """Capability/config plumbing for trim-split-grouped-conv."""
+
+    def test_capability_exists_and_defaults_false(self) -> None:
+        capability = SURGERY_CAPABILITIES["trim-split-grouped-conv"]
+        assert capability.ort_name is None
+        assert capability.default is False
+
+    def test_build_config_enable_via_kwarg(self) -> None:
+        config = SurgeryPipe.build_config(trim_split_grouped_conv=True)
+        assert config.trim_split_grouped_conv is True
+        assert SurgeryPipe.should_process(config) is True
+
+
+class TestTrimSplitGroupedConvProcess:
+    """Static reachability rewrite behavior."""
+
+    @staticmethod
+    def _assert_no_rewrite(model: onnx.ModelProto) -> None:
+        original = model.SerializeToString()
+        result = SurgeryPipe().process(
+            model,
+            SurgeryPipeConfig(trim_split_grouped_conv=True),
+        )
+        assert model.SerializeToString() == original
+        assert result.SerializeToString() == original
+
+    def test_rewrites_supported_graph_and_emits_region_hint(self) -> None:
+        model = _make_grouped_conv_tail_slice_model()
+        original = model.SerializeToString()
+
+        result = SurgeryPipe().process(model, SurgeryPipeConfig(trim_split_grouped_conv=True))
+
+        assert model.SerializeToString() == original
+        onnx.checker.check_model(result, full_check=True)
+        assert [node.op_type for node in result.graph.node] == [
+            "Split",
+            "Conv",
+            "Conv",
+            "Concat",
+        ]
+        convs = [node for node in result.graph.node if node.op_type == "Conv"]
+        assert len(convs) == 2
+        for conv in convs:
+            attributes = {
+                attribute.name: onnx.helper.get_attribute_value(attribute)
+                for attribute in conv.attribute
+            }
+            assert attributes["group"] == 8
+            assert attributes["kernel_shape"] == [5]
+            assert attributes["pads"] == [2, 2]
+        concat = next(node for node in result.graph.node if node.op_type == "Concat")
+        assert concat.output == ["output"]
+        initializer_names = {initializer.name for initializer in result.graph.initializer}
+        assert not {"weights", "bias", "starts", "ends", "axes", "steps"}.intersection(
+            initializer_names
+        )
+        assert {
+            "weights__winml_part0",
+            "weights__winml_part1",
+            "bias__winml_part0",
+            "bias__winml_part1",
+        }.issubset(initializer_names)
+
+        metadata = {item.key: item.value for item in result.metadata_props}
+        hint = json.loads(metadata["winml.quantization.region_hints"])
+        assert hint == {
+            "version": 1,
+            "regions": [
+                {
+                    "kind": "conv_concat",
+                    "branches": [convs[0].name, convs[1].name],
+                    "concat": concat.name,
+                }
+            ],
+        }
+
+    def test_preserves_cpu_outputs_and_is_idempotent(self) -> None:
+        import onnxruntime as ort
+
+        model = _make_grouped_conv_tail_slice_model()
+        pipe = SurgeryPipe()
+        config = SurgeryPipeConfig(trim_split_grouped_conv=True)
+        transformed = pipe.process(model, config)
+        second_pass = pipe.process(transformed, config)
+        feed = {"input": np.random.RandomState(7).randn(1, 32, 3).astype(np.float32)}
+
+        expected = ort.InferenceSession(
+            model.SerializeToString(), providers=["CPUExecutionProvider"]
+        ).run(None, feed)[0]
+        actual = ort.InferenceSession(
+            transformed.SerializeToString(), providers=["CPUExecutionProvider"]
+        ).run(None, feed)[0]
+
+        np.testing.assert_array_equal(actual, expected)
+        assert second_pass.SerializeToString() == transformed.SerializeToString()
+
+    @pytest.mark.parametrize(
+        ("model", "expected_kernel", "expected_pads"),
+        [
+            (
+                _make_grouped_conv_tail_slice_model(
+                    input_length=5,
+                    pads=(4, 2),
+                    slice_end=3,
+                ),
+                [6],
+                [2, 1],
+            ),
+            (
+                _make_grouped_conv_tail_slice_model(
+                    input_length=3,
+                    pads=(1, 7),
+                    slice_end=-1,
+                ),
+                [4],
+                [1, 2],
+            ),
+        ],
+    )
+    def test_trims_one_kernel_edge_with_exact_cpu_outputs(
+        self,
+        model: onnx.ModelProto,
+        expected_kernel: list[int],
+        expected_pads: list[int],
+    ) -> None:
+        import onnxruntime as ort
+
+        transformed = SurgeryPipe().process(
+            model,
+            SurgeryPipeConfig(trim_split_grouped_conv=True),
+        )
+        convs = [node for node in transformed.graph.node if node.op_type == "Conv"]
+        for conv in convs:
+            attributes = {
+                attribute.name: onnx.helper.get_attribute_value(attribute)
+                for attribute in conv.attribute
+            }
+            assert attributes["kernel_shape"] == expected_kernel
+            assert attributes["pads"] == expected_pads
+
+        input_length = model.graph.input[0].type.tensor_type.shape.dim[2].dim_value
+        feed = {"input": np.random.RandomState(7).randn(1, 32, input_length).astype(np.float32)}
+        expected = ort.InferenceSession(
+            model.SerializeToString(), providers=["CPUExecutionProvider"]
+        ).run(None, feed)[0]
+        actual = ort.InferenceSession(
+            transformed.SerializeToString(), providers=["CPUExecutionProvider"]
+        ).run(None, feed)[0]
+        np.testing.assert_array_equal(actual, expected)
+
+    def test_dynamic_spatial_length_is_unchanged(self) -> None:
+        model = _make_grouped_conv_tail_slice_model()
+        spatial_dimension = model.graph.input[0].type.tensor_type.shape.dim[2]
+        spatial_dimension.ClearField("dim_value")
+        spatial_dimension.dim_param = "sequence"
+
+        self._assert_no_rewrite(model)
+
+    def test_conv_fanout_is_unchanged(self) -> None:
+        model = _make_grouped_conv_tail_slice_model()
+        model.graph.node.append(
+            onnx.helper.make_node(
+                "Identity",
+                ["conv_output"],
+                ["other_output"],
+                name="other_consumer",
+            )
+        )
+
+        self._assert_no_rewrite(model)
+
+    def test_nonunit_stride_is_unchanged(self) -> None:
+        model = _make_grouped_conv_tail_slice_model()
+        conv = next(node for node in model.graph.node if node.op_type == "Conv")
+        strides = next(attribute for attribute in conv.attribute if attribute.name == "strides")
+        strides.CopyFrom(onnx.helper.make_attribute("strides", [2]))
+
+        self._assert_no_rewrite(model)
+
+    def test_slice_that_keeps_full_output_is_unchanged(self) -> None:
+        model = _make_grouped_conv_tail_slice_model()
+        ends = next(
+            initializer for initializer in model.graph.initializer if initializer.name == "ends"
+        )
+        ends.CopyFrom(numpy_helper.from_array(np.array([4], dtype=np.int64), "ends"))
+
+        self._assert_no_rewrite(model)
+
+    def test_non_grouped_conv_is_unchanged(self) -> None:
+        model = _make_grouped_conv_tail_slice_model()
+        conv = next(node for node in model.graph.node if node.op_type == "Conv")
+        group = next(attribute for attribute in conv.attribute if attribute.name == "group")
+        group.CopyFrom(onnx.helper.make_attribute("group", 1))
+        weights = next(
+            initializer for initializer in model.graph.initializer if initializer.name == "weights"
+        )
+        weights.CopyFrom(
+            numpy_helper.from_array(
+                np.random.RandomState(1).randn(32, 32, 8).astype(np.float32),
+                "weights",
+            )
+        )
+
+        self._assert_no_rewrite(model)
+
+    def test_generated_names_do_not_collide(self) -> None:
+        model = _make_grouped_conv_tail_slice_model()
+        model.graph.node.append(
+            onnx.helper.make_node(
+                "Identity",
+                ["input"],
+                ["collision_output"],
+                name="grouped_conv__winml_part0",
+            )
+        )
+
+        result = SurgeryPipe().process(
+            model,
+            SurgeryPipeConfig(trim_split_grouped_conv=True),
+        )
+
+        onnx.checker.check_model(result, full_check=True)
+        node_names = [node.name for node in result.graph.node]
+        assert len(node_names) == len(set(node_names))
+        hint = json.loads(
+            next(
+                item.value
+                for item in result.metadata_props
+                if item.key == "winml.quantization.region_hints"
+            )
+        )
+        assert hint["regions"][0]["branches"][0] == "grouped_conv__winml_part0_1"
+
+    def test_shared_source_initializer_is_preserved(self) -> None:
+        from onnx import TensorProto
+
+        model = _make_grouped_conv_tail_slice_model()
+        model.graph.node.append(
+            onnx.helper.make_node(
+                "Identity",
+                ["weights"],
+                ["shared_weights_output"],
+                name="shared_weights",
+            )
+        )
+        model.graph.output.append(
+            onnx.helper.make_tensor_value_info(
+                "shared_weights_output",
+                TensorProto.FLOAT,
+                [32, 2, 8],
+            )
+        )
+
+        result = SurgeryPipe().process(
+            model,
+            SurgeryPipeConfig(trim_split_grouped_conv=True),
+        )
+
+        onnx.checker.check_model(result, full_check=True)
+        initializer_names = {initializer.name for initializer in result.graph.initializer}
+        assert "weights" in initializer_names
+        assert not {"bias", "starts", "ends", "axes", "steps"}.intersection(initializer_names)
+
+    def test_source_initializer_captured_by_subgraph_is_preserved(self) -> None:
+        from onnx import TensorProto
+
+        model = _make_grouped_conv_tail_slice_model()
+        model.graph.initializer.append(
+            numpy_helper.from_array(np.array(True, dtype=np.bool_), "condition")
+        )
+
+        def branch_graph(name: str) -> onnx.GraphProto:
+            identity = onnx.helper.make_node(
+                "Identity",
+                ["weights"],
+                [f"{name}_output"],
+                name=f"{name}_identity",
+            )
+            return onnx.helper.make_graph(
+                [identity],
+                name,
+                [],
+                [
+                    onnx.helper.make_tensor_value_info(
+                        f"{name}_output",
+                        TensorProto.FLOAT,
+                        [32, 2, 8],
+                    )
+                ],
+            )
+
+        model.graph.node.append(
+            onnx.helper.make_node(
+                "If",
+                ["condition"],
+                ["captured_weights_output"],
+                name="capture_weights",
+                then_branch=branch_graph("then_branch"),
+                else_branch=branch_graph("else_branch"),
+            )
+        )
+        model.graph.output.append(
+            onnx.helper.make_tensor_value_info(
+                "captured_weights_output",
+                TensorProto.FLOAT,
+                [32, 2, 8],
+            )
+        )
+
+        result = SurgeryPipe().process(
+            model,
+            SurgeryPipeConfig(trim_split_grouped_conv=True),
+        )
+
+        onnx.checker.check_model(result, full_check=True)
+        assert "weights" in {initializer.name for initializer in result.graph.initializer}
+
+    @pytest.mark.parametrize(
+        "metadata_values",
+        [
+            ["not-json"],
+            [
+                json.dumps(
+                    {
+                        "version": 1,
+                        "regions": [
+                            {
+                                "kind": "unknown",
+                                "branches": ["old_branch0", "old_branch1"],
+                                "concat": "old_concat",
+                            }
+                        ],
+                    }
+                )
+            ],
+            [
+                json.dumps(
+                    {
+                        "version": 1,
+                        "regions": [
+                            {
+                                "kind": "conv_concat",
+                                "branches": ["missing_branch0", "missing_branch1"],
+                                "concat": "missing_concat",
+                            }
+                        ],
+                    }
+                )
+            ],
+            [
+                json.dumps(
+                    {
+                        "version": 1,
+                        "regions": [
+                            {
+                                "kind": "conv_concat",
+                                "branches": ["old_branch0", "old_branch1"],
+                                "concat": "old_concat",
+                            }
+                        ],
+                    }
+                ),
+                json.dumps(
+                    {
+                        "version": 1,
+                        "regions": [
+                            {
+                                "kind": "conv_concat",
+                                "branches": ["other_branch0", "other_branch1"],
+                                "concat": "other_concat",
+                            }
+                        ],
+                    }
+                ),
+            ],
+        ],
+    )
+    def test_invalid_existing_hint_fails_without_mutating_input(
+        self,
+        metadata_values: list[str],
+    ) -> None:
+        model = _make_grouped_conv_tail_slice_model()
+        for value in metadata_values:
+            model.metadata_props.add(key="winml.quantization.region_hints", value=value)
+        original = model.SerializeToString()
+
+        with pytest.raises(QuantizationHintError):
+            SurgeryPipe().process(
+                model,
+                SurgeryPipeConfig(trim_split_grouped_conv=True),
+            )
+
+        assert model.SerializeToString() == original

--- a/tests/unit/quant/test_hints.py
+++ b/tests/unit/quant/test_hints.py
@@ -9,9 +9,16 @@ from __future__ import annotations
 import json
 
 import numpy as np
-import onnx
 import pytest
-from onnx import TensorProto, helper, numpy_helper
+from onnx import (
+    GraphProto,
+    ModelProto,
+    StringStringEntryProto,
+    TensorProto,
+    checker,
+    helper,
+    numpy_helper,
+)
 
 from winml.modelkit.quant.hints import (
     QUANTIZATION_REGION_HINT_KEY,
@@ -28,11 +35,11 @@ _REMOVED_NODE_NAMES = {
 }
 
 
-def _scalar(value: object, dtype: np.dtype, name: str) -> onnx.TensorProto:
+def _scalar(value: object, dtype: np.dtype, name: str) -> TensorProto:
     return numpy_helper.from_array(np.asarray(value, dtype=dtype), name)
 
 
-def _make_hinted_qdq_model() -> onnx.ModelProto:
+def _make_hinted_qdq_model() -> ModelProto:
     initializers = [
         _scalar(0.1, np.dtype(np.float32), "input_scale"),
         _scalar(128, np.dtype(np.uint8), "input_zero_point"),
@@ -189,11 +196,11 @@ def _make_hinted_qdq_model() -> onnx.ModelProto:
             }
         ),
     )
-    onnx.checker.check_model(model, full_check=True)
+    checker.check_model(model, full_check=True)
     return model
 
 
-def _hint_entry(model: onnx.ModelProto) -> onnx.StringStringEntryProto:
+def _hint_entry(model: ModelProto) -> StringStringEntryProto:
     return next(item for item in model.metadata_props if item.key == QUANTIZATION_REGION_HINT_KEY)
 
 
@@ -209,7 +216,7 @@ class TestCanonicalizeQuantizationRegionHints:
         result = canonicalize_quantization_region_hints(model)
 
         assert model.SerializeToString() == original
-        onnx.checker.check_model(result, full_check=True)
+        checker.check_model(result, full_check=True)
         assert {node.name for node in result.graph.node} == original_nodes - _REMOVED_NODE_NAMES
         assert [
             initializer.SerializeToString() for initializer in result.graph.initializer
@@ -327,6 +334,58 @@ class TestCanonicalizeQuantizationRegionHints:
         original = model.SerializeToString()
 
         with pytest.raises(QuantizationHintError, match="graph output"):
+            canonicalize_quantization_region_hints(model)
+
+        assert model.SerializeToString() == original
+
+    @pytest.mark.parametrize(
+        ("captured_name", "data_type"),
+        [
+            ("branch0_output_q_value", TensorProto.UINT8),
+            ("branch0_output_dq_value", TensorProto.FLOAT),
+        ],
+    )
+    def test_nested_capture_fails_without_mutating_input(
+        self,
+        captured_name: str,
+        data_type: int,
+    ) -> None:
+        model = _make_hinted_qdq_model()
+        model.graph.initializer.append(_scalar(True, np.dtype(np.bool_), "condition"))
+
+        def branch_graph(name: str) -> GraphProto:
+            output_name = f"{name}_output"
+            return helper.make_graph(
+                [
+                    helper.make_node(
+                        "Identity",
+                        [captured_name],
+                        [output_name],
+                        name=f"{name}_identity",
+                    )
+                ],
+                name,
+                [],
+                [helper.make_tensor_value_info(output_name, data_type, [1, 2, 3])],
+            )
+
+        model.graph.node.append(
+            helper.make_node(
+                "If",
+                ["condition"],
+                ["captured_output"],
+                name="capture_nested_value",
+                then_branch=branch_graph("then_branch"),
+                else_branch=branch_graph("else_branch"),
+            )
+        )
+        model.graph.output.append(
+            helper.make_tensor_value_info("captured_output", data_type, [1, 2, 3])
+        )
+        checker.check_model(model, full_check=True)
+        original = model.SerializeToString()
+
+        with pytest.raises(QuantizationHintError, match="consumer"):
             canonicalize_quantization_region_hints(model)
 
         assert model.SerializeToString() == original

--- a/tests/unit/quant/test_hints.py
+++ b/tests/unit/quant/test_hints.py
@@ -411,7 +411,56 @@ class TestCanonicalizeQuantizationRegionHints:
 
         assert model.SerializeToString() == original
 
-    def test_direct_branch_to_concat_fails_without_mutating_input(self) -> None:
+    @pytest.mark.parametrize("direct_branch_index", [0, 1])
+    def test_partially_quantized_branches_are_canonicalized(
+        self,
+        direct_branch_index: int,
+    ) -> None:
+        model = _make_hinted_qdq_model()
+        direct_branch = f"branch{direct_branch_index}"
+        removed = {f"{direct_branch}_output_q", f"{direct_branch}_output_dq"}
+        kept = [node for node in model.graph.node if node.name not in removed]
+        del model.graph.node[:]
+        model.graph.node.extend(kept)
+        concat = next(node for node in model.graph.node if node.name == "concat")
+        concat.input[direct_branch_index] = f"{direct_branch}_output"
+        original = model.SerializeToString()
+        original_nodes = {node.name for node in model.graph.node}
+        quantized_branch_index = 1 - direct_branch_index
+        quantized_branch = f"branch{quantized_branch_index}"
+
+        result = canonicalize_quantization_region_hints(model)
+
+        assert model.SerializeToString() == original
+        checker.check_model(result, full_check=True)
+        assert {node.name for node in result.graph.node} == original_nodes - {
+            f"{quantized_branch}_output_q",
+            f"{quantized_branch}_output_dq",
+        }
+        result_concat = next(node for node in result.graph.node if node.name == "concat")
+        assert list(result_concat.input) == ["branch0_output", "branch1_output"]
+        assert {item.key: item.value for item in result.metadata_props} == {"keep.me": "untouched"}
+
+    def test_direct_branches_are_already_canonical(self) -> None:
+        model = _make_hinted_qdq_model()
+        kept = [node for node in model.graph.node if node.name not in _REMOVED_NODE_NAMES]
+        del model.graph.node[:]
+        model.graph.node.extend(kept)
+        concat = next(node for node in model.graph.node if node.name == "concat")
+        concat.input[:] = ["branch0_output", "branch1_output"]
+        original = model.SerializeToString()
+        original_nodes = {node.name for node in model.graph.node}
+
+        result = canonicalize_quantization_region_hints(model)
+
+        assert model.SerializeToString() == original
+        checker.check_model(result, full_check=True)
+        assert {node.name for node in result.graph.node} == original_nodes
+        result_concat = next(node for node in result.graph.node if node.name == "concat")
+        assert list(result_concat.input) == ["branch0_output", "branch1_output"]
+        assert {item.key: item.value for item in result.metadata_props} == {"keep.me": "untouched"}
+
+    def test_direct_branch_fanout_fails_without_mutating_input(self) -> None:
         model = _make_hinted_qdq_model()
         removed = {"branch0_output_q", "branch0_output_dq"}
         kept = [node for node in model.graph.node if node.name not in removed]
@@ -419,9 +468,17 @@ class TestCanonicalizeQuantizationRegionHints:
         model.graph.node.extend(kept)
         concat = next(node for node in model.graph.node if node.name == "concat")
         concat.input[0] = "branch0_output"
+        model.graph.node.append(
+            helper.make_node(
+                "Identity",
+                ["branch0_output"],
+                ["fanout_output"],
+                name="direct_branch_fanout",
+            )
+        )
         original = model.SerializeToString()
 
-        with pytest.raises(QuantizationHintError, match="consumer is Concat"):
+        with pytest.raises(QuantizationHintError, match="consumer"):
             canonicalize_quantization_region_hints(model)
 
         assert model.SerializeToString() == original

--- a/tests/unit/quant/test_hints.py
+++ b/tests/unit/quant/test_hints.py
@@ -1,0 +1,419 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Tests for optimizer-to-quantizer region hints."""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import onnx
+import pytest
+from onnx import TensorProto, helper, numpy_helper
+
+from winml.modelkit.quant.hints import (
+    QUANTIZATION_REGION_HINT_KEY,
+    QuantizationHintError,
+    canonicalize_quantization_region_hints,
+)
+
+
+_REMOVED_NODE_NAMES = {
+    "branch0_output_q",
+    "branch0_output_dq",
+    "branch1_output_q",
+    "branch1_output_dq",
+}
+
+
+def _scalar(value: object, dtype: np.dtype, name: str) -> onnx.TensorProto:
+    return numpy_helper.from_array(np.asarray(value, dtype=dtype), name)
+
+
+def _make_hinted_qdq_model() -> onnx.ModelProto:
+    initializers = [
+        _scalar(0.1, np.dtype(np.float32), "input_scale"),
+        _scalar(128, np.dtype(np.uint8), "input_zero_point"),
+        _scalar(0.05, np.dtype(np.float32), "weight_scale"),
+        _scalar(120, np.dtype(np.uint8), "weight_zero_point"),
+        _scalar(0.005, np.dtype(np.float32), "bias_scale"),
+        _scalar(0, np.dtype(np.int32), "bias_zero_point"),
+        _scalar(0.2, np.dtype(np.float32), "output_scale"),
+        _scalar(127, np.dtype(np.uint8), "output_zero_point"),
+        numpy_helper.from_array(np.full((2, 2, 1), 121, dtype=np.uint8), "weight0_q"),
+        numpy_helper.from_array(np.full((2, 2, 1), 122, dtype=np.uint8), "weight1_q"),
+        numpy_helper.from_array(np.array([1, 2], dtype=np.int32), "bias0_q"),
+        numpy_helper.from_array(np.array([3, 4], dtype=np.int32), "bias1_q"),
+        numpy_helper.from_array(np.ones((1, 4, 1), dtype=np.float32), "other_weight"),
+    ]
+    nodes = [
+        helper.make_node(
+            "QuantizeLinear",
+            ["input", "input_scale", "input_zero_point"],
+            ["input_q"],
+            name="input_q",
+        ),
+        helper.make_node(
+            "DequantizeLinear",
+            ["input_q", "input_scale", "input_zero_point"],
+            ["input_dq"],
+            name="input_dq",
+        ),
+        helper.make_node(
+            "Split", ["input_dq"], ["branch0_input", "branch1_input"], name="split", axis=1
+        ),
+        helper.make_node(
+            "DequantizeLinear",
+            ["weight0_q", "weight_scale", "weight_zero_point"],
+            ["weight0_dq"],
+            name="weight0_dq",
+        ),
+        helper.make_node(
+            "DequantizeLinear",
+            ["bias0_q", "bias_scale", "bias_zero_point"],
+            ["bias0_dq"],
+            name="bias0_dq",
+        ),
+        helper.make_node(
+            "Conv",
+            ["branch0_input", "weight0_dq", "bias0_dq"],
+            ["branch0_output"],
+            name="branch0",
+        ),
+        helper.make_node(
+            "QuantizeLinear",
+            ["branch0_output", "output_scale", "output_zero_point"],
+            ["branch0_output_q_value"],
+            name="branch0_output_q",
+        ),
+        helper.make_node(
+            "DequantizeLinear",
+            ["branch0_output_q_value", "output_scale", "output_zero_point"],
+            ["branch0_output_dq_value"],
+            name="branch0_output_dq",
+        ),
+        helper.make_node(
+            "DequantizeLinear",
+            ["weight1_q", "weight_scale", "weight_zero_point"],
+            ["weight1_dq"],
+            name="weight1_dq",
+        ),
+        helper.make_node(
+            "DequantizeLinear",
+            ["bias1_q", "bias_scale", "bias_zero_point"],
+            ["bias1_dq"],
+            name="bias1_dq",
+        ),
+        helper.make_node(
+            "Conv",
+            ["branch1_input", "weight1_dq", "bias1_dq"],
+            ["branch1_output"],
+            name="branch1",
+        ),
+        helper.make_node(
+            "QuantizeLinear",
+            ["branch1_output", "output_scale", "output_zero_point"],
+            ["branch1_output_q_value"],
+            name="branch1_output_q",
+        ),
+        helper.make_node(
+            "DequantizeLinear",
+            ["branch1_output_q_value", "output_scale", "output_zero_point"],
+            ["branch1_output_dq_value"],
+            name="branch1_output_dq",
+        ),
+        helper.make_node(
+            "Concat",
+            ["branch0_output_dq_value", "branch1_output_dq_value"],
+            ["concat_output"],
+            name="concat",
+            axis=1,
+        ),
+        helper.make_node(
+            "QuantizeLinear",
+            ["concat_output", "output_scale", "output_zero_point"],
+            ["concat_output_q"],
+            name="concat_output_q",
+        ),
+        helper.make_node(
+            "DequantizeLinear",
+            ["concat_output_q", "output_scale", "output_zero_point"],
+            ["output"],
+            name="concat_output_dq",
+        ),
+        helper.make_node(
+            "Conv",
+            ["input_dq", "other_weight"],
+            ["other_conv_output"],
+            name="other_conv",
+        ),
+        helper.make_node(
+            "QuantizeLinear",
+            ["other_conv_output", "output_scale", "output_zero_point"],
+            ["other_output_q"],
+            name="other_output_q",
+        ),
+        helper.make_node(
+            "DequantizeLinear",
+            ["other_output_q", "output_scale", "output_zero_point"],
+            ["other_output"],
+            name="other_output_dq",
+        ),
+    ]
+    graph = helper.make_graph(
+        nodes,
+        "hinted_qdq",
+        [helper.make_tensor_value_info("input", TensorProto.FLOAT, [1, 4, 3])],
+        [
+            helper.make_tensor_value_info("output", TensorProto.FLOAT, [1, 4, 3]),
+            helper.make_tensor_value_info("other_output", TensorProto.FLOAT, [1, 1, 3]),
+        ],
+        initializer=initializers,
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+    model.metadata_props.add(key="keep.me", value="untouched")
+    model.metadata_props.add(
+        key=QUANTIZATION_REGION_HINT_KEY,
+        value=json.dumps(
+            {
+                "version": 1,
+                "regions": [
+                    {
+                        "kind": "conv_concat",
+                        "branches": ["branch0", "branch1"],
+                        "concat": "concat",
+                    }
+                ],
+            }
+        ),
+    )
+    onnx.checker.check_model(model, full_check=True)
+    return model
+
+
+def _hint_entry(model: onnx.ModelProto) -> onnx.StringStringEntryProto:
+    return next(item for item in model.metadata_props if item.key == QUANTIZATION_REGION_HINT_KEY)
+
+
+class TestCanonicalizeQuantizationRegionHints:
+    def test_removes_only_hinted_branch_output_qdq(self) -> None:
+        model = _make_hinted_qdq_model()
+        original = model.SerializeToString()
+        original_nodes = {node.name for node in model.graph.node}
+        original_initializers = [
+            initializer.SerializeToString() for initializer in model.graph.initializer
+        ]
+
+        result = canonicalize_quantization_region_hints(model)
+
+        assert model.SerializeToString() == original
+        onnx.checker.check_model(result, full_check=True)
+        assert {node.name for node in result.graph.node} == original_nodes - _REMOVED_NODE_NAMES
+        assert [
+            initializer.SerializeToString() for initializer in result.graph.initializer
+        ] == original_initializers
+        concat = next(node for node in result.graph.node if node.name == "concat")
+        assert list(concat.input) == ["branch0_output", "branch1_output"]
+        assert {item.key: item.value for item in result.metadata_props} == {"keep.me": "untouched"}
+        assert {node.name for node in result.graph.node if node.op_type == "QuantizeLinear"} == {
+            "input_q",
+            "concat_output_q",
+            "other_output_q",
+        }
+
+    def test_no_hint_returns_original_model(self) -> None:
+        model = _make_hinted_qdq_model()
+        model.metadata_props.remove(_hint_entry(model))
+
+        assert canonicalize_quantization_region_hints(model) is model
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            "not-json",
+            json.dumps({"version": 2, "regions": []}),
+            json.dumps({"version": 1, "regions": []}),
+            json.dumps(
+                {
+                    "version": 1,
+                    "regions": [
+                        {"kind": "unknown", "branches": ["branch0", "branch1"], "concat": "concat"}
+                    ],
+                }
+            ),
+        ],
+    )
+    def test_invalid_hint_fails_without_mutating_input(self, payload: str) -> None:
+        model = _make_hinted_qdq_model()
+        _hint_entry(model).value = payload
+        original = model.SerializeToString()
+
+        with pytest.raises(QuantizationHintError):
+            canonicalize_quantization_region_hints(model)
+
+        assert model.SerializeToString() == original
+
+    def test_stale_branch_name_fails_without_mutating_input(self) -> None:
+        model = _make_hinted_qdq_model()
+        next(node for node in model.graph.node if node.name == "branch1").name = "renamed_branch"
+        original = model.SerializeToString()
+
+        with pytest.raises(QuantizationHintError, match="branch1"):
+            canonicalize_quantization_region_hints(model)
+
+        assert model.SerializeToString() == original
+
+    def test_branch_q_fanout_fails_without_mutating_input(self) -> None:
+        model = _make_hinted_qdq_model()
+        model.graph.node.append(
+            helper.make_node(
+                "Identity",
+                ["branch0_output_q_value"],
+                ["fanout_output"],
+                name="fanout",
+            )
+        )
+        original = model.SerializeToString()
+
+        with pytest.raises(QuantizationHintError, match="consumer"):
+            canonicalize_quantization_region_hints(model)
+
+        assert model.SerializeToString() == original
+
+    def test_q_graph_output_fails_without_mutating_input(self) -> None:
+        model = _make_hinted_qdq_model()
+        model.graph.output.append(
+            helper.make_tensor_value_info(
+                "branch0_output_q_value",
+                TensorProto.UINT8,
+                [1, 2, 3],
+            )
+        )
+        original = model.SerializeToString()
+
+        with pytest.raises(QuantizationHintError, match="graph output"):
+            canonicalize_quantization_region_hints(model)
+
+        assert model.SerializeToString() == original
+
+    def test_branch_dq_fanout_fails_without_mutating_input(self) -> None:
+        model = _make_hinted_qdq_model()
+        model.graph.node.append(
+            helper.make_node(
+                "Identity",
+                ["branch0_output_dq_value"],
+                ["fanout_output"],
+                name="fanout",
+            )
+        )
+        original = model.SerializeToString()
+
+        with pytest.raises(QuantizationHintError, match="consumer"):
+            canonicalize_quantization_region_hints(model)
+
+        assert model.SerializeToString() == original
+
+    def test_dq_graph_output_fails_without_mutating_input(self) -> None:
+        model = _make_hinted_qdq_model()
+        model.graph.output.append(
+            helper.make_tensor_value_info(
+                "branch0_output_dq_value",
+                TensorProto.FLOAT,
+                [1, 2, 3],
+            )
+        )
+        original = model.SerializeToString()
+
+        with pytest.raises(QuantizationHintError, match="graph output"):
+            canonicalize_quantization_region_hints(model)
+
+        assert model.SerializeToString() == original
+
+    def test_duplicate_hinted_branch_name_fails_without_mutating_input(self) -> None:
+        model = _make_hinted_qdq_model()
+        _hint_entry(model).value = json.dumps(
+            {
+                "version": 1,
+                "regions": [
+                    {
+                        "kind": "conv_concat",
+                        "branches": ["branch0", "branch0"],
+                        "concat": "concat",
+                    }
+                ],
+            }
+        )
+        original = model.SerializeToString()
+
+        with pytest.raises(QuantizationHintError, match="Invalid conv_concat"):
+            canonicalize_quantization_region_hints(model)
+
+        assert model.SerializeToString() == original
+
+    def test_direct_branch_to_concat_fails_without_mutating_input(self) -> None:
+        model = _make_hinted_qdq_model()
+        removed = {"branch0_output_q", "branch0_output_dq"}
+        kept = [node for node in model.graph.node if node.name not in removed]
+        del model.graph.node[:]
+        model.graph.node.extend(kept)
+        concat = next(node for node in model.graph.node if node.name == "concat")
+        concat.input[0] = "branch0_output"
+        original = model.SerializeToString()
+
+        with pytest.raises(QuantizationHintError, match="consumer is Concat"):
+            canonicalize_quantization_region_hints(model)
+
+        assert model.SerializeToString() == original
+
+    def test_branch_output_used_as_q_parameter_fails_without_mutating_input(self) -> None:
+        model = _make_hinted_qdq_model()
+        q_node = next(node for node in model.graph.node if node.name == "branch0_output_q")
+        q_node.input[0] = "branch0_input"
+        q_node.input[1] = "branch0_output"
+        original = model.SerializeToString()
+
+        with pytest.raises(QuantizationHintError, match="data input"):
+            canonicalize_quantization_region_hints(model)
+
+        assert model.SerializeToString() == original
+
+    def test_q_output_used_as_dq_parameter_fails_without_mutating_input(self) -> None:
+        model = _make_hinted_qdq_model()
+        dq_node = next(node for node in model.graph.node if node.name == "branch0_output_dq")
+        dq_node.input[0] = "input_q"
+        dq_node.input[2] = "branch0_output_q_value"
+        original = model.SerializeToString()
+
+        with pytest.raises(QuantizationHintError, match="data input"):
+            canonicalize_quantization_region_hints(model)
+
+        assert model.SerializeToString() == original
+
+    @pytest.mark.parametrize(
+        "node_name",
+        ["branch0", "concat", "branch0_output_q", "branch0_output_dq"],
+    )
+    def test_unknown_operator_domain_fails_without_mutating_input(self, node_name: str) -> None:
+        model = _make_hinted_qdq_model()
+        node = next(node for node in model.graph.node if node.name == node_name)
+        node.domain = "example.custom"
+        model.opset_import.append(helper.make_opsetid("example.custom", 1))
+        original = model.SerializeToString()
+
+        with pytest.raises(QuantizationHintError, match="domain"):
+            canonicalize_quantization_region_hints(model)
+
+        assert model.SerializeToString() == original
+
+    def test_microsoft_qdq_domain_is_supported(self) -> None:
+        model = _make_hinted_qdq_model()
+        for node in model.graph.node:
+            if node.name in _REMOVED_NODE_NAMES:
+                node.domain = "com.microsoft"
+        model.opset_import.append(helper.make_opsetid("com.microsoft", 1))
+
+        result = canonicalize_quantization_region_hints(model)
+
+        assert {node.name for node in result.graph.node}.isdisjoint(_REMOVED_NODE_NAMES)

--- a/tests/unit/test_quant_passes.py
+++ b/tests/unit/test_quant_passes.py
@@ -12,10 +12,9 @@ from types import ModuleType, SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-import onnx
 import pytest
 from google.protobuf.message import EncodeError
-from onnx import TensorProto, helper, numpy_helper
+from onnx import ModelProto, TensorProto, checker, helper, load, numpy_helper, save
 
 from winml.modelkit.optim.pipes import SurgeryPipe, SurgeryPipeConfig
 from winml.modelkit.quant import WinMLQuantizationConfig
@@ -654,7 +653,7 @@ class TestDynamicConfigSerialization:
 # ---------------------------------------------------------------------------
 
 
-def _make_static_grouped_conv_model() -> onnx.ModelProto:
+def _make_static_grouped_conv_model() -> ModelProto:
     weights = numpy_helper.from_array(
         np.random.RandomState(0).randn(4, 2, 8).astype(np.float32),
         "weights",
@@ -731,7 +730,7 @@ class TestStaticPassQuantizationRegionHints:
 
         model_path = tmp_path / "optimized.onnx"
         output_path = tmp_path / "quantized.onnx"
-        onnx.save(optimized, model_path)
+        save(optimized, model_path)
         result = StaticPass(
             WinMLQuantizationConfig(
                 mode="static",
@@ -744,8 +743,8 @@ class TestStaticPassQuantizationRegionHints:
         ).run(model_path, output_path, use_external_data=False)
 
         assert result.success
-        quantized = onnx.load(output_path)
-        onnx.checker.check_model(quantized, full_check=True)
+        quantized = load(output_path)
+        checker.check_model(quantized, full_check=True)
         metadata = {item.key: item.value for item in quantized.metadata_props}
         assert metadata["keep.me"] == "restored"
         assert QUANTIZATION_REGION_HINT_KEY not in metadata
@@ -779,11 +778,11 @@ class TestStaticPassQuantizationRegionHints:
         model_path = tmp_path / "optimized.onnx"
         output_path = tmp_path / "quantized.onnx"
         sidecar_path = tmp_path / "quantized.onnx.data"
-        onnx.save(optimized, model_path)
+        save(optimized, model_path)
         output_path.write_bytes(b"previous-output")
         sidecar_path.write_bytes(b"previous-sidecar")
 
-        def fail_postprocessing(_model: onnx.ModelProto) -> onnx.ModelProto:
+        def fail_postprocessing(_model: ModelProto) -> ModelProto:
             raise QuantizationHintError("stale hint")
 
         monkeypatch.setattr(

--- a/tests/unit/test_quant_passes.py
+++ b/tests/unit/test_quant_passes.py
@@ -752,6 +752,61 @@ class TestStaticPassQuantizationRegionHints:
         concat = nodes[concat_name]
         assert list(concat.input) == [nodes[name].output[0] for name in branch_names]
 
+    def test_accepts_hints_when_generated_convs_are_not_quantized(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        from onnxruntime.quantization import CalibrationDataReader
+
+        class Reader(CalibrationDataReader):
+            def __init__(self) -> None:
+                self.rewind()
+
+            def get_next(self) -> dict[str, np.ndarray] | None:
+                return next(self._iterator, None)
+
+            def rewind(self) -> None:
+                self._iterator = iter(
+                    [{"input": np.random.RandomState(7).randn(1, 4, 3).astype(np.float32)}]
+                )
+
+        optimized = SurgeryPipe().process(
+            _make_static_grouped_conv_model(),
+            SurgeryPipeConfig(trim_split_grouped_conv=True),
+        )
+        hint = json.loads(
+            next(
+                item.value
+                for item in optimized.metadata_props
+                if item.key == QUANTIZATION_REGION_HINT_KEY
+            )
+        )
+        branch_names = hint["regions"][0]["branches"]
+        concat_name = hint["regions"][0]["concat"]
+        model_path = tmp_path / "optimized.onnx"
+        output_path = tmp_path / "quantized.onnx"
+        save(optimized, model_path)
+        config = WinMLQuantizationConfig(
+            mode="static",
+            samples=1,
+            calibration_data=Reader(),
+            activation_type="uint8",
+            weight_type="uint8",
+            per_channel=False,
+            op_types_to_quantize=["MatMul"],
+        )
+
+        result = StaticPass(config).run(model_path, output_path, use_external_data=False)
+
+        assert result.success
+        quantized = load(output_path)
+        checker.check_model(quantized, full_check=True)
+        metadata = {item.key: item.value for item in quantized.metadata_props}
+        assert QUANTIZATION_REGION_HINT_KEY not in metadata
+        nodes = {node.name: node for node in quantized.graph.node}
+        concat = nodes[concat_name]
+        assert list(concat.input) == [nodes[name].output[0] for name in branch_names]
+
     def test_postprocessing_failure_preserves_existing_output(
         self,
         tmp_path: Path,

--- a/tests/unit/test_quant_passes.py
+++ b/tests/unit/test_quant_passes.py
@@ -22,6 +22,7 @@ from winml.modelkit.quant.config import QuantizeResult
 from winml.modelkit.quant.fp16 import convert_to_fp16
 from winml.modelkit.quant.hints import QUANTIZATION_REGION_HINT_KEY, QuantizationHintError
 from winml.modelkit.quant.passes import BaseQuantPass, DynamicPass, FP16Pass, RTNPass, StaticPass
+from winml.modelkit.quant.passes.static import _publish_staged_model
 
 
 if TYPE_CHECKING:
@@ -687,6 +688,71 @@ def _make_static_grouped_conv_model() -> ModelProto:
         initializer=[weights, *slice_values],
     )
     return helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+
+
+class TestPublishStagedModel:
+    @pytest.mark.parametrize("output_name", ["previous-output.onnx", "previous-output.onnx.data"])
+    def test_backup_paths_do_not_alias_staged_artifacts(
+        self,
+        tmp_path: Path,
+        output_name: str,
+    ) -> None:
+        staging_directory = tmp_path / "staging"
+        output_directory = tmp_path / "output"
+        staging_directory.mkdir()
+        output_directory.mkdir()
+        staged_path = staging_directory / output_name
+        staged_sidecar = staging_directory / f"{output_name}.data"
+        output_path = output_directory / output_name
+        output_sidecar = output_directory / f"{output_name}.data"
+        staged_path.write_bytes(b"new-model")
+        staged_sidecar.write_bytes(b"new-sidecar")
+        output_path.write_bytes(b"old-model")
+        output_sidecar.write_bytes(b"old-sidecar")
+
+        _publish_staged_model(staged_path, output_path)
+
+        assert output_path.read_bytes() == b"new-model"
+        assert output_sidecar.read_bytes() == b"new-sidecar"
+
+    @pytest.mark.parametrize(
+        ("directory_target", "message"),
+        [
+            ("model", "Output path exists but is not a file"),
+            ("sidecar", "Output sidecar path exists but is not a file"),
+        ],
+    )
+    def test_rejects_directory_destinations_without_mutation(
+        self,
+        tmp_path: Path,
+        directory_target: str,
+        message: str,
+    ) -> None:
+        staging_directory = tmp_path / "staging"
+        output_directory = tmp_path / "output"
+        staging_directory.mkdir()
+        output_directory.mkdir()
+        staged_path = staging_directory / "quantized.onnx"
+        staged_sidecar = staging_directory / "quantized.onnx.data"
+        output_path = output_directory / "quantized.onnx"
+        output_sidecar = output_directory / "quantized.onnx.data"
+        staged_path.write_bytes(b"new-model")
+        staged_sidecar.write_bytes(b"new-sidecar")
+        directory_path = output_path if directory_target == "model" else output_sidecar
+        file_path = output_sidecar if directory_target == "model" else output_path
+        directory_path.mkdir()
+        sentinel = directory_path / "keep.bin"
+        sentinel.write_bytes(b"keep")
+        file_path.write_bytes(b"old-file")
+
+        with pytest.raises(ValueError, match=message):
+            _publish_staged_model(staged_path, output_path)
+
+        assert directory_path.is_dir()
+        assert sentinel.read_bytes() == b"keep"
+        assert file_path.read_bytes() == b"old-file"
+        assert staged_path.read_bytes() == b"new-model"
+        assert staged_sidecar.read_bytes() == b"new-sidecar"
 
 
 class TestStaticPassQuantizationRegionHints:

--- a/tests/unit/test_quant_passes.py
+++ b/tests/unit/test_quant_passes.py
@@ -6,16 +6,22 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from types import ModuleType, SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
+import numpy as np
+import onnx
 import pytest
 from google.protobuf.message import EncodeError
+from onnx import TensorProto, helper, numpy_helper
 
+from winml.modelkit.optim.pipes import SurgeryPipe, SurgeryPipeConfig
 from winml.modelkit.quant import WinMLQuantizationConfig
 from winml.modelkit.quant.config import QuantizeResult
 from winml.modelkit.quant.fp16 import convert_to_fp16
+from winml.modelkit.quant.hints import QUANTIZATION_REGION_HINT_KEY, QuantizationHintError
 from winml.modelkit.quant.passes import BaseQuantPass, DynamicPass, FP16Pass, RTNPass, StaticPass
 
 
@@ -641,3 +647,161 @@ class TestDynamicConfigSerialization:
     def test_reduce_range_omitted_for_non_dynamic_modes(self) -> None:
         config = WinMLQuantizationConfig(mode="static", reduce_range=True)
         assert "reduce_range" not in config.to_dict()
+
+
+# ---------------------------------------------------------------------------
+# StaticPass — optimizer quantization-region hint integration
+# ---------------------------------------------------------------------------
+
+
+def _make_static_grouped_conv_model() -> onnx.ModelProto:
+    weights = numpy_helper.from_array(
+        np.random.RandomState(0).randn(4, 2, 8).astype(np.float32),
+        "weights",
+    )
+    slice_values = [
+        numpy_helper.from_array(np.array([value], dtype=np.int64), name)
+        for name, value in (("starts", 0), ("ends", -1), ("axes", 2), ("steps", 1))
+    ]
+    conv = helper.make_node(
+        "Conv",
+        ["input", "weights"],
+        ["conv_output"],
+        name="grouped_conv",
+        group=2,
+        kernel_shape=[8],
+        pads=[4, 4],
+        strides=[1],
+        dilations=[1],
+    )
+    tail_slice = helper.make_node(
+        "Slice",
+        ["conv_output", "starts", "ends", "axes", "steps"],
+        ["output"],
+        name="tail_slice",
+    )
+    graph = helper.make_graph(
+        [conv, tail_slice],
+        "static_grouped_conv",
+        [helper.make_tensor_value_info("input", TensorProto.FLOAT, [1, 4, 3])],
+        [helper.make_tensor_value_info("output", TensorProto.FLOAT, [1, 4, 3])],
+        initializer=[weights, *slice_values],
+    )
+    return helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+
+
+class TestStaticPassQuantizationRegionHints:
+    def test_restores_model_only_hint_and_canonicalizes_branch_outputs(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        from onnxruntime.quantization import CalibrationDataReader
+
+        from winml.modelkit.onnx import capture_metadata
+
+        class Reader(CalibrationDataReader):
+            def __init__(self) -> None:
+                self.rewind()
+
+            def get_next(self) -> dict[str, np.ndarray] | None:
+                return next(self._iterator, None)
+
+            def rewind(self) -> None:
+                self._iterator = iter(
+                    [{"input": np.random.RandomState(7).randn(1, 4, 3).astype(np.float32)}]
+                )
+
+        optimized = SurgeryPipe().process(
+            _make_static_grouped_conv_model(),
+            SurgeryPipeConfig(trim_split_grouped_conv=True),
+        )
+        optimized.metadata_props.add(key="keep.me", value="restored")
+        snapshot = capture_metadata(optimized)
+        assert snapshot.node_count == 0
+        assert snapshot.model_prop_count == 2
+        hint = json.loads(
+            next(
+                item.value
+                for item in optimized.metadata_props
+                if item.key == QUANTIZATION_REGION_HINT_KEY
+            )
+        )
+        branch_names = hint["regions"][0]["branches"]
+        concat_name = hint["regions"][0]["concat"]
+
+        model_path = tmp_path / "optimized.onnx"
+        output_path = tmp_path / "quantized.onnx"
+        onnx.save(optimized, model_path)
+        result = StaticPass(
+            WinMLQuantizationConfig(
+                mode="static",
+                samples=1,
+                calibration_data=Reader(),
+                activation_type="uint8",
+                weight_type="uint8",
+                per_channel=False,
+            )
+        ).run(model_path, output_path, use_external_data=False)
+
+        assert result.success
+        quantized = onnx.load(output_path)
+        onnx.checker.check_model(quantized, full_check=True)
+        metadata = {item.key: item.value for item in quantized.metadata_props}
+        assert metadata["keep.me"] == "restored"
+        assert QUANTIZATION_REGION_HINT_KEY not in metadata
+        nodes = {node.name: node for node in quantized.graph.node}
+        concat = nodes[concat_name]
+        assert list(concat.input) == [nodes[name].output[0] for name in branch_names]
+
+    def test_postprocessing_failure_preserves_existing_output(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from onnxruntime.quantization import CalibrationDataReader
+
+        class Reader(CalibrationDataReader):
+            def __init__(self) -> None:
+                self.rewind()
+
+            def get_next(self) -> dict[str, np.ndarray] | None:
+                return next(self._iterator, None)
+
+            def rewind(self) -> None:
+                self._iterator = iter(
+                    [{"input": np.random.RandomState(7).randn(1, 4, 3).astype(np.float32)}]
+                )
+
+        optimized = SurgeryPipe().process(
+            _make_static_grouped_conv_model(),
+            SurgeryPipeConfig(trim_split_grouped_conv=True),
+        )
+        model_path = tmp_path / "optimized.onnx"
+        output_path = tmp_path / "quantized.onnx"
+        sidecar_path = tmp_path / "quantized.onnx.data"
+        onnx.save(optimized, model_path)
+        output_path.write_bytes(b"previous-output")
+        sidecar_path.write_bytes(b"previous-sidecar")
+
+        def fail_postprocessing(_model: onnx.ModelProto) -> onnx.ModelProto:
+            raise QuantizationHintError("stale hint")
+
+        monkeypatch.setattr(
+            "winml.modelkit.quant.hints.canonicalize_quantization_region_hints",
+            fail_postprocessing,
+        )
+
+        with pytest.raises(QuantizationHintError, match="stale hint"):
+            StaticPass(
+                WinMLQuantizationConfig(
+                    mode="static",
+                    samples=1,
+                    calibration_data=Reader(),
+                    activation_type="uint8",
+                    weight_type="uint8",
+                    per_channel=False,
+                )
+            ).run(model_path, output_path, use_external_data=False)
+
+        assert output_path.read_bytes() == b"previous-output"
+        assert sidecar_path.read_bytes() == b"previous-sidecar"

--- a/tests/unit/test_quantizer.py
+++ b/tests/unit/test_quantizer.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
@@ -14,8 +15,6 @@ from winml.modelkit.quant import WinMLQuantizationConfig, quantize_onnx
 
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     import numpy as np
     import pytest
 
@@ -74,6 +73,10 @@ class _FakeQdqFixModule(ModuleType):
     fix_qdq_dtype_info: Any
 
 
+class _FakeHintsModule(ModuleType):
+    canonicalize_quantization_region_hints: Any
+
+
 class _FakeCompilerModule(ModuleType):
     QDQ_OP_TYPES: set[str]
 
@@ -108,7 +111,7 @@ def test_quantize_onnx_removes_only_exact_external_data_sidecar(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Cleanup should remove only the exact .data sidecar for the output model."""
+    """Publishing should replace only the exact output model and sidecar."""
     model_path = tmp_path / "model.onnx"
     _write_minimal_onnx_model(model_path)
     output_path = tmp_path / "quantized.onnx"
@@ -123,11 +126,14 @@ def test_quantize_onnx_removes_only_exact_external_data_sidecar(
 
     def fake_quantize(*, model_input, model_output: str, quant_config) -> None:
         assert model_input is input_model
-        assert model_output == str(output_path.resolve())
+        staged_output = Path(model_output)
+        assert staged_output.name == output_path.name
+        assert staged_output.parent.parent == output_path.parent
+        assert staged_output != output_path
         assert quant_config.use_external_data_format is True
-        assert not exact_sidecar.exists()
+        assert exact_sidecar.exists()
         assert extra_suffix_sidecar.exists()
-        output_path.write_text("quantized")
+        _write_minimal_onnx_model(staged_output)
 
     _install_fake_ort_quantization(monkeypatch, quantize_impl=fake_quantize)
 
@@ -136,7 +142,10 @@ def test_quantize_onnx_removes_only_exact_external_data_sidecar(
         graph=SimpleNamespace(node=[SimpleNamespace(op_type="QuantizeLinear")])
     )
     load_results = [input_model, quantized_model]
-    fake_onnx_module.capture_metadata = lambda _model: SimpleNamespace(node_count=0)
+    fake_onnx_module.capture_metadata = lambda _model: SimpleNamespace(
+        model_prop_count=0,
+        node_count=0,
+    )
     fake_onnx_module.load_onnx = lambda *_args, **_kwargs: load_results.pop(0)
     fake_onnx_module.restore_metadata = lambda *_args, **_kwargs: None
     fake_onnx_module.save_onnx = lambda *_args, **_kwargs: None
@@ -146,6 +155,10 @@ def test_quantize_onnx_removes_only_exact_external_data_sidecar(
     fake_qdq_fix_module = _FakeQdqFixModule("winml.modelkit.quant.qdq_fix")
     fake_qdq_fix_module.fix_qdq_dtype_info = lambda _model: SimpleNamespace(warnings=[])
     monkeypatch.setitem(sys.modules, "winml.modelkit.quant.qdq_fix", fake_qdq_fix_module)
+
+    fake_hints_module = _FakeHintsModule("winml.modelkit.quant.hints")
+    fake_hints_module.canonicalize_quantization_region_hints = lambda model: model
+    monkeypatch.setitem(sys.modules, "winml.modelkit.quant.hints", fake_hints_module)
 
     fake_compiler_module = _FakeCompilerModule("winml.modelkit.compiler")
     fake_compiler_module.QDQ_OP_TYPES = {"QuantizeLinear", "DequantizeLinear"}
@@ -158,6 +171,8 @@ def test_quantize_onnx_removes_only_exact_external_data_sidecar(
     )
 
     assert result.success is True
+    assert output_path.exists()
+    assert not exact_sidecar.exists()
     assert extra_suffix_sidecar.exists()
 
 

--- a/tests/unit/test_quantizer.py
+++ b/tests/unit/test_quantizer.py
@@ -107,14 +107,15 @@ def _install_fake_ort_quantization(monkeypatch: pytest.MonkeyPatch, *, quantize_
     monkeypatch.setitem(sys.modules, "onnxruntime.quantization.quant_utils", quant_utils_module)
 
 
-def test_quantize_onnx_removes_only_exact_external_data_sidecar(
+def test_quantize_onnx_publishes_relative_output_and_replaces_only_exact_sidecar(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Publishing should replace only the exact output model and sidecar."""
+    monkeypatch.chdir(tmp_path)
     model_path = tmp_path / "model.onnx"
     _write_minimal_onnx_model(model_path)
-    output_path = tmp_path / "quantized.onnx"
+    output_path = Path("quantized.onnx")
     exact_sidecar = tmp_path / f"{output_path.name}.data"
     extra_suffix_sidecar = tmp_path / f"{output_path.name}.data.bak"
     exact_sidecar.write_text("stale")
@@ -127,8 +128,9 @@ def test_quantize_onnx_removes_only_exact_external_data_sidecar(
     def fake_quantize(*, model_input, model_output: str, quant_config) -> None:
         assert model_input is input_model
         staged_output = Path(model_output)
+        assert staged_output.is_absolute()
         assert staged_output.name == output_path.name
-        assert staged_output.parent.parent == output_path.parent
+        assert staged_output.parent.parent == tmp_path
         assert staged_output != output_path
         assert quant_config.use_external_data_format is True
         assert exact_sidecar.exists()


### PR DESCRIPTION
## Summary

Add an opt-in `trim-split-grouped-conv` optimizer surgery for a strictly guarded static grouped Conv followed by a tail Slice. The surgery trims kernel taps proven to multiply only zero padding, decomposes an even grouped Conv into two equal group-aligned branches, and records a versioned quantization-region hint. Static quantization runs through the existing generic QDQ path, then consumes only the generated branches' output Q/DQ pairs so Concat remains inside one region. The compiler is unchanged.

## Root cause

QNN QHAS attributed 99.94% of accelerator time to the positional grouped Conv, with a 20.58-second dominant path. Controlled variants isolated the mechanism: separate scale names measured 40.913 ms; independent branch weight encodings measured 40.025 ms; branch input QDQ alone measured 40.264 ms; branch output QDQ alone measured 39.558 ms; complete branch-local DQ-Conv-Q units regressed to 7,073.188 ms. Scale identity and values are not causal; QDQ node-unit boundaries are.

A broad pre-quantization policy using ORT `OpTypesToExcludeOutputQuantization` also worked, but changed unrelated Conv boundaries and measured 52.037 ms. The versioned hint keeps the policy local to optimizer-generated regions without introducing a QNN compiler option.

## Safety

The capability is disabled by default and appears as `optim.trim_split_grouped_conv` in build config JSON; it changes cache identity. The FP32 matcher requires static 1D shapes, explicit pads, unit stride and dilation, constant weights and optional bias, an even group count, an exact prefix-retaining tail Slice, exclusive topology, and a strict kernel reduction proven by reachability math. Unsupported graphs are no-ops. Source initializers are removed only when no top-level or nested-subgraph reference remains.

The hint consumer validates the complete region before cloning or mutation. It requires exact Conv -> Q -> DQ -> Concat data-input positions, exclusive consumers, no graph-output escape, unique names and roles, standard Conv/Concat domains, and standard or ORT `com.microsoft` QDQ domains. StaticPass stages quantization and all post-processing, path-validates the external-data result, and publishes the model and sidecar transactionally.

## Validation

- 443 focused and adjacent tests passed in separate repository-supported test processes: 116 optimizer/quantization/metadata, 115 optimizer/config, 175 build-config, and 37 cache tests.
- Ruff check and format check passed; touched-file editor diagnostics were clean.
- FP32 target rewrite, 12 samples: logits mean/min cosine 0.9999999999999966/0.9999999999999876, max absolute difference 1.19e-7.
- Final W8A16 CPU, 12 samples: logits mean/min cosine 0.999652/0.998877, max absolute difference 0.052961.
- Final W8A16 QNN, 12 samples: logits mean/min cosine 0.999238/0.998084, max absolute difference 0.045169.
- Compiled graph: one EPContext; all seven unrelated feature-extractor Conv output QDQ boundaries preserved.
- Final QNN performance, 100 iterations: p50 42.606 ms, p90 47.278 ms, versus the original 20,786.384 ms p50.
- Balanced A/B, B/A, A/B, B/A confirmation: every gain positive, mean paired gain 99.7947%, Student-t 95% CI [99.7851%, 99.8043%].
- Independent final review found no remaining Critical or Important issues.

## Rollback

Disable `trim-split-grouped-conv`. Unhinted models retain the existing optimization, quantization, and compile behavior.
