### PR TITLE
recipe(ms-marco-MiniLM-L12-v2): add CPU reranking recipes

### DIFF
--- a/examples/recipes/cross-encoder_ms-marco-MiniLM-L12-v2/cpu/cpu/reranking_fp16_config.json
+++ b/examples/recipes/cross-encoder_ms-marco-MiniLM-L12-v2/cpu/cpu/reranking_fp16_config.json
@@ -1,0 +1,65 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [1, 512],
+        "value_range": [0, 30522]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [1, 512],
+        "value_range": [0, 2]
+      },
+      {
+        "name": "token_type_ids",
+        "dtype": "int32",
+        "shape": [1, 512],
+        "value_range": [0, 2]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "reranking",
+    "model_class": "AutoModelForSequenceClassification",
+    "model_type": "bert"
+  }
+}

--- a/examples/recipes/cross-encoder_ms-marco-MiniLM-L12-v2/cpu/cpu/reranking_fp32_config.json
+++ b/examples/recipes/cross-encoder_ms-marco-MiniLM-L12-v2/cpu/cpu/reranking_fp32_config.json
@@ -1,0 +1,46 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [1, 512],
+        "value_range": [0, 30522]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [1, 512],
+        "value_range": [0, 2]
+      },
+      {
+        "name": "token_type_ids",
+        "dtype": "int32",
+        "shape": [1, 512],
+        "value_range": [0, 2]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "reranking",
+    "model_class": "AutoModelForSequenceClassification",
+    "model_type": "bert"
+  }
+}


### PR DESCRIPTION
# Summary

This adds CPU fp32 and fp16 reranking recipes for `cross-encoder/ms-marco-MiniLM-L12-v2`, a cross-encoder that scores query-document pairs for ranking. The contribution has Effort L2 and Outcome L2 because its independent delta remains recipe-only while generic L2 reranking support is owned by stacked dependency PR #1322. The highest Goal verdict reached is L3 PASS with full coverage across both required CPU precision tuples.

# Model metadata

### What the model does

Cross-encoder reranker that scores a query-document pair with a single scalar relevance logit for ranking. Evidence: Hugging Face model metadata pipeline tag and model card task tags; pinned checkpoint configuration identifies `BertForSequenceClassification` with `num_labels=1`. Confidence: `verified`.

### Primary user stories

- A user supplies a search query and a small candidate document list to obtain relevance scores used to rank results. Evidence: MS MARCO reranking model card intent. Confidence: `mapped`.
- A retrieval pipeline supplies top-k candidates to obtain better ordering before final answer generation. Evidence: cross-encoder reranker usage pattern. Confidence: `inferred`.

### Supported tasks

- `text-ranking` across the checkpoint, Transformers, Optimum ONNX, and WinML support surfaces. Evidence: pipeline tag, WinML inspect pipeline task, and Optimum probe tasks. Confidence: `mapped`.

### Model architecture

```text
BertForSequenceClassification
|-- BertEmbeddings
|-- BertEncoder (12 Transformer layers)
|   |-- Self-attention
|   |-- Feed-forward
|   `-- Residual + LayerNorm
`-- Sequence classification head (single scalar logit)
```

- Source/confidence: pinned checkpoint `cross-encoder/ms-marco-MiniLM-L12-v2` configuration and Transformers BERT class structure (`mapped`).

# Validation and support evidence

### Baseline

Current `main` and the frozen baseline remain `0876e5ae1c98a169a6137e092e0d7b30bf9cee33` with WinML `0.0.1.dev0`. Recipe-free auto-resolution used `text-classification`: build PASS in 49.9s, followed by perf PASS at 98.69 ms mean, 98.21 ms p50, 10.13 samples/s, and +79.4 MB RAM. The build output reported an Optimize stage despite `--no-optimize`. Canonical `text-ranking` config was unsupported by TasksManager (exit 2), and canonical text-ranking eval was unsupported (exit 1). The Optimum probe was `VENDOR-ONLY`: BERT export was vendor-covered for text-classification, with no task added by WinML at baseline.

The dependency baseline for this stacked contribution is PR #1322 at `3708969b731425b0c6d4b97920d1b5e6519bb013`, advanced by fast-forward from `030e79fa6482acb08e51338ab4172ac4387b387d`. The current L12 candidate is `8dae90fbd75c30c79d0bd5ec60f7817d23d5bd6d`, with that exact dependency commit as its parent.

### Goal

- Effort: L2.
- Goal ceiling: L3.
- Outcome: L2.
- Success definition: L0 build/structure, L1 performance, L2 numerical parity, and L3 bounded reranking functional smoke.
- Ceiling change: none; the committed L3 ceiling was reached.

The L2 context is stacked: PR #1322 owns generic reranking task resolution, inference/evaluator dispatch, grouped ranking data handling, and ranking metrics. This independent commit adds model recipes only and does not claim to add generic source support.

### Outcome

L3 PASS was reached with `full` coverage. Both required tuples, `CPUExecutionProvider/cpu/fp32` and `CPUExecutionProvider/cpu/fp16`, pass L0, L1, and L2; the bounded fp32 public evaluator smoke passes L3. Deferred tuples: `[]`. Unresolved tuples: `[]`. The shipped Outcome remains L2 because this PR's independent delta contains exactly two CPU recipes and relies on PR #1322 for generic L2 reranking code.

Learner findings v4 retain `bert-011`, `bert-013`, `bert-014`, `bert-015`, and `bert-016`, and update:

- `bert-012`: L12 reranker CPU fp16 completes a bounded one-run probe despite historical multi-iteration timeouts. The current tuple is PASS; scaled-run completion and a stable latency distribution remain unmeasured.

The methodology audit is not a no-friction result: reviewer R4 exposed a hash-valid root with contradictory terminal-state semantics, so learner finding `_meta-111` now requires semantic agreement across terminal-state and identity fields in addition to immutable roots and hashes. Lane A pushed the implementation in `2c5700a047fc85e5fb3405d361f8fb06e1c846fd` and exact-SHA metadata finalization in `e70be83aefd621dbb4170aa647fe6344a6d4884c`; review it at https://github.com/gim-home/ModelKitArtifacts/compare/main...ssss141414/learner-l12-bert-knowledge-20260823?expand=1. These knowledge and skill edits remain separate from this model PR.

### Per-EP/device/precision results and Functional smoke Eval

| Tier | EP / Device | Precision | Verdict | Mean | p50 | Throughput | RAM / RSS | Detail |
|---|---|---|---|---|---|---|---|---|
| L0 | CPUExecutionProvider / cpu | fp32 | PASS | - | - | - | - | 133,589,610 bytes; 204 FLOAT + 56 INT64 initializers; 388 nodes; three `[1,512]` int32 inputs; `[1,1]` float logits |
| L0 | CPUExecutionProvider / cpu | fp16 | PASS | - | - | - | - | 66,856,699 bytes; 204 FLOAT16 + 56 INT64 initializers; 389 nodes; three `[1,512]` int32 inputs; `[1,1]` float logits |
| L1 | CPUExecutionProvider / cpu | fp32 | PASS | 101.383 ms | 99.193 ms | 9.86 samples/s | +79.65 MB | 30 iterations after 5 warmups; reused after recipe byte-equivalence and Eval-only dependency delta |
| L1 | CPUExecutionProvider / cpu | fp16 | PASS | 187.938499962911 ms | - | 5.320889547364412 samples/s | 647761920 bytes before; 695275520 bytes after; +47513600 bytes | True-fp16 model; 1 measured iteration, 0 warmups, 1800-second cap; no peak RSS was sampled and no peak claim is made |

Historical context only: prior candidate `07a7ee4fa097210a43e2ca9ce7f68b659a2cedb0` exceeded 2700 seconds at 2743.499 seconds for a 30-iteration/5-warmup run, and a 10-iteration/3-warmup attempt reached 600 seconds after setup without a result. Those bounded prior attempts are superseded as the tuple verdict by the current one-sample PASS and are not stable benchmark evidence.

R4 terminal-state integrity is repaired in a fresh immutable Tester v3 root: the corrected controller records result `PASS`, phase `completed`, and outer exit `0`. Cross-file validation reports semantic agreement, and the 26-entry final seal reports zero hash mismatches. The old sealed root is preserved only as incident provenance and is not authoritative for the current fp16 result.

L2 named-input parity PASS for both artifacts over three pairs: fp32 cosine `0.9999999999999853`, max absolute difference `0.000002384185791015625`; fp16 cosine `0.9999990532003638`, max absolute difference `0.03248405456542969`. L0 and L2 were reused only after range-diff and blob comparison proved both recipes byte-identical across the restack; the dependency delta is Eval-only.

#### Functional smoke Eval

L3 PASS on final candidate `8dae90fbd75c30c79d0bd5ec60f7817d23d5bd6d`, FP32 `CPUExecutionProvider/cpu`, through the public `winml eval` command and `winml.modelkit.eval.reranking_evaluator.WinMLRerankingEvaluator`. The pinned dataset is `mteb/scidocs-reranking` revision `56a6d0140cf6356659e2a7c1413286a774468d44`, split `test`, streamed without shuffle. The deterministic first 2 groups were selected and processed with 0 skipped groups, producing 20 query-document pairs. Positive and negative passage text was materialized before scoring; positives are relevant, negatives are non-relevant, and each pair produces one scalar relevance logit ranked in descending order. Caps were 10 candidates per group and sequence length 512.

Results: MRR@10 `1.0`, Recall@1 `1.0`, and Recall@10 `1.0`; 2 scored groups and 0 groups without a positive. This is a bounded functional operability smoke only, not representative accuracy or benchmark quality, and it does not claim fp16 Eval accuracy. Baseline main could not run canonical text-ranking Eval; PR #1322 at `3708969b731425b0c6d4b97920d1b5e6519bb013` supplies the generic public evaluator capability exercised here.

### Delta

The independent PR #1334 delta adds exactly:

- `examples/recipes/cross-encoder_ms-marco-MiniLM-L12-v2/cpu/cpu/reranking_fp32_config.json`
- `examples/recipes/cross-encoder_ms-marco-MiniLM-L12-v2/cpu/cpu/reranking_fp16_config.json`

There are no modified or deleted files and no source, test, or README changes; the production recipe README remains untouched. The canonical baseline recipe is `NOT-COMPARABLE`: baseline TasksManager could not emit canonical text-ranking config, so there are no baseline JSON-pointer old/new values. Both recipe blobs are byte-identical to old candidate `07a7ee4fa097210a43e2ca9ce7f68b659a2cedb0` after restacking on dependency `3708969b731425b0c6d4b97920d1b5e6519bb013`. Recipe-free acceptance PASSes with resolved task `reranking`, `AutoModelForSequenceClassification`, and canonical paired BERT inputs. The delta remains reducibility-consistent with the charter.

#### Bug fix explanation (dependency PR #1322)

1. **Symptom and trigger:** public no-dataset `winml eval --task reranking --samples 2` selected an ID-only MS MARCO dataset whose rows lacked candidate passage text, so `WinMLRerankingEvaluator` rejected them before scoring.
2. **Root cause:** the default dataset contract and evaluator schema were incompatible. Resolving IDs through the canonical 8.8M-passage corpus or top1000 archive would require an unbounded multi-gigabyte download or scan even for a tiny smoke.
3. **Changed symbols and mechanism:** PR #1322 changes `_DEFAULT_DATASETS['reranking']`, `_RERANKING_SCHEMA`, `RerankingDatasetMode`, `detect_reranking_dataset_mode`, and `WinMLRerankingEvaluator` group materialization. The default is pinned streaming SciDocs; grouped `query`/`positive`/`negative` text is detected and materialized with deterministic candidate IDs, positive retention, and `max_candidates=10`.
4. **General rule:** the fix is schema- and data-driven for grouped reranking datasets, with no checkpoint-specific branch or hardcoded L12 behavior.
5. **Compatibility and blast radius:** existing pairwise and already-materialized `candidates_column` paths remain supported; materialized candidate order remains unchanged and is not capped. The intentional changes are the default streaming SciDocs dataset and bounded grouped positive/negative text support.
6. **Regression evidence:** focused default/evaluator coverage passed 109 tests; commands/config/build/compiler/session/eval passed 3641 tests with 9 skipped and 1 warning; datasets passed 78; utils passed 279 with 1 skipped; Ruff passed; mypy reported no issues in 438 source files. The final candidate public CLI smoke passed on 2 groups and 20 pairs with the metrics above.

This generic bug fix belongs to dependency PR #1322. PR #1334's own diff remains exactly the two recipes listed above.

### Analyze summary &mdash; component level and op level

`ANALYZE-PARTIAL-SUCCESS` (exit 1): OpenVINO CPU rule analysis completed, while CPUExecutionProvider has no runtime rule data. This is static compatibility analysis, not runtime execution.

#### Component-level summary

| Artifact | Architecture coverage | Mapping | Actionable EP findings |
|---|---|---|---|
| fp32 | embeddings; 12x encoder attention/FFN; scalar head | 429 mapped, 7 unmapped; mapped with explicit optimization provenance | None |

Final optimization removes hierarchy metadata and renames nodes; semantic components use the preserved tagged export hierarchy or native ONNX scopes, while op/EP counts come from the final graph.

#### Op-level summary

| Artifact | Graph | Dominant ops | EP roll-up |
|---|---|---|---|
| fp32 | 388 operators / 16 unique types | Reshape 120; Gemm 74; Transpose 48; Add 38 | OpenVINOExecutionProvider/CPU fully supported |

CPUExecutionProvider/CPU has no rule data and therefore an empty classification; this is not a runtime support claim.

### Reproduce commands

```powershell
$OUT='temp/ms-marco-MiniLM-L12-v2-repro'
winml build -c examples/recipes/cross-encoder_ms-marco-MiniLM-L12-v2/cpu/cpu/reranking_fp32_config.json -m cross-encoder/ms-marco-MiniLM-L12-v2 -o $OUT/fp32
winml build -c examples/recipes/cross-encoder_ms-marco-MiniLM-L12-v2/cpu/cpu/reranking_fp16_config.json -m cross-encoder/ms-marco-MiniLM-L12-v2 -o $OUT/fp16 --precision fp16
winml analyze --model $OUT/fp32/model.onnx --ep all --output $OUT/analyze.json
winml perf -m $OUT/fp32/model.onnx --device cpu --ep cpu --iterations 30 --warmup 5
winml eval -m $OUT/fp32/model.onnx --model-id cross-encoder/ms-marco-MiniLM-L12-v2 --task reranking --ep cpu --device cpu --samples 2
```