### PR TITLE
fix(marian): restore Transformers 5 export compatibility

### DIFF
--- a/src/winml/modelkit/loader/_autoconfig.py
+++ b/src/winml/modelkit/loader/_autoconfig.py
@@ -14,6 +14,7 @@ concrete architecture can be inferred safely.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any, Literal, TypeAlias, cast, overload
 
@@ -22,7 +23,88 @@ if TYPE_CHECKING:
     from transformers import PretrainedConfig
 
 
+logger = logging.getLogger(__name__)
+
+
 _RawConfigLoader: TypeAlias = Callable[..., tuple[dict[str, Any], dict[str, Any]]]
+
+
+def _is_strict_none_bool_validation_error(exc: Exception) -> bool:
+    """Return whether *exc* matches strict dataclass bool-vs-None validation."""
+    message = str(exc)
+    return (
+        "Validation error for field" in message
+        and "expected bool" in message
+        and "NoneType" in message
+    )
+
+
+def _declared_bool_fields(config_cls: type[Any]) -> set[str]:
+    """Collect fields annotated as ``bool`` across a config class hierarchy."""
+
+    def _is_bool_annotation(annotation: Any) -> bool:
+        if annotation is bool:
+            return True
+        if isinstance(annotation, str):
+            return annotation == "bool" or annotation == "builtins.bool"
+        return getattr(annotation, "__forward_arg__", None) == "bool"
+
+    fields: set[str] = set()
+    for cls in config_cls.__mro__:
+        annotations = getattr(cls, "__annotations__", {})
+        if not isinstance(annotations, dict):
+            continue
+        for field_name, field_type in annotations.items():
+            if _is_bool_annotation(field_type) and isinstance(field_name, str):
+                fields.add(field_name)
+    return fields
+
+
+def _normalize_none_bool_fields(
+    config_cls: type[Any],
+    config_dict: dict[str, Any],
+) -> tuple[dict[str, Any], list[str]]:
+    """Replace ``None`` with ``False`` for bool-annotated fields present in config."""
+    normalized = config_dict.copy()
+    replaced_fields: list[str] = []
+    for field_name in sorted(_declared_bool_fields(config_cls)):
+        if normalized.get(field_name) is None:
+            normalized[field_name] = False
+            replaced_fields.append(field_name)
+    return normalized, replaced_fields
+
+
+def _load_from_dict_with_strict_none_fallback(
+    *,
+    config_dict: dict[str, Any],
+    unused_kwargs: dict[str, Any],
+    model_id: str,
+    return_unused_kwargs: bool,
+) -> PretrainedConfig | tuple[PretrainedConfig, dict[str, Any]] | None:
+    """Try rebuilding config after normalizing strict ``None`` bool fields."""
+    model_type = config_dict.get("model_type")
+    if not isinstance(model_type, str):
+        return None
+
+    from transformers.models.auto.configuration_auto import CONFIG_MAPPING
+
+    if model_type not in CONFIG_MAPPING:
+        return None
+
+    config_cls = CONFIG_MAPPING[model_type]
+    normalized_config_dict, replaced_fields = _normalize_none_bool_fields(config_cls, config_dict)
+    if not replaced_fields:
+        return None
+
+    logger.warning(
+        "Strict dataclass validation failed for '%s'; normalizing None->False for bool fields: %s",
+        model_id,
+        ", ".join(replaced_fields),
+    )
+    from_dict_kwargs = unused_kwargs.copy()
+    if return_unused_kwargs:
+        from_dict_kwargs["return_unused_kwargs"] = True
+    return config_cls.from_dict(normalized_config_dict, **from_dict_kwargs)
 
 
 def _fallback_identifiers(config_dict: dict[str, Any], model_id: str) -> list[str]:
@@ -189,14 +271,27 @@ def load_hf_config(
     auto_map = config_dict.get("auto_map")
     has_remote_config = isinstance(auto_map, dict) and isinstance(auto_map.get("AutoConfig"), str)
     if "model_type" in config_dict or has_remote_config:
-        return cast(
-            "PretrainedConfig | tuple[PretrainedConfig, dict[str, Any]]",
-            auto_config.from_pretrained(
-                model_id,
-                trust_remote_code=trust_remote_code,
-                **load_kwargs,
-            ),
-        )
+        try:
+            return cast(
+                "PretrainedConfig | tuple[PretrainedConfig, dict[str, Any]]",
+                auto_config.from_pretrained(
+                    model_id,
+                    trust_remote_code=trust_remote_code,
+                    **load_kwargs,
+                ),
+            )
+        except Exception as exc:
+            if not _is_strict_none_bool_validation_error(exc):
+                raise
+            fallback_result = _load_from_dict_with_strict_none_fallback(
+                config_dict=config_dict,
+                unused_kwargs=unused_kwargs,
+                model_id=model_id,
+                return_unused_kwargs=return_unused_kwargs,
+            )
+            if fallback_result is None:
+                raise
+            return fallback_result
 
     from transformers.models.auto.configuration_auto import CONFIG_MAPPING
 

--- a/src/winml/modelkit/models/hf/bart.py
+++ b/src/winml/modelkit/models/hf/bart.py
@@ -328,6 +328,10 @@ class BartDecoderWrapper(nn.Module):
             layer.keys = args[kv_start + i * 2]
             layer.values = args[kv_start + i * 2 + 1]
 
+        # Transformers 5 may call Cache.update without cache_kwargs; preserve
+        # the explicit ONNX cache_position input for WinMLStaticCache.update.
+        self_attn_cache.set_trace_position(cache_position)
+
         # Thread absolute seq pos to the (patched) learned embedding via a
         # module attribute.  The patched forward reads this and uses it for
         # the lookup, ignoring the explicit position_ids kwarg that HF would

--- a/src/winml/modelkit/models/hf/marian.py
+++ b/src/winml/modelkit/models/hf/marian.py
@@ -227,7 +227,8 @@ class MarianDecoderWrapper(nn.Module):
             self_attn_cache._layer(i).values = args[kv_start + i * 2 + 1]
 
         self_attn_cache.set_trace_position(cache_position)
-        decoder = self.model.get_decoder()
+        model = cast("MarianMTModel", self.model)
+        decoder = model.get_decoder()
         if "cache_position" not in inspect.signature(decoder.forward).parameters:
             decoder.embed_positions.position_id = cache_position
             expanded_mask = decoder_attention_mask[:, None, None, :].to(
@@ -243,7 +244,7 @@ class MarianDecoderWrapper(nn.Module):
         cross_attn_cache = DynamicCache()
         cache = EncoderDecoderCache(self_attn_cache, cross_attn_cache)
 
-        out = self.model(
+        out = model(
             decoder_input_ids=decoder_input_ids,
             encoder_outputs=(encoder_hidden_states,),
             attention_mask=attention_mask,

--- a/src/winml/modelkit/models/hf/marian.py
+++ b/src/winml/modelkit/models/hf/marian.py
@@ -5,75 +5,30 @@
 """Marian (Helsinki-NLP/opus-mt) HuggingFace Model Configuration.
 
 Provides encoder/decoder export wrappers and OnnxConfig registrations for
-Marian translation models with sliding-window KV cache (Slice+Concat;
-no ScatterElements).
+Marian translation models with a static KV cache.
 
 Export Strategy (split by task):
 - MarianEncoderWrapper + MarianEncoderIOConfig: ``feature-extraction`` task
   → encoder-only ONNX (input_ids, attention_mask → encoder_hidden_states)
 - MarianDecoderWrapper + MarianDecoderIOConfig: ``text2text-generation`` task
-  → decoder ONNX with sliding-window buffer input + single-token KV output.
+  → decoder ONNX with a static cache buffer input + single-token KV output.
 
-Why the compute_bias-free design works with sliding window:
+Transformers cache compatibility:
 
-Marian's positional encoding is the frozen sinusoidal table
-``MarianSinusoidalPositionalEmbedding`` added to ``inputs_embeds`` *before*
-the first attention layer.  Stock ``MarianDecoder.forward`` feeds the
-decoder's ``cache_position`` input into two consumers that want different
-semantics under sliding window:
+Transformers 4.57 passes ``cache_position`` through Marian's decoder and
+attention layers. Transformers 5 removes that explicit parameter and calls
+``Cache.update`` without cache kwargs; it also derives position IDs and the
+causal mask from ``Cache.get_seq_length``. The wrapper handles both APIs:
 
-1. ``self.embed_positions(..., position_ids=cache_position)`` — indices into
-   the sin/cos lookup table.  Needs the token's *absolute sequence position*.
-2. ``create_causal_mask(..., cache_position=cache_position)`` — HF's
-   ``kv_idx <= q_idx`` check over the KV buffer.  Needs the query's
-   *buffer index*.
+1. ``WinMLStaticCache.set_trace_position`` supplies the explicit ONNX input
+    when Transformers omits ``cache_kwargs`` from ``Cache.update``.
+2. On the Transformers 5 path, the positional-embedding patch reads that same
+    input directly, avoiding the unsupported integer ``arange + length`` graph.
+3. A precomputed 4D additive mask bypasses Transformers 5's internal dynamic
+    causal-mask offsets. Transformers 4 keeps its native mask path.
 
-For static cache these coincide.  For sliding window, the query is permanently
-pinned at the rightmost buffer slot (``max_cache_len - 1``), while its
-absolute seq position grows unboundedly.  To serve both, we:
-
-- Bake ``cache_position = [max_cache_len - 1]`` as a Constant in the graph
-  (same trick as the T5 decoder) — constant-folds the causal mask.
-- Add ``position_id`` as an ONNX input carrying the absolute seq position.
-- Patch ``MarianSinusoidalPositionalEmbedding.forward`` via ``PATCHING_SPECS``
-  so the sin/cos lookup reads the query's absolute seq position from a
-  ``position_id`` tensor attribute set on the embedding module by the
-  export wrapper — bypassing the kwarg-based plumbing entirely.  This
-  threads the seq pos into the graph as a dynamic ONNX input while the
-  causal mask still sees ``cache_position = [max_cache_len - 1]``.
-
-The patch is a no-op when ``position_id`` is not set — the embedding
-forward then behaves exactly like stock HF.
-
-Cache type:
-
-The default configuration uses ``WinMLSlidingWindowCache`` (FIFO
-Slice+Concat) plus the ``MarianSinusoidalPositionalEmbedding.forward``
-patch described above.  ``WinMLEncoderDecoderModel`` is cache-agnostic —
-mask construction and cache updates are delegated to the cache class via
-``build_decoder_mask``, ``get_query_cache_position``, and
-``update_all_layers``.  To switch to ``WinMLStaticCache`` (index_copy_
-via multi-dim index_put_ → ScatterND):
-
-1. **Export wrapper**: change ``MarianDecoderWrapper.forward()`` to
-   instantiate ``WinMLStaticCache`` instead of ``WinMLSlidingWindowCache``;
-   take ``cache_position`` as the explicit ONNX input at ``args[4]``
-   (instead of ``position_id``); pass it directly to ``self.model(...)``
-   without the ``[max_cache_len - 1]`` bake; and delete the
-   ``embed_positions.position_id = ...`` attribute hook — under static
-   cache, ``cache_position`` already equals the absolute seq pos, so
-   stock HF's ``self.embed_positions(..., position_ids=cache_position)``
-   produces correct sin/cos indices with no patching needed.
-2. **OnnxConfig inputs**: rename ``"position_id"`` to ``"cache_position"``
-   in ``MarianDecoderIOConfig.inputs``.  The ``PATCHING_SPECS`` entry
-   becomes a no-op (the patched forward only activates when
-   ``position_id`` is set on the embedding module) — safe to leave, but
-   can be removed for clarity.
-3. **Inference**: override ``get_cache_class()`` on ``WinMLMarianModel``
-   to return ``WinMLStaticCache``.  ``WinMLEncoderDecoderModel`` feeds
-   both ``cache_position`` and ``position_id`` every step and lets
-   ``pad_inputs`` filter to whatever the decoder ONNX declares, so the
-   inference-side switch is automatic once the ONNX input name flips.
+The static cache writes new KV at ``cache_position`` through ScatterND and
+preserves ``buffer_position == sequence_position``.
 
 Models: Helsinki-NLP/opus-mt-fr-en, opus-mt-en-ru, opus-mt-es-en, etc.
 
@@ -84,6 +39,7 @@ Usage:
 
 from __future__ import annotations
 
+import inspect
 import logging
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
@@ -102,8 +58,6 @@ from ...export import register_onnx_overwrite
 from ...optim import WinMLOptimizationConfig
 from ..winml.composite_model import register_composite_model
 from ..winml.encoder_decoder import EncoderDecoderInputGenerator, WinMLEncoderDecoderModel
-
-# from ..winml.kv_cache import PastKeyValueInputGenerator, WinMLSlidingWindowCache
 from ..winml.kv_cache import PastKeyValueInputGenerator, WinMLStaticCache
 
 
@@ -115,69 +69,12 @@ logger = logging.getLogger(__name__)
 
 
 # =============================================================================
-# Patch for sliding-window-compatible sin/cos lookup
+# Patch for Transformers 5 positional lookup
 # =============================================================================
-#
-# Why this patch is *required* (not just preferred) for sliding-window export
-# -----------------------------------------------------------------------------
-# In transformers==4.57.6, ``MarianDecoder.forward`` (modeling_marian.py:882)
-# drives the sinusoidal positional embedding with:
-#
-#     position_ids = self.embed_positions(
-#         (batch_size, seq_length), past_key_values_length,
-#         position_ids=cache_position,                         # L1042-1043
-#     )
-#     hidden_states = inputs_embeds + position_ids
-#
-# and ``MarianSinusoidalPositionalEmbedding.forward`` indexes the frozen sin/cos
-# table directly with whatever ``position_ids`` it receives.  So the sin/cos
-# lookup indices are ``cache_position`` values — nothing else.
-#
-# For sliding-window + single-token gen, our wrapper *must* bake
-# ``cache_position = [max_cache_len - 1]`` (the rightmost buffer slot) so HF's
-# causal mask ``kv_idx <= q_idx`` reduces to all-True and constant-folds.  But
-# that same ``cache_position`` is then handed verbatim to the sin/cos table —
-# which would make every step look up row ``W-1`` regardless of actual
-# generation position.  That is wrong for every step.
-#
-# The two consumers of ``cache_position`` want different things (buffer index
-# for the mask, absolute seq pos for the sin/cos table) and there is no
-# parameter in stock ``MarianDecoder.forward`` that splits them.  We therefore
-# patch ``MarianSinusoidalPositionalEmbedding.forward`` to read the absolute
-# seq pos from a tensor attribute ``position_id`` set on the embedding module
-# by the wrapper, ignoring the ``position_ids`` kwarg that HF passes in.
-# With the patch, ``cache_position`` serves only the causal mask, and the sin/cos
-# lookup is driven by our separately-fed ``position_id`` input.  Without the
-# patch, there is no other HF hook to inject a different sin/cos index — this
-# is the minimal intrusion that makes sliding-window Marian correct.
-#
-# TODO(transformers-upgrade): This patch works for transformers==4.57.6.
-# In the newer (main-branch) transformers, ``MarianDecoder.forward`` has been
-# refactored (see D:\cc_ws\transformers\src\transformers\models\marian\
-# modeling_marian.py:540-622):
-#
-#   * ``cache_position`` was removed as an explicit parameter; the forward now
-#     builds ``position_ids = arange(seq_length) + past_key_values_length``
-#     internally and feeds that to ``self.embed_positions``.
-#   * The causal mask is built via ``create_causal_mask(config, inputs_embeds,
-#     attention_mask, past_key_values=self_attn_cache)`` — ``cache_position``
-#     is *not* threaded through.  Instead, ``past_key_values.get_seq_length()``
-#     is the only signal telling the graph where the query is.
-#
-# Consequences for this wrapper when we upgrade past 4.57.6:
-#   1. The wrapper's ``cache_position=...`` kwarg to ``self.model(...)`` will
-#      be silently absorbed by ``**kwargs`` and dropped.  The baked
-#      ``[max_cache_len - 1]`` will NOT reach the causal mask — the mask will
-#      be built from ``get_seq_length()`` (which is 0 at trace for our fresh
-#      cache), and the mask will be wrong at inference.
-#   2. ``MarianSinusoidalPositionalEmbedding.forward`` is still called with a
-#      ``position_ids`` kwarg (now derived from ``past_key_values_length``),
-#      so the ``position_id`` attribute override still works for sin/cos.
-#
-# When upgrading, rework this wrapper to: (a) override the export cache's
-# ``get_seq_length()`` to return a tensor fed from an ONNX input, and/or
-# (b) pre-compute a 4D attention_mask and pass it in so HF's internal mask
-# construction is skipped.  The sin/cos patch here can likely stay as-is.
+# Transformers 5 no longer forwards ``cache_position`` through MarianDecoder.
+# The export wrapper stores the tensor on the embedding module, and this patch
+# reads it directly. Without the attribute, it preserves stock behavior for
+# Transformers 4 and other Marian export paths.
 
 
 def _patched_marian_sinusoidal_forward(
@@ -188,20 +85,9 @@ def _patched_marian_sinusoidal_forward(
 ) -> torch.Tensor:
     """Patched ``MarianSinusoidalPositionalEmbedding.forward``.
 
-    If the export wrapper has stored an absolute-seq-pos tensor on this
-    module as the attribute ``position_id``, use it as the sin/cos lookup
-    indices and ignore the explicit ``position_ids`` kwarg that HF's
-    ``MarianDecoder.forward`` would otherwise pass in (which, under
-    sliding-window semantics, carries the query's *buffer index* — the
-    baked ``[max_cache_len - 1]`` — not its sequence position).
-
-    See the module header for why this override cannot be avoided under
-    the stock transformers==4.57.6 ``MarianDecoder.forward`` flow.
-
-    Without ``position_id`` set, behavior is bit-identical to the
-    original HF implementation — which keeps the patch safe if someone
-    exports Marian via a different wrapper (e.g., a static-cache variant
-    that has no need to override).
+    When the export wrapper stores ``cache_position`` on ``position_id``, use
+    it directly as the sin/cos lookup index. Without that attribute, preserve
+    the stock implementation for Transformers 4 and other export paths.
     """
     abs_pos = getattr(self, "position_id", None)
     if abs_pos is not None:
@@ -277,31 +163,13 @@ class MarianEncoderWrapper(nn.Module):
 
 
 class MarianDecoderWrapper(nn.Module):
-    """Wraps ``MarianMTModel`` with sliding-window KV cache I/O.
+    """Wraps ``MarianMTModel`` with static KV cache I/O.
 
     Input: full buffer ``[batch, heads, max_decode, d_kv]`` per layer.
     Output: only the new token's KV ``[batch, heads, 1, d_kv]`` per layer.
 
-    Uses ``WinMLSlidingWindowCache`` (Slice+Concat eviction) wrapped in
-    ``EncoderDecoderCache``.  Two design choices handle the two-consumer
-    problem of Marian's ``cache_position``:
-
-    1. ``cache_position`` is NOT an ONNX input — it is pinned to
-       ``[max_cache_len - 1]`` as a Constant inside ``forward``, matching
-       the rightmost slot invariant of sliding-window + single-token gen.
-       HF's causal mask ``kv_idx <= q_idx`` then reduces to all-True and
-       constant-folds away.
-    2. ``position_id`` IS an ONNX input (absolute seq pos) and is threaded
-       to ``MarianSinusoidalPositionalEmbedding`` via the ``position_id``
-       tensor attribute set on that module.  The patched embedding forward
-       (registered in ``PATCHING_SPECS``) reads that attribute instead of
-       HF's default position_ids derivation, giving dynamic sin/cos
-       indexing that tracks the actual generation step.
-
-    This couples the exported graph to sliding-window semantics at build
-    time.  Callers who want static-cache semantics must subclass this
-    wrapper, restore ``cache_position`` as an input, and re-export —
-    ``WinMLStaticCache`` remains fully supported for that path.
+    ``cache_position`` is an explicit ONNX input used for both the static
+    cache write and Marian's absolute sinusoidal position.
     """
 
     def __init__(self, model: nn.Module, num_layers: int) -> None:
@@ -315,7 +183,7 @@ class MarianDecoderWrapper(nn.Module):
 
     @classmethod
     def from_pretrained(cls, model_name_or_path: str, **kwargs: Any) -> MarianDecoderWrapper:
-        """Load full MarianMTModel, wrap with sliding-window cache."""
+        """Load full MarianMTModel and wrap its decoder with a static cache."""
         full_model = MarianMTModel.from_pretrained(model_name_or_path, **kwargs)
         num_layers = full_model.config.decoder_layers
         wrapper = cls(full_model, num_layers)
@@ -327,11 +195,11 @@ class MarianDecoderWrapper(nn.Module):
         return tuple(inputs.values())
 
     def forward(self, *args: torch.Tensor) -> tuple[torch.Tensor, ...]:
-        """Run decoder with sliding-window KV cache.
+        """Run decoder with static KV cache.
 
         Positional args (order matches OnnxConfig.inputs):
             decoder_input_ids, encoder_hidden_states, attention_mask,
-            decoder_attention_mask, position_id,
+            decoder_attention_mask, cache_position,
             past_0_key, past_0_value, past_1_key, past_1_value, ...
 
         Returns:
@@ -342,12 +210,10 @@ class MarianDecoderWrapper(nn.Module):
         encoder_hidden_states = args[1]
         attention_mask = args[2]
         decoder_attention_mask = args[3]
-        # position_id = args[4]  # sliding-window cache
-        cache_position = args[4]  # static cache: absolute seq pos, drives mask + sin/cos
+        cache_position = args[4]
         kv_start = 5
 
         max_cache_len = args[kv_start].size(2)
-        # self_attn_cache = WinMLSlidingWindowCache(self.config, max_cache_len=max_cache_len)
         self_attn_cache = WinMLStaticCache(self.config, max_cache_len=max_cache_len)
         self_attn_cache.early_initialization(
             batch_size=decoder_input_ids.size(0),
@@ -360,23 +226,16 @@ class MarianDecoderWrapper(nn.Module):
             self_attn_cache._layer(i).keys = args[kv_start + i * 2]
             self_attn_cache._layer(i).values = args[kv_start + i * 2 + 1]
 
-        # Thread absolute seq pos to the (patched) sin/cos embedding via a
-        # module attribute.  The patched forward reads this and uses it for
-        # the lookup, ignoring the explicit position_ids kwarg that HF would
-        # otherwise pass (which under sliding window is the buffer index).
-        # See the module-level TODO for why this hook is transformers-version-
-        # specific (works on 4.57.6; needs rework for newer).
-        # self.model.get_decoder().embed_positions.position_id = position_id  # sliding only
-        # Static cache: stock HF passes `cache_position` as `position_ids` into
-        # MarianSinusoidalPositionalEmbedding.forward, which equals the absolute
-        # seq pos under static semantics — no attribute hook needed.
-
-        # Sliding window + single-token gen: the query is always at the
-        # rightmost slot.  Constructing this constant inside forward traces
-        # it as a Constant node — the causal-mask subgraph then constant-folds.
-        # cache_position = torch.tensor(
-        #     [max_cache_len - 1], dtype=torch.int64, device=decoder_input_ids.device
-        # )  # sliding-window cache only; static cache uses the ONNX `cache_position` input directly
+        self_attn_cache.set_trace_position(cache_position)
+        decoder = self.model.get_decoder()
+        if "cache_position" not in inspect.signature(decoder.forward).parameters:
+            decoder.embed_positions.position_id = cache_position
+            expanded_mask = decoder_attention_mask[:, None, None, :].to(
+                dtype=encoder_hidden_states.dtype
+            )
+            decoder_attention_mask = (1.0 - expanded_mask) * torch.finfo(
+                encoder_hidden_states.dtype
+            ).min
 
         # EncoderDecoderCache routes self-attention vs cross-attention to
         # separate caches.  DynamicCache for cross-attn is a no-op during
@@ -456,17 +315,15 @@ class _MarianDecoderNormalizedConfig(NormalizedConfig):  # type: ignore[misc]  #
 
 @register_onnx_overwrite("marian", "text2text-generation", library_name="transformers")
 class MarianDecoderIOConfig(OnnxConfig):  # type: ignore[misc]  # optimum base is untyped
-    """ONNX config for Marian decoder with sliding-window KV cache.
+    """ONNX config for Marian decoder with static KV cache.
 
     Inputs:  decoder_input_ids, encoder_hidden_states, attention_mask,
-             decoder_attention_mask, position_id, past_{i}_key/value
+             decoder_attention_mask, cache_position, past_{i}_key/value
     Outputs: logits, present_{i}_key/value
 
-    ``cache_position`` is *not* an input: ``MarianDecoderWrapper.forward``
-    pins it to ``[max_cache_len - 1]`` (rightmost buffer slot) as a
-    Constant.  ``position_id`` (absolute seq pos) drives the patched
-    sin/cos lookup — see the wrapper and
-    ``_patched_marian_sinusoidal_forward`` for details.
+    ``cache_position`` is both the static buffer index and absolute sequence
+    position. Transformers 5 receives it through the export compatibility
+    path described by ``MarianDecoderWrapper``.
 
     Input past KV: full buffer ``[batch, heads, max_decode, d_kv]``.
     Output present KV: new token only ``[batch, heads, 1, d_kv]``.
@@ -477,7 +334,7 @@ class MarianDecoderIOConfig(OnnxConfig):  # type: ignore[misc]  # optimum base i
         EncoderDecoderInputGenerator,
         PastKeyValueInputGenerator,
     )
-    # PATCHING_SPECS = _build_marian_patching_specs()  # sliding only; no-op under static
+    PATCHING_SPECS = _build_marian_patching_specs()
 
     @property
     def inputs(self) -> dict[str, dict[int, str]]:  # noqa: D102
@@ -486,8 +343,7 @@ class MarianDecoderIOConfig(OnnxConfig):  # type: ignore[misc]  # optimum base i
             "encoder_hidden_states": {0: "batch_size"},
             "attention_mask": {0: "batch_size"},
             "decoder_attention_mask": {0: "batch_size"},
-            # "position_id": {},  # sliding-window cache input name
-            "cache_position": {},  # static-cache input name (== absolute seq pos)
+            "cache_position": {},
         }
         num_layers = self._normalized_config.num_layers
         for i in range(num_layers):
@@ -537,8 +393,8 @@ class WinMLMarianModel(WinMLEncoderDecoderModel):
 
     Declares Marian sub-component tasks and generation-config defaults.
     All encoder-decoder forward/cache logic lives in
-    ``WinMLEncoderDecoderModel``.  Uses ``WinMLSlidingWindowCache`` — see
-    module docstring for the rationale.
+    ``WinMLEncoderDecoderModel``. Uses ``WinMLStaticCache`` so inference cache
+    positions match the decoder's exported ``cache_position`` input.
     """
 
     _SUB_MODEL_CONFIG: ClassVar[dict[str, str]] = {
@@ -548,21 +404,8 @@ class WinMLMarianModel(WinMLEncoderDecoderModel):
 
     @classmethod
     def get_cache_class(cls) -> type:
-        """Marian defaults to ``WinMLSlidingWindowCache`` (Slice+Concat; no ScatterElements).
-
-        The sin/cos embedding is fed the absolute seq pos via the
-        ``position_id`` ONNX input (threaded through the patched
-        ``MarianSinusoidalPositionalEmbedding.forward``); the causal mask
-        consumes a baked ``cache_position = [max_cache_len - 1]`` Constant.
-        See the module docstring for the full reasoning.
-
-        ``WinMLStaticCache`` remains fully supported — subclass
-        ``WinMLMarianModel`` and override this method to get index_copy_
-        semantics.  A matching re-export of the decoder wrapper is
-        required if you switch.
-        """
-        # return WinMLSlidingWindowCache  # sliding-window cache (FIFO Slice+Concat)
-        return WinMLStaticCache  # static cache (index_put_ → ScatterND)
+        """Use the same static cache semantics as the exported decoder."""
+        return WinMLStaticCache
 
     @property
     def generation_config(self) -> GenerationConfig:  # noqa: D102

--- a/tests/unit/loader/test_autoconfig.py
+++ b/tests/unit/loader/test_autoconfig.py
@@ -30,6 +30,25 @@ class _FakeConfig:
         return ("specific", config_dict, kwargs)
 
 
+class _StrictFallbackConfig:
+    dilation: bool = False
+
+    @classmethod
+    def from_dict(cls, config_dict, **kwargs):
+        return ("normalized", config_dict, kwargs)
+
+
+class _StrictFallbackConfigWithUnused:
+    dilation: bool = False
+
+    @classmethod
+    def from_dict(cls, config_dict, **kwargs):
+        payload = ("normalized", config_dict, kwargs)
+        if kwargs.get("return_unused_kwargs"):
+            return payload, {"sentinel": kwargs.get("sentinel")}
+        return payload
+
+
 def test_local_path_uses_saved_model_identifier(tmp_path: Path) -> None:
     local_model_dir = tmp_path / "exports" / "run1"
     local_model_dir.mkdir(parents=True)
@@ -270,6 +289,93 @@ def test_concrete_or_trusted_remote_config_uses_auto_config(
         "owner/model",
         trust_remote_code=trust_remote_code,
     )
+
+
+def test_concrete_config_strict_none_bool_validation_uses_normalized_from_dict() -> None:
+    strict_error = type(
+        "StrictDataclassFieldValidationError",
+        (Exception,),
+        {},
+    )(
+        "Validation error for field 'dilation': "
+        "TypeError: Field 'dilation' expected bool, got NoneType (value: None)"
+    )
+    auto_config = MagicMock()
+    auto_config.from_pretrained.side_effect = strict_error
+    source_config_dict = {
+        "model_type": "table-transformer",
+        "dilation": None,
+        "hidden_size": 256,
+    }
+
+    with (
+        patch(
+            "transformers.PretrainedConfig.get_config_dict",
+            return_value=(source_config_dict, {"sentinel": "unused"}),
+        ),
+        patch(
+            "transformers.models.auto.configuration_auto.CONFIG_MAPPING",
+            {"table-transformer": _StrictFallbackConfig},
+        ),
+    ):
+        config = load_hf_config(auto_config, "owner/model")
+
+    assert config[0] == "normalized"
+    assert config[1]["dilation"] is False
+    assert source_config_dict["dilation"] is None
+    assert config[2] == {"sentinel": "unused"}
+
+
+def test_concrete_config_strict_none_bool_validation_preserves_return_unused_kwargs() -> None:
+    strict_error = type(
+        "StrictDataclassFieldValidationError",
+        (Exception,),
+        {},
+    )(
+        "Validation error for field 'dilation': "
+        "TypeError: Field 'dilation' expected bool, got NoneType (value: None)"
+    )
+    auto_config = MagicMock()
+    auto_config.from_pretrained.side_effect = strict_error
+
+    with (
+        patch(
+            "transformers.PretrainedConfig.get_config_dict",
+            return_value=(
+                {"model_type": "table-transformer", "dilation": None},
+                {"sentinel": "unused"},
+            ),
+        ),
+        patch(
+            "transformers.models.auto.configuration_auto.CONFIG_MAPPING",
+            {"table-transformer": _StrictFallbackConfigWithUnused},
+        ),
+    ):
+        config, unused_kwargs = load_hf_config(
+            auto_config,
+            "owner/model",
+            return_unused_kwargs=True,
+            sentinel="unused",
+        )
+
+    assert config[0] == "normalized"
+    assert config[1]["dilation"] is False
+    assert config[2]["return_unused_kwargs"] is True
+    assert unused_kwargs == {"sentinel": "unused"}
+
+
+def test_concrete_config_non_strict_error_is_raised() -> None:
+    auto_config = MagicMock()
+    auto_config.from_pretrained.side_effect = RuntimeError("boom")
+
+    with (
+        patch(
+            "transformers.PretrainedConfig.get_config_dict",
+            return_value=({"model_type": "table-transformer"}, {}),
+        ),
+        pytest.raises(RuntimeError, match="boom"),
+    ):
+        load_hf_config(auto_config, "owner/model")
 
 
 def test_generic_fallback_preserves_return_unused_kwargs_shape() -> None:

--- a/tests/unit/loader/test_autoconfig.py
+++ b/tests/unit/loader/test_autoconfig.py
@@ -35,7 +35,11 @@ class _StrictFallbackConfig:
 
     @classmethod
     def from_dict(cls, config_dict, **kwargs):
-        return ("normalized", config_dict, kwargs)
+        return {
+            "kind": "normalized",
+            "config_dict": config_dict,
+            "kwargs": kwargs,
+        }
 
 
 class _StrictFallbackConfigWithUnused:
@@ -43,7 +47,11 @@ class _StrictFallbackConfigWithUnused:
 
     @classmethod
     def from_dict(cls, config_dict, **kwargs):
-        payload = ("normalized", config_dict, kwargs)
+        payload = {
+            "kind": "normalized",
+            "config_dict": config_dict,
+            "kwargs": kwargs,
+        }
         if kwargs.get("return_unused_kwargs"):
             return payload, {"sentinel": kwargs.get("sentinel")}
         return payload
@@ -320,10 +328,10 @@ def test_concrete_config_strict_none_bool_validation_uses_normalized_from_dict()
     ):
         config = load_hf_config(auto_config, "owner/model")
 
-    assert config[0] == "normalized"
-    assert config[1]["dilation"] is False
+    assert config["kind"] == "normalized"
+    assert config["config_dict"]["dilation"] is False
     assert source_config_dict["dilation"] is None
-    assert config[2] == {"sentinel": "unused"}
+    assert config["kwargs"] == {"sentinel": "unused"}
 
 
 def test_concrete_config_strict_none_bool_validation_preserves_return_unused_kwargs() -> None:
@@ -358,9 +366,9 @@ def test_concrete_config_strict_none_bool_validation_preserves_return_unused_kwa
             sentinel="unused",
         )
 
-    assert config[0] == "normalized"
-    assert config[1]["dilation"] is False
-    assert config[2]["return_unused_kwargs"] is True
+    assert config["kind"] == "normalized"
+    assert config["config_dict"]["dilation"] is False
+    assert config["kwargs"]["return_unused_kwargs"] is True
     assert unused_kwargs == {"sentinel": "unused"}
 
 

--- a/tests/unit/models/marian/test_onnx_config.py
+++ b/tests/unit/models/marian/test_onnx_config.py
@@ -13,14 +13,20 @@ Tests for Marian IOConfig classes and the WinML composite model:
 
 from __future__ import annotations
 
+import inspect
+from typing import TYPE_CHECKING
+
+import onnx
 import pytest
+import torch
 from optimum.exporters.tasks import TasksManager
 from optimum.utils.input_generators import DummyTextInputGenerator
-from transformers import MarianConfig
+from transformers import MarianConfig, MarianMTModel
 
 # Import triggers registration
 from winml.modelkit.models.hf.marian import (
     MarianDecoderIOConfig,
+    MarianDecoderWrapper,
     MarianEncoderIOConfig,
     WinMLMarianModel,
     _MarianDecoderNormalizedConfig,
@@ -31,6 +37,10 @@ from winml.modelkit.models.winml.kv_cache import (
     PastKeyValueInputGenerator,
     WinMLStaticCache,
 )
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 # =============================================================================
@@ -63,7 +73,30 @@ def marian_config() -> MarianConfig:
         encoder_attention_heads=ENCODER_ATTENTION_HEADS,
         vocab_size=VOCAB_SIZE,
         max_position_embeddings=MAX_POSITION_EMBEDDINGS,
+        pad_token_id=0,
+        eos_token_id=1,
+        decoder_start_token_id=0,
     )
+
+
+@pytest.fixture()
+def marian_decoder_args() -> list[torch.Tensor]:
+    cache_shape = (1, DECODER_ATTENTION_HEADS, MAX_POSITION_EMBEDDINGS, HEAD_DIM)
+    args = [
+        torch.ones((1, 1), dtype=torch.int64),
+        torch.zeros((1, 4, D_MODEL), dtype=torch.float32),
+        torch.ones((1, 4), dtype=torch.int64),
+        torch.ones((1, MAX_POSITION_EMBEDDINGS), dtype=torch.int64),
+        torch.tensor([3], dtype=torch.int64),
+    ]
+    for _ in range(DECODER_LAYERS):
+        args.extend(
+            [
+                torch.zeros(cache_shape, dtype=torch.float32),
+                torch.zeros(cache_shape, dtype=torch.float32),
+            ]
+        )
+    return args
 
 
 # =============================================================================
@@ -149,6 +182,52 @@ class TestMarianEncoderIOConfig:
 class TestMarianDecoderIOConfig:
     """Tests for MarianDecoderIOConfig (decoder with KV cache, text2text-generation)."""
 
+    def test_wrapper_forward_captures_kv_with_transformers_cache_api(
+        self, marian_config, marian_decoder_args
+    ) -> None:
+        wrapper = MarianDecoderWrapper(MarianMTModel(marian_config), DECODER_LAYERS)
+
+        outputs = wrapper(*marian_decoder_args)
+
+        assert len(outputs) == 1 + DECODER_LAYERS * 2
+        assert outputs[0].shape == (1, 1, VOCAB_SIZE)
+        for present in outputs[1:]:
+            assert present.shape == (1, DECODER_ATTENTION_HEADS, 1, HEAD_DIM)
+
+    def test_transformers_5_export_uses_explicit_position_and_mask(
+        self,
+        marian_config,
+        marian_decoder_args,
+        tmp_path: Path,
+    ) -> None:
+        wrapper = MarianDecoderWrapper(MarianMTModel(marian_config), DECODER_LAYERS)
+        decoder = wrapper.model.get_decoder()
+        if "cache_position" in inspect.signature(decoder.forward).parameters:
+            pytest.skip("Transformers 4.x passes cache_position through MarianDecoder")
+
+        onnx_config = MarianDecoderIOConfig(marian_config, task="text2text-generation")
+        output_path = tmp_path / "marian_decoder.onnx"
+        with onnx_config.patch_model_for_export(wrapper):
+            torch.onnx.export(
+                wrapper,
+                tuple(marian_decoder_args),
+                output_path,
+                input_names=list(onnx_config.inputs),
+                output_names=list(onnx_config.outputs),
+                opset_version=17,
+                dynamo=False,
+            )
+
+        model = onnx.load(output_path, load_external_data=False)
+        position_gathers = [
+            node
+            for node in model.graph.node
+            if node.op_type == "Gather" and "embed_positions" in node.name
+        ]
+        assert len(position_gathers) == 1
+        assert position_gathers[0].input[1] == "cache_position"
+        assert all(node.op_type != "LessOrEqual" for node in model.graph.node)
+
     def test_registration(self):
         config_cls = TasksManager.get_exporter_config_constructor(
             model_type="marian",
@@ -166,6 +245,14 @@ class TestMarianDecoderIOConfig:
             EncoderDecoderInputGenerator,
             PastKeyValueInputGenerator,
         ) == MarianDecoderIOConfig.DUMMY_INPUT_GENERATOR_CLASSES
+
+    def test_patches_positional_embedding_for_transformers_5(self) -> None:
+        specs = MarianDecoderIOConfig.PATCHING_SPECS
+
+        assert any(
+            spec.name == "forward" and spec.o.__name__ == "MarianSinusoidalPositionalEmbedding"
+            for spec in specs
+        )
 
     def test_non_kv_inputs(self, marian_config) -> None:
         onnx_config = MarianDecoderIOConfig(marian_config, task="text2text-generation")


### PR DESCRIPTION
## Summary
- adapt Marian decoder export to the Transformers 5 cache API while retaining the Transformers 4 path
- use an explicit static cache position and additive decoder mask when Transformers no longer forwards `cache_position`
- add unit and ONNX graph coverage for KV capture, positional lookup, and causal-mask export

## Validation
- `uv run pytest tests/unit/models/marian/test_onnx_config.py -q` (21 passed)
- `uv run ruff check src/winml/modelkit/models/hf/marian.py tests/unit/models/marian/test_onnx_config.py`
- `uv run ruff format --check src/winml/modelkit/models/hf/marian.py tests/unit/models/marian/test_onnx_config.py`
- Transformers 5.14.1 environment smoke check: `FacebookAI/roberta-base` OpenVINO NPU perf and accuracy passed for fp16 and w8a16
