### PR TITLE
fix(serve): harden CLI API security boundaries

### DIFF
--- a/.github/workflows/modelkit-ci.yml
+++ b/.github/workflows/modelkit-ci.yml
@@ -35,7 +35,7 @@ jobs:
             paths: >-
               tests/unit/core tests/unit/onnx tests/unit/cache
               tests/unit/utils tests/unit/test_helpers tests/unit/sysinfo tests/unit/inspect
-              tests/unit/optracing tests/regression tests/cli
+              tests/unit/optracing tests/unit/serve tests/regression tests/cli
 
     name: test (${{ matrix.group }})
 
@@ -50,6 +50,12 @@ jobs:
 
       - name: Set up Python
         run: uv python install 3.11
+
+      - name: Set up Node.js
+        if: matrix.group == 'remaining'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
 
       - name: Install dependencies
         run: uv sync --locked --all-extras

--- a/src/winml/modelkit/commands/serve.py
+++ b/src/winml/modelkit/commands/serve.py
@@ -134,7 +134,14 @@ def serve(
         except ImportError as e:
             raise click.ClickException(f"Failed to load serving module: {e}") from e
         _banner0(host=host, port=port)
-        uvicorn.run(app, host=host, port=port, reload=auto_reload, log_level="warning")
+        uvicorn.run(
+            app,
+            host=host,
+            port=port,
+            reload=auto_reload,
+            log_level="warning",
+            proxy_headers=False,
+        )
         return
 
     # ------------------------------------------------------------------
@@ -172,4 +179,5 @@ def serve(
         port=port,
         reload=auto_reload,
         log_level="warning",
+        proxy_headers=False,
     )

--- a/src/winml/modelkit/loader/_autoconfig.py
+++ b/src/winml/modelkit/loader/_autoconfig.py
@@ -154,6 +154,11 @@ def load_hf_config(
         first tries identifier-based concrete config inference and otherwise
         returns a tagged generic config.
     """
+    if trust_remote_code:
+        from ..utils._security import _require_remote_code_execution_allowed
+
+        _require_remote_code_execution_allowed()
+
     from transformers import PretrainedConfig, __version__
 
     load_kwargs = kwargs.copy()

--- a/src/winml/modelkit/loader/hf.py
+++ b/src/winml/modelkit/loader/hf.py
@@ -202,8 +202,10 @@ def load_hf_model(
     logger.info("Loading HF model: %s", model_name_or_path)
 
     if trust_remote_code:
+        from ..utils._security import _require_remote_code_execution_allowed
         from ..utils.cli import warn_trust_remote_code
 
+        _require_remote_code_execution_allowed()
         warn_trust_remote_code()
 
     # Validate user_script requirements before any network calls

--- a/src/winml/modelkit/serve/_security.py
+++ b/src/winml/modelkit/serve/_security.py
@@ -20,14 +20,6 @@ if TYPE_CHECKING:
     from starlette.types import ASGIApp, Receive, Scope, Send
 
 
-_CLI_API_LOOPBACK_ONLY_ROUTES: dict[str, set[str] | None] = {"/v1/cli": None}
-_MODEL_API_LOOPBACK_ONLY_ROUTES: dict[str, set[str] | None] = {
-    "/v1/cli": None,
-    "/v1/ep": {"POST"},
-    "/v1/models": {"POST", "DELETE"},
-}
-
-
 class SameOriginMiddleware:
     """Enforce browser-origin and local-only route boundaries."""
 

--- a/src/winml/modelkit/serve/_security.py
+++ b/src/winml/modelkit/serve/_security.py
@@ -1,0 +1,114 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Security middleware for local WinML HTTP servers."""
+
+from __future__ import annotations
+
+import ipaddress
+from typing import TYPE_CHECKING
+from urllib.parse import urlsplit
+
+from starlette.responses import PlainTextResponse
+
+
+if TYPE_CHECKING:
+    from starlette.types import ASGIApp, Receive, Scope, Send
+
+
+class SameOriginMiddleware:
+    """Reject browser requests whose origin differs from the target server."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "http" and not _is_same_origin(scope):
+            response = PlainTextResponse("Cross-origin requests are not allowed.", status_code=403)
+            await response(scope, receive, send)
+            return
+        await self.app(scope, receive, send)
+
+
+def _is_same_origin(scope: Scope) -> bool:
+    headers = {key.lower(): value for key, value in scope.get("headers", [])}
+    origin_header = headers.get(b"origin")
+    if origin_header is None:
+        return True
+
+    try:
+        origin = urlsplit(origin_header.decode("ascii"))
+    except (UnicodeDecodeError, ValueError):
+        return False
+    if origin.scheme not in {"http", "https"} or origin.path or origin.query or origin.fragment:
+        return False
+    if origin.username is not None or origin.password is not None:
+        return False
+    if not _is_allowed_http_host(origin.hostname):
+        return False
+    try:
+        origin_port = _effective_port(origin.port, origin.scheme)
+    except ValueError:
+        return False
+
+    target_scheme = scope.get("scheme", "http").lower()
+    if target_scheme not in {"http", "https"}:
+        return False
+    host_header = headers.get(b"host")
+    if host_header is None:
+        server = scope.get("server")
+        if server is None:
+            return False
+        target_host, target_port = server
+        target_host = _normalize_host(target_host)
+        target_port = _effective_port(target_port, target_scheme)
+    else:
+        try:
+            target = urlsplit(f"{target_scheme}://{host_header.decode('ascii')}")
+        except (UnicodeDecodeError, ValueError):
+            return False
+        if (
+            target.path
+            or target.query
+            or target.fragment
+            or target.username is not None
+            or target.password is not None
+        ):
+            return False
+        target_host = _normalize_host(target.hostname)
+        try:
+            target_port = _effective_port(target.port, target_scheme)
+        except ValueError:
+            return False
+
+    return (
+        origin.scheme == target_scheme
+        and _normalize_host(origin.hostname) == target_host
+        and origin_port == target_port
+    )
+
+
+def _default_port(scheme: str) -> int:
+    return 443 if scheme == "https" else 80
+
+
+def _effective_port(port: int | None, scheme: str) -> int:
+    return _default_port(scheme) if port is None else port
+
+
+def _normalize_host(hostname: str | None) -> str | None:
+    return hostname.rstrip(".").lower() if hostname is not None else None
+
+
+def _is_allowed_http_host(hostname: str | None) -> bool:
+    normalized = _normalize_host(hostname)
+    if normalized is None:
+        return False
+    if normalized == "localhost":
+        return True
+    try:
+        ipaddress.ip_address(normalized)
+    except ValueError:
+        return False
+    return True

--- a/src/winml/modelkit/serve/_security.py
+++ b/src/winml/modelkit/serve/_security.py
@@ -7,28 +7,87 @@
 from __future__ import annotations
 
 import ipaddress
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit
 
+from starlette._utils import get_route_path
 from starlette.responses import PlainTextResponse
 
 
 if TYPE_CHECKING:
+    from collections.abc import Collection, Mapping
+
     from starlette.types import ASGIApp, Receive, Scope, Send
 
 
-class SameOriginMiddleware:
-    """Reject browser requests whose origin differs from the target server."""
+_CLI_API_LOOPBACK_ONLY_ROUTES: dict[str, set[str] | None] = {"/v1/cli": None}
+_MODEL_API_LOOPBACK_ONLY_ROUTES: dict[str, set[str] | None] = {
+    "/v1/cli": None,
+    "/v1/ep": {"POST"},
+    "/v1/models": {"POST", "DELETE"},
+}
 
-    def __init__(self, app: ASGIApp) -> None:
+
+class SameOriginMiddleware:
+    """Enforce browser-origin and local-only route boundaries."""
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        loopback_only_routes: Mapping[str, Collection[str] | None] | None = None,
+    ) -> None:
         self.app = app
+        self._loopback_only_routes = {
+            prefix.rstrip("/"): (
+                None if methods is None else frozenset(method.upper() for method in methods)
+            )
+            for prefix, methods in (loopback_only_routes or {}).items()
+        }
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["type"] == "http" and not _is_same_origin(scope):
-            response = PlainTextResponse("Cross-origin requests are not allowed.", status_code=403)
-            await response(scope, receive, send)
-            return
+        if scope["type"] == "http":
+            if self._requires_loopback(scope) and not _is_loopback_client(scope):
+                response = PlainTextResponse(
+                    "This route is available only to local clients.",
+                    status_code=403,
+                )
+                await response(scope, receive, send)
+                return
+            if not _is_same_origin(scope):
+                response = PlainTextResponse(
+                    "Cross-origin requests are not allowed.",
+                    status_code=403,
+                )
+                await response(scope, receive, send)
+                return
         await self.app(scope, receive, send)
+
+    def _requires_loopback(self, scope: Scope) -> bool:
+        path = get_route_path(scope)
+        method = scope.get("method", "").upper()
+        for prefix, methods in self._loopback_only_routes.items():
+            if path != prefix and not path.startswith(f"{prefix}/"):
+                continue
+            if methods is None or method in methods:
+                return True
+        return False
+
+
+def _is_loopback_client(scope: Mapping[str, Any]) -> bool:
+    client = scope.get("client")
+    if not isinstance(client, (tuple, list)) or not client:
+        return False
+    host = client[0]
+    if not isinstance(host, str):
+        return False
+    try:
+        address = ipaddress.ip_address(host.split("%", maxsplit=1)[0])
+    except ValueError:
+        return False
+    if isinstance(address, ipaddress.IPv6Address) and address.ipv4_mapped is not None:
+        address = address.ipv4_mapped
+    return address.is_loopback
 
 
 def _is_same_origin(scope: Scope) -> bool:

--- a/src/winml/modelkit/serve/app.py
+++ b/src/winml/modelkit/serve/app.py
@@ -34,13 +34,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from fastapi import FastAPI, File, Form, HTTPException, UploadFile
-from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
 from .. import __version__
 from ..inference import InferenceEngine
 from ..inference.types import PredictionResult
+from ._security import SameOriginMiddleware
 from .cli_api import CliRequest, CliResponse, _run_with_semaphore
 from .manager import ModelSlotManager, SingleModelManager
 from .schema import (
@@ -213,14 +213,7 @@ def create_app(
         ),
         lifespan=lifespan,
     )
-    # Permissive CORS for local dev server; no credentials to protect.
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=["*"],
-        allow_credentials=False,
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
+    app.add_middleware(SameOriginMiddleware)
 
     # Serve demo UI at /demo
     _static_dir = Path(__file__).parent / "static"

--- a/src/winml/modelkit/serve/app.py
+++ b/src/winml/modelkit/serve/app.py
@@ -33,14 +33,18 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
-from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from fastapi import FastAPI, File, Form, HTTPException, Request, UploadFile
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
 from .. import __version__
 from ..inference import InferenceEngine
 from ..inference.types import PredictionResult
-from ._security import SameOriginMiddleware
+from ._security import (
+    _MODEL_API_LOOPBACK_ONLY_ROUTES,
+    SameOriginMiddleware,
+    _is_loopback_client,
+)
 from .cli_api import CliRequest, CliResponse, _run_with_semaphore
 from .manager import ModelSlotManager, SingleModelManager
 from .schema import (
@@ -213,7 +217,10 @@ def create_app(
         ),
         lifespan=lifespan,
     )
-    app.add_middleware(SameOriginMiddleware)
+    app.add_middleware(
+        SameOriginMiddleware,
+        loopback_only_routes=_MODEL_API_LOOPBACK_ONLY_ROUTES,
+    )
 
     # Serve demo UI at /demo
     _static_dir = Path(__file__).parent / "static"
@@ -280,6 +287,7 @@ def _register_routes(app: FastAPI, *, mode: str) -> None:
         summary="Single file upload inference (image, audio, …)",
     )
     async def predict_file(
+        request: Request,
         file: UploadFile = File(..., description="Media file (image, audio, …)"),
         model_id: str = Form("_", description="Model ID (multi-model mode). Omit to auto-route."),
         task: str | None = Form(
@@ -312,7 +320,11 @@ def _register_routes(app: FastAPI, *, mode: str) -> None:
         except json.JSONDecodeError as exc:
             raise HTTPException(status_code=422, detail=f"Invalid params JSON: {exc}") from exc
         try:
-            async with mgr.borrow(model_id, task=task) as engine:
+            async with mgr.borrow(
+                model_id,
+                task=task,
+                load_if_missing=_is_loopback_client(request.scope),
+            ) as engine:
                 loop = asyncio.get_running_loop()
                 base_inputs = _build_file_inputs(data, text, engine.user_input_schema)
 
@@ -359,20 +371,25 @@ def _register_routes(app: FastAPI, *, mode: str) -> None:
         summary="JSON inference — named inputs with optional pipeline params",
     )
     async def predict_json(
-        request: PredictJsonRequest,
+        request: Request,
+        body: PredictJsonRequest,
         model_id: str = "_",
     ) -> PredictionResult:
         mgr = _get_mgr()
         try:
-            async with mgr.borrow(model_id, task=request.task) as engine:
+            async with mgr.borrow(
+                model_id,
+                task=body.task,
+                load_if_missing=_is_loopback_client(request.scope),
+            ) as engine:
                 loop = asyncio.get_running_loop()
-                task_override = request.task
+                task_override = body.task
 
                 # Decode base64 for binary inputs based on schema
-                inputs = _decode_rest_inputs(request.inputs, engine.user_input_schema)
+                inputs = _decode_rest_inputs(body.inputs, engine.user_input_schema)
 
                 # Check inputs/params collision
-                collision = set(inputs.keys()) & set(request.params.keys())
+                collision = set(inputs.keys()) & set(body.params.keys())
                 if collision:
                     key = sorted(collision)[0]
                     raise HTTPException(
@@ -383,7 +400,7 @@ def _register_routes(app: FastAPI, *, mode: str) -> None:
                         ),
                     )
 
-                pipe_params = dict(request.params)
+                pipe_params = dict(body.params)
                 return await loop.run_in_executor(
                     None,
                     lambda: engine.predict(inputs=inputs, task=task_override, **pipe_params),

--- a/src/winml/modelkit/serve/app.py
+++ b/src/winml/modelkit/serve/app.py
@@ -40,11 +40,7 @@ from fastapi.staticfiles import StaticFiles
 from .. import __version__
 from ..inference import InferenceEngine
 from ..inference.types import PredictionResult
-from ._security import (
-    _MODEL_API_LOOPBACK_ONLY_ROUTES,
-    SameOriginMiddleware,
-    _is_loopback_client,
-)
+from ._security import SameOriginMiddleware, _is_loopback_client
 from .cli_api import CliRequest, CliResponse, _run_with_semaphore
 from .manager import ModelSlotManager, SingleModelManager
 from .schema import (
@@ -219,7 +215,11 @@ def create_app(
     )
     app.add_middleware(
         SameOriginMiddleware,
-        loopback_only_routes=_MODEL_API_LOOPBACK_ONLY_ROUTES,
+        loopback_only_routes={
+            "/v1/cli": None,
+            "/v1/ep": {"POST"},
+            "/v1/models": {"POST", "DELETE"},
+        },
     )
 
     # Serve demo UI at /demo

--- a/src/winml/modelkit/serve/cli_api.py
+++ b/src/winml/modelkit/serve/cli_api.py
@@ -30,13 +30,14 @@ from pathlib import Path
 from typing import Any, cast
 
 from fastapi import FastAPI, HTTPException
-from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
 from .. import __version__
 from ..cli import main as winml_cli
+from ..utils._security import _disable_remote_code_execution
+from ._security import SameOriginMiddleware
 
 
 # ---------------------------------------------------------------------------
@@ -144,14 +145,7 @@ app = FastAPI(
     version=__version__,
 )
 
-# Permissive CORS for local dev server; no credentials to protect.
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=False,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+app.add_middleware(SameOriginMiddleware)
 
 _static_dir = Path(__file__).parent / "static"
 if _static_dir.exists():
@@ -178,6 +172,15 @@ def _args_to_flags(args: dict[str, Any]) -> list[str]:
     - None       → omits the flag entirely
     - Other      → ``--flag value``
     """
+    if any(
+        key.replace("-", "_") == "trust_remote_code" and value is True
+        for key, value in args.items()
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail="trust_remote_code cannot be enabled through the HTTP API.",
+        )
+
     flags: list[str] = []
     for key, value in args.items():
         flag = "--" + key.replace("_", "-")
@@ -248,7 +251,8 @@ def _invoke(command: str, args: dict[str, Any]) -> CliResponse:
     cli_args = [command, *_args_to_flags(effective_args)]
 
     t0 = time.perf_counter()
-    result = runner.invoke(winml_cli, cli_args, catch_exceptions=True)
+    with _disable_remote_code_execution():
+        result = runner.invoke(winml_cli, cli_args, catch_exceptions=True)
     duration_ms = (time.perf_counter() - t0) * 1000
 
     # Build stderr from unhandled exceptions
@@ -291,6 +295,13 @@ def _invoke(command: str, args: dict[str, Any]) -> CliResponse:
 
 async def _run_with_semaphore(command: str, args: dict[str, Any]) -> CliResponse:
     """Acquire the appropriate semaphore and invoke the command."""
+    if command not in _ALL_COMMANDS:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Unknown command '{command}'. Valid commands: {sorted(_ALL_COMMANDS)}",
+        )
+    _args_to_flags(args)
+
     sem = _heavy_semaphore if command in _HEAVY_COMMANDS else _light_semaphore
     try:
         await asyncio.wait_for(sem.acquire(), timeout=_SEMAPHORE_TIMEOUT_SEC)
@@ -362,11 +373,6 @@ async def run_cli_command(command: str, body: CliRequest) -> CliResponse:
     **HTTP status**: always 200. Check ``exit_code`` (0 = success).
     Failures are reported in ``stderr`` and ``exit_code != 0``.
     """
-    if command not in _ALL_COMMANDS:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Unknown command '{command}'. Valid commands: {sorted(_ALL_COMMANDS)}",
-        )
     return await _run_with_semaphore(command, body.args)
 
 

--- a/src/winml/modelkit/serve/cli_api.py
+++ b/src/winml/modelkit/serve/cli_api.py
@@ -37,7 +37,7 @@ from pydantic import BaseModel
 from .. import __version__
 from ..cli import main as winml_cli
 from ..utils._security import _disable_remote_code_execution
-from ._security import _CLI_API_LOOPBACK_ONLY_ROUTES, SameOriginMiddleware
+from ._security import SameOriginMiddleware
 
 
 # ---------------------------------------------------------------------------
@@ -147,7 +147,7 @@ app = FastAPI(
 
 app.add_middleware(
     SameOriginMiddleware,
-    loopback_only_routes=_CLI_API_LOOPBACK_ONLY_ROUTES,
+    loopback_only_routes={"/v1/cli": None},
 )
 
 _static_dir = Path(__file__).parent / "static"

--- a/src/winml/modelkit/serve/cli_api.py
+++ b/src/winml/modelkit/serve/cli_api.py
@@ -37,7 +37,7 @@ from pydantic import BaseModel
 from .. import __version__
 from ..cli import main as winml_cli
 from ..utils._security import _disable_remote_code_execution
-from ._security import SameOriginMiddleware
+from ._security import _CLI_API_LOOPBACK_ONLY_ROUTES, SameOriginMiddleware
 
 
 # ---------------------------------------------------------------------------
@@ -145,7 +145,10 @@ app = FastAPI(
     version=__version__,
 )
 
-app.add_middleware(SameOriginMiddleware)
+app.add_middleware(
+    SameOriginMiddleware,
+    loopback_only_routes=_CLI_API_LOOPBACK_ONLY_ROUTES,
+)
 
 _static_dir = Path(__file__).parent / "static"
 if _static_dir.exists():

--- a/src/winml/modelkit/serve/manager.py
+++ b/src/winml/modelkit/serve/manager.py
@@ -49,12 +49,20 @@ class ModelManager(Protocol):
     """
 
     @asynccontextmanager
-    def borrow(self, model_id: str, task: str | None = None) -> AsyncIterator[InferenceEngine]:
+    def borrow(
+        self,
+        model_id: str,
+        task: str | None = None,
+        *,
+        load_if_missing: bool = True,
+    ) -> AsyncIterator[InferenceEngine]:
         """Context manager that yields a ready InferenceEngine.
 
         Blocks until the engine is available (respects concurrency limits).
         ``task`` is a routing hint used by ModelSlotManager when ``model_id``
         is the sentinel ``"_"``.
+        ``load_if_missing`` controls whether ModelSlotManager may create a new
+        slot for an explicit model ID.
         """
         raise NotImplementedError
 
@@ -110,7 +118,11 @@ class SingleModelManager:
 
     @asynccontextmanager
     async def borrow(
-        self, model_id: str = "_", task: str | None = None
+        self,
+        model_id: str = "_",
+        task: str | None = None,
+        *,
+        load_if_missing: bool = True,
     ) -> AsyncIterator[InferenceEngine]:
         """Acquire the lock, reload if idle-unloaded, yield engine, then start idle timer."""
         async with self._lock:
@@ -248,7 +260,11 @@ class ModelSlotManager:
 
     @asynccontextmanager
     async def borrow(
-        self, model_id: str, task: str | None = None
+        self,
+        model_id: str,
+        task: str | None = None,
+        *,
+        load_if_missing: bool = True,
     ) -> AsyncIterator[InferenceEngine]:
         """Acquire an engine for model_id, loading it if necessary.
 
@@ -259,7 +275,7 @@ class ModelSlotManager:
           4. Otherwise → raise ValueError listing available (model_id, task) pairs
         """
         resolved = await self._resolve(model_id, task)
-        slot = await self._acquire_slot(resolved)
+        slot = await self._acquire_slot(resolved, load_if_missing=load_if_missing)
         try:
             # Per-slot lock serialises inference for the same model so that
             # concurrent requests don't race inside the (non-thread-safe)
@@ -436,7 +452,12 @@ class ModelSlotManager:
                 f"Multiple models loaded — specify model_id or task. Available: {available}"
             )
 
-    async def _acquire_slot(self, model_id: str) -> ModelSlot:
+    async def _acquire_slot(
+        self,
+        model_id: str,
+        *,
+        load_if_missing: bool = True,
+    ) -> ModelSlot:
         # Fast path: model already loaded — just bump refcount under lock.
         # Also decides whether *this* coroutine is the designated loader.
         am_loader = False
@@ -449,6 +470,12 @@ class ModelSlotManager:
                 slot.refcount += 1
                 slot.last_used = time.monotonic()
                 return slot
+
+            if not load_if_missing:
+                raise ValueError(
+                    f"Model '{model_id}' is not loaded. "
+                    "Load it first from a local client via POST /v1/models."
+                )
 
             if model_id not in self._loading:
                 # We are the designated loader for this model_id

--- a/src/winml/modelkit/serve/static/index.html
+++ b/src/winml/modelkit/serve/static/index.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta http-equiv="Content-Security-Policy" content="connect-src 'self'">
 <title>WinML CLI Inference Demo</title>
 <style>
 :root {
@@ -297,7 +298,7 @@ canvas.spark{width:100%;height:60px;display:block}
   </div>
   <div class="server-row">
     <span class="status-dot" id="statusDot"></span>
-    <input type="text" id="serverUrl">
+    <input type="text" id="serverUrl" readonly aria-label="Server URL">
     <button class="btn btn-outline" onclick="connectServer()">Connect</button>
   </div>
   <span class="status-label" id="statusLabel">Not connected</span>
@@ -917,7 +918,7 @@ canvas.spark{width:100%;height:60px;display:block}
 // ══════════════════════════════════════════════════
 // State
 // ══════════════════════════════════════════════════
-let serverUrl = window.location.origin;
+const serverUrl = window.location.origin;
 let selectedFile = null;
 let pollTimer = null;
 let _log_handler_seq = 0;  // tracks last seen log seq for /v1/logs polling
@@ -942,7 +943,6 @@ function showPage(name, el) {
 // Server
 // ══════════════════════════════════════════════════
 async function connectServer() {
-  serverUrl = document.getElementById('serverUrl').value.replace(/\/$/, '');
   try {
     const r = await fetch(`${serverUrl}/v1/health`, { signal: AbortSignal.timeout(3000) });
     const d = await r.json();

--- a/src/winml/modelkit/serve/static/index.html
+++ b/src/winml/modelkit/serve/static/index.html
@@ -918,7 +918,7 @@ canvas.spark{width:100%;height:60px;display:block}
 // ══════════════════════════════════════════════════
 // State
 // ══════════════════════════════════════════════════
-const serverUrl = window.location.origin;
+const serverUrl = new URL('.', window.location.href).href.replace(/\/$/, '');
 let selectedFile = null;
 let pollTimer = null;
 let _log_handler_seq = 0;  // tracks last seen log seq for /v1/logs polling

--- a/src/winml/modelkit/utils/_security.py
+++ b/src/winml/modelkit/utils/_security.py
@@ -1,0 +1,39 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Internal execution policy for code-loading entry points."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+_REMOTE_CODE_EXECUTION_ALLOWED: ContextVar[bool] = ContextVar(
+    "remote_code_execution_allowed",
+    default=True,
+)
+
+
+@contextmanager
+def _disable_remote_code_execution() -> Iterator[None]:
+    """Disable remote or user-provided code for the current invocation."""
+    token = _REMOTE_CODE_EXECUTION_ALLOWED.set(False)
+    try:
+        yield
+    finally:
+        _REMOTE_CODE_EXECUTION_ALLOWED.reset(token)
+
+
+def _require_remote_code_execution_allowed() -> None:
+    """Reject code-loading paths disabled by the current execution policy."""
+    if not _REMOTE_CODE_EXECUTION_ALLOWED.get():
+        raise PermissionError(
+            "Remote and user-provided code execution is disabled for HTTP CLI requests."
+        )

--- a/tests/unit/commands/test_serve_security.py
+++ b/tests/unit/commands/test_serve_security.py
@@ -1,0 +1,34 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Security tests for the serve command's Uvicorn configuration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import uvicorn
+from click.testing import CliRunner
+
+from winml.modelkit.commands.serve import serve
+
+
+@pytest.mark.parametrize("args", [[], ["--multi"]])
+def test_serve_disables_proxy_headers(
+    args: list[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_calls: list[dict[str, Any]] = []
+
+    def record_run(_app: Any, **kwargs: Any) -> None:
+        run_calls.append(kwargs)
+
+    monkeypatch.setattr(uvicorn, "run", record_run)
+
+    result = CliRunner().invoke(serve, args)
+
+    assert result.exit_code == 0, result.output
+    assert len(run_calls) == 1
+    assert run_calls[0]["proxy_headers"] is False

--- a/tests/unit/serve/test_cli_api_security.py
+++ b/tests/unit/serve/test_cli_api_security.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+from html.parser import HTMLParser
 from typing import Any
 
 import click
@@ -15,8 +16,10 @@ from fastapi.testclient import TestClient
 
 import winml.modelkit.serve.app as serve_app_module
 import winml.modelkit.serve.cli_api as cli_api
+from winml.modelkit.inference import InferenceEngine, PredictionResult
 from winml.modelkit.loader import load_hf_config, load_hf_model
 from winml.modelkit.serve._security import _is_same_origin
+from winml.modelkit.serve.manager import ModelSlot
 
 
 def _successful_cli_response(command: str) -> cli_api.CliResponse:
@@ -28,6 +31,24 @@ def _successful_cli_response(command: str) -> cli_api.CliResponse:
         stderr="",
         duration_ms=0,
     )
+
+
+class _DemoPolicyParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.content_security_policy: str | None = None
+        self.server_url_attributes: dict[str, str | None] | None = None
+
+    def handle_starttag(
+        self,
+        tag: str,
+        attrs: list[tuple[str, str | None]],
+    ) -> None:
+        attributes = dict(attrs)
+        if tag == "meta" and attributes.get("http-equiv", "").lower() == "content-security-policy":
+            self.content_security_policy = attributes.get("content")
+        if tag == "input" and attributes.get("id") == "serverUrl":
+            self.server_url_attributes = attributes
 
 
 class TestOriginProtection:
@@ -45,7 +66,7 @@ class TestOriginProtection:
 
         monkeypatch.setattr(cli_api, "_invoke", fake_invoke)
 
-        with TestClient(cli_api.app) as client:
+        with TestClient(cli_api.app, client=("127.0.0.1", 50000)) as client:
             response = client.post(
                 "/v1/cli/sys",
                 headers={"Origin": "https://example.invalid"},
@@ -91,7 +112,7 @@ class TestOriginProtection:
         assert _is_same_origin(scope) is expected
 
     def test_phase_zero_rejects_foreign_origin_preflight(self) -> None:
-        with TestClient(cli_api.app) as client:
+        with TestClient(cli_api.app, client=("127.0.0.1", 50000)) as client:
             response = client.options(
                 "/v1/cli/build",
                 headers={
@@ -133,7 +154,11 @@ class TestOriginProtection:
         ],
     )
     def test_phase_zero_allows_local_clients(self, headers: dict[str, str]) -> None:
-        with TestClient(cli_api.app, base_url="http://127.0.0.1:8000") as client:
+        with TestClient(
+            cli_api.app,
+            base_url="http://127.0.0.1:8000",
+            client=("127.0.0.1", 50000),
+        ) as client:
             response = client.get("/v1/health", headers=headers)
 
         assert response.status_code == 200
@@ -153,6 +178,279 @@ class TestOriginProtection:
         assert "access-control-allow-origin" not in response.headers
 
 
+class TestLoopbackProtection:
+    """Only clients on this machine can invoke privileged HTTP routes."""
+
+    def test_remote_client_cannot_invoke_cli_without_origin(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        invocations: list[str] = []
+
+        def fake_invoke(command: str, _args: dict[str, Any]) -> cli_api.CliResponse:
+            invocations.append(command)
+            return _successful_cli_response(command)
+
+        monkeypatch.setattr(cli_api, "_invoke", fake_invoke)
+
+        with TestClient(cli_api.app, client=("192.0.2.20", 50000)) as client:
+            response = client.post(
+                "/v1/cli/compile",
+                json={
+                    "args": {
+                        "model": "model.onnx",
+                        "compiler": "qairt",
+                        "qnn_sdk_root": r"\\attacker\share\sdk",
+                    }
+                },
+            )
+
+        assert response.status_code == 403
+        assert invocations == []
+
+    def test_remote_client_cannot_bypass_cli_guard_through_mount(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        invocations: list[str] = []
+
+        def fake_invoke(command: str, _args: dict[str, Any]) -> cli_api.CliResponse:
+            invocations.append(command)
+            return _successful_cli_response(command)
+
+        monkeypatch.setattr(cli_api, "_invoke", fake_invoke)
+        parent = FastAPI()
+        parent.mount("/proxy", cli_api.app)
+
+        with TestClient(parent, client=("192.0.2.20", 50000)) as client:
+            response = client.post("/proxy/v1/cli/sys", json={"args": {}})
+
+        assert response.status_code == 403
+        assert invocations == []
+
+    def test_remote_client_cannot_use_management_route_without_origin(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        invocations: list[str] = []
+
+        async def fake_run(
+            command: str,
+            _args: dict[str, Any],
+        ) -> cli_api.CliResponse:
+            invocations.append(command)
+            return _successful_cli_response(command)
+
+        monkeypatch.setattr(serve_app_module, "_run_with_semaphore", fake_run)
+        app = serve_app_module.create_app(model_path="unused")
+        client = TestClient(app, client=("192.0.2.20", 50000))
+        try:
+            cli_response = client.post("/v1/cli/sys", json={"args": {}})
+            ep_response = client.post("/v1/ep", json={"ep": "cpu"})
+            load_response = client.post("/v1/models", json={"model_id": "owner/model"})
+            unload_response = client.delete("/v1/models/owner/model")
+            read_only_response = client.get("/v1/models")
+            inference_response = client.post(
+                "/v1/predict",
+                json={"inputs": {"text": "hello"}, "params": {}},
+            )
+        finally:
+            client.close()
+
+        assert cli_response.status_code == 403
+        assert ep_response.status_code == 403
+        assert load_response.status_code == 403
+        assert unload_response.status_code == 403
+        assert read_only_response.status_code == 503
+        assert inference_response.status_code == 503
+        assert invocations == []
+
+    @pytest.mark.parametrize("client_host", ["127.0.0.1", "::1"])
+    def test_loopback_client_can_invoke_cli_without_origin(
+        self,
+        client_host: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            cli_api,
+            "_invoke",
+            lambda command, _args: _successful_cli_response(command),
+        )
+
+        with TestClient(cli_api.app, client=(client_host, 50000)) as client:
+            response = client.post("/v1/cli/sys", json={"args": {}})
+
+        assert response.status_code == 200
+
+    @pytest.mark.parametrize(
+        ("path", "request_kwargs"),
+        [
+            (
+                "/v1/predict?model_id=owner/unloaded-model",
+                {"json": {"inputs": {"text": "hello"}, "params": {}}},
+            ),
+            (
+                "/v1/predict/file",
+                {
+                    "files": {"file": ("input.bin", b"data")},
+                    "data": {"model_id": "owner/unloaded-model"},
+                },
+            ),
+        ],
+    )
+    def test_remote_inference_cannot_lazy_load_model(
+        self,
+        path: str,
+        request_kwargs: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        load_calls: list[str] = []
+
+        def record_load(
+            _engine: InferenceEngine,
+            model_path: str,
+            **_kwargs: Any,
+        ) -> None:
+            load_calls.append(str(model_path))
+            raise AssertionError("remote request reached model loading")
+
+        monkeypatch.setattr(InferenceEngine, "load", record_load)
+        app = serve_app_module.create_app(model_path=None, mode="multi")
+
+        with TestClient(
+            app,
+            client=("192.0.2.20", 50000),
+            raise_server_exceptions=False,
+        ) as client:
+            response = client.post(path, **request_kwargs)
+
+        assert response.status_code == 400
+        assert "not loaded" in response.text
+        assert load_calls == []
+
+    def test_loopback_inference_retains_lazy_load(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        load_calls: list[str] = []
+
+        def fake_load(
+            engine: InferenceEngine,
+            model_path: str,
+            *,
+            task: str | None = None,
+            device: str = "auto",
+            **_kwargs: Any,
+        ) -> None:
+            load_calls.append(str(model_path))
+            engine._model = object()
+            engine._model_id = str(model_path)
+            engine._model_path = str(model_path)
+            engine._task = task or "unit-test"
+            engine._device = device
+            engine._user_input_schema = None
+
+        def fake_predict(
+            engine: InferenceEngine,
+            *,
+            inputs: dict[str, Any],
+            task: str | None = None,
+            **_kwargs: Any,
+        ) -> PredictionResult:
+            assert inputs == {"text": "hello"}
+            return PredictionResult(
+                task=task or engine.task or "unit-test",
+                model_id=engine.model_id,
+                device=engine.device,
+                predictions={},
+                latency_ms=0,
+            )
+
+        monkeypatch.setattr(InferenceEngine, "load", fake_load)
+        monkeypatch.setattr(InferenceEngine, "predict", fake_predict)
+        app = serve_app_module.create_app(model_path=None, mode="multi")
+
+        with TestClient(app, client=("127.0.0.1", 50000)) as client:
+            response = client.post(
+                "/v1/predict?model_id=owner/local-model",
+                json={"inputs": {"text": "hello"}, "params": {}},
+            )
+
+        assert response.status_code == 200
+        assert load_calls == ["owner/local-model"]
+
+    def test_remote_inference_can_use_loaded_model(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        load_calls: list[str] = []
+
+        def record_load(
+            _engine: InferenceEngine,
+            model_path: str,
+            **_kwargs: Any,
+        ) -> None:
+            load_calls.append(str(model_path))
+            raise AssertionError("loaded slot unexpectedly reloaded")
+
+        def fake_predict(
+            engine: InferenceEngine,
+            *,
+            inputs: dict[str, Any],
+            task: str | None = None,
+            **_kwargs: Any,
+        ) -> PredictionResult:
+            assert inputs == {"text": "hello"}
+            return PredictionResult(
+                task=task or engine.task or "unit-test",
+                model_id=engine.model_id,
+                device=engine.device,
+                predictions={},
+                latency_ms=0,
+            )
+
+        monkeypatch.setattr(InferenceEngine, "load", record_load)
+        monkeypatch.setattr(InferenceEngine, "predict", fake_predict)
+        app = serve_app_module.create_app(model_path=None, mode="multi")
+
+        with TestClient(app, client=("192.0.2.20", 50000)) as client:
+            engine = InferenceEngine()
+            engine._model = object()
+            engine._model_id = "owner/loaded-model"
+            engine._model_path = "owner/loaded-model"
+            engine._task = "unit-test"
+            engine._device = "cpu"
+            engine._user_input_schema = None
+            client.app.state.manager._slots["owner/loaded-model"] = ModelSlot(
+                model_id="owner/loaded-model",
+                engine=engine,
+            )
+
+            response = client.post(
+                "/v1/predict?model_id=owner/loaded-model",
+                json={"inputs": {"text": "hello"}, "params": {}},
+            )
+
+        assert response.status_code == 200
+        assert load_calls == []
+
+
+class TestDemoSecurity:
+    """The bundled UI cannot select a server outside its own origin."""
+
+    def test_demo_uses_only_window_origin(self) -> None:
+        with TestClient(cli_api.app, client=("127.0.0.1", 50000)) as client:
+            response = client.get("/demo")
+
+        parser = _DemoPolicyParser()
+        parser.feed(response.text)
+
+        assert response.status_code == 200
+        assert parser.content_security_policy == "connect-src 'self'"
+        assert parser.server_url_attributes is not None
+        assert "readonly" in parser.server_url_attributes
+
+
 class TestCliHttpPolicy:
     """HTTP dispatch exposes only the explicitly safe CLI capability set."""
 
@@ -170,7 +468,7 @@ class TestCliHttpPolicy:
 
         monkeypatch.setattr(cli_api, "_invoke", fake_invoke)
 
-        with TestClient(cli_api.app) as client:
+        with TestClient(cli_api.app, client=("127.0.0.1", 50000)) as client:
             response = client.post(
                 "/v1/cli/build",
                 json={"args": {key: True}},

--- a/tests/unit/serve/test_cli_api_security.py
+++ b/tests/unit/serve/test_cli_api_security.py
@@ -1,0 +1,260 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Security boundaries for the local CLI HTTP API."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import click
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import winml.modelkit.serve.app as serve_app_module
+import winml.modelkit.serve.cli_api as cli_api
+from winml.modelkit.loader import load_hf_config, load_hf_model
+from winml.modelkit.serve._security import _is_same_origin
+
+
+def _successful_cli_response(command: str) -> cli_api.CliResponse:
+    return cli_api.CliResponse(
+        command=command,
+        exit_code=0,
+        result=None,
+        stdout="",
+        stderr="",
+        duration_ms=0,
+    )
+
+
+class TestOriginProtection:
+    """Browser origins cannot cross the local HTTP trust boundary."""
+
+    def test_phase_zero_rejects_foreign_origin_before_dispatch(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        invocations: list[str] = []
+
+        def fake_invoke(command: str, _args: dict[str, Any]) -> cli_api.CliResponse:
+            invocations.append(command)
+            return _successful_cli_response(command)
+
+        monkeypatch.setattr(cli_api, "_invoke", fake_invoke)
+
+        with TestClient(cli_api.app) as client:
+            response = client.post(
+                "/v1/cli/sys",
+                headers={"Origin": "https://example.invalid"},
+                json={"args": {}},
+            )
+
+        assert response.status_code == 403
+        assert "access-control-allow-origin" not in response.headers
+        assert invocations == []
+
+    @pytest.mark.parametrize(
+        ("origin", "host", "scheme", "expected"),
+        [
+            ("http://127.0.0.1:8000", "127.0.0.1:8000", "http", True),
+            ("https://localhost", "localhost", "https", True),
+            ("http://[::1]:8000", "[::1]:8000", "http", True),
+            ("http://LOCALHOST", "localhost:80", "http", True),
+            ("http://localhost:0", "localhost:80", "http", False),
+            ("http://127.0.0.1:8001", "127.0.0.1:8000", "http", False),
+            ("http://192.0.2.10:8000", "192.0.2.10:8000", "http", True),
+            ("http://example.invalid", "127.0.0.1:8000", "http", False),
+            ("http://user@localhost", "localhost", "http", False),
+            ("http://localhost", "[::1", "http", False),
+            ("null", "127.0.0.1:8000", "http", False),
+        ],
+    )
+    def test_origin_parser(
+        self,
+        origin: str,
+        host: str,
+        scheme: str,
+        expected: bool,
+    ) -> None:
+        scope = {
+            "type": "http",
+            "scheme": scheme,
+            "headers": [
+                (b"host", host.encode("ascii")),
+                (b"origin", origin.encode("ascii")),
+            ],
+        }
+
+        assert _is_same_origin(scope) is expected
+
+    def test_phase_zero_rejects_foreign_origin_preflight(self) -> None:
+        with TestClient(cli_api.app) as client:
+            response = client.options(
+                "/v1/cli/build",
+                headers={
+                    "Origin": "https://example.invalid",
+                    "Access-Control-Request-Method": "POST",
+                    "Access-Control-Request-Headers": "content-type",
+                },
+            )
+
+        assert response.status_code == 403
+        assert "access-control-allow-origin" not in response.headers
+
+    def test_phase_zero_allows_same_origin_ip_host(self) -> None:
+        with TestClient(cli_api.app, base_url="http://192.0.2.10:8000") as client:
+            response = client.get(
+                "/v1/health",
+                headers={"Origin": "http://192.0.2.10:8000"},
+            )
+
+        assert response.status_code == 200
+
+    def test_phase_zero_rejects_dns_rebinding_origin(self) -> None:
+        with TestClient(cli_api.app) as client:
+            response = client.get(
+                "/v1/health",
+                headers={
+                    "Host": "example.invalid",
+                    "Origin": "http://example.invalid",
+                },
+            )
+
+        assert response.status_code == 403
+
+    @pytest.mark.parametrize(
+        "headers",
+        [
+            {},
+            {"Origin": "http://127.0.0.1:8000"},
+        ],
+    )
+    def test_phase_zero_allows_local_clients(self, headers: dict[str, str]) -> None:
+        with TestClient(cli_api.app, base_url="http://127.0.0.1:8000") as client:
+            response = client.get("/v1/health", headers=headers)
+
+        assert response.status_code == 200
+
+    def test_model_server_rejects_foreign_origin(self) -> None:
+        app = serve_app_module.create_app(model_path="unused")
+        client = TestClient(app)
+        try:
+            response = client.get(
+                "/openapi.json",
+                headers={"Origin": "https://example.invalid"},
+            )
+        finally:
+            client.close()
+
+        assert response.status_code == 403
+        assert "access-control-allow-origin" not in response.headers
+
+
+class TestCliHttpPolicy:
+    """HTTP dispatch exposes only the explicitly safe CLI capability set."""
+
+    @pytest.mark.parametrize("key", ["trust_remote_code", "trust-remote-code"])
+    def test_remote_code_opt_in_is_rejected_before_dispatch(
+        self,
+        key: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        invocations: list[tuple[str, dict[str, Any]]] = []
+
+        def fake_invoke(command: str, args: dict[str, Any]) -> cli_api.CliResponse:
+            invocations.append((command, args))
+            return _successful_cli_response(command)
+
+        monkeypatch.setattr(cli_api, "_invoke", fake_invoke)
+
+        with TestClient(cli_api.app) as client:
+            response = client.post(
+                "/v1/cli/build",
+                json={"args": {key: True}},
+            )
+
+        assert response.status_code == 400
+        assert invocations == []
+
+    def test_model_server_rejects_commands_outside_allowlist(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        invocations: list[str] = []
+
+        def fake_invoke(command: str, _args: dict[str, Any]) -> cli_api.CliResponse:
+            invocations.append(command)
+            return _successful_cli_response(command)
+
+        monkeypatch.setattr(cli_api, "_invoke", fake_invoke)
+        app = FastAPI()
+        serve_app_module._register_routes(app, mode="single")
+
+        with TestClient(app) as client:
+            response = client.post(
+                "/v1/cli/eval",
+                json={"args": {}},
+            )
+
+        assert response.status_code == 404
+        assert invocations == []
+
+    def test_http_invocation_blocks_nested_remote_code_and_resets_policy(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        forwarded_values: list[bool] = []
+
+        class RecordingAutoConfig:
+            @staticmethod
+            def from_pretrained(_model_id: str, **kwargs: Any) -> object:
+                forwarded_values.append(kwargs["trust_remote_code"])
+                return object()
+
+        def raw_config_loader(
+            _model_id: str,
+            **_kwargs: Any,
+        ) -> tuple[dict[str, str], dict[str, Any]]:
+            return {"model_type": "unit-test"}, {}
+
+        @click.group()
+        def test_cli() -> None:
+            pass
+
+        @test_cli.command("build")
+        def build_command() -> None:
+            load_hf_config(
+                RecordingAutoConfig,
+                "owner/model",
+                trust_remote_code=True,
+                raw_config_loader=raw_config_loader,
+            )
+
+        monkeypatch.setattr(cli_api, "winml_cli", test_cli)
+
+        response = cli_api._invoke("build", {})
+
+        assert response.exit_code != 0
+        assert forwarded_values == []
+
+        load_hf_config(
+            RecordingAutoConfig,
+            "owner/model",
+            trust_remote_code=True,
+            raw_config_loader=raw_config_loader,
+        )
+        assert forwarded_values == [True]
+
+    def test_preloaded_config_cannot_bypass_http_remote_code_policy(self) -> None:
+        with (
+            cli_api._disable_remote_code_execution(),
+            pytest.raises(PermissionError, match="disabled for HTTP"),
+        ):
+            load_hf_model(
+                "owner/model",
+                trust_remote_code=True,
+                hf_config=object(),
+            )

--- a/tests/unit/serve/test_cli_api_security.py
+++ b/tests/unit/serve/test_cli_api_security.py
@@ -6,6 +6,10 @@
 
 from __future__ import annotations
 
+import json
+import re
+import shutil
+import subprocess
 from html.parser import HTMLParser
 from typing import Any
 
@@ -49,6 +53,26 @@ class _DemoPolicyParser(HTMLParser):
             self.content_security_policy = attributes.get("content")
         if tag == "input" and attributes.get("id") == "serverUrl":
             self.server_url_attributes = attributes
+
+
+def _evaluate_demo_server_url(html: str, document_url: str) -> str:
+    match = re.search(r"^const serverUrl = (?P<expression>.+);\r?$", html, re.MULTILINE)
+    assert match is not None
+
+    node = shutil.which("node")
+    assert node is not None
+    script = (
+        f"const window = {{ location: new URL({json.dumps(document_url)}) }};\n"
+        f"const serverUrl = {match.group('expression')};\n"
+        "process.stdout.write(serverUrl);"
+    )
+    result = subprocess.run(  # noqa: S603 -- fixed Node executable and repository JS
+        [node, "-e", script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
 
 
 class TestOriginProtection:
@@ -438,7 +462,7 @@ class TestLoopbackProtection:
 class TestDemoSecurity:
     """The bundled UI cannot select a server outside its own origin."""
 
-    def test_demo_uses_only_window_origin(self) -> None:
+    def test_demo_locks_server_selection_to_document_origin(self) -> None:
         with TestClient(cli_api.app, client=("127.0.0.1", 50000)) as client:
             response = client.get("/demo")
 
@@ -449,6 +473,19 @@ class TestDemoSecurity:
         assert parser.content_security_policy == "connect-src 'self'"
         assert parser.server_url_attributes is not None
         assert "readonly" in parser.server_url_attributes
+        assert _evaluate_demo_server_url(response.text, str(response.url)) == "http://testserver"
+
+    def test_demo_preserves_mount_path_in_server_url(self) -> None:
+        parent = FastAPI()
+        parent.mount("/proxy", cli_api.app)
+
+        with TestClient(parent, client=("127.0.0.1", 50000)) as client:
+            response = client.get("/proxy/demo")
+
+        assert response.status_code == 200
+        assert _evaluate_demo_server_url(response.text, str(response.url)) == (
+            "http://testserver/proxy"
+        )
 
 
 class TestCliHttpPolicy:


### PR DESCRIPTION
## Summary

- replace wildcard CORS with same-origin request protection for WinML serve apps
- reject HTTP attempts to enable remote code and enforce the policy at model/config loading boundaries
- centralize CLI command allowlist validation for both server modes
- add regression coverage for origin parsing, DNS rebinding, malformed headers, nested configuration, and direct-CLI compatibility

## Validation

- 23 security regression tests passed
- 44 serve tests passed
- 512 loader tests passed
- 191 build/config/direct-CLI tests passed
- Ruff and git diff checks passed
- the full suite was attempted; an unrelated OpenVINO NPU integration test timed out after its worker process pool crashed