### PR TITLE
feat(eval): support Common Voice gender classification

### DIFF
--- a/examples/recipes/MIT_ast-finetuned-audioset-10-10-0.4593/cpu/cpu/audio-classification_fp16_config.json
+++ b/examples/recipes/MIT_ast-finetuned-audioset-10-10-0.4593/cpu/cpu/audio-classification_fp16_config.json
@@ -28,7 +28,10 @@
       {
         "name": "logits"
       }
-    ]
+    ],
+    "compatibility": {
+      "transformers_attention": "eager"
+    }
   },
   "optim": {},
   "quant": {

--- a/examples/recipes/MIT_ast-finetuned-audioset-10-10-0.4593/cpu/cpu/audio-classification_fp32_config.json
+++ b/examples/recipes/MIT_ast-finetuned-audioset-10-10-0.4593/cpu/cpu/audio-classification_fp32_config.json
@@ -28,7 +28,10 @@
       {
         "name": "logits"
       }
-    ]
+    ],
+    "compatibility": {
+      "transformers_attention": "eager"
+    }
   },
   "optim": {},
   "quant": null,

--- a/examples/recipes/prithivMLmods_Common-Voice-Gender-Detection/cpu/cpu/audio-classification_fp16_config.json
+++ b/examples/recipes/prithivMLmods_Common-Voice-Gender-Detection/cpu/cpu/audio-classification_fp16_config.json
@@ -27,7 +27,10 @@
       {
         "name": "logits"
       }
-    ]
+    ],
+    "compatibility": {
+      "transformers_attention": "eager"
+    }
   },
   "optim": {},
   "quant": {

--- a/examples/recipes/prithivMLmods_Common-Voice-Gender-Detection/cpu/cpu/audio-classification_fp32_config.json
+++ b/examples/recipes/prithivMLmods_Common-Voice-Gender-Detection/cpu/cpu/audio-classification_fp32_config.json
@@ -27,7 +27,10 @@
       {
         "name": "logits"
       }
-    ]
+    ],
+    "compatibility": {
+      "transformers_attention": "eager"
+    }
   },
   "optim": {},
   "quant": null,

--- a/src/winml/modelkit/eval/__init__.py
+++ b/src/winml/modelkit/eval/__init__.py
@@ -19,6 +19,7 @@ from .evaluate import EvalResult, evaluate, get_evaluator_class
 
 
 if TYPE_CHECKING:
+    from .audio_classification_evaluator import WinMLAudioClassificationEvaluator
     from .depth_estimation_evaluator import WinMLDepthEstimationEvaluator
     from .feature_extraction_evaluator import WinMLFeatureExtractionEvaluator
     from .fill_mask_evaluator import WinMLFillMaskEvaluator
@@ -47,6 +48,9 @@ if TYPE_CHECKING:
 
 _LAZY_ATTRS: dict[str, str] = {
     # Evaluators
+    "WinMLAudioClassificationEvaluator": (
+        ".audio_classification_evaluator:WinMLAudioClassificationEvaluator"
+    ),
     "WinMLDepthEstimationEvaluator": ".depth_estimation_evaluator:WinMLDepthEstimationEvaluator",
     "WinMLFeatureExtractionEvaluator": (
         ".feature_extraction_evaluator:WinMLFeatureExtractionEvaluator"
@@ -126,6 +130,7 @@ __all__ = [
     "SpearmanCorrelationMetric",
     "TensorSimilarityEvaluator",
     "TopKAccuracyMetric",
+    "WinMLAudioClassificationEvaluator",
     "WinMLDepthEstimationEvaluator",
     "WinMLEvaluationConfig",
     "WinMLEvaluator",

--- a/src/winml/modelkit/eval/audio_classification_evaluator.py
+++ b/src/winml/modelkit/eval/audio_classification_evaluator.py
@@ -1,0 +1,430 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+"""Audio classification evaluation for scalar and multi-label targets."""
+
+from __future__ import annotations
+
+import math
+from io import BytesIO
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+import numpy as np
+
+from ..utils.eval_utils import DatasetValidationError
+from .base_evaluator import WinMLEvaluator
+
+
+if TYPE_CHECKING:
+    from datasets import Dataset
+    from numpy.typing import NDArray
+    from transformers.pipelines.base import Pipeline
+
+    from .config import DatasetConfig, WinMLEvaluationConfig
+
+
+class _AudioModelAdapter:
+    """One preprocessing and forward contract for native-HF and WinML models."""
+
+    def __init__(self, config: WinMLEvaluationConfig, model: Any) -> None:
+        from transformers import AutoFeatureExtractor
+
+        if not config.model_id:
+            raise ValueError("model_id is required to load the audio feature extractor.")
+        self._config = config
+        self._model = model
+        self._feature_extractor = AutoFeatureExtractor.from_pretrained(
+            config.model_id,
+            trust_remote_code=config.trust_remote_code,
+        )
+        self._input_contract = self._resolve_input_contract()
+
+    def predict_logits(self, audio: Any) -> NDArray[np.float32]:
+        """Decode and process one audio row, then perform exactly one forward."""
+        import torch
+
+        waveform, sampling_rate = self._decode_audio(audio)
+        waveform = self._downmix(waveform)
+        target_rate = int(getattr(self._feature_extractor, "sampling_rate", sampling_rate))
+        if sampling_rate != target_rate:
+            waveform = self._resample(waveform, sampling_rate, target_rate)
+
+        processor_kwargs: dict[str, Any] = {
+            "sampling_rate": target_rate,
+            "return_tensors": "pt",
+        }
+        if self._input_contract is not None and len(self._input_contract[1]) == 2:
+            sequence_length = self._input_contract[1][1]
+            processor_kwargs.update(
+                padding="max_length",
+                truncation=True,
+                max_length=sequence_length,
+            )
+        encoded = self._feature_extractor(waveform, **processor_kwargs)
+        model_inputs = self._select_model_inputs(encoded)
+        device = self._config.pipeline_device if self._config.runtime == "pytorch" else "cpu"
+        model_inputs = {
+            name: (
+                value.to(device)
+                if hasattr(value, "to")
+                else torch.as_tensor(value, device=device)
+            )
+            for name, value in model_inputs.items()
+        }
+        outputs = self._model(**model_inputs)
+        logits = self._extract_logits(outputs)
+        array = logits.detach().float().cpu().numpy() if hasattr(logits, "detach") else logits
+        array = np.asarray(array, dtype=np.float32)
+        if array.ndim != 2 or array.shape[0] != 1:
+            raise ValueError(f"expected logits shape [1, classes], got {array.shape}")
+        return cast("NDArray[np.float32]", array[0])
+
+    def _resolve_input_contract(self) -> tuple[str, list[int]] | None:
+        io_config = getattr(self._model, "io_config", None) or {}
+        names = io_config.get("input_names") or []
+        shapes = io_config.get("input_shapes") or []
+        if not names and not shapes:
+            return None
+        if len(names) != 1 or len(shapes) != 1:
+            raise ValueError(
+                "audio-classification adapter supports one model input; "
+                f"got names={names}, shapes={shapes}"
+            )
+        shape = list(shapes[0])
+        if len(shape) < 2 or any(not isinstance(value, int) for value in shape[1:]):
+            raise ValueError(
+                "audio-classification adapter requires static non-batch input dimensions; "
+                f"got {shape}"
+            )
+        if isinstance(shape[0], int) and shape[0] != 1:
+            raise ValueError("audio-classification adapter requires batch size 1.")
+        return str(names[0]), [1, *(int(value) for value in shape[1:])]
+
+    def _select_model_inputs(self, encoded: Any) -> dict[str, Any]:
+        values = dict(encoded)
+        if self._input_contract is None:
+            if not values:
+                raise ValueError("audio feature extractor produced no model inputs.")
+            return values
+
+        input_name, expected_shape = self._input_contract
+        if input_name not in values:
+            raise ValueError(
+                f"audio feature extractor output must contain {input_name!r}; "
+                f"got {sorted(values)}"
+            )
+        tensor = values[input_name]
+        actual_shape = list(getattr(tensor, "shape", ()))
+        if actual_shape != expected_shape:
+            raise ValueError(
+                f"audio feature extractor produced {input_name} shape {actual_shape}; "
+                f"expected {expected_shape}"
+            )
+        return {input_name: tensor}
+
+    @staticmethod
+    def _extract_logits(outputs: Any) -> Any:
+        logits = (
+            outputs.get("logits")
+            if isinstance(outputs, dict)
+            else getattr(outputs, "logits", None)
+        )
+        if logits is None:
+            raise ValueError("audio-classification model output does not contain logits.")
+        return logits
+
+    @staticmethod
+    def _decode_audio(audio: Any) -> tuple[np.ndarray, int]:
+        if isinstance(audio, dict):
+            if audio.get("array") is not None and audio.get("sampling_rate") is not None:
+                return np.asarray(audio["array"], dtype=np.float32), int(audio["sampling_rate"])
+            encoded_bytes = audio.get("bytes")
+            encoded_path = audio.get("path")
+            if encoded_bytes is not None or encoded_path:
+                try:
+                    import soundfile as sf
+                except ImportError as error:
+                    raise RuntimeError(
+                        "Encoded audio decoding requires the optional audio dependencies."
+                    ) from error
+                source = BytesIO(encoded_bytes) if encoded_bytes is not None else str(encoded_path)
+                try:
+                    waveform, sampling_rate = sf.read(
+                        source,
+                        dtype="float32",
+                        always_2d=False,
+                    )
+                except (OSError, RuntimeError) as error:
+                    raise ValueError(f"failed to decode audio: {error}") from error
+                return np.asarray(waveform, dtype=np.float32), int(sampling_rate)
+        raise TypeError(
+            "audio value must contain array and sampling_rate, or encoded bytes/path"
+        )
+
+    @staticmethod
+    def _downmix(waveform: np.ndarray) -> np.ndarray:
+        waveform = np.asarray(waveform, dtype=np.float32)
+        if waveform.ndim == 1:
+            mono = waveform
+        elif waveform.ndim == 2:
+            mono = waveform.mean(axis=1)
+        else:
+            raise ValueError(f"audio must be mono or frames-by-channels, got {waveform.shape}")
+        if mono.size == 0:
+            raise ValueError("audio waveform is empty.")
+        return np.asarray(mono, dtype=np.float32)
+
+    @staticmethod
+    def _resample(waveform: np.ndarray, source_rate: int, target_rate: int) -> np.ndarray:
+        from scipy.signal import resample_poly
+
+        if source_rate <= 0 or target_rate <= 0:
+            raise ValueError("audio sampling rates must be positive.")
+        divisor = math.gcd(source_rate, target_rate)
+        return np.asarray(
+            resample_poly(waveform, target_rate // divisor, source_rate // divisor),
+            dtype=np.float32,
+        )
+
+
+class WinMLAudioClassificationEvaluator(WinMLEvaluator):
+    """Evaluate audio classifiers with schema-driven target semantics."""
+
+    def __init__(self, config: WinMLEvaluationConfig, model: Any) -> None:
+        mapping = config.dataset.columns_mapping
+        self._audio_column = mapping.get("input_column", "audio")
+        self._label_column = mapping.get("label_column", "label")
+        self._label_name_column = mapping.get("label_name_column", "human_labels")
+        self._target_kind = ""
+        self._label_feature: Any = None
+        self._model_id2label, self._model_label2id = self._model_labels(model)
+        super().__init__(config, model)
+
+    def prepare_pipeline(self) -> Pipeline:
+        """Create the shared native-HF/WinML audio adapter."""
+        return cast("Pipeline", _AudioModelAdapter(self.config, self.model))
+
+    def prepare_data(self) -> Dataset:
+        """Load, validate, explicitly disable media decoding, and select rows."""
+        from datasets import (
+            Audio,
+            Dataset,
+            DatasetDict,
+            IterableDataset,
+            load_dataset,
+            load_from_disk,
+        )
+
+        ds = self.config.dataset
+        try:
+            ds_path = Path(ds.path).expanduser() if ds.path else None
+            if ds_path and ds_path.is_dir():
+                loaded = load_from_disk(str(ds_path))
+                if isinstance(loaded, DatasetDict):
+                    if ds.split not in loaded:
+                        raise DatasetValidationError(
+                            f"saved dataset has no split {ds.split!r}; available: {sorted(loaded)}"
+                        )
+                    dataset = loaded[ds.split]
+                else:
+                    dataset = loaded
+            else:
+                dataset = load_dataset(
+                    ds.path,
+                    name=ds.name,
+                    split=ds.split,
+                    streaming=ds.streaming,
+                    revision=ds.revision,
+                )
+        except DatasetValidationError:
+            raise
+        except Exception as error:
+            raise DatasetValidationError(
+                f"Failed to load dataset {ds.path!r} (name={ds.name!r}, split={ds.split!r}): "
+                f"{error}"
+            ) from error
+
+        self._validate_target_schema(dataset)
+        audio_feature = dataset.features[self._audio_column]
+        if isinstance(audio_feature, Audio) and audio_feature.decode:
+            dataset = dataset.cast_column(
+                self._audio_column,
+                Audio(sampling_rate=audio_feature.sampling_rate, decode=False),
+            )
+        if ds.shuffle:
+            dataset = dataset.shuffle(seed=ds.seed)
+        if isinstance(dataset, IterableDataset):
+            dataset = Dataset.from_list(list(dataset.take(ds.samples)), features=dataset.features)
+        else:
+            dataset = dataset.select(range(min(ds.samples, len(dataset))))
+        return dataset
+
+    def align_labels(self, dataset: Dataset, ds_config: DatasetConfig) -> Dataset:
+        """Leave target alignment to the scalar/multi-label decoder."""
+        return dataset
+
+    def compute(self) -> dict[str, Any]:
+        """Run one forward per selected row and compute task-appropriate metrics."""
+        logits: list[np.ndarray] = []
+        targets: list[Any] = []
+        rejected_by_reason: dict[str, int] = {}
+        adapter = cast("_AudioModelAdapter", self.pipe)
+        for row in self.data:
+            target = self._target_for_row(row)
+            try:
+                prediction = adapter.predict_logits(row[self._audio_column])
+            except (TypeError, ValueError, RuntimeError) as error:
+                reason = type(error).__name__
+                rejected_by_reason[reason] = rejected_by_reason.get(reason, 0) + 1
+                continue
+            logits.append(prediction)
+            targets.append(target)
+        if not logits:
+            raise DatasetValidationError("No selected audio samples were successfully processed.")
+        scores = np.stack(logits)
+        if scores.shape[1] != len(self._model_id2label):
+            raise DatasetValidationError(
+                f"model returned {scores.shape[1]} classes but config defines "
+                f"{len(self._model_id2label)} labels."
+            )
+        if self._target_kind == "multi-label":
+            metrics = self._multi_label_metrics(scores, targets)
+        else:
+            metrics = self._single_label_metrics(scores, targets)
+        selected = len(self.data)
+        metrics.update(
+            requested_samples=self.config.dataset.samples,
+            selected_samples=selected,
+            processed_samples=len(targets),
+            rejected_samples=selected - len(targets),
+            rejected_by_reason=dict(sorted(rejected_by_reason.items())),
+        )
+        return metrics
+
+    def _validate_target_schema(self, dataset: Any) -> None:
+        from datasets import ClassLabel, Sequence, Value
+
+        missing = [
+            name
+            for name in (self._audio_column, self._label_column)
+            if name not in dataset.column_names
+        ]
+        if missing:
+            raise DatasetValidationError(
+                f"missing required column(s) {missing}; dataset has {sorted(dataset.column_names)}"
+            )
+        feature = dataset.features[self._label_column]
+        if isinstance(feature, ClassLabel):
+            self._target_kind = "single-label"
+        elif isinstance(feature, Sequence) and isinstance(feature.feature, (ClassLabel, Value)):
+            self._target_kind = "multi-label"
+        else:
+            raise DatasetValidationError(
+                f"Column {self._label_column!r} must be ClassLabel or a sequence of "
+                f"ClassLabel/string values; got {feature!r}."
+            )
+        self._label_feature = feature
+
+    def _target_for_row(self, row: dict[str, Any]) -> Any:
+        from datasets import ClassLabel
+
+        raw_target = row[self._label_column]
+        if self._target_kind == "single-label":
+            assert isinstance(self._label_feature, ClassLabel)
+            return self._resolve_label(self._label_feature.int2str(int(raw_target)))
+
+        values = list(raw_target)
+        feature = self._label_feature.feature
+        decoded = (
+            [feature.int2str(int(value)) for value in values]
+            if isinstance(feature, ClassLabel)
+            else values
+        )
+        parallel_names = row.get(self._label_name_column)
+        if parallel_names is not None and len(parallel_names) != len(decoded):
+            raise DatasetValidationError(
+                f"Columns {self._label_column!r} and {self._label_name_column!r} "
+                "must contain the same number of labels."
+            )
+        resolved: list[int] = []
+        for index, value in enumerate(decoded):
+            fallback_name = parallel_names[index] if parallel_names is not None else None
+            resolved.append(self._resolve_label(str(value), fallback_name=fallback_name))
+        if not resolved:
+            raise DatasetValidationError("Multi-label targets must contain at least one label.")
+        return sorted(set(resolved))
+
+    def _resolve_label(self, value: str, *, fallback_name: Any = None) -> int:
+        mapping = self.config.dataset.label_mapping or {}
+        if value in mapping:
+            model_id = int(mapping[value])
+        elif value in self._model_label2id:
+            model_id = self._model_label2id[value]
+        elif fallback_name is not None and str(fallback_name) in self._model_label2id:
+            model_id = self._model_label2id[str(fallback_name)]
+        else:
+            raise DatasetValidationError(
+                f"Dataset label {value!r} has no exact model-label match; provide an "
+                "authoritative label mapping or parallel exact label-name column."
+            )
+        if model_id not in self._model_id2label:
+            raise DatasetValidationError(
+                f"Label mapping target {model_id} is absent from model.config.id2label."
+            )
+        return model_id
+
+    def _single_label_metrics(
+        self,
+        logits: np.ndarray,
+        targets: list[int],
+    ) -> dict[str, Any]:
+        from .metrics import ClassificationMetric
+
+        predictions = [self._model_id2label[int(index)] for index in np.argmax(logits, axis=1)]
+        references = [self._model_id2label[int(index)] for index in targets]
+        represented = sorted(set(references))
+        result = ClassificationMetric().compute(predictions, references, represented)
+        return {
+            "accuracy": result["accuracy"],
+            "macro_f1": result["f1"],
+            "represented_classes": len(represented),
+            "total_classes": len(self._model_id2label),
+            "class_coverage": len(represented) / len(self._model_id2label),
+        }
+
+    def _multi_label_metrics(
+        self,
+        logits: np.ndarray,
+        targets: list[list[int]],
+    ) -> dict[str, Any]:
+        from sklearn.metrics import average_precision_score
+
+        references = np.zeros_like(logits, dtype=np.int8)
+        for row_index, model_ids in enumerate(targets):
+            references[row_index, model_ids] = 1
+        probabilities = 1.0 / (1.0 + np.exp(-logits))
+        sample_ap = float(average_precision_score(references, probabilities, average="samples"))
+        micro_ap = float(average_precision_score(references, probabilities, average="micro"))
+        if not np.isfinite(sample_ap) or not np.isfinite(micro_ap):
+            raise DatasetValidationError("Multi-label average precision must be finite.")
+        return {
+            "sample_average_precision": sample_ap,
+            "micro_average_precision": micro_ap,
+        }
+
+    @staticmethod
+    def _model_labels(model: Any) -> tuple[dict[int, str], dict[str, int]]:
+        config = getattr(model, "config", None)
+        raw_id2label = getattr(config, "id2label", None) or {}
+        id2label = {int(index): str(label) for index, label in raw_id2label.items()}
+        if not id2label or sorted(id2label) != list(range(len(id2label))):
+            raise DatasetValidationError(
+                "model.config.id2label must define contiguous class IDs starting at zero."
+            )
+        label2id = {label: index for index, label in id2label.items()}
+        if len(label2id) != len(id2label):
+            raise DatasetValidationError("model.config.id2label contains duplicate label names.")
+        return id2label, label2id

--- a/src/winml/modelkit/eval/audio_classification_evaluator.py
+++ b/src/winml/modelkit/eval/audio_classification_evaluator.py
@@ -257,7 +257,7 @@ class WinMLAudioClassificationEvaluator(WinMLEvaluator):
         if ds.shuffle:
             dataset = dataset.shuffle(seed=ds.seed)
         if isinstance(dataset, IterableDataset):
-            dataset = Dataset.from_list(list(dataset.take(ds.samples)), features=dataset.features)
+            dataset = Dataset.from_list(list(dataset.take(ds.samples)))
         else:
             dataset = dataset.select(range(min(ds.samples, len(dataset))))
         return dataset

--- a/src/winml/modelkit/eval/audio_classification_evaluator.py
+++ b/src/winml/modelkit/eval/audio_classification_evaluator.py
@@ -319,12 +319,16 @@ class WinMLAudioClassificationEvaluator(WinMLEvaluator):
         feature = dataset.features[self._label_column]
         if isinstance(feature, ClassLabel):
             self._target_kind = "single-label"
+        elif isinstance(feature, Value) and feature.dtype == "string":
+            self._validate_scalar_string_mapping()
+            self._target_kind = "single-label-string"
         elif isinstance(feature, Sequence) and isinstance(feature.feature, (ClassLabel, Value)):
             self._target_kind = "multi-label"
         else:
             raise DatasetValidationError(
                 f"Column {self._label_column!r} must be ClassLabel or a sequence of "
-                f"ClassLabel/string values; got {feature!r}."
+                "ClassLabel/string values, or a scalar string with an explicit label mapping; "
+                f"got {feature!r}."
             )
         self._label_feature = feature
 
@@ -335,6 +339,15 @@ class WinMLAudioClassificationEvaluator(WinMLEvaluator):
         if self._target_kind == "single-label":
             assert isinstance(self._label_feature, ClassLabel)
             return self._resolve_label(self._label_feature.int2str(int(raw_target)))
+        if self._target_kind == "single-label-string":
+            mapping = self.config.dataset.label_mapping
+            assert mapping is not None
+            value = str(raw_target)
+            if value not in mapping:
+                raise DatasetValidationError(
+                    f"Dataset label {value!r} is absent from the explicit label mapping."
+                )
+            return int(mapping[value])
 
         values = list(raw_target)
         feature = self._label_feature.feature
@@ -356,6 +369,43 @@ class WinMLAudioClassificationEvaluator(WinMLEvaluator):
         if not resolved:
             raise DatasetValidationError("Multi-label targets must contain at least one label.")
         return sorted(set(resolved))
+
+    def _validate_scalar_string_mapping(self) -> None:
+        mapping = self.config.dataset.label_mapping
+        if not mapping:
+            raise DatasetValidationError(
+                "Scalar string targets require a non-empty explicit label mapping."
+            )
+        if any(not isinstance(label, str) for label in mapping):
+            raise DatasetValidationError(
+                "Scalar string label mapping keys must be exact strings."
+            )
+        invalid_destinations = any(
+            not isinstance(model_id, int) or isinstance(model_id, bool)
+            for model_id in mapping.values()
+        )
+        if invalid_destinations:
+            raise DatasetValidationError(
+                "Scalar string label mapping destinations must be checkpoint IDs."
+            )
+        destinations = list(mapping.values())
+        if len(set(destinations)) != len(destinations):
+            raise DatasetValidationError(
+                "Scalar string label mapping contains duplicate checkpoint ID destinations."
+            )
+        checkpoint_ids = set(self._model_id2label)
+        mapped_ids = set(destinations)
+        unknown_ids = sorted(mapped_ids - checkpoint_ids)
+        if unknown_ids:
+            raise DatasetValidationError(
+                f"Label mapping target IDs {unknown_ids} are absent from model.config.id2label."
+            )
+        missing_ids = sorted(checkpoint_ids - mapped_ids)
+        if missing_ids:
+            raise DatasetValidationError(
+                "Scalar string label mapping must cover every checkpoint ID; "
+                f"missing {missing_ids}."
+            )
 
     def _resolve_label(self, value: str, *, fallback_name: Any = None) -> int:
         mapping = self.config.dataset.label_mapping or {}

--- a/src/winml/modelkit/eval/evaluate.py
+++ b/src/winml/modelkit/eval/evaluate.py
@@ -60,6 +60,8 @@ def _select_model_loader(config: WinMLEvaluationConfig) -> _ModelLoaderKind:
 # default formatter layout) yields >100-char lines that trip E501.
 # fmt: off
 _EVALUATOR_REGISTRY: dict[str, str] = {
+    "audio-classification":
+        "winml.modelkit.eval.audio_classification_evaluator:WinMLAudioClassificationEvaluator",
     "image-classification":
         "winml.modelkit.eval.base_evaluator:WinMLEvaluator",
     "text-classification":

--- a/src/winml/modelkit/utils/eval_utils.py
+++ b/src/winml/modelkit/utils/eval_utils.py
@@ -57,6 +57,30 @@ _IMAGE_CLASSIFICATION_SCHEMA = TaskSchema(
     ),
 )
 
+_AUDIO_CLASSIFICATION_SCHEMA = TaskSchema(
+    columns=(
+        SchemaItem(
+            "input_column",
+            "encoded audio bytes/path or decoded waveform with sampling rate",
+            default="audio",
+            remap_hint="<your_audio_column>",
+        ),
+        SchemaItem(
+            "label_column",
+            "scalar ClassLabel or sequence of exact class labels",
+            default="label",
+            remap_hint="<your_label_column>",
+        ),
+    ),
+    params=(
+        SchemaItem(
+            "label_name_column",
+            "parallel exact label names for sequence-valued identifiers (optional)",
+            remap_hint="<your_label_name_column>",
+        ),
+    ),
+)
+
 _TEXT_CLASSIFICATION_SCHEMA = TaskSchema(
     columns=(
         SchemaItem(
@@ -449,6 +473,7 @@ _TEXT_GENERATION_SCHEMA = TaskSchema(
 )
 
 TASK_SCHEMAS: dict[str, TaskSchema] = {
+    "audio-classification": _AUDIO_CLASSIFICATION_SCHEMA,
     "image-classification": _IMAGE_CLASSIFICATION_SCHEMA,
     "text-classification": _TEXT_CLASSIFICATION_SCHEMA,
     "sequence-classification": _TEXT_CLASSIFICATION_SCHEMA,

--- a/src/winml/modelkit/utils/eval_utils.py
+++ b/src/winml/modelkit/utils/eval_utils.py
@@ -67,7 +67,7 @@ _AUDIO_CLASSIFICATION_SCHEMA = TaskSchema(
         ),
         SchemaItem(
             "label_column",
-            "scalar ClassLabel or sequence of exact class labels",
+            "scalar ClassLabel, explicitly mapped scalar string, or sequence of exact class labels",
             default="label",
             remap_hint="<your_label_column>",
         ),

--- a/tests/unit/eval/test_audio_classification_evaluator.py
+++ b/tests/unit/eval/test_audio_classification_evaluator.py
@@ -280,6 +280,147 @@ def test_scalar_binary_classlabel_preserves_argmax_accuracy_and_f1() -> None:
     assert metrics["class_coverage"] == 1.0
 
 
+def test_scalar_string_labels_use_explicit_checkpoint_id_mapping() -> None:
+    features = Features(
+        {
+            "audio": {
+                "array": Sequence(Value("float32")),
+                "sampling_rate": Value("int32"),
+            },
+            "gender": Value("string"),
+        }
+    )
+    dataset = Dataset.from_list(
+        [
+            {"audio": {"array": [-1.0] * 8, "sampling_rate": 16_000}, "gender": "female"},
+            {"audio": {"array": [1.0] * 8, "sampling_rate": 16_000}, "gender": "male"},
+        ],
+        features=features,
+    )
+    config = WinMLEvaluationConfig(
+        model_id="example/gender-audio",
+        task="audio-classification",
+        runtime="pytorch",
+        dataset=DatasetConfig(
+            path="example/gender-audio",
+            split="test",
+            samples=2,
+            shuffle=False,
+            columns_mapping={"label_column": "gender"},
+            label_mapping={"female": 0, "male": 1},
+        ),
+    )
+    model = _BinaryModel()
+
+    with (
+        patch("datasets.load_dataset", return_value=dataset),
+        patch(
+            "transformers.AutoFeatureExtractor.from_pretrained",
+            return_value=_IdentityWaveformExtractor(),
+        ),
+    ):
+        metrics = WinMLAudioClassificationEvaluator(config, model).compute()
+
+    assert model.forward_count == 2
+    assert metrics["accuracy"] == 1.0
+    assert metrics["macro_f1"] == 1.0
+
+
+@pytest.mark.parametrize(
+    ("label_mapping", "message"),
+    [
+        (None, "non-empty explicit label mapping"),
+        ({}, "non-empty explicit label mapping"),
+        ({"female": "0", "male": 1}, "destinations must be checkpoint IDs"),
+        ({"female": 0, "male": 0}, "duplicate checkpoint ID destinations"),
+        ({"female": 2, "male": 3}, "absent from model.config.id2label"),
+        ({"female": 0}, "must cover every checkpoint ID"),
+    ],
+    ids=[
+        "missing",
+        "empty",
+        "non-integer-destination",
+        "duplicate-destination",
+        "unknown-destinations",
+        "incomplete",
+    ],
+)
+def test_scalar_string_label_mapping_rejects_malformed_mappings(
+    label_mapping,
+    message,
+) -> None:
+    features = Features(
+        {
+            "audio": {
+                "array": Sequence(Value("float32")),
+                "sampling_rate": Value("int32"),
+            },
+            "gender": Value("string"),
+        }
+    )
+    dataset = Dataset.from_list(
+        [{"audio": {"array": [0.0], "sampling_rate": 16_000}, "gender": "female"}],
+        features=features,
+    )
+    config = WinMLEvaluationConfig(
+        model_id="example/gender-audio",
+        task="audio-classification",
+        dataset=DatasetConfig(
+            path="example/gender-audio",
+            samples=1,
+            shuffle=False,
+            columns_mapping={"label_column": "gender"},
+            label_mapping=label_mapping,
+        ),
+    )
+
+    with (
+        patch("datasets.load_dataset", return_value=dataset),
+        pytest.raises(DatasetValidationError, match=message),
+    ):
+        WinMLAudioClassificationEvaluator(config, _BinaryModel())
+
+
+def test_scalar_string_label_mapping_rejects_unmapped_observed_value() -> None:
+    features = Features(
+        {
+            "audio": {
+                "array": Sequence(Value("float32")),
+                "sampling_rate": Value("int32"),
+            },
+            "gender": Value("string"),
+        }
+    )
+    dataset = Dataset.from_list(
+        [{"audio": {"array": [0.0], "sampling_rate": 16_000}, "gender": "unknown"}],
+        features=features,
+    )
+    config = WinMLEvaluationConfig(
+        model_id="example/gender-audio",
+        task="audio-classification",
+        dataset=DatasetConfig(
+            path="example/gender-audio",
+            samples=1,
+            shuffle=False,
+            columns_mapping={"label_column": "gender"},
+            label_mapping={"female": 0, "male": 1},
+        ),
+    )
+    model = _BinaryModel()
+
+    with (
+        patch("datasets.load_dataset", return_value=dataset),
+        patch(
+            "transformers.AutoFeatureExtractor.from_pretrained",
+            return_value=_IdentityWaveformExtractor(),
+        ),
+        pytest.raises(DatasetValidationError, match=r"'unknown'.*absent"),
+    ):
+        WinMLAudioClassificationEvaluator(config, model).compute()
+
+    assert model.forward_count == 0
+
+
 def test_native_hf_model_without_io_config_uses_shared_adapter() -> None:
     config = WinMLEvaluationConfig(
         model_id="example/native-audio",
@@ -443,6 +584,10 @@ def test_registry_schema_and_no_universal_default() -> None:
 
     assert "audio-classification" in TASK_SCHEMAS
     assert "audio-classification" not in _DEFAULT_DATASETS
+    label_schema = next(
+        item for item in TASK_SCHEMAS["audio-classification"].columns if item.name == "label_column"
+    )
+    assert "explicitly mapped scalar string" in label_schema.description
     assert get_evaluator_class(WinMLEvaluationConfig(task="audio-classification")) is (
         WinMLAudioClassificationEvaluator
     )

--- a/tests/unit/eval/test_audio_classification_evaluator.py
+++ b/tests/unit/eval/test_audio_classification_evaluator.py
@@ -1,0 +1,353 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import ClassVar
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+import soundfile as sf
+import torch
+from datasets import ClassLabel, Dataset, DatasetDict, Features, Sequence, Value
+
+from winml.modelkit.eval import DatasetConfig, WinMLEvaluationConfig
+from winml.modelkit.eval.audio_classification_evaluator import (
+    WinMLAudioClassificationEvaluator,
+    _AudioModelAdapter,
+)
+from winml.modelkit.utils.eval_utils import DatasetValidationError
+
+
+class _ASTFeatureExtractor:
+    sampling_rate = 16_000
+
+    def __call__(self, waveform, *, sampling_rate, return_tensors):
+        assert waveform.shape == (16_000,)
+        assert sampling_rate == self.sampling_rate
+        assert return_tensors == "pt"
+        return {"input_values": torch.ones((1, 1024, 128), dtype=torch.float32)}
+
+
+class _CountingASTModel:
+    io_config: ClassVar = {
+        "input_names": ["input_values"],
+        "input_shapes": [[1, 1024, 128]],
+    }
+    config = SimpleNamespace(
+        id2label={0: "Speech", 1: "Music", 2: "Dog"},
+        label2id={"Speech": 0, "Music": 1, "Dog": 2},
+    )
+
+    def __init__(self) -> None:
+        self.forward_count = 0
+
+    def __call__(self, **inputs):
+        assert inputs["input_values"].shape == (1, 1024, 128)
+        logits = (
+            torch.tensor([[8.0, 7.0, -8.0]])
+            if self.forward_count == 0
+            else torch.tensor([[-8.0, 7.0, 8.0]])
+        )
+        self.forward_count += 1
+        return {"logits": logits}
+
+
+class _IdentityWaveformExtractor:
+    sampling_rate = 16_000
+
+    def __init__(self) -> None:
+        self.last_waveform = None
+
+    def __call__(self, waveform, *, sampling_rate, return_tensors, **_kwargs):
+        self.last_waveform = waveform
+        assert sampling_rate == self.sampling_rate
+        assert return_tensors == "pt"
+        return {"input_values": torch.as_tensor(waveform[None, :], dtype=torch.float32)}
+
+
+class _BinaryModel:
+    config = SimpleNamespace(
+        id2label={0: "negative", 1: "positive"},
+        label2id={"negative": 0, "positive": 1},
+    )
+
+    def __init__(self) -> None:
+        self.forward_count = 0
+
+    def __call__(self, **inputs):
+        score = inputs["input_values"].mean()
+        self.forward_count += 1
+        return {"logits": torch.stack((-score, score)).reshape(1, 2)}
+
+
+def test_rank_three_multilabel_uses_one_forward_per_row_and_finite_ap() -> None:
+    features = Features(
+        {
+            "audio": {
+                "array": Sequence(Value("float32")),
+                "sampling_rate": Value("int32"),
+            },
+            "labels": Sequence(Value("string")),
+            "human_labels": Sequence(Value("string")),
+        }
+    )
+    dataset = Dataset.from_list(
+        [
+            {
+                "audio": {"array": [0.0] * 16_000, "sampling_rate": 16_000},
+                "labels": ["/m/speech", "/m/music"],
+                "human_labels": ["Speech", "Music"],
+            },
+            {
+                "audio": {"array": [0.0] * 16_000, "sampling_rate": 16_000},
+                "labels": ["/m/music", "/m/dog"],
+                "human_labels": ["Music", "Dog"],
+            },
+        ],
+        features=features,
+    )
+    config = WinMLEvaluationConfig(
+        model_id="example/ast",
+        task="audio-classification",
+        dataset=DatasetConfig(
+            path="example/audioset",
+            split="test",
+            samples=2,
+            shuffle=False,
+            columns_mapping={"label_column": "labels"},
+        ),
+    )
+    model = _CountingASTModel()
+
+    with (
+        patch("datasets.load_dataset", return_value=dataset),
+        patch(
+            "transformers.AutoFeatureExtractor.from_pretrained",
+            return_value=_ASTFeatureExtractor(),
+        ),
+    ):
+        metrics = WinMLAudioClassificationEvaluator(config, model).compute()
+
+    assert model.forward_count == 2
+    assert metrics["processed_samples"] == 2
+    assert np.isfinite(metrics["sample_average_precision"])
+    assert np.isfinite(metrics["micro_average_precision"])
+    assert 0.0 <= metrics["sample_average_precision"] <= 1.0
+    assert 0.0 <= metrics["micro_average_precision"] <= 1.0
+    assert metrics["requested_samples"] == 2
+    assert metrics["selected_samples"] == 2
+    assert metrics["rejected_samples"] == 0
+
+
+def test_scalar_binary_classlabel_preserves_argmax_accuracy_and_f1() -> None:
+    features = Features(
+        {
+            "audio": {
+                "array": Sequence(Value("float32")),
+                "sampling_rate": Value("int32"),
+            },
+            "label": ClassLabel(names=["negative", "positive"]),
+        }
+    )
+    dataset = Dataset.from_list(
+        [
+            {"audio": {"array": [-1.0] * 8, "sampling_rate": 16_000}, "label": 0},
+            {"audio": {"array": [1.0] * 8, "sampling_rate": 16_000}, "label": 1},
+        ],
+        features=features,
+    )
+    config = WinMLEvaluationConfig(
+        model_id="example/binary-audio",
+        task="audio-classification",
+        runtime="pytorch",
+        dataset=DatasetConfig(path="example/binary", split="test", samples=2, shuffle=False),
+    )
+    model = _BinaryModel()
+
+    with (
+        patch("datasets.load_dataset", return_value=dataset),
+        patch(
+            "transformers.AutoFeatureExtractor.from_pretrained",
+            return_value=_IdentityWaveformExtractor(),
+        ),
+    ):
+        metrics = WinMLAudioClassificationEvaluator(config, model).compute()
+
+    assert model.forward_count == 2
+    assert metrics["accuracy"] == 1.0
+    assert metrics["macro_f1"] == 1.0
+    assert metrics["represented_classes"] == 2
+    assert metrics["class_coverage"] == 1.0
+
+
+def test_native_hf_model_without_io_config_uses_shared_adapter() -> None:
+    config = WinMLEvaluationConfig(
+        model_id="example/native-audio",
+        task="audio-classification",
+        runtime="pytorch",
+    )
+    model = _BinaryModel()
+    extractor = _IdentityWaveformExtractor()
+
+    with patch(
+        "transformers.AutoFeatureExtractor.from_pretrained",
+        return_value=extractor,
+    ):
+        adapter = _AudioModelAdapter(config, model)
+        logits = adapter.predict_logits(
+            {"array": np.ones(8, dtype=np.float32), "sampling_rate": 16_000}
+        )
+
+    assert model.forward_count == 1
+    assert logits.shape == (2,)
+
+
+def test_encoded_stereo_audio_is_downmixed_and_resampled(tmp_path) -> None:
+    audio_path = tmp_path / "stereo.wav"
+    frames = np.column_stack(
+        (
+            np.full(8_000, 0.25, dtype=np.float32),
+            np.full(8_000, 0.75, dtype=np.float32),
+        )
+    )
+    sf.write(audio_path, frames, 8_000)
+    config = WinMLEvaluationConfig(model_id="example/audio", task="audio-classification")
+    model = _BinaryModel()
+    extractor = _IdentityWaveformExtractor()
+
+    with patch(
+        "transformers.AutoFeatureExtractor.from_pretrained",
+        return_value=extractor,
+    ):
+        adapter = _AudioModelAdapter(config, model)
+        adapter.predict_logits({"bytes": None, "path": str(audio_path)})
+
+    assert extractor.last_waveform.shape == (16_000,)
+    np.testing.assert_allclose(extractor.last_waveform[100:-100], 0.5, atol=2e-3)
+
+
+def test_saved_dataset_dict_selects_requested_split() -> None:
+    features = Features(
+        {
+            "audio": {
+                "array": Sequence(Value("float32")),
+                "sampling_rate": Value("int32"),
+            },
+            "label": ClassLabel(names=["negative", "positive"]),
+        }
+    )
+    train = Dataset.from_list(
+        [{"audio": {"array": [-1.0], "sampling_rate": 16_000}, "label": 0}],
+        features=features,
+    )
+    test = Dataset.from_list(
+        [{"audio": {"array": [1.0], "sampling_rate": 16_000}, "label": 1}],
+        features=features,
+    )
+    config = WinMLEvaluationConfig(
+        model_id="example/audio",
+        task="audio-classification",
+        dataset=DatasetConfig(path="saved-dataset", split="test", samples=1, shuffle=False),
+    )
+
+    with (
+        patch("pathlib.Path.is_dir", return_value=True),
+        patch("datasets.load_from_disk", return_value=DatasetDict(train=train, test=test)),
+        patch(
+            "transformers.AutoFeatureExtractor.from_pretrained",
+            return_value=_IdentityWaveformExtractor(),
+        ),
+    ):
+        evaluator = WinMLAudioClassificationEvaluator(config, _BinaryModel())
+
+    assert evaluator.data[0]["label"] == 1
+
+
+@pytest.mark.parametrize(
+    "label_feature",
+    [Value("int64"), Sequence(Sequence(Value("string")))],
+    ids=["ambiguous-scalar-integer", "malformed-nested-sequence"],
+)
+def test_ambiguous_or_malformed_target_schema_fails_closed(label_feature) -> None:
+    features = Features(
+        {
+            "audio": {
+                "array": Sequence(Value("float32")),
+                "sampling_rate": Value("int32"),
+            },
+            "label": label_feature,
+        }
+    )
+    label = 0 if isinstance(label_feature, Value) else [["negative"]]
+    dataset = Dataset.from_list(
+        [{"audio": {"array": [0.0], "sampling_rate": 16_000}, "label": label}],
+        features=features,
+    )
+    config = WinMLEvaluationConfig(
+        model_id="example/audio",
+        task="audio-classification",
+        dataset=DatasetConfig(path="example/audio", samples=1, shuffle=False),
+    )
+
+    with (
+        patch("datasets.load_dataset", return_value=dataset),
+        pytest.raises(DatasetValidationError, match="must be ClassLabel or a sequence"),
+    ):
+        WinMLAudioClassificationEvaluator(config, _BinaryModel())
+
+
+def test_unmapped_sequence_target_fails_as_ambiguous() -> None:
+    features = Features(
+        {
+            "audio": {
+                "array": Sequence(Value("float32")),
+                "sampling_rate": Value("int32"),
+            },
+            "labels": Sequence(Value("string")),
+        }
+    )
+    dataset = Dataset.from_list(
+        [
+            {
+                "audio": {"array": [0.0], "sampling_rate": 16_000},
+                "labels": ["/m/not-a-model-label"],
+            }
+        ],
+        features=features,
+    )
+    config = WinMLEvaluationConfig(
+        model_id="example/audio",
+        task="audio-classification",
+        dataset=DatasetConfig(
+            path="example/audio",
+            samples=1,
+            shuffle=False,
+            columns_mapping={"label_column": "labels"},
+        ),
+    )
+
+    with (
+        patch("datasets.load_dataset", return_value=dataset),
+        patch(
+            "transformers.AutoFeatureExtractor.from_pretrained",
+            return_value=_IdentityWaveformExtractor(),
+        ),
+        pytest.raises(DatasetValidationError, match="no exact model-label match"),
+    ):
+        WinMLAudioClassificationEvaluator(config, _BinaryModel()).compute()
+
+
+def test_registry_schema_and_no_universal_default() -> None:
+    from winml.modelkit.eval.evaluate import _DEFAULT_DATASETS, get_evaluator_class
+    from winml.modelkit.utils.eval_utils import TASK_SCHEMAS
+
+    assert "audio-classification" in TASK_SCHEMAS
+    assert "audio-classification" not in _DEFAULT_DATASETS
+    assert get_evaluator_class(WinMLEvaluationConfig(task="audio-classification")) is (
+        WinMLAudioClassificationEvaluator
+    )

--- a/tests/unit/eval/test_audio_classification_evaluator.py
+++ b/tests/unit/eval/test_audio_classification_evaluator.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from io import BytesIO
 from types import SimpleNamespace
 from typing import ClassVar
 from unittest.mock import patch
@@ -13,7 +14,16 @@ import numpy as np
 import pytest
 import soundfile as sf
 import torch
-from datasets import ClassLabel, Dataset, DatasetDict, Features, Sequence, Value
+from datasets import (
+    Audio,
+    ClassLabel,
+    Dataset,
+    DatasetDict,
+    Features,
+    IterableDataset,
+    Sequence,
+    Value,
+)
 
 from winml.modelkit.eval import DatasetConfig, WinMLEvaluationConfig
 from winml.modelkit.eval.audio_classification_evaluator import (
@@ -83,6 +93,91 @@ class _BinaryModel:
         score = inputs["input_values"].mean()
         self.forward_count += 1
         return {"logits": torch.stack((-score, score)).reshape(1, 2)}
+
+
+class _EncodingMustNotRunAudio(Audio):
+    def encode_example(self, value):
+        raise AssertionError("bounded selection must not re-encode raw audio")
+
+
+class _RawAudioIterableDataset(IterableDataset):
+    def __init__(self, rows, features) -> None:
+        self._rows = rows
+        self._raw_features = features
+
+    @property
+    def features(self):
+        return self._raw_features
+
+    @property
+    def column_names(self):
+        return list(self._raw_features)
+
+    def take(self, count):
+        return iter(self._rows[:count])
+
+
+def test_streaming_raw_audio_is_bounded_without_feature_reencoding() -> None:
+    def wav_bytes(value: float) -> bytes:
+        buffer = BytesIO()
+        sf.write(buffer, np.full(16_000, value, dtype=np.float32), 16_000, format="WAV")
+        return buffer.getvalue()
+
+    rows = [
+        {"audio": {"bytes": wav_bytes(-0.5), "path": None}, "labels": ["negative"]},
+        {"audio": {"bytes": wav_bytes(0.5), "path": None}, "labels": ["positive"]},
+    ]
+    dataset = _RawAudioIterableDataset(
+        rows,
+        Features(
+            {
+                "audio": _EncodingMustNotRunAudio(decode=False),
+                "labels": Sequence(Value("string")),
+            }
+        ),
+    )
+    config = WinMLEvaluationConfig(
+        model_id="example/streaming-audio",
+        task="audio-classification",
+        runtime="pytorch",
+        dataset=DatasetConfig(
+            path="example/streaming-audio",
+            split="test",
+            streaming=True,
+            samples=2,
+            shuffle=False,
+            columns_mapping={"label_column": "labels"},
+        ),
+    )
+    model = _BinaryModel()
+    extractor = _IdentityWaveformExtractor()
+    decoded_payloads = []
+    decode_audio = _AudioModelAdapter._decode_audio
+
+    def track_decode(audio):
+        decoded_payloads.append(audio)
+        return decode_audio(audio)
+
+    with (
+        patch("datasets.load_dataset", return_value=dataset),
+        patch(
+            "transformers.AutoFeatureExtractor.from_pretrained",
+            return_value=extractor,
+        ),
+        patch.object(_AudioModelAdapter, "_decode_audio", side_effect=track_decode),
+    ):
+        metrics = WinMLAudioClassificationEvaluator(config, model).compute()
+
+    assert [payload["bytes"] for payload in decoded_payloads] == [
+        row["audio"]["bytes"] for row in rows
+    ]
+    assert model.forward_count == 2
+    assert metrics["requested_samples"] == 2
+    assert metrics["selected_samples"] == 2
+    assert metrics["processed_samples"] == 2
+    assert metrics["rejected_samples"] == 0
+    assert np.isfinite(metrics["sample_average_precision"])
+    assert np.isfinite(metrics["micro_average_precision"])
 
 
 def test_rank_three_multilabel_uses_one_forward_per_row_and_finite_ap() -> None:


### PR DESCRIPTION
## Summary

This dependent contribution adds WinML CPU FP32 and FP16 support for `prithivMLmods/Common-Voice-Gender-Detection`, a Wav2Vec2 audio classifier that emits female or male voice labels. Effort L2 ships model recipes plus a class-wide scalar-string label-mapping extension; Outcome L2 is complete, and the highest tested Goal is L3 PASS. The branch is stacked on Draft #1326 at exact head `1bd919b583aa8ccd974e35fa6a1a132ac7e1c9f8`; that PR owns the generic audio-classification evaluator and raw-streaming implementation included in this PR's diff against `main`.

## Model metadata

### What the model does

This Wav2Vec2 sequence-classification checkpoint accepts 16 kHz speech waveforms and emits two logits interpreted as female or male voice labels (`verified`). Evidence: pinned checkpoint `prithivMLmods/Common-Voice-Gender-Detection@ebbf41293c8dbea45c5bb0de6e3ef77bf89cc2ee`, its audio-classification model card, and the pinned `Wav2Vec2ForSequenceClassification` implementation.

### Primary user stories

- A user supplies a speech recording to obtain the checkpoint's female-or-male voice classification for audio analysis (`verified` from the checkpoint model card and `id2label` metadata).

### Supported tasks

- `audio-classification` across the checkpoint, Transformers, Optimum ONNX, and WinML surfaces (`verified` from the checkpoint pipeline tag, `Wav2Vec2ForSequenceClassification`, the Optimum Wav2Vec2 ONNX task registry, and WinML inspect/config behavior).

### Model architecture

```text
Wav2Vec2ForSequenceClassification
|-- Input waveform [batch, samples] at 16 kHz
|-- Wav2Vec2Model
|   |-- Convolutional feature encoder x 7
|   |-- Feature projection (conv width -> 768)
|   |-- Encoder prelude: positional convolution + LayerNorm
|   `-- Transformer encoder layer x 12
|       |-- Self-attention (12 heads, 768 hidden)
|       `-- Feed-forward + residual + normalization
|-- Projector (768 -> 256)
|-- Mean pooling over time
`-- Classifier (256 -> 2 logits)
```

- Source/confidence: pinned checkpoint config and pinned Wav2Vec2 source structure, with final ONNX regions mapped from node/tensor scopes and topology (`mapped`).

## Validation and support evidence

### 1. Baseline

The frozen baseline is `microsoft/winml-cli` main commit `0876e5ae1c98a169a6137e092e0d7b30bf9cee33`, WinML `0.3.0`. Recipe-free FP32 CPU build passed in 46.1 s, producing an approximately 360.9 MB model with 619/619 tagged ONNX nodes and `input_values float32[1,16000] -> logits float32[1,2]`. CPU perf over three measured iterations was 59.565 ms mean, 57.39 ms p50, 16.79 samples/s, and +63.55 MB RSS total delta. Eval failed before dataset loading because current-main WinML did not register `audio-classification`. Generated config already selected `export.compatibility.transformers_attention=eager`. Optimum exposed `audio-classification` and `feature-extraction` both before and after WinML registration, so the probe verdict was `VENDOR-ONLY` with no WinML-added task.

### 2. Goal

- **Effort:** L2.
- **Goal ceiling:** L3, with a floor of L1.
- **Outcome:** L2.
- **Success definition:** march L0-L3 plus mandatory perf, functional smoke, Analyze, compatibility, and CI parity for CPU FP32 and FP16.
- **Ceiling history:** charter-r2 reissued only the planner-owned final-artifact semantic mapping after technical PASS; it did not change or downgrade the L3 ceiling.

### 3. Outcome

The shipped tier is L2 and the highest Goal verdict is **L3 PASS**, with full technical coverage. Required tuples `CPUExecutionProvider/cpu/fp32` and `CPUExecutionProvider/cpu/fp16` both passed; no tuples are deferred. The contribution adds two CPU recipes and a generic, schema-driven scalar `Value('string')` mapping path. The model branch deliberately depends on Draft #1326 at `1bd919b583aa8ccd974e35fa6a1a132ac7e1c9f8`; #1326 retains ownership of evaluator registration, the base audio-classification implementation, raw `Audio(decode=False)` plus SoundFile decoding, fixed-window aggregation, and existing ClassLabel/sequence behavior. This PR adds only exact scalar-string mapping validation/resolution, its focused tests, schema help, and the model recipes.

Lane A knowledge was appended separately in [gim-home/ModelKitArtifacts#254](https://github.com/gim-home/ModelKitArtifacts/pull/254) at commit `0c896ff8e9eff8e26f41c3ee40058e960f149e85`, with published `wav2vec2.json` SHA-256 `14d78c8ae620e646f72a9255a924767c3b273633844e3219c7a6a9e0dcb279c0`. `No methodology friction observed.`

### 4. Per-EP/device/precision results and Functional smoke Eval

| Tier | EP / Device | Precision | Verdict | Mean | p50 | Throughput | RAM total delta |
|---|---|---|---|---:|---:|---:|---:|
| L0 | CPUExecutionProvider / cpu | fp32 | PASS; build 54.5 s | - | - | - | - |
| L0 | CPUExecutionProvider / cpu | fp16 | PASS; build 66.8 s | - | - | - | - |
| L1 | CPUExecutionProvider / cpu | fp32 | PASS | 51.024 ms | 51.123 ms | 19.6 samples/s | +63.52 MB |
| L1 | CPUExecutionProvider / cpu | fp16 | PASS | 61.586 ms | 62.633 ms | 16.24 samples/s | +41.48 MB |

L2 parity passed against pinned PyTorch `Wav2Vec2ForSequenceClassification@ebbf41293c8dbea45c5bb0de6e3ef77bf89cc2ee` using deterministic float32 input `[1,16000]`. FP32 cosine was `0.9999999999999206`, max absolute error `8.821487426757812e-06`, mean absolute error `8.225440979003906e-06`, finite output, and matching argmax. FP16 cosine was `0.9999999999953266`, max absolute error `0.0008280277252197266`, mean absolute error `0.0007888078689575195`, finite output, and matching argmax.

**Functional smoke Eval:** L3 PASS on final candidate `e4d19ba1d4af532ba4cf0b047ff2fb395ac9d868`, FP32 CPU, using `AsmaaQ/gender_audio_1080@47f6563cf1b819cbf1cbc8569a8dfe8fc426bab3`, config `default`, split `test`, streaming, no shuffle. Exact mapping was `female -> 0`, `male -> 1`, matching the checkpoint. Selection took the first eligible row for each exact mapped label in source order. Accounting was requested/selected/processed/rejected = `2/2/2/0`, with no rejection reasons; both classes were represented. The female row was mono 16 kHz PCM16, 55,872 frames (3.492 s), four 16,000-sample windows; the male row was mono 16 kHz PCM16, 81,216 frames (5.076 s), six windows. Fan-out caps were 2 rows, 2 classes, 10 total windows, 1 beam, and 0 other expansion. Accuracy was `1.0`; macro-F1 was `1.0`; represented classes were `2/2` and class coverage was `1.0`.

This is bounded real-data end-to-end operability evidence only. Two rows are not representative accuracy and are not a benchmark-quality claim. Only FP32 CPU Eval was measured; no FP16 or other-EP accuracy is implied. The former blocker was rejection of scalar `datasets.Value('string')` targets before inference; the new capability accepts them only through a complete, exact, explicit mapping to checkpoint class IDs.

### 5. Delta

Recipes added:

- `examples/recipes/prithivMLmods_Common-Voice-Gender-Detection/cpu/cpu/audio-classification_fp32_config.json`: `/export/compatibility/transformers_attention` is `eager`, identical to the generated baseline value.
- `examples/recipes/prithivMLmods_Common-Voice-Gender-Detection/cpu/cpu/audio-classification_fp16_config.json`: `/export/compatibility/transformers_attention` is `eager`, identical to baseline; `/quant` is the existing FP16 quantization object, while baseline has no `/quant`.

Parsed FP32 recipe content equals the baseline exactly. Parsed FP16 content equals baseline after substituting only the FP16 `/quant` object. Recipe-free Eval acceptance passed through the final built FP32 model. `examples/recipes/README.md` remains untouched.

Code delta relative to dependency #1326:

- `src/winml/modelkit/eval/audio_classification_evaluator.py`: `_validate_target_schema`, `_target_for_row`, and `_validate_scalar_string_mapping` add exact scalar-string mapping support.
- `src/winml/modelkit/utils/eval_utils.py`: `_AUDIO_CLASSIFICATION_SCHEMA` documents explicitly mapped scalar strings.
- `tests/unit/eval/test_audio_classification_evaluator.py`: focused class-wide regressions cover the new and preserved paths.

**Bug fix explanation:**

1. **Symptom and trigger:** a valid audio-classification dataset with scalar `datasets.Value('string')` targets, such as `female` and `male`, was rejected during target-schema validation before inference even when the caller supplied an explicit mapping.
2. **Root cause:** the inherited evaluator accepted scalar `ClassLabel` and sequence-valued label forms but had no scalar-string validation/resolution branch, so schema validation rejected the feature before exact mapping semantics could be applied.
3. **Changed symbols and mechanism:** `_validate_target_schema` recognizes scalar string features only when `_validate_scalar_string_mapping` proves a non-empty, one-to-one, complete mapping to contiguous checkpoint IDs; `_target_for_row` resolves each observed value by exact key lookup. `_AUDIO_CLASSIFICATION_SCHEMA` exposes that contract.
4. **General rule:** behavior is derived from dataset feature type, explicit caller mapping, and checkpoint class inventory. Production code contains no model ID, dataset ID, female/male special case, inferred ordinal, fuzzy match, or case folding.
5. **Compatibility and blast radius:** scalar `ClassLabel`, sequence `ClassLabel`/string multi-label behavior, metrics, raw streaming `decode=False`, SoundFile decoding, and fixed-window aggregation are preserved. Intentional change is limited to explicitly mapped scalar strings. Missing, empty, non-integer, duplicate-destination, out-of-range, incomplete, and unmapped observed values fail closed before inference.
6. **Regression evidence:** the focused evaluator suite passed `18` tests in `11.18 s`; the previously failing scalar-string mapping test passed; related eval/metric/recipe/command coverage passed `198` tests in producer verification. Tester CI passed 3,648 tests with 9 skipped in the commands group and 1,538 tests with 6 skipped and 2 expected failures in the models group. Ruff, full-package mypy, and license checks all passed.

### 6. Analyze summary - component level and op level

Analyze completed as `ANALYZE-PARTIAL-SUCCESS` with exit code 1 because six targets have no populated static rules. Static rule classification is not accelerator runtime execution.

#### Component-level summary

| Artifact | Architecture coverage | Mapping | Explicit gaps |
|---|---|---|---|
| fp32 | feature encoder; feature projection; encoder prelude; 12x encoder layers; projector; pooling; classifier | 392/397 mapped; planner-frozen with explicit gaps | 5 cross-component optimizer transition nodes |
| fp16 | same seven regions | 392/399 mapped; planner-frozen with explicit gaps | same 5 transitions plus 2 graph-boundary Casts |

The five shared gaps are the final feature-extractor Gelu, feature-projection output Reshape, first encoder-layer Gemm input Reshape, projector Gemm input Reshape, and projector output Reshape. They remain unattributed because adjacency alone is not accepted as semantic ownership evidence. FP16 additionally has input/output precision-adapter Casts. Every source component is mapped; resolving transition ownership would require exporter provenance or an instrumented unoptimized export with stable correspondence, and requires no product repair.

#### Op-level summary

| Artifact | Graph | Dominant ops | Rule-backed EP roll-up |
|---|---|---|---|
| fp32 | 397 ops / 14 types | Reshape 126; Gemm 75; Transpose 51; Add 38; LayerNormalization 26; MatMul 24 | Fully supported: NvTensorRTRTX/GPU, QNN/NPU, QNN/GPU, OpenVINO/NPU, OpenVINO/GPU, OpenVINO/CPU |
| fp16 | 399 ops / 15 types | same dominant counts, plus 2 Casts | Fully supported: NvTensorRTRTX/GPU, QNN/NPU, QNN/GPU, OpenVINO/NPU, OpenVINO/GPU, OpenVINO/CPU |

Rule-less targets CUDA/GPU, MIGraphX/GPU, TensorRT/GPU, DML/GPU, CPU/CPU, and VitisAI/NPU have no populated classifications. These are rules-availability gaps, not runtime failures or measured support claims.

### 7. Reproduce commands

Prerequisites: Windows PowerShell, Git, [`uv`](https://docs.astral.sh/uv/), internet access to the public Hugging Face checkpoint/dataset, and sufficient disk/RAM for approximately 361 MB FP32 and 180 MB FP16 external-weight payloads. The commands clone the exact dependent branch, verify its SHA and dependency ancestry, install the locked environment, clone the public static-rule repository, and reproduce build, perf, Analyze, bounded Eval, and quality checks.

```powershell
$CandidateRef = 'ssss141414/add-common-voice-gender-dependent'
$ExpectedCandidate = 'e4d19ba1d4af532ba4cf0b047ff2fb395ac9d868'
$ExpectedDependency = '1bd919b583aa8ccd974e35fa6a1a132ac7e1c9f8'

git clone https://github.com/microsoft/winml-cli.git winml-cli-common-voice-gender
Set-Location winml-cli-common-voice-gender
git fetch origin $CandidateRef
$ResolvedCandidate = (git rev-parse 'FETCH_HEAD^{commit}').Trim()
if ($ResolvedCandidate -ne $ExpectedCandidate) { throw "remote ref resolved to $ResolvedCandidate, expected $ExpectedCandidate" }
git merge-base --is-ancestor $ExpectedDependency $ResolvedCandidate
if ($LASTEXITCODE -ne 0) { throw 'candidate does not descend from the exact dependency SHA' }
git checkout --detach $ResolvedCandidate
if ((git rev-parse HEAD).Trim() -ne $ExpectedCandidate) { throw 'wrong candidate SHA after checkout' }
if (git status --porcelain) { throw 'checkout is not clean' }

uv sync --locked --all-extras --all-groups
$OUT = Join-Path $PWD 'temp/common-voice-gender-repro'
$FP32 = Join-Path $OUT 'fp32'
$FP16 = Join-Path $OUT 'fp16'
New-Item -ItemType Directory -Force -Path $OUT | Out-Null

uv run --no-sync winml build -c examples/recipes/prithivMLmods_Common-Voice-Gender-Detection/cpu/cpu/audio-classification_fp32_config.json -m prithivMLmods/Common-Voice-Gender-Detection -o $FP32 --rebuild
uv run --no-sync winml build -c examples/recipes/prithivMLmods_Common-Voice-Gender-Detection/cpu/cpu/audio-classification_fp16_config.json -m prithivMLmods/Common-Voice-Gender-Detection -o $FP16 --rebuild --precision fp16
uv run --no-sync winml perf -m (Join-Path $FP32 'model.onnx') --device cpu --ep cpu --iterations 10 --warmup 3 --memory --format json -o (Join-Path $OUT 'perf-fp32.json')
uv run --no-sync winml perf -m (Join-Path $FP16 'model.onnx') --device cpu --ep cpu --iterations 10 --warmup 3 --memory --format json -o (Join-Path $OUT 'perf-fp16.json')

git clone https://github.com/gim-home/ModelKitArtifacts.git (Join-Path $OUT 'ModelKitArtifacts')
$env:WINMLCLI_RULES_DIR = (Resolve-Path (Join-Path $OUT 'ModelKitArtifacts/rules')).Path
uv run --no-sync winml analyze --model (Join-Path $FP32 'model.onnx') --ep all --device all --output (Join-Path $OUT 'analyze-fp32.json')
uv run --no-sync winml analyze --model (Join-Path $FP16 'model.onnx') --ep all --device all --output (Join-Path $OUT 'analyze-fp16.json')
Remove-Item Env:WINMLCLI_RULES_DIR

$Mapping = Join-Path $OUT 'gender-label-mapping.json'
'{"female":0,"male":1}' | Set-Content -Path $Mapping -Encoding ascii
uv run --no-sync winml eval -m (Join-Path $FP32 'model.onnx') --model-id prithivMLmods/Common-Voice-Gender-Detection --task audio-classification --ep cpu --device cpu --dataset AsmaaQ/gender_audio_1080 --dataset-revision 47f6563cf1b819cbf1cbc8569a8dfe8fc426bab3 --split test --streaming --samples 2 --no-shuffle --column input_column=path --column label_column=gender --label-mapping $Mapping -o (Join-Path $OUT 'functional-smoke.json')

uv run --no-sync pytest tests/unit/commands tests/unit/config tests/unit/build tests/unit/compiler tests/unit/session tests/unit/eval --tb=short --no-cov -m "not e2e and not npu and not gpu"
uv run --no-sync pytest tests/unit/models tests/unit/loader tests/unit/datasets tests/unit/export --tb=short --no-cov -m "not e2e and not npu and not gpu"
uv run --no-sync ruff check src/ tests/
uv run --no-sync mypy -p winml.modelkit
uv run --no-sync pre-commit run insert-license --all-files
```

The Eval command is a two-row functional smoke only, not representative accuracy. Analyze is static rule classification, not accelerator runtime evidence.

### Dependency and provenance

- Dependency: Draft [microsoft/winml-cli#1326](https://github.com/microsoft/winml-cli/pull/1326), exact head `1bd919b583aa8ccd974e35fa6a1a132ac7e1c9f8`, owns the generic audio evaluator implementation described above. This dependent PR does not duplicate or rewrite that ownership.
- Candidate: `ssss141414/add-common-voice-gender-dependent`, exact head `e4d19ba1d4af532ba4cf0b047ff2fb395ac9d868`; the dependency head is its verified ancestor.
- Lane A: Draft [gim-home/ModelKitArtifacts#254](https://github.com/gim-home/ModelKitArtifacts/pull/254), exact commit `0c896ff8e9eff8e26f41c3ee40058e960f149e85`, published knowledge-file SHA-256 `14d78c8ae620e646f72a9255a924767c3b273633844e3219c7a6a9e0dcb279c0`.