### PR TITLE
fix(serve): block cross-origin CLI requests

### DIFF
--- a/src/winml/modelkit/serve/app.py
+++ b/src/winml/modelkit/serve/app.py
@@ -34,14 +34,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from fastapi import FastAPI, File, Form, HTTPException, UploadFile
-from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
 from .. import __version__
 from ..inference import InferenceEngine
 from ..inference.types import PredictionResult
-from .cli_api import CliRequest, CliResponse, _run_with_semaphore
+from .cli_api import CliRequest, CliResponse, _add_same_origin_middleware, _run_with_semaphore
 from .manager import ModelSlotManager, SingleModelManager
 from .schema import (
     EPSwitchRequest,
@@ -213,14 +212,7 @@ def create_app(
         ),
         lifespan=lifespan,
     )
-    # Permissive CORS for local dev server; no credentials to protect.
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=["*"],
-        allow_credentials=False,
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
+    _add_same_origin_middleware(app)
 
     # Serve demo UI at /demo
     _static_dir = Path(__file__).parent / "static"

--- a/src/winml/modelkit/serve/cli_api.py
+++ b/src/winml/modelkit/serve/cli_api.py
@@ -27,16 +27,19 @@ import json
 import tempfile
 import time
 from pathlib import Path
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
-from fastapi import FastAPI, HTTPException
-from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse
+from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
 from .. import __version__
 from ..cli import main as winml_cli
+
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
 
 
 # ---------------------------------------------------------------------------
@@ -133,6 +136,24 @@ class HealthResponse(BaseModel):
 # FastAPI app
 # ---------------------------------------------------------------------------
 
+def _add_same_origin_middleware(app: FastAPI) -> None:
+    """Reject browser requests from origins other than the server itself."""
+
+    @app.middleware("http")
+    async def require_same_origin(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        origin = request.headers.get("origin")
+        server_origin = str(request.base_url).removesuffix("/")
+        if origin is not None and origin != server_origin:
+            return JSONResponse(
+                status_code=403,
+                content={"detail": "Cross-origin requests are not allowed"},
+            )
+        return await call_next(request)
+
+
 app = FastAPI(
     title="WinML CLI API",
     description=(
@@ -143,15 +164,7 @@ app = FastAPI(
     ),
     version=__version__,
 )
-
-# Permissive CORS for local dev server; no credentials to protect.
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=False,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+_add_same_origin_middleware(app)
 
 _static_dir = Path(__file__).parent / "static"
 if _static_dir.exists():

--- a/tests/unit/serve/test_cors.py
+++ b/tests/unit/serve/test_cors.py
@@ -1,0 +1,96 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Security tests for browser access to the local serve APIs."""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from winml.modelkit.serve.app import create_app
+from winml.modelkit.serve.cli_api import app as cli_app
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from fastapi import FastAPI
+
+
+@pytest.fixture(params=["cli", "inference"])
+def protected_app(request: pytest.FixtureRequest) -> Iterator[tuple[FastAPI, AsyncMock]]:
+    invoke = AsyncMock()
+    invoke.return_value = {
+        "command": "sys",
+        "exit_code": 0,
+        "result": {},
+        "stdout": "",
+        "stderr": "",
+        "duration_ms": 1.0,
+    }
+    target = (
+        "winml.modelkit.serve.cli_api._run_with_semaphore"
+        if request.param == "cli"
+        else "winml.modelkit.serve.app._run_with_semaphore"
+    )
+
+    with ExitStack() as stack:
+        stack.enter_context(patch(target, invoke))
+        app = cli_app if request.param == "cli" else create_app(model_path=None, mode="multi")
+        yield app, invoke
+
+
+def test_cross_origin_preflight_is_rejected(
+    protected_app: tuple[FastAPI, AsyncMock],
+) -> None:
+    app, invoke = protected_app
+
+    response = TestClient(app).options(
+        "/v1/cli/sys",
+        headers={
+            "Origin": "https://evil.example",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "content-type",
+        },
+    )
+
+    assert response.status_code == 403
+    assert "access-control-allow-origin" not in response.headers
+    invoke.assert_not_awaited()
+
+
+def test_cross_origin_post_is_rejected_before_cli_dispatch(
+    protected_app: tuple[FastAPI, AsyncMock],
+) -> None:
+    app, invoke = protected_app
+
+    response = TestClient(app).post(
+        "/v1/cli/sys",
+        headers={"Origin": "https://evil.example"},
+        json={"args": {}},
+    )
+
+    assert response.status_code == 403
+    assert "access-control-allow-origin" not in response.headers
+    invoke.assert_not_awaited()
+
+
+def test_same_origin_post_reaches_cli_dispatch(
+    protected_app: tuple[FastAPI, AsyncMock],
+) -> None:
+    app, invoke = protected_app
+
+    response = TestClient(app).post(
+        "/v1/cli/sys",
+        headers={"Origin": "http://testserver"},
+        json={"args": {}},
+    )
+
+    assert response.status_code == 200
+    invoke.assert_awaited_once_with("sys", {})


### PR DESCRIPTION
## Summary
- replace wildcard CORS with same-origin request enforcement
- protect both CLI-only and inference serve applications
- add regression coverage for hostile preflight and POST requests plus valid same-origin dispatch