### PR TITLE
Eval: Add independent device and EP for ONNX references

### DIFF
--- a/docs/commands/eval.md
+++ b/docs/commands/eval.md
@@ -42,7 +42,9 @@ $ winml eval [options]
 | `--schema` | | flag | `false` | Print the expected dataset schema for the given `--task` and exit. Does not run evaluation. |
 | `--mode` | | `onnx\|compare` | `onnx` | Evaluation mode. `onnx` evaluates the ONNX candidate on a dataset. `compare` runs the ONNX candidate and a reference on identical random inputs and reports per-tensor similarity metrics — no dataset required. The reference is the HuggingFace model from `--model-id` by default, or a second ONNX file when `--reference` is given. |
 | `--input-data` | | `PATH` | — | Path to a `.npz` file of real input tensors to compare with instead of randomly generated ones (used with `--mode compare`). Keys must match the candidate model's input names. The **leading axis of each array is the sample axis**, so an archive shaped `(N, ...)` yields `N` samples (mean/std/min/max are computed across them); all inputs must share the same `N`. Each run is shaped to the candidate's batch size — a dynamic batch runs one row per sample, a static batch `B` chunks the axis into `N // B` batches (trailing rows are dropped with a warning). Note this differs from `winml perf --input-data`, which runs the **whole archive as a single batch**. |
-| `--reference` | | `TEXT` | — | Reference `.onnx` file to compare the candidate against (used with `--mode compare`). Compares two ONNX models on identical random inputs; `--model-id` and `--task` are not required in this mode. Both models run on the same `--device` / `--ep`. |
+| `--reference` | | `TEXT` | — | Reference `.onnx` file to compare the candidate against (used with `--mode compare`). Compares two ONNX models on identical random inputs; `--model-id` and `--task` are not required in this mode. |
+| `--reference-device` | | `cpu\|gpu\|npu\|auto` | `cpu` | Device used for the reference ONNX model. Only valid with `--reference`. |
+| `--reference-ep` | | `TEXT` | — | Explicit execution provider used for the reference ONNX model, for example `dml`. Only valid with `--reference`. |
 
 ## How it works
 
@@ -98,6 +100,12 @@ Compare two ONNX files directly (e.g. an fp32 baseline vs a quantized build), re
 
 ```bash
 $ winml eval --mode compare -m quantized.onnx --reference baseline.onnx
+```
+
+Compare a candidate running on DML with an ONNX reference running on CPU:
+
+```bash
+$ winml eval --mode compare -m candidate.onnx --device gpu --ep dml --reference baseline.onnx
 ```
 
 Check what dataset columns are expected before running, then remap them to match your dataset:
@@ -159,10 +167,10 @@ Evaluation reuses persistent model build artifacts by default. Pass
 a fresh build that replaces the persistent cache entry.
 
 For a pre-built ONNX input, cache controls apply only when
-`--no-skip-build` is set. Cache controls are ignored when no model build runs,
-including two-ONNX comparisons; the CLI warns when an explicit cache control
-has no effect. GenAI's runtime `_compiled/` artifacts are a separate cache and
-are not currently governed by these model build cache controls. Explicit build
+`--no-skip-build` is set. The CLI warns when an explicit cache control has no
+effect because no model build runs. GenAI's runtime `_compiled/` artifacts are
+a separate cache and are not currently governed by these model build cache
+controls. Explicit build
 or cache controls on a GenAI bundle produce a warning that distinguishes the
 model-build pipeline from the runtime compilation cache.
 

--- a/src/winml/modelkit/commands/eval.py
+++ b/src/winml/modelkit/commands/eval.py
@@ -17,6 +17,7 @@ import click
 from rich.console import Console
 
 from ..utils import cli as cli_utils
+from ..utils.constants import ALL_EP_NAMES, SUPPORTED_DEVICES
 from ..utils.eval_utils import EVAL_MODES, TASK_SCHEMAS, EvalMode, TaskSchema
 from ..utils.logging import configure_logging
 
@@ -220,6 +221,22 @@ logger = logging.getLogger(__name__)
         "--model-id / --task are not required in this mode."
     ),
 )
+@click.option(
+    "--reference-device",
+    type=click.Choice(
+        ["auto", *(device.lower() for device in SUPPORTED_DEVICES)],
+        case_sensitive=False,
+    ),
+    default="cpu",
+    show_default=True,
+    help="Device used to run the reference ONNX model.",
+)
+@click.option(
+    "--reference-ep",
+    type=click.Choice(ALL_EP_NAMES, case_sensitive=False),
+    default=None,
+    help="Execution provider used to run the reference ONNX model.",
+)
 @cli_utils.cache_options()
 @cli_utils.skip_build_option()
 @cli_utils.format_option()
@@ -265,6 +282,8 @@ def eval(
     mode: EvalMode,
     input_data: str | None,
     reference: str | None,
+    reference_device: str,
+    reference_ep: EPNameOrAlias | None,
     config_file: Path | None,
     use_cache: bool,
     rebuild: bool,
@@ -325,6 +344,17 @@ def eval(
 
     if cfg.reference_path is not None and cfg.mode != "compare":
         raise click.UsageError("--reference is only valid with --mode compare.")
+
+    reference_environment_requested = (
+        cli_utils.is_cli_provided(ctx, "reference_device")
+        or cli_utils.is_cli_provided(ctx, "reference_ep")
+        or "reference_device" in config_fields
+        or "reference_ep" in config_fields
+    )
+    if cfg.reference_path is None and reference_environment_requested:
+        raise click.UsageError(
+            "--reference-device and --reference-ep require --reference <onnx>."
+        )
 
     # ── 2. Resolve in place ──
     _resolve_model(cfg, model, model_id, allow_missing_model_id=cfg.reference_path is not None)
@@ -483,8 +513,6 @@ def _model_build_bypass(cfg: WinMLEvaluationConfig) -> _ModelBuildBypass | None:
                 "model build cache controls do not govern the GenAI runtime _compiled/ cache"
             ),
         )
-    if loader is _ModelLoaderKind.DIRECT_ONNX_COMPARE:
-        return _ModelBuildBypass("two-ONNX comparisons")
     if loader is _ModelLoaderKind.EVALUATOR_MANAGED:
         return _ModelBuildBypass("evaluator-managed composite inputs")
     if loader is _ModelLoaderKind.ONNX and cfg.skip_build:
@@ -851,7 +879,7 @@ def _resolve_model_path(
 
     When ``allow_missing_model_id`` is set (two-ONNX ``--mode compare``), a
     plain ``-m <file>.onnx`` is accepted without ``--model-id`` because the
-    candidate runs as a raw ORT session with no HF config resolution.
+    candidate uses the generic WinML model without HF config resolution.
     """
     if not model:
         if model_id is not None:
@@ -1013,6 +1041,9 @@ def display_eval_report(result: EvalResult, console: Console) -> None:
         console.print(f"[dim]ONNX:[/dim]       {cfg.model_path}")
     if cfg.reference_path:
         console.print(f"[dim]Reference:[/dim]  {cfg.reference_path}")
+        console.print(f"[dim]Reference device:[/dim] {cfg.reference_device}")
+        if cfg.reference_ep:
+            console.print(f"[dim]Reference EP:[/dim] {cfg.reference_ep}")
 
     # Metrics table
     console.print()

--- a/src/winml/modelkit/eval/config.py
+++ b/src/winml/modelkit/eval/config.py
@@ -118,8 +118,10 @@ class WinMLEvaluationConfig:
             same leading length.
         reference_path: Path to a second ``.onnx`` file used as the reference in
             ``--mode compare``. When set, both ``model_path`` and ``reference_path``
-            run as raw ORT sessions and their output tensors are compared directly,
-            so no ``model_id`` / ``task`` / HF reference is needed.
+            load as WinML model instances and their output tensors are compared
+            directly, so no ``model_id`` / ``task`` / HF reference is needed.
+        reference_device: Device used for a reference ONNX model. Defaults to CPU.
+        reference_ep: Explicit execution provider for a reference ONNX model.
         task: HF pipeline task. Auto-detected from model_id if omitted.
         device: Target device for inference.
         ep: Explicit execution provider (e.g., "qnn", "dml"). Overrides
@@ -158,6 +160,8 @@ class WinMLEvaluationConfig:
     model_path: str | dict[str, str] | None = None
     input_data: str | None = None
     reference_path: str | None = field(default=None, metadata={"cli_name": "reference"})
+    reference_device: str = "cpu"
+    reference_ep: EPNameOrAlias | None = None
     task: str | None = None
     device: str = "auto"
     precision: str = "auto"
@@ -212,6 +216,9 @@ class WinMLEvaluationConfig:
             result["input_data"] = self.input_data
         if self.reference_path is not None:
             result["reference_path"] = self.reference_path
+            result["reference_device"] = self.reference_device
+        if self.reference_ep is not None:
+            result["reference_ep"] = self.reference_ep
         if self.task is not None:
             result["task"] = self.task
         result["device"] = self.device
@@ -270,6 +277,8 @@ class WinMLEvaluationConfig:
             model_path=data.get("model_path"),
             input_data=data.get("input_data"),
             reference_path=data.get("reference_path"),
+            reference_device=data.get("reference_device", "cpu"),
+            reference_ep=data.get("reference_ep"),
             task=data.get("task"),
             device=data.get("device", "auto"),
             precision=data.get("precision", "auto"),

--- a/src/winml/modelkit/eval/evaluate.py
+++ b/src/winml/modelkit/eval/evaluate.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from ..models.winml.composite_model import WinMLCompositeModel
     from ..models.winml.genai_causal_lm import WinMLGenaiCausalLM
     from .base_evaluator import WinMLEvaluator
+    from .tensor_similarity_evaluator import TensorSimilarityEvaluator
 
 logger = logging.getLogger(__name__)
 
@@ -375,7 +376,8 @@ def _load_model(
         rebuild=config.rebuild,
     )
 
-    if config.model_id is None and loader is not _ModelLoaderKind.ONNX:
+    model_id = config.model_id
+    if model_id is None and loader is not _ModelLoaderKind.ONNX:
         raise ValueError("model_id is required.")
 
     if loader is _ModelLoaderKind.EVALUATOR_MANAGED:
@@ -402,10 +404,10 @@ def _load_model(
             hf_config = (
                 load_hf_config(
                     AutoConfig,
-                    config.model_id,
+                    model_id,
                     trust_remote_code=config.trust_remote_code,
                 )
-                if config.model_id is not None
+                if model_id is not None
                 else None
             )
             model = WinMLAutoModel.from_onnx(
@@ -423,6 +425,8 @@ def _load_model(
             model.config = hf_config
             return model
 
+        assert model_id is not None
+
         # HuggingFace build path — export overrides (--input-specs/
         # --export-config/--dynamic-axes) are merged under the build config's
         # ``export`` section as a sparse dict so from_pretrained routes them
@@ -438,7 +442,7 @@ def _load_model(
             build_override = override_dict
 
         return WinMLAutoModel.from_pretrained(
-            config.model_id,
+            model_id,
             ep_device,
             task=config.task,
             device=config.device,
@@ -753,8 +757,10 @@ def evaluate(
     cls = get_evaluator_class(config)
     try:
         console.print("[bold]Loading dataset and evaluating...[/bold]")
+        task_evaluator: WinMLEvaluator | TensorSimilarityEvaluator
         if config.mode == "compare":
-            task_evaluator = cls(config, model, reference_model)
+            compare_evaluator = cast("type[TensorSimilarityEvaluator]", cls)
+            task_evaluator = compare_evaluator(config, model, reference_model)
         else:
             task_evaluator = cls(config, model)
         metrics = task_evaluator.compute()

--- a/src/winml/modelkit/eval/evaluate.py
+++ b/src/winml/modelkit/eval/evaluate.py
@@ -36,7 +36,6 @@ logger = logging.getLogger(__name__)
 class _ModelLoaderKind(Enum):
     PYTORCH = auto()
     GENAI = auto()
-    DIRECT_ONNX_COMPARE = auto()
     EVALUATOR_MANAGED = auto()
     ONNX = auto()
     PRETRAINED = auto()
@@ -48,8 +47,6 @@ def _select_model_loader(config: WinMLEvaluationConfig) -> _ModelLoaderKind:
         return _ModelLoaderKind.PYTORCH
     if config.task == "text-generation":
         return _ModelLoaderKind.GENAI
-    if config.mode == "compare" and config.reference_path is not None:
-        return _ModelLoaderKind.DIRECT_ONNX_COMPARE
     if isinstance(config.model_path, dict) and config.task == "mask-generation":
         return _ModelLoaderKind.EVALUATOR_MANAGED
     if config.model_path is not None:
@@ -361,11 +358,6 @@ def _load_model(
     if loader is _ModelLoaderKind.GENAI:
         return _load_genai_causal_lm(config)
 
-    # Two-ONNX compare: the evaluator builds both raw ORT sessions directly from
-    # config.model_path / config.reference_path — no WinMLAutoModel / HF config.
-    if loader is _ModelLoaderKind.DIRECT_ONNX_COMPARE:
-        return None
-
     quant_override: Any = None
     if not config.quant:
         from ..config import WinMLBuildConfig
@@ -383,7 +375,7 @@ def _load_model(
         rebuild=config.rebuild,
     )
 
-    if config.model_id is None:
+    if config.model_id is None and loader is not _ModelLoaderKind.ONNX:
         raise ValueError("model_id is required.")
 
     if loader is _ModelLoaderKind.EVALUATOR_MANAGED:
@@ -407,10 +399,14 @@ def _load_model(
 
             from ..loader import load_hf_config
 
-            hf_config = load_hf_config(
-                AutoConfig,
-                config.model_id,
-                trust_remote_code=config.trust_remote_code,
+            hf_config = (
+                load_hf_config(
+                    AutoConfig,
+                    config.model_id,
+                    trust_remote_code=config.trust_remote_code,
+                )
+                if config.model_id is not None
+                else None
             )
             model = WinMLAutoModel.from_onnx(
                 # ``model_path`` is narrowed to ``str | dict[str, str]`` here;
@@ -472,6 +468,45 @@ def _load_model(
         config.ep = "cpu"
         config._auto_device_selected = False
         return _load_model(config)
+
+
+def _make_reference_config(config: WinMLEvaluationConfig) -> WinMLEvaluationConfig:
+    """Derive an ordinary model-loading config for the compare reference.
+
+    An explicit ``--reference`` is currently an ONNX path and uses its own
+    device and EP. Without ``--reference``, compare mode preserves the existing
+    behavior of loading the candidate's Hugging Face ``model_id`` as a PyTorch
+    reference on CPU. A separate reference Hugging Face ID is not supported.
+    """
+    if config.reference_path is not None:
+        # Explicit reference: load the resolved ONNX path as a WinML model.
+        return replace(
+            config,
+            model_id=None,
+            model_path=config.reference_path,
+            reference_path=None,
+            runtime="winml",
+            device=config.reference_device,
+            ep=config.reference_ep,
+            precision="auto",
+            mode="onnx",
+            skip_build=True,
+        )
+
+    if config.model_id is None:
+        raise ValueError("model_id is required to load the Hugging Face reference model.")
+
+    # Implicit reference: load the candidate's original HF model with PyTorch.
+    return replace(
+        config,
+        model_path=None,
+        reference_path=None,
+        runtime="pytorch",
+        device="cpu",
+        ep=None,
+        precision="auto",
+        mode="onnx",
+    )
 
 
 def _load_genai_causal_lm(config: WinMLEvaluationConfig) -> WinMLGenaiCausalLM:
@@ -654,8 +689,8 @@ def evaluate(
     mode = config.mode if config.mode is not None else "onnx"
     if mode not in EVAL_MODES:
         raise ValueError(f"Invalid mode {mode!r}; expected one of {EVAL_MODES} or None.")
-    # Two-ONNX compare: both candidate and reference run as raw ORT sessions, so
-    # HF task resolution / model_id are not required — keep task as-is.
+    # Two-ONNX compare does not require HF task resolution or model metadata.
+    # With no explicit task, WinMLAutoModel selects its generic raw-output model.
     onnx_compare = mode == "compare" and config.reference_path is not None
     config = replace(
         config,
@@ -707,12 +742,21 @@ def evaluate(
                 "to see supported role=path model options.",
             ) from error
 
+    reference_model = (
+        _load_model(_make_reference_config(config))
+        if config.mode == "compare"
+        else None
+    )
+
     from ..utils.eval_utils import DatasetValidationError
 
     cls = get_evaluator_class(config)
     try:
         console.print("[bold]Loading dataset and evaluating...[/bold]")
-        task_evaluator = cls(config, model)
+        if config.mode == "compare":
+            task_evaluator = cls(config, model, reference_model)
+        else:
+            task_evaluator = cls(config, model)
         metrics = task_evaluator.compute()
     except DatasetValidationError as error:
         raise ValueError(

--- a/src/winml/modelkit/eval/evaluate.py
+++ b/src/winml/modelkit/eval/evaluate.py
@@ -29,7 +29,6 @@ if TYPE_CHECKING:
     from ..models.winml.composite_model import WinMLCompositeModel
     from ..models.winml.genai_causal_lm import WinMLGenaiCausalLM
     from .base_evaluator import WinMLEvaluator
-    from .tensor_similarity_evaluator import TensorSimilarityEvaluator
 
 logger = logging.getLogger(__name__)
 
@@ -311,7 +310,7 @@ class EvalResult:
         return result
 
 
-def _load_model(
+def load_model(
     config: WinMLEvaluationConfig,
     pytorch_model: nn.Module | None = None,
     *,
@@ -474,46 +473,7 @@ def _load_model(
         config.device = "cpu"
         config.ep = "cpu"
         config._auto_device_selected = False
-        return _load_model(config, torch_dtype=torch_dtype)
-
-
-def _make_reference_config(config: WinMLEvaluationConfig) -> WinMLEvaluationConfig:
-    """Derive an ordinary model-loading config for the compare reference.
-
-    An explicit ``--reference`` is currently an ONNX path and uses its own
-    device and EP. Without ``--reference``, compare mode preserves the existing
-    behavior of loading the candidate's Hugging Face ``model_id`` as a PyTorch
-    reference on CPU. A separate reference Hugging Face ID is not supported.
-    """
-    if config.reference_path is not None:
-        # Explicit reference: load the resolved ONNX path as a WinML model.
-        return replace(
-            config,
-            model_id=None,
-            model_path=config.reference_path,
-            reference_path=None,
-            runtime="winml",
-            device=config.reference_device,
-            ep=config.reference_ep,
-            precision="auto",
-            mode="onnx",
-            skip_build=True,
-        )
-
-    if config.model_id is None:
-        raise ValueError("model_id is required to load the Hugging Face reference model.")
-
-    # Implicit reference: load the candidate's original HF model with PyTorch.
-    return replace(
-        config,
-        model_path=None,
-        reference_path=None,
-        runtime="pytorch",
-        device="cpu",
-        ep=None,
-        precision="auto",
-        mode="onnx",
-    )
+        return load_model(config, torch_dtype=torch_dtype)
 
 
 def _load_genai_causal_lm(config: WinMLEvaluationConfig) -> WinMLGenaiCausalLM:
@@ -702,7 +662,7 @@ def evaluate(
     config = replace(
         config,
         mode=mode,
-        task=(config.task if onnx_compare else _resolve_task(config, pytorch_model)),
+        task=(None if onnx_compare else _resolve_task(config, pytorch_model)),
         dataset=deepcopy(config.dataset),
     )
     _validate_pytorch_runtime_config(config)
@@ -736,11 +696,11 @@ def evaluate(
     model: Any
     if pytorch_model is not None:
         console.print("\n[bold]Using supplied PyTorch model...[/bold]")
-        model = _load_model(config, pytorch_model)
+        model = load_model(config, pytorch_model)
     else:
         console.print("\n[bold]Loading model...[/bold]")
         try:
-            model = _load_model(config)
+            model = load_model(config)
         except Exception as error:
             raise ValueError(
                 f"Failed to load model '{config.model_id}'. "
@@ -749,28 +709,12 @@ def evaluate(
                 "to see supported role=path model options.",
             ) from error
 
-    import torch
-
-    reference_model = (
-        _load_model(
-            _make_reference_config(config),
-            torch_dtype=torch.float32,
-        )
-        if config.mode == "compare"
-        else None
-    )
-
     from ..utils.eval_utils import DatasetValidationError
 
     cls = get_evaluator_class(config)
     try:
         console.print("[bold]Loading dataset and evaluating...[/bold]")
-        task_evaluator: WinMLEvaluator | TensorSimilarityEvaluator
-        if config.mode == "compare":
-            compare_evaluator = cast("type[TensorSimilarityEvaluator]", cls)
-            task_evaluator = compare_evaluator(config, model, reference_model)
-        else:
-            task_evaluator = cls(config, model)
+        task_evaluator = cls(config, model)
         metrics = task_evaluator.compute()
     except DatasetValidationError as error:
         raise ValueError(

--- a/src/winml/modelkit/eval/evaluate.py
+++ b/src/winml/modelkit/eval/evaluate.py
@@ -314,6 +314,8 @@ class EvalResult:
 def _load_model(
     config: WinMLEvaluationConfig,
     pytorch_model: nn.Module | None = None,
+    *,
+    torch_dtype: Any = "auto",
 ) -> (
     nn.Module | HFCausalLM | WinMLPreTrainedModel | WinMLCompositeModel | WinMLGenaiCausalLM | None
 ):
@@ -352,6 +354,7 @@ def _load_model(
             task=config.task,
             device=config.device,
             trust_remote_code=config.trust_remote_code,
+            torch_dtype=torch_dtype,
         )
         config.device = loaded.device.name
         return loaded.model
@@ -471,7 +474,7 @@ def _load_model(
         config.device = "cpu"
         config.ep = "cpu"
         config._auto_device_selected = False
-        return _load_model(config)
+        return _load_model(config, torch_dtype=torch_dtype)
 
 
 def _make_reference_config(config: WinMLEvaluationConfig) -> WinMLEvaluationConfig:
@@ -746,8 +749,13 @@ def evaluate(
                 "to see supported role=path model options.",
             ) from error
 
+    import torch
+
     reference_model = (
-        _load_model(_make_reference_config(config))
+        _load_model(
+            _make_reference_config(config),
+            torch_dtype=torch.float32,
+        )
         if config.mode == "compare"
         else None
     )

--- a/src/winml/modelkit/eval/tensor_similarity_evaluator.py
+++ b/src/winml/modelkit/eval/tensor_similarity_evaluator.py
@@ -10,9 +10,8 @@ drawn from :class:`RandomDataset` over the candidate's model I/O metadata)
 and reports per-output tensor-parity metrics (SQNR, PSNR, cosine, MSE,
 max absolute diff) via :class:`TensorSimilarityMetric`.
 
-The evaluator receives already-loaded candidate and reference model instances.
-The reference is an HF PyTorch model by default or a WinML model when
-``config.reference_path`` is set.
+The evaluator receives the candidate model and loads an HF PyTorch reference
+by default or a WinML reference when ``config.reference_path`` is set.
 
 When ``config.input_data`` is set, both sides run on real tensors from a
 ``.npz`` archive instead of random inputs.
@@ -24,6 +23,7 @@ reflects the build pipeline (optimize / quantize / compile) only.
 from __future__ import annotations
 
 import logging
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
 
@@ -36,6 +36,37 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _make_reference_config(config: WinMLEvaluationConfig) -> WinMLEvaluationConfig:
+    """Derive an ordinary model-loading config for the compare reference."""
+    if config.reference_path is not None:
+        return replace(
+            config,
+            model_id=None,
+            model_path=config.reference_path,
+            reference_path=None,
+            runtime="winml",
+            device=config.reference_device,
+            ep=config.reference_ep,
+            precision="auto",
+            mode="onnx",
+            skip_build=True,
+        )
+
+    if config.model_id is None:
+        raise ValueError("model_id is required to load the Hugging Face reference model.")
+
+    return replace(
+        config,
+        model_path=None,
+        reference_path=None,
+        runtime="pytorch",
+        device="cpu",
+        ep=None,
+        precision="auto",
+        mode="onnx",
+    )
+
+
 class TensorSimilarityEvaluator:
     """Per-output tensor parity between a candidate and a reference model."""
 
@@ -43,7 +74,6 @@ class TensorSimilarityEvaluator:
         self,
         config: WinMLEvaluationConfig,
         model: WinMLPreTrainedModel | WinMLCompositeModel,
-        reference_model: Any,
     ) -> None:
         from ..models.winml.composite_model import WinMLCompositeModel
 
@@ -60,8 +90,15 @@ class TensorSimilarityEvaluator:
                 "Example: winml eval --mode compare --task <sub_task> "
                 f"--model <sub_onnx_path> --model-id {config.model_id}"
             )
+        import torch
+
+        from .evaluate import load_model
+
         self.model = model
-        self.reference_model = reference_model
+        self.reference_model = load_model(
+            _make_reference_config(config),
+            torch_dtype=torch.float32,
+        )
         self.data = self.prepare_data()
 
     def prepare_data(self) -> Any:

--- a/src/winml/modelkit/eval/tensor_similarity_evaluator.py
+++ b/src/winml/modelkit/eval/tensor_similarity_evaluator.py
@@ -5,14 +5,14 @@
 
 """Tensor-similarity evaluator.
 
-Runs an ONNX candidate and a reference on identical inputs (random by
-default, drawn from :class:`RandomDataset` over the candidate's ONNX I/O)
+Runs a candidate and a reference on identical inputs (random by default,
+drawn from :class:`RandomDataset` over the candidate's model I/O metadata)
 and reports per-output tensor-parity metrics (SQNR, PSNR, cosine, MSE,
 max absolute diff) via :class:`TensorSimilarityMetric`.
 
-The reference is an HF PyTorch model resolved from ``model_id`` by default.
-When ``config.reference_path`` is set, the reference is instead a second
-ONNX file and both sides run as raw ORT sessions (no HF config / task).
+The evaluator receives already-loaded candidate and reference model instances.
+The reference is an HF PyTorch model by default or a WinML model when
+``config.reference_path`` is set.
 
 When ``config.input_data`` is set, both sides run on real tensors from a
 ``.npz`` archive instead of random inputs.
@@ -36,67 +36,18 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class _ONNXSessionModel:
-    """Minimal raw-ORT wrapper for two-ONNX ``--mode compare``.
-
-    Exposes just the slice of the :class:`WinMLPreTrainedModel` surface that
-    the tensor-similarity loop needs — ``onnx_path``, ``io_config`` and a
-    callable returning named ``torch`` tensors — without any HF config or
-    task-specific output renaming, so both sides compare on their raw ONNX
-    output names.
-    """
-
-    def __init__(self, onnx_path: str, device: str = "auto", ep: Any | None = None) -> None:
-        from pathlib import Path
-
-        from ..session.session import WinMLSession
-
-        self.onnx_path = Path(onnx_path)
-        self._session = WinMLSession(onnx_path=self.onnx_path, device=device, ep=ep)
-
-    @property
-    def io_config(self) -> dict:
-        """ONNX I/O metadata (delegated to the session)."""
-        return self._session.io_config
-
-    def __call__(self, **inputs: Any) -> dict[str, Any]:
-        """Run one sample and return raw outputs as named ``torch`` tensors."""
-        import torch
-
-        # ``inputs`` may be torch tensors (fed by _inference_model); WinMLSession.run
-        # -> _prepare_inputs converts them to numpy and enforces the graph dtype, so
-        # no explicit .numpy() conversion is needed here.
-        outputs = self._session.run(inputs)
-        return {name: torch.from_numpy(arr) for name, arr in outputs.items()}
-
-
 class TensorSimilarityEvaluator:
-    """Per-output tensor parity between an ONNX candidate and an HF reference."""
-
-    # Either an HF-backed model (default path) or a raw-ORT wrapper (two-ONNX
-    # compare); annotated here so both __init__ branches type-check.
-    model: WinMLPreTrainedModel | _ONNXSessionModel
+    """Per-output tensor parity between a candidate and a reference model."""
 
     def __init__(
         self,
         config: WinMLEvaluationConfig,
         model: WinMLPreTrainedModel | WinMLCompositeModel,
+        reference_model: Any,
     ) -> None:
         from ..models.winml.composite_model import WinMLCompositeModel
 
         self.config = config
-
-        # Two-ONNX compare: build both raw ORT sessions directly, bypassing the
-        # HF PyTorch reference. ``model`` is None here (see evaluate._load_model).
-        if config.reference_path is not None:
-            self.model = _ONNXSessionModel(
-                str(config.model_path), device=config.device, ep=config.ep
-            )
-            self.reference_model = _ONNXSessionModel(
-                str(config.reference_path), device=config.device, ep=config.ep
-            )
-            self.data = self.prepare_data()
-            return
 
         # Composite models must be split into their sub-components before
         # tensor-similarity comparison — the union param keeps this runtime
@@ -110,35 +61,11 @@ class TensorSimilarityEvaluator:
                 f"--model <sub_onnx_path> --model-id {config.model_id}"
             )
         self.model = model
-        self.reference_model = self._load_reference_model()
+        self.reference_model = reference_model
         self.data = self.prepare_data()
 
-    def _load_reference_model(self) -> Any:
-        """Load the HF PyTorch reference model on CPU/fp32 in eval mode.
-
-        Resolves the appropriate ``AutoModelFor*`` class via
-        :func:`resolve_task` so no task-specific mapping is
-        needed here.
-        """
-        import torch
-        from transformers import AutoConfig
-
-        from ..loader import load_hf_config
-        from ..loader.resolution import resolve_task
-
-        if self.config.model_id is None:
-            raise ValueError("model_id is required to load the HF reference model.")
-
-        hf_config = load_hf_config(AutoConfig, self.config.model_id)
-        cls = resolve_task(hf_config, task=self.config.task).model_class
-        logger.info("Loading HF reference %s on CPU/fp32", cls.__name__)
-        # cls is a HF model class which exposes from_pretrained; not in `type`.
-        return cls.from_pretrained(  # type: ignore[attr-defined]
-            self.config.model_id, dtype=torch.float32
-        ).eval()
-
     def prepare_data(self) -> Any:
-        """Build the compare dataset over the candidate ONNX's I/O spec.
+        """Build the compare dataset over the candidate model's I/O spec.
 
         Uses real tensors from ``config.input_data`` (wrapped as a multi-sample
         :class:`InputDataDataset` whose leading axis is the sample axis and
@@ -179,8 +106,7 @@ class TensorSimilarityEvaluator:
         common_keys: list[str] | None = None
         ort_keys: set[str] = set()
         hf_keys: set[str] = set()
-        # Both sides are raw ONNX in the two-ONNX path; only the default path
-        # has an HF PyTorch reference. Label diagnostics accordingly.
+        # Only the default path has an HF PyTorch reference.
         reference_label = "reference ONNX" if self.config.reference_path else "HF reference"
 
         with torch.no_grad():

--- a/src/winml/modelkit/loader/native.py
+++ b/src/winml/modelkit/loader/native.py
@@ -59,6 +59,7 @@ def load_native_hf_model(
     task: str | None = None,
     device: str = "auto",
     trust_remote_code: bool = False,
+    torch_dtype: Any = "auto",
 ) -> NativeHFModel:
     """Load the task-resolved Hugging Face model without ONNX export."""
     resolved_device = resolve_native_device(device)
@@ -69,7 +70,7 @@ def load_native_hf_model(
             model_id,
             resolved_device.torch_device,
             trust_remote_code=trust_remote_code,
-            torch_dtype="auto",
+            torch_dtype=torch_dtype,
         )
         return NativeHFModel(model=causal_model, device=resolved_device)
 
@@ -79,7 +80,7 @@ def load_native_hf_model(
         model_id,
         task=task,
         trust_remote_code=trust_remote_code,
-        torch_dtype="auto",
+        torch_dtype=torch_dtype,
     )
     model = model.to(resolved_device.torch_device).eval()
     return NativeHFModel(

--- a/tests/unit/commands/test_eval.py
+++ b/tests/unit/commands/test_eval.py
@@ -1011,7 +1011,7 @@ class TestPerTaskDefaultDataset:
     @staticmethod
     def _run_and_capture(runner: CliRunner, args: list[str]):
         """Invoke the eval CLI, letting ``evaluate()`` run end-to-end with
-        ``_load_model`` and the evaluator class stubbed. Returns the cfg
+        ``load_model`` and the evaluator class stubbed. Returns the cfg
         observed by the evaluator (i.e. after default-injection)."""
         import importlib
 
@@ -1029,7 +1029,7 @@ class TestPerTaskDefaultDataset:
                 return {"accuracy": 1.0}
 
         with (
-            patch.object(evaluate_mod, "_load_model", return_value=object()),
+            patch.object(evaluate_mod, "load_model", return_value=object()),
             patch.object(
                 evaluate_mod,
                 "get_evaluator_class",
@@ -1830,11 +1830,11 @@ class TestEvalExportOverrides:
         assert cfg.export_overrides is None
 
     def test_load_model_hf_threads_export_overrides(self):
-        """_load_model forwards export overrides as a sparse {"export": ...} dict."""
+        """load_model forwards export overrides as a sparse {"export": ...} dict."""
         from unittest.mock import MagicMock
 
         from winml.modelkit.eval.config import WinMLEvaluationConfig
-        from winml.modelkit.eval.evaluate import _load_model
+        from winml.modelkit.eval.evaluate import load_model
 
         cfg = WinMLEvaluationConfig(
             model_id="microsoft/resnet-50",
@@ -1847,7 +1847,7 @@ class TestEvalExportOverrides:
             "winml.modelkit.models.auto.WinMLAutoModel.from_pretrained",
             return_value=MagicMock(),
         ) as mock_fp:
-            _load_model(cfg)
+            load_model(cfg)
 
         kwargs = mock_fp.call_args.kwargs
         assert kwargs["config"] == {"export": {"dynamic_axes": {"pixel_values": {"0": "batch"}}}}
@@ -1858,7 +1858,7 @@ class TestEvalExportOverrides:
         from unittest.mock import MagicMock
 
         from winml.modelkit.eval.config import WinMLEvaluationConfig
-        from winml.modelkit.eval.evaluate import _load_model
+        from winml.modelkit.eval.evaluate import load_model
 
         cfg = WinMLEvaluationConfig(
             model_id="microsoft/resnet-50",
@@ -1871,7 +1871,7 @@ class TestEvalExportOverrides:
             "winml.modelkit.models.auto.WinMLAutoModel.from_pretrained",
             return_value=MagicMock(),
         ) as mock_fp:
-            _load_model(cfg)
+            load_model(cfg)
 
         assert mock_fp.call_args.kwargs["config"] == {
             "export": {"opset_version": 18},
@@ -1883,7 +1883,7 @@ class TestEvalExportOverrides:
         from unittest.mock import MagicMock
 
         from winml.modelkit.eval.config import WinMLEvaluationConfig
-        from winml.modelkit.eval.evaluate import _load_model
+        from winml.modelkit.eval.evaluate import load_model
 
         cfg = WinMLEvaluationConfig(
             model_id="microsoft/resnet-50",
@@ -1894,7 +1894,7 @@ class TestEvalExportOverrides:
             "winml.modelkit.models.auto.WinMLAutoModel.from_pretrained",
             return_value=MagicMock(),
         ) as mock_fp:
-            _load_model(cfg)
+            load_model(cfg)
 
         assert mock_fp.call_args.kwargs["config"] is None
         assert mock_fp.call_args.kwargs["shape_config"] is None

--- a/tests/unit/commands/test_eval.py
+++ b/tests/unit/commands/test_eval.py
@@ -445,6 +445,8 @@ class TestEvalHelp:
 
         assert result.exit_code == 0, result.output
         assert "--reference" in result.output
+        assert "--reference-device" in result.output
+        assert "--reference-ep" in result.output
 
     def test_help_mentions_cache_controls(self, runner: CliRunner):
         from winml.modelkit.commands.eval import eval as eval_cmd
@@ -522,6 +524,37 @@ class TestReferenceModeGuard:
         )
         assert result.exit_code != 0
         assert "--reference is only valid with --mode compare" in result.output
+
+    @pytest.mark.parametrize(
+        ("option", "value"),
+        [("--reference-device", "gpu"), ("--reference-ep", "dml")],
+    )
+    def test_reference_environment_requires_reference(
+        self,
+        runner: CliRunner,
+        onnx_file,
+        option,
+        value,
+    ):
+        from winml.modelkit.commands.eval import eval as eval_cmd
+
+        result = runner.invoke(
+            eval_cmd,
+            [
+                "--mode",
+                "compare",
+                "-m",
+                str(onnx_file),
+                "--model-id",
+                "some/model",
+                option,
+                value,
+            ],
+            obj={"debug": False},
+        )
+
+        assert result.exit_code != 0
+        assert "require --reference <onnx>" in result.output
 
 
 class TestInputDataModeGuard:
@@ -1361,7 +1394,7 @@ class TestIgnoredCacheFlags:
         assert any("rebuild=true from --config" in message for message in messages)
         assert not any("--no-use-cache ignored" in message for message in messages)
 
-    def test_two_onnx_comparison_warns_even_with_build_enabled(
+    def test_two_onnx_comparison_honors_build_enabled(
         self,
         runner: CliRunner,
         onnx_file,
@@ -1386,12 +1419,8 @@ class TestIgnoredCacheFlags:
             )
 
         assert result.exit_code == 0, result.output
-        assert any(
-            "--rebuild ignored for two-ONNX comparisons" in record.getMessage()
-            for record in caplog.records
-        )
-        assert any(
-            "--no-optimize ignored for two-ONNX comparisons" in record.getMessage()
+        assert not any(
+            "ignored for two-ONNX comparisons" in record.getMessage()
             for record in caplog.records
         )
 

--- a/tests/unit/commands/test_eval_pytorch.py
+++ b/tests/unit/commands/test_eval_pytorch.py
@@ -343,7 +343,7 @@ class TestNativeEvaluation:
                 return_value=FakeEvaluator,
             ),
             patch(
-                "winml.modelkit.eval.evaluate._load_model",
+                "winml.modelkit.eval.evaluate.load_model",
                 return_value=model,
             ) as load_model,
         ):
@@ -475,7 +475,7 @@ class TestNativeEvaluation:
             evaluate(config)
 
     def test_load_model_uses_shared_native_loader(self) -> None:
-        from winml.modelkit.eval.evaluate import _load_model
+        from winml.modelkit.eval.evaluate import load_model
 
         model = MagicMock()
         loaded = NativeHFModel(
@@ -494,7 +494,7 @@ class TestNativeEvaluation:
             "winml.modelkit.loader.load_native_hf_model",
             return_value=loaded,
         ) as load:
-            assert _load_model(config) is model
+            assert load_model(config) is model
 
         load.assert_called_once_with(
             "fake/model",

--- a/tests/unit/commands/test_eval_pytorch.py
+++ b/tests/unit/commands/test_eval_pytorch.py
@@ -501,6 +501,7 @@ class TestNativeEvaluation:
             task="image-classification",
             device="gpu",
             trust_remote_code=True,
+            torch_dtype="auto",
         )
         assert config.device == "gpu"
 

--- a/tests/unit/eval/test_eval.py
+++ b/tests/unit/eval/test_eval.py
@@ -145,11 +145,30 @@ class TestEvaluationConfig:
         config = WinMLEvaluationConfig(
             model_path="cand.onnx",
             reference_path="ref.onnx",
+            reference_device="gpu",
+            reference_ep="dml",
             mode="compare",
         )
-        restored = WinMLEvaluationConfig.from_dict(config.to_dict())
+        serialized = config.to_dict()
+        restored = WinMLEvaluationConfig.from_dict(serialized)
         assert restored.reference_path == "ref.onnx"
+        assert serialized["reference_device"] == "gpu"
+        assert serialized["reference_ep"] == "dml"
+        assert restored.reference_device == "gpu"
+        assert restored.reference_ep == "dml"
         assert restored.mode == "compare"
+
+    def test_reference_environment_defaults_to_cpu(self):
+        config = WinMLEvaluationConfig(
+            model_path="cand.onnx",
+            reference_path="ref.onnx",
+            mode="compare",
+        )
+
+        assert config.reference_device == "cpu"
+        assert config.reference_ep is None
+        assert config.to_dict()["reference_device"] == "cpu"
+        assert "reference_ep" not in config.to_dict()
 
     def test_eval_result_to_dict(self):
         config = WinMLEvaluationConfig(
@@ -379,32 +398,34 @@ class TestEvaluate:
 
         evaluator = MagicMock()
         evaluator.compute.return_value = {"cosine_mean": {"logits": 1.0}}
+        candidate = MagicMock()
+        reference = MagicMock()
+        evaluator_factory = MagicMock(return_value=evaluator)
         with (
             patch.object(
                 eval_mod,
                 "_resolve_task",
                 side_effect=AssertionError("task resolution must be skipped"),
             ),
-            patch.object(eval_mod, "_load_model", return_value=None) as load_model,
-            patch.object(eval_mod, "get_evaluator_class", return_value=lambda *_a, **_k: evaluator),
+            patch.object(
+                eval_mod,
+                "_load_model",
+                side_effect=[candidate, reference],
+            ) as load_model,
+            patch.object(eval_mod, "get_evaluator_class", return_value=evaluator_factory),
         ):
             result = eval_mod.evaluate(config)
 
         assert result.config.mode == "compare"
         assert result.config.task is None
         assert result.metrics == {"cosine_mean": {"logits": 1.0}}
-        load_model.assert_called_once()
-
-    def test_load_model_returns_none_for_onnx_compare(self):
-        """_load_model short-circuits (no model_id needed) for two-ONNX compare."""
-        from winml.modelkit.eval.evaluate import _load_model
-
-        config = WinMLEvaluationConfig(
-            model_path="cand.onnx",
-            reference_path="ref.onnx",
-            mode="compare",
-        )
-        assert _load_model(config) is None
+        assert load_model.call_count == 2
+        reference_config = load_model.call_args_list[1].args[0]
+        assert reference_config.model_path == "ref.onnx"
+        assert reference_config.reference_path is None
+        assert reference_config.device == "cpu"
+        assert reference_config.skip_build is True
+        evaluator_factory.assert_called_once_with(result.config, candidate, reference)
 
     def test_no_dataset_no_default_raises(self):
         """Tasks without a default dataset raise ValueError."""
@@ -1553,6 +1574,78 @@ class TestLoadModel:
         assert call_args.kwargs["use_cache"] is True
         assert call_args.kwargs["force_rebuild"] is False
         assert result is mock_model
+
+    def test_load_onnx_without_model_id_returns_generic_winml_model(self):
+        import importlib
+        import sys
+
+        eval_mod = sys.modules.get(
+            "winml.modelkit.eval.evaluate",
+        ) or importlib.import_module("winml.modelkit.eval.evaluate")
+
+        mock_model = MagicMock()
+        mock_auto = MagicMock()
+        mock_auto.from_onnx.return_value = mock_model
+        config = WinMLEvaluationConfig(
+            model_path="candidate.onnx",
+            reference_path="reference.onnx",
+            mode="compare",
+            device="cpu",
+        )
+
+        with patch.dict(
+            "sys.modules",
+            {"winml.modelkit.models": MagicMock(WinMLAutoModel=mock_auto)},
+        ):
+            result = eval_mod._load_model(config)
+
+        assert result is mock_model
+        mock_auto.from_onnx.assert_called_once()
+        assert mock_auto.from_onnx.call_args.kwargs["hf_config"] is None
+        assert mock_auto.from_onnx.call_args.kwargs["task"] is None
+        assert mock_auto.from_onnx.call_args.kwargs["skip_build"] is True
+
+    def test_make_onnx_reference_config_uses_independent_environment(self):
+        from winml.modelkit.eval.evaluate import _make_reference_config
+
+        config = WinMLEvaluationConfig(
+            model_path="candidate.onnx",
+            reference_path="reference.onnx",
+            reference_device="gpu",
+            reference_ep="dml",
+            mode="compare",
+        )
+
+        reference = _make_reference_config(config)
+
+        assert reference.model_path == "reference.onnx"
+        assert reference.model_id is None
+        assert reference.reference_path is None
+        assert reference.runtime == "winml"
+        assert reference.device == "gpu"
+        assert reference.ep == "dml"
+        assert reference.mode == "onnx"
+        assert reference.skip_build is True
+
+    def test_make_default_hf_reference_config_uses_native_defaults(self):
+        from winml.modelkit.eval.evaluate import _make_reference_config
+
+        config = WinMLEvaluationConfig(
+            model_id="test/model",
+            task="image-classification",
+            mode="compare",
+        )
+
+        reference = _make_reference_config(config)
+
+        assert reference.model_id == "test/model"
+        assert reference.model_path is None
+        assert reference.reference_path is None
+        assert reference.runtime == "pytorch"
+        assert reference.device == "cpu"
+        assert reference.ep is None
+        assert reference.precision == "auto"
+        assert reference.mode == "onnx"
 
     def test_auto_target_retries_cpu_after_ort_runtime_failure(self, caplog):
         """An unusable auto-selected accelerator retries with the CPU EP."""

--- a/tests/unit/eval/test_eval.py
+++ b/tests/unit/eval/test_eval.py
@@ -375,14 +375,14 @@ class TestEvaluate:
         evaluator = MagicMock()
         evaluator.compute.return_value = {"accuracy": 1.0}
         with (
-            patch.object(eval_mod, "_load_model", return_value=MagicMock()),
+            patch.object(eval_mod, "load_model", return_value=MagicMock()),
             patch.object(eval_mod, "get_evaluator_class", return_value=lambda *_a, **_k: evaluator),
         ):
             result = eval_mod.evaluate(config)
         assert result.config.mode == "onnx"
 
-    def test_onnx_compare_skips_task_resolution_and_dataset(self):
-        """Two-ONNX compare skips HF task resolution and default-dataset lookup."""
+    def test_onnx_compare_ignores_explicit_task_and_skips_resolution(self):
+        """Two-ONNX compare preserves all raw outputs by clearing the task."""
         import importlib
         import sys
 
@@ -394,12 +394,12 @@ class TestEvaluate:
             model_path="cand.onnx",
             reference_path="ref.onnx",
             mode="compare",
+            task="image-classification",
         )
 
         evaluator = MagicMock()
         evaluator.compute.return_value = {"cosine_mean": {"logits": 1.0}}
         candidate = MagicMock()
-        reference = MagicMock()
         evaluator_factory = MagicMock(return_value=evaluator)
         with (
             patch.object(
@@ -409,8 +409,8 @@ class TestEvaluate:
             ),
             patch.object(
                 eval_mod,
-                "_load_model",
-                side_effect=[candidate, reference],
+                "load_model",
+                return_value=candidate,
             ) as load_model,
             patch.object(eval_mod, "get_evaluator_class", return_value=evaluator_factory),
         ):
@@ -419,13 +419,8 @@ class TestEvaluate:
         assert result.config.mode == "compare"
         assert result.config.task is None
         assert result.metrics == {"cosine_mean": {"logits": 1.0}}
-        assert load_model.call_count == 2
-        reference_config = load_model.call_args_list[1].args[0]
-        assert reference_config.model_path == "ref.onnx"
-        assert reference_config.reference_path is None
-        assert reference_config.device == "cpu"
-        assert reference_config.skip_build is True
-        evaluator_factory.assert_called_once_with(result.config, candidate, reference)
+        load_model.assert_called_once_with(result.config)
+        evaluator_factory.assert_called_once_with(result.config, candidate)
 
     def test_no_dataset_no_default_raises(self):
         """Tasks without a default dataset raise ValueError."""
@@ -448,7 +443,7 @@ class TestEvaluate:
         )
 
         with (
-            patch.object(eval_mod, "_load_model", return_value=MagicMock()),
+            patch.object(eval_mod, "load_model", return_value=MagicMock()),
             pytest.raises(ValueError, match="No dataset provided"),
         ):
             eval_mod.evaluate(config)
@@ -475,7 +470,7 @@ class TestEvaluate:
 
         with (
             patch.object(eval_mod, "_resolve_task", return_value="text-classification"),
-            patch.object(eval_mod, "_load_model", return_value=MagicMock()),
+            patch.object(eval_mod, "load_model", return_value=MagicMock()),
             # _EVALUATOR_REGISTRY now stores "module:Class" strings; patch the
             # public resolver instead of injecting a callable into the dict.
             patch.object(
@@ -513,7 +508,7 @@ class TestEvaluate:
 
         with (
             patch.object(eval_mod, "print_config", side_effect=fake_print_config),
-            patch.object(eval_mod, "_load_model", side_effect=fake_load_model),
+            patch.object(eval_mod, "load_model", side_effect=fake_load_model),
             pytest.raises(ValueError) as exc_info,
         ):
             eval_mod.evaluate(config)
@@ -546,7 +541,7 @@ class TestEvaluate:
 
         with (
             patch.object(eval_mod, "print_config", return_value=None),
-            patch.object(eval_mod, "_load_model", return_value=object()),
+            patch.object(eval_mod, "load_model", return_value=object()),
             patch.object(eval_mod, "get_evaluator_class", return_value=FailingEvaluator),
             pytest.raises(RuntimeError, match="internal evaluator failure"),
         ):
@@ -576,7 +571,7 @@ class TestEvaluate:
 
         with (
             patch.object(eval_mod, "print_config", return_value=None),
-            patch.object(eval_mod, "_load_model", return_value=object()),
+            patch.object(eval_mod, "load_model", return_value=object()),
             patch.object(eval_mod, "get_evaluator_class", return_value=FailingEvaluator),
             pytest.raises(ValueError, match="expected schema") as exc_info,
         ):
@@ -1498,7 +1493,7 @@ class TestDefaultDatasetImmutability:
             dataset=caller_dataset,
         )
 
-        with patch.object(eval_mod, "_load_model", return_value=MagicMock()):
+        with patch.object(eval_mod, "load_model", return_value=MagicMock()):
             eval_mod.evaluate(config)
 
         # Caller's dataset must be untouched (full dataclass state)
@@ -1510,7 +1505,7 @@ class TestDefaultDatasetImmutability:
 
 
 class TestLoadModel:
-    """Tests for _load_model."""
+    """Tests for load_model."""
 
     @pytest.fixture(autouse=True)
     def _mock_resolve_device(self):
@@ -1529,12 +1524,12 @@ class TestLoadModel:
             yield
 
     def test_load_model_no_model_id_raises(self):
-        """_load_model raises ValueError when model_id is None."""
-        from winml.modelkit.eval.evaluate import _load_model
+        """load_model raises ValueError when model_id is None."""
+        from winml.modelkit.eval.evaluate import load_model
 
         config = WinMLEvaluationConfig(model_id=None)
         with pytest.raises(ValueError, match="model_id is required"):
-            _load_model(config)
+            load_model(config)
 
     def test_load_model_from_pretrained(self):
         """When no model_path, calls from_pretrained."""
@@ -1559,11 +1554,11 @@ class TestLoadModel:
             "sys.modules",
             {"winml.modelkit.models": MagicMock(WinMLAutoModel=mock_auto)},
         ):
-            result = eval_mod._load_model(config)
+            result = eval_mod.load_model(config)
 
         mock_auto.from_pretrained.assert_called_once()
         call_args = mock_auto.from_pretrained.call_args
-        # _load_model now passes a WinMLEPDevice as the 2nd positional arg.
+        # load_model passes a WinMLEPDevice as the 2nd positional arg.
         assert call_args.args[0] == "test/model"
         # The mock auto_device returns a MagicMock — just confirm it landed.
         assert call_args.args[1] is not None
@@ -1597,7 +1592,7 @@ class TestLoadModel:
             "sys.modules",
             {"winml.modelkit.models": MagicMock(WinMLAutoModel=mock_auto)},
         ):
-            result = eval_mod._load_model(config)
+            result = eval_mod.load_model(config)
 
         assert result is mock_model
         mock_auto.from_onnx.assert_called_once()
@@ -1606,7 +1601,9 @@ class TestLoadModel:
         assert mock_auto.from_onnx.call_args.kwargs["skip_build"] is True
 
     def test_make_onnx_reference_config_uses_independent_environment(self):
-        from winml.modelkit.eval.evaluate import _make_reference_config
+        from winml.modelkit.eval.tensor_similarity_evaluator import (
+            _make_reference_config,
+        )
 
         config = WinMLEvaluationConfig(
             model_path="candidate.onnx",
@@ -1628,7 +1625,9 @@ class TestLoadModel:
         assert reference.skip_build is True
 
     def test_make_default_hf_reference_config_uses_native_defaults(self):
-        from winml.modelkit.eval.evaluate import _make_reference_config
+        from winml.modelkit.eval.tensor_similarity_evaluator import (
+            _make_reference_config,
+        )
 
         config = WinMLEvaluationConfig(
             model_id="test/model",
@@ -1646,40 +1645,6 @@ class TestLoadModel:
         assert reference.ep is None
         assert reference.precision == "auto"
         assert reference.mode == "onnx"
-
-    def test_implicit_hf_reference_loads_on_cpu_fp32(self):
-        import importlib
-        import sys
-
-        import torch
-
-        eval_mod = sys.modules.get(
-            "winml.modelkit.eval.evaluate",
-        ) or importlib.import_module("winml.modelkit.eval.evaluate")
-        config = WinMLEvaluationConfig(
-            model_id="test/model",
-            model_path="candidate.onnx",
-            task="image-classification",
-            mode="compare",
-        )
-        evaluator = MagicMock()
-        evaluator.compute.return_value = {}
-        evaluator_factory = MagicMock(return_value=evaluator)
-
-        with (
-            patch.object(
-                eval_mod,
-                "_load_model",
-                side_effect=[MagicMock(), MagicMock()],
-            ) as load_model,
-            patch.object(eval_mod, "get_evaluator_class", return_value=evaluator_factory),
-        ):
-            eval_mod.evaluate(config)
-
-        reference_call = load_model.call_args_list[1]
-        assert reference_call.args[0].runtime == "pytorch"
-        assert reference_call.args[0].device == "cpu"
-        assert reference_call.kwargs["torch_dtype"] is torch.float32
 
     def test_auto_target_retries_cpu_after_ort_runtime_failure(self, caplog):
         """An unusable auto-selected accelerator retries with the CPU EP."""
@@ -1730,7 +1695,7 @@ class TestLoadModel:
                 gpu_ep_device,
                 cpu_ep_device,
             ]
-            result = eval_mod._load_model(config)
+            result = eval_mod.load_model(config)
 
         assert result is mock_model
         assert [call.args[1] for call in mock_auto.from_pretrained.call_args_list] == [
@@ -1770,7 +1735,7 @@ class TestLoadModel:
             "sys.modules",
             {"winml.modelkit.models": MagicMock(WinMLAutoModel=mock_auto)},
         ):
-            eval_mod._load_model(config)
+            eval_mod.load_model(config)
 
         kwargs = mock_auto.from_pretrained.call_args.kwargs
         # --no-quant -> WinMLBuildConfig override with quant cleared.
@@ -1814,7 +1779,7 @@ class TestLoadModel:
                 return_value=mock_hf_config,
             ) as load_hf_config,
         ):
-            result = eval_mod._load_model(config)
+            result = eval_mod.load_model(config)
 
         assert load_hf_config.call_args.kwargs["trust_remote_code"] is True
         mock_auto.from_onnx.assert_called_once()

--- a/tests/unit/eval/test_eval.py
+++ b/tests/unit/eval/test_eval.py
@@ -1647,6 +1647,40 @@ class TestLoadModel:
         assert reference.precision == "auto"
         assert reference.mode == "onnx"
 
+    def test_implicit_hf_reference_loads_on_cpu_fp32(self):
+        import importlib
+        import sys
+
+        import torch
+
+        eval_mod = sys.modules.get(
+            "winml.modelkit.eval.evaluate",
+        ) or importlib.import_module("winml.modelkit.eval.evaluate")
+        config = WinMLEvaluationConfig(
+            model_id="test/model",
+            model_path="candidate.onnx",
+            task="image-classification",
+            mode="compare",
+        )
+        evaluator = MagicMock()
+        evaluator.compute.return_value = {}
+        evaluator_factory = MagicMock(return_value=evaluator)
+
+        with (
+            patch.object(
+                eval_mod,
+                "_load_model",
+                side_effect=[MagicMock(), MagicMock()],
+            ) as load_model,
+            patch.object(eval_mod, "get_evaluator_class", return_value=evaluator_factory),
+        ):
+            eval_mod.evaluate(config)
+
+        reference_call = load_model.call_args_list[1]
+        assert reference_call.args[0].runtime == "pytorch"
+        assert reference_call.args[0].device == "cpu"
+        assert reference_call.kwargs["torch_dtype"] is torch.float32
+
     def test_auto_target_retries_cpu_after_ort_runtime_failure(self, caplog):
         """An unusable auto-selected accelerator retries with the CPU EP."""
         import importlib

--- a/tests/unit/eval/test_tensor_similarity_evaluator.py
+++ b/tests/unit/eval/test_tensor_similarity_evaluator.py
@@ -13,6 +13,7 @@ and end-to-end ``compute()`` is covered by ``tests/e2e/test_eval_e2e.py``.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import ClassVar
 
 import numpy as np
@@ -22,10 +23,7 @@ from transformers import PretrainedConfig
 from transformers.modeling_outputs import BaseModelOutput
 
 from winml.modelkit.eval import DatasetConfig, WinMLEvaluationConfig
-from winml.modelkit.eval.tensor_similarity_evaluator import (
-    TensorSimilarityEvaluator,
-    _ONNXSessionModel,
-)
+from winml.modelkit.eval.tensor_similarity_evaluator import TensorSimilarityEvaluator
 from winml.modelkit.models.winml.composite_model import WinMLCompositeModel
 
 
@@ -99,7 +97,7 @@ class TestCompositeGuard:
             dataset=DatasetConfig(),
         )
         with pytest.raises(TypeError) as exc:
-            TensorSimilarityEvaluator(config, composite)
+            TensorSimilarityEvaluator(config, composite, object())
         msg = str(exc.value)
         assert "composite" in msg.lower()
         assert "image-feature-extraction" in msg
@@ -115,17 +113,25 @@ class TestCompositeGuard:
 class _FakeCandidateModel:
     """Minimal candidate stand-in exposing the ONNX I/O config prepare_data reads."""
 
-    def __init__(self, io_config: dict) -> None:
+    def __init__(
+        self,
+        io_config: dict,
+        *,
+        path: str = "cand.onnx",
+        output_name: str = "logits",
+    ) -> None:
         self.io_config = io_config
+        self.onnx_path = Path(path)
+        self.output_name = output_name
+
+    def __call__(self, **inputs):
+        value = next(iter(inputs.values()))
+        return {self.output_name: value.reshape(1, -1)[:, :3]}
 
 
 class TestInputDataCompare:
     def test_prepare_data_uses_input_data_npz(self, monkeypatch, tmp_path):
         from winml.modelkit.datasets.input_data import InputDataDataset
-
-        # Skip loading the HF reference model (network) -- this test only
-        # exercises prepare_data's dataset selection off the candidate I/O.
-        monkeypatch.setattr(TensorSimilarityEvaluator, "_load_reference_model", lambda self: None)
 
         npz = tmp_path / "inputs.npz"
         np.savez(npz, input=np.ones((2, 3), dtype=np.float32))
@@ -138,7 +144,7 @@ class TestInputDataCompare:
         )
         model = _FakeCandidateModel({"input_names": ["input"], "input_types": ["float32"]})
 
-        evaluator = TensorSimilarityEvaluator(config, model)  # type: ignore[arg-type]
+        evaluator = TensorSimilarityEvaluator(config, model, object())  # type: ignore[arg-type]
 
         assert isinstance(evaluator.data, InputDataDataset)
         # Leading axis is the sample axis: (2, 3) -> 2 samples of shape (1, 3).
@@ -153,21 +159,8 @@ class TestInputDataCompare:
 
 
 # ---------------------------------------------------------------------------
-# Two-ONNX compare (reference_path set)
+# Injected candidate and reference models
 # ---------------------------------------------------------------------------
-
-
-class _FakeSession:
-    """Stand-in for WinMLSession that records construction and echoes outputs."""
-
-    created: ClassVar[list[tuple[str, str, object]]] = []
-
-    def __init__(self, onnx_path, device="auto", ep=None):
-        _FakeSession.created.append((str(onnx_path), device, ep))
-        self.io_config = {"input_names": ["input"]}
-
-    def run(self, inputs):
-        return {"logits": np.arange(3.0, dtype=np.float32).reshape(1, 3)}
 
 
 class _FakeRandomDataset:
@@ -178,92 +171,41 @@ class _FakeRandomDataset:
         return 0
 
 
-class TestONNXReferenceInit:
-    def test_builds_two_raw_sessions_honoring_device(self, monkeypatch):
+class TestInjectedModels:
+    def test_uses_models_loaded_by_evaluate(self, monkeypatch):
         import winml.modelkit.datasets.random_dataset as rd_mod
-        import winml.modelkit.session.session as session_mod
 
-        _FakeSession.created = []
-        monkeypatch.setattr(session_mod, "WinMLSession", _FakeSession)
         monkeypatch.setattr(rd_mod, "RandomDataset", _FakeRandomDataset)
 
         config = WinMLEvaluationConfig(
             model_path="cand.onnx",
             reference_path="ref.onnx",
             mode="compare",
-            device="cpu",
-            ep="dml",
+            device="npu",
+            ep="qnn",
+            reference_device="gpu",
+            reference_ep="dml",
             dataset=DatasetConfig(samples=5, seed=1),
         )
+        candidate = _FakeCandidateModel({"input_names": ["input"]})
+        reference = _FakeCandidateModel({"input_names": ["input"]}, path="ref.onnx")
 
-        # ``model`` is None in this path (evaluate._load_model returns None).
-        evaluator = TensorSimilarityEvaluator(config, None)  # type: ignore[arg-type]
+        evaluator = TensorSimilarityEvaluator(
+            config,
+            candidate,  # type: ignore[arg-type]
+            reference,
+        )
 
-        assert isinstance(evaluator.model, _ONNXSessionModel)
-        assert isinstance(evaluator.reference_model, _ONNXSessionModel)
-        # Candidate first, reference second; both honor --device / --ep.
-        assert _FakeSession.created[0][0].endswith("cand.onnx")
-        assert _FakeSession.created[1][0].endswith("ref.onnx")
-        assert [c[1] for c in _FakeSession.created] == ["cpu", "cpu"]
-        assert [c[2] for c in _FakeSession.created] == ["dml", "dml"]
+        assert evaluator.model is candidate
+        assert evaluator.reference_model is reference
         # RandomDataset is built over the candidate ONNX I/O.
         assert evaluator.data.kwargs["model_path"].endswith("cand.onnx")
         assert evaluator.data.kwargs["max_samples"] == 5
         assert evaluator.data.kwargs["seed"] == 1
 
-
-class TestONNXSessionModel:
-    def test_call_returns_named_torch_tensors(self, monkeypatch):
-        import winml.modelkit.session.session as session_mod
-
-        _FakeSession.created = []
-        monkeypatch.setattr(session_mod, "WinMLSession", _FakeSession)
-
-        model = _ONNXSessionModel("x.onnx", device="cpu")
-        out = model(input=torch.zeros(1, 3))
-
-        assert set(out) == {"logits"}
-        assert isinstance(out["logits"], torch.Tensor)
-        assert out["logits"].shape == (1, 3)
-
-    def test_io_config_delegates_to_session(self, monkeypatch):
-        import winml.modelkit.session.session as session_mod
-
-        _FakeSession.created = []
-        monkeypatch.setattr(session_mod, "WinMLSession", _FakeSession)
-
-        model = _ONNXSessionModel("x.onnx")
-        assert model.io_config["input_names"] == ["input"]
-
-
-# ---------------------------------------------------------------------------
-# --input-data combined with two-ONNX compare (reference_path + input_data)
-# ---------------------------------------------------------------------------
-
-
-class _FakeIOSession:
-    """Fake session exposing ``input_types`` so ``InputDataDataset`` validates,
-    and echoing a fixed named output so ``compute()`` finds overlapping outputs.
-
-    ``run`` mirrors ``WinMLSession`` by accepting torch-tensor inputs (the real
-    session converts them via ``_prepare_inputs``), so this doubles as a guard
-    that ``_ONNXSessionModel`` forwarding torch tensors is safe.
-    """
-
-    def __init__(self, onnx_path, device="auto", ep=None):
-        self.io_config = {"input_names": ["input"], "input_types": ["float32"]}
-
-    def run(self, inputs):
-        arr = np.asarray(next(iter(inputs.values()))).astype(np.float32)
-        return {"logits": arr.reshape(1, -1)[:, :3]}
-
-
 class TestONNXReferenceWithInputData:
-    def test_prepare_data_uses_input_data_over_candidate_session(self, monkeypatch, tmp_path):
-        import winml.modelkit.session.session as session_mod
+    def test_prepare_data_uses_input_data_over_candidate_model(self, tmp_path):
         from winml.modelkit.datasets.input_data import InputDataDataset
-
-        monkeypatch.setattr(session_mod, "WinMLSession", _FakeIOSession)
 
         npz = tmp_path / "inputs.npz"
         np.savez(npz, input=np.ones((3, 4), dtype=np.float32))
@@ -274,27 +216,27 @@ class TestONNXReferenceWithInputData:
             mode="compare",
             input_data=str(npz),
         )
+        candidate = _FakeCandidateModel(
+            {"input_names": ["input"], "input_types": ["float32"]}
+        )
+        reference = _FakeCandidateModel(
+            {"input_names": ["input"], "input_types": ["float32"]},
+            path="ref.onnx",
+        )
 
-        # ``model`` is None in the two-ONNX path (evaluate._load_model returns None).
-        evaluator = TensorSimilarityEvaluator(config, None)  # type: ignore[arg-type]
+        evaluator = TensorSimilarityEvaluator(
+            config,
+            candidate,  # type: ignore[arg-type]
+            reference,
+        )
 
-        # Both sides are raw ORT wrappers ...
-        assert isinstance(evaluator.model, _ONNXSessionModel)
-        assert isinstance(evaluator.reference_model, _ONNXSessionModel)
-        # ... and the real-input dataset is built over the candidate session's
-        # io_config (not a RandomDataset), proving --input-data composes with
-        # --reference.
         assert isinstance(evaluator.data, InputDataDataset)
         assert len(evaluator.data) == 3
         sample = evaluator.data[0]
         assert set(sample) == {"input"}
         assert sample["input"].shape == (1, 4)
 
-    def test_compute_runs_real_inputs_through_both_sessions(self, monkeypatch, tmp_path):
-        import winml.modelkit.session.session as session_mod
-
-        monkeypatch.setattr(session_mod, "WinMLSession", _FakeIOSession)
-
+    def test_compute_runs_real_inputs_through_both_models(self, tmp_path):
         npz = tmp_path / "inputs.npz"
         np.savez(npz, input=np.ones((2, 3), dtype=np.float32))
 
@@ -304,37 +246,21 @@ class TestONNXReferenceWithInputData:
             mode="compare",
             input_data=str(npz),
         )
-        evaluator = TensorSimilarityEvaluator(config, None)  # type: ignore[arg-type]
+        io_config = {"input_names": ["input"], "input_types": ["float32"]}
+        evaluator = TensorSimilarityEvaluator(
+            config,
+            _FakeCandidateModel(io_config),  # type: ignore[arg-type]
+            _FakeCandidateModel(io_config, path="ref.onnx"),
+        )
 
         result = evaluator.compute()
 
-        # Candidate and reference share the same fake session, so the compare
-        # loop ran end-to-end on the two real samples through both raw ORT
-        # sessions (torch tensors in, numpy out) without error and produced a
-        # per-metric table over the common "logits" output.
         assert result
         assert all("logits" in per_output for per_output in result.values())
 
 
-class _FakePathAwareSession:
-    """Fake session returning a different output name per model path, so the
-    candidate and reference disagree and compute() hits the no-overlap error."""
-
-    def __init__(self, onnx_path, device="auto", ep=None):
-        self._path = str(onnx_path)
-        self.io_config = {"input_names": ["input"], "input_types": ["float32"]}
-
-    def run(self, inputs):
-        name = "cand_out" if "cand" in self._path else "ref_out"
-        return {name: np.zeros((1, 3), dtype=np.float32)}
-
-
 class TestReferenceLabelInDiagnostics:
-    def test_non_overlapping_outputs_error_names_reference_onnx(self, monkeypatch, tmp_path):
-        import winml.modelkit.session.session as session_mod
-
-        monkeypatch.setattr(session_mod, "WinMLSession", _FakePathAwareSession)
-
+    def test_non_overlapping_outputs_error_names_reference_onnx(self, tmp_path):
         npz = tmp_path / "inputs.npz"
         np.savez(npz, input=np.ones((1, 3), dtype=np.float32))
 
@@ -344,7 +270,16 @@ class TestReferenceLabelInDiagnostics:
             mode="compare",
             input_data=str(npz),
         )
-        evaluator = TensorSimilarityEvaluator(config, None)  # type: ignore[arg-type]
+        io_config = {"input_names": ["input"], "input_types": ["float32"]}
+        evaluator = TensorSimilarityEvaluator(
+            config,
+            _FakeCandidateModel(io_config, output_name="cand_out"),  # type: ignore[arg-type]
+            _FakeCandidateModel(
+                io_config,
+                path="ref.onnx",
+                output_name="ref_out",
+            ),
+        )
 
         with pytest.raises(ValueError) as exc:
             evaluator.compute()

--- a/tests/unit/eval/test_tensor_similarity_evaluator.py
+++ b/tests/unit/eval/test_tensor_similarity_evaluator.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import ClassVar
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -97,7 +98,7 @@ class TestCompositeGuard:
             dataset=DatasetConfig(),
         )
         with pytest.raises(TypeError) as exc:
-            TensorSimilarityEvaluator(config, composite, object())
+            TensorSimilarityEvaluator(config, composite)
         msg = str(exc.value)
         assert "composite" in msg.lower()
         assert "image-feature-extraction" in msg
@@ -144,7 +145,11 @@ class TestInputDataCompare:
         )
         model = _FakeCandidateModel({"input_names": ["input"], "input_types": ["float32"]})
 
-        evaluator = TensorSimilarityEvaluator(config, model, object())  # type: ignore[arg-type]
+        with patch(
+            "winml.modelkit.eval.evaluate.load_model",
+            return_value=object(),
+        ):
+            evaluator = TensorSimilarityEvaluator(config, model)  # type: ignore[arg-type]
 
         assert isinstance(evaluator.data, InputDataDataset)
         # Leading axis is the sample axis: (2, 3) -> 2 samples of shape (1, 3).
@@ -171,8 +176,8 @@ class _FakeRandomDataset:
         return 0
 
 
-class TestInjectedModels:
-    def test_uses_models_loaded_by_evaluate(self, monkeypatch):
+class TestReferenceLoading:
+    def test_loads_onnx_reference_with_independent_config(self, monkeypatch):
         import winml.modelkit.datasets.random_dataset as rd_mod
 
         monkeypatch.setattr(rd_mod, "RandomDataset", _FakeRandomDataset)
@@ -190,18 +195,53 @@ class TestInjectedModels:
         candidate = _FakeCandidateModel({"input_names": ["input"]})
         reference = _FakeCandidateModel({"input_names": ["input"]}, path="ref.onnx")
 
-        evaluator = TensorSimilarityEvaluator(
-            config,
-            candidate,  # type: ignore[arg-type]
-            reference,
-        )
+        with patch(
+            "winml.modelkit.eval.evaluate.load_model",
+            return_value=reference,
+        ) as load_model:
+            evaluator = TensorSimilarityEvaluator(
+                config,
+                candidate,  # type: ignore[arg-type]
+            )
 
         assert evaluator.model is candidate
         assert evaluator.reference_model is reference
+        reference_config = load_model.call_args.args[0]
+        assert reference_config.model_path == "ref.onnx"
+        assert reference_config.reference_path is None
+        assert reference_config.device == "gpu"
+        assert reference_config.ep == "dml"
+        assert reference_config.task is None
+        assert load_model.call_args.kwargs["torch_dtype"] is torch.float32
         # RandomDataset is built over the candidate ONNX I/O.
         assert evaluator.data.kwargs["model_path"].endswith("cand.onnx")
         assert evaluator.data.kwargs["max_samples"] == 5
         assert evaluator.data.kwargs["seed"] == 1
+
+    def test_implicit_hf_reference_loads_on_cpu_fp32(self, monkeypatch):
+        import winml.modelkit.datasets.random_dataset as rd_mod
+
+        monkeypatch.setattr(rd_mod, "RandomDataset", _FakeRandomDataset)
+        config = WinMLEvaluationConfig(
+            model_id="test/model",
+            model_path="cand.onnx",
+            task="image-classification",
+            mode="compare",
+            dataset=DatasetConfig(samples=1),
+        )
+        candidate = _FakeCandidateModel({"input_names": ["input"]})
+
+        with patch(
+            "winml.modelkit.eval.evaluate.load_model",
+            return_value=object(),
+        ) as load_model:
+            TensorSimilarityEvaluator(config, candidate)  # type: ignore[arg-type]
+
+        reference_config = load_model.call_args.args[0]
+        assert reference_config.runtime == "pytorch"
+        assert reference_config.device == "cpu"
+        assert load_model.call_args.kwargs["torch_dtype"] is torch.float32
+
 
 class TestONNXReferenceWithInputData:
     def test_prepare_data_uses_input_data_over_candidate_model(self, tmp_path):
@@ -224,11 +264,14 @@ class TestONNXReferenceWithInputData:
             path="ref.onnx",
         )
 
-        evaluator = TensorSimilarityEvaluator(
-            config,
-            candidate,  # type: ignore[arg-type]
-            reference,
-        )
+        with patch(
+            "winml.modelkit.eval.evaluate.load_model",
+            return_value=reference,
+        ):
+            evaluator = TensorSimilarityEvaluator(
+                config,
+                candidate,  # type: ignore[arg-type]
+            )
 
         assert isinstance(evaluator.data, InputDataDataset)
         assert len(evaluator.data) == 3
@@ -247,11 +290,14 @@ class TestONNXReferenceWithInputData:
             input_data=str(npz),
         )
         io_config = {"input_names": ["input"], "input_types": ["float32"]}
-        evaluator = TensorSimilarityEvaluator(
-            config,
-            _FakeCandidateModel(io_config),  # type: ignore[arg-type]
-            _FakeCandidateModel(io_config, path="ref.onnx"),
-        )
+        with patch(
+            "winml.modelkit.eval.evaluate.load_model",
+            return_value=_FakeCandidateModel(io_config, path="ref.onnx"),
+        ):
+            evaluator = TensorSimilarityEvaluator(
+                config,
+                _FakeCandidateModel(io_config),  # type: ignore[arg-type]
+            )
 
         result = evaluator.compute()
 
@@ -271,15 +317,21 @@ class TestReferenceLabelInDiagnostics:
             input_data=str(npz),
         )
         io_config = {"input_names": ["input"], "input_types": ["float32"]}
-        evaluator = TensorSimilarityEvaluator(
-            config,
-            _FakeCandidateModel(io_config, output_name="cand_out"),  # type: ignore[arg-type]
-            _FakeCandidateModel(
+        with patch(
+            "winml.modelkit.eval.evaluate.load_model",
+            return_value=_FakeCandidateModel(
                 io_config,
                 path="ref.onnx",
                 output_name="ref_out",
             ),
-        )
+        ):
+            evaluator = TensorSimilarityEvaluator(
+                config,
+                _FakeCandidateModel(  # type: ignore[arg-type]
+                    io_config,
+                    output_name="cand_out",
+                ),
+            )
 
         with pytest.raises(ValueError) as exc:
             evaluator.compute()

--- a/tests/unit/loader/test_native_hf.py
+++ b/tests/unit/loader/test_native_hf.py
@@ -66,6 +66,24 @@ def test_load_native_hf_model_preserves_dtype_and_task_selection() -> None:
     assert result.device.name == "cpu"
 
 
+def test_load_native_hf_model_accepts_dtype_override() -> None:
+    model = MagicMock()
+    model.to.return_value = model
+    model.eval.return_value = model
+    with patch(
+        "winml.modelkit.loader.hf.load_hf_model",
+        return_value=(model, MagicMock(), "image-classification"),
+    ) as load:
+        load_native_hf_model(
+            "fake/model",
+            task="image-classification",
+            device="cpu",
+            torch_dtype=torch.float32,
+        )
+
+    assert load.call_args.kwargs["torch_dtype"] is torch.float32
+
+
 def test_load_native_text_generation_uses_causal_lm_adapter() -> None:
     adapter = MagicMock()
     with patch(


### PR DESCRIPTION
## Summary

Two-ONNX compare mode already supported `--reference`, but it created raw ORT sessions inside `TensorSimilarityEvaluator` and used the candidate's execution settings for both models.

This PR:

- loads the candidate and reference ONNX models through the standard `WinMLAutoModel` loading path before constructing the evaluator
- adds `--reference-device` (default: `cpu`) and `--reference-ep` so the reference can run independently from the candidate
- preserves the existing Hugging Face reference behavior when `--reference` is omitted
- reports and serializes the effective reference settings, with updated documentation and unit coverage

## Example

Run the candidate on CPU and the reference ONNX model on DML, then compare their output tensors on identical random inputs:

```bash
winml eval --mode compare \
  -m candidate.onnx \
  --device cpu \
  --reference baseline.onnx \
  --reference-device gpu \
  --reference-ep dml \
  --samples 10
```