### PR TITLE
recipe(gte-reranker-modernbert-base): add CPU reranking recipes

### DIFF
--- a/examples/recipes/Alibaba-NLP_gte-reranker-modernbert-base/cpu/cpu/reranking_fp16_config.json
+++ b/examples/recipes/Alibaba-NLP_gte-reranker-modernbert-base/cpu/cpu/reranking_fp16_config.json
@@ -1,0 +1,91 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          1024
+        ],
+        "value_range": [
+          0,
+          50368
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          1024
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "reranking",
+    "model_id": "Alibaba-NLP/gte-reranker-modernbert-base",
+    "model_type": "modernbert",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "reranking",
+    "model_class": "AutoModelForSequenceClassification",
+    "model_type": "modernbert"
+  },
+  "eval": {
+    "task": "reranking",
+    "dataset": {
+      "path": "mteb/scidocs-reranking",
+      "split": "test",
+      "samples": 2,
+      "shuffle": false,
+      "streaming": true,
+      "revision": "56a6d0140cf6356659e2a7c1413286a774468d44",
+      "columns_mapping": {
+        "query_column": "query",
+        "positive_column": "positive",
+        "negative_column": "negative",
+        "max_candidates": "10"
+      }
+    }
+  }
+}

--- a/examples/recipes/Alibaba-NLP_gte-reranker-modernbert-base/cpu/cpu/reranking_fp32_config.json
+++ b/examples/recipes/Alibaba-NLP_gte-reranker-modernbert-base/cpu/cpu/reranking_fp32_config.json
@@ -1,0 +1,69 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          1024
+        ],
+        "value_range": [
+          0,
+          50368
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          1024
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "reranking",
+    "model_class": "AutoModelForSequenceClassification",
+    "model_type": "modernbert"
+  },
+  "eval": {
+    "task": "reranking",
+    "dataset": {
+      "path": "mteb/scidocs-reranking",
+      "split": "test",
+      "samples": 2,
+      "shuffle": false,
+      "streaming": true,
+      "revision": "56a6d0140cf6356659e2a7c1413286a774468d44",
+      "columns_mapping": {
+        "query_column": "query",
+        "positive_column": "positive",
+        "negative_column": "negative",
+        "max_candidates": "10"
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Summary

This adds CPU fp32 and fp16 reranking recipes for `Alibaba-NLP/gte-reranker-modernbert-base`, an English cross-encoder that emits one raw relevance logit per query-document pair. The shipped Effort and Outcome are L2, with model-specific recipe configuration layered on the generic reranking capability owned by dependency PR #1322. Sealed candidate evidence reaches L3 PASS with full coverage, and exact candidate-SHA quality evidence passes all required GitHub Actions gates.

### Model metadata

#### What the model does

An English cross-encoder text reranker that jointly encodes a query and candidate document and emits one raw relevance logit per pair for descending-score ranking.

- Evidence: the [pinned model card](https://huggingface.co/Alibaba-NLP/gte-reranker-modernbert-base/tree/f7481e6055501a30fb19d090657df9ec1f79ab2c) identifies the model as a text reranker and demonstrates pair scoring; its pinned `config.json` declares `model_type=modernbert`, `ModernBertForSequenceClassification`, `num_labels=1`, and `classifier_pooling=mean`.
- Confidence: `verified`.

#### Primary user stories

- A user supplies a query and candidate documents to obtain one relevance score per query-document pair and reorder retrieval results for search or RAG. Evidence: pinned model card pair-scoring example. Confidence: `verified`.
- A user supplies an English question and passages to obtain a higher score for the more relevant passage in a bounded reranking stage. Evidence: pinned model card pair-scoring example. Confidence: `verified`.

#### Supported tasks

- `reranking` on the checkpoint surface. Evidence: pinned model card model type and pair-scoring example. Confidence: `verified`.
- `text-classification` on the Transformers, Optimum ONNX, and WinML surfaces. Evidence: pinned `config.json`; Optimum's ModernBERT vendor tasks include text classification; WinML recipe-free export resolved text classification successfully. Confidence: `verified`.

#### Model architecture

```text
ModernBertForSequenceClassification
|-- ModernBertModel
|   |-- Token embeddings + LayerNorm (vocab 50,368 -> hidden 768)
|   |-- Rotary embeddings (local/full layer types)
|   |-- Encoder layer x 22
|   |   |-- Fused-QKV self-attention (12 heads; sliding/full bidirectional masks)
|   |   |-- Residual + LayerNorm
|   |   `-- Gated MLP (768 -> 2 x 1,152 -> 768) + residual
|   `-- Final LayerNorm
|-- Attention-mask mean pooling
|-- ModernBertPredictionHead (768 -> 768, GELU, LayerNorm)
`-- Regression classifier (768 -> 1 raw relevance logit)
```

- Source/confidence: pinned checkpoint config, selected Transformers `ModernBertForSequenceClassification` source, and exported hierarchy metadata (`verified`). The encoder-only cross-encoder has 149,605,633 parameters; the export traced 22 encoder layers and produces scalar logits.

### Validation and support evidence

#### 1. Baseline

- Pinned `main`: `0876e5ae1c98a169a6137e092e0d7b30bf9cee33`; WinML version `0.0.1.dev0`.
- Recipe-free auto-config resolved `text-classification`. Optimum advertised `feature-extraction`, `fill-mask`, `text-classification`, and `token-classification`; WinML added no vendor export task. Reranking is a WinML semantic over the same single-logit sequence-classification export supplied by dependency PR #1322.
- Build: PASS, `ModernBertForSequenceClassification`, task `text-classification`, opset 17, logits output, completed in 81.2 s; an independent repeat also passed.
- Perf floor: 941.98 ms mean, 941.60 ms p50, 975.66 ms p95, 1.06 samples/s, and +380.8 MB RAM on Intel Core i9-10900X; input `[1,1024]`, output logits `[1,1]` float32.
- Eval floor: exit 1 because `main` resolved the requested task string but reported that `reranking` was not supported by WinML eval.
- Goal floor: L1. Baseline evidence was freshly rerun at the pinned commit; no prior stages were reused.

#### 2. Goal

- Committed Effort: L2.
- Committed Goal ceiling: L3.
- Committed Outcome: L2.
- Success definition: build the required CPU/cpu fp32 and fp16 tuples; report CPU perf; establish PyTorch-to-ONNX raw-logit parity and descending-order agreement on pinned model-card pairs; and run one bounded fp32 CPU SciDocs reranking functional smoke with explicit group, candidate, pair, and sequence caps.
- No ceiling change or re-issued charter occurred. The sealed Goal result reached L3 PASS with full coverage and no deferred tuples.

#### 3. Outcome

The model-specific Outcome is L2: exactly two checked-in CPU reranking recipes select dependency-owned generic reranking behavior without adding shared code. The highest reached Goal verdict is **L3 PASS**, sealed for candidate `5833e0f8bb3d2b3df95cf813861c7692fa6459af`, with full coverage and no deferred tuples.

Learner findings `modernbert-001` through `modernbert-004` retain the fp32/fp16 export, perf, parity, SciDocs smoke, and analyze evidence. Methodology finding `_meta-112` records that quality conclusions require a candidate-local interpreter, tool, import root, and exact-lock provenance; its Lane A changes are separate from this model PR ([compare](https://github.com/gim-home/ModelKitArtifacts/compare/main...ssss141414/learner-modernbert-knowledge-20260823?expand=1)).

**Current candidate quality status:** reentry8 is **PASS** for exact candidate `5833e0f8bb3d2b3df95cf813861c7692fa6459af`. The authoritative [exact-head validation run](https://github.com/microsoft/winml-cli/actions/runs/32648982234) passed all six jobs: [analyze](https://github.com/microsoft/winml-cli/actions/runs/32648982234/job/97217553289) 1,526 passed / 45 skipped; [optim](https://github.com/microsoft/winml-cli/actions/runs/32648982234/job/97217553333) 848 passed / 16 skipped / 1 xfailed; [commands](https://github.com/microsoft/winml-cli/actions/runs/32648982234/job/97217553344) 3,641 passed / 9 skipped / 1 warning; [models](https://github.com/microsoft/winml-cli/actions/runs/32648982234/job/97217553355) 1,534 passed / 6 skipped / 2 xfailed; [remaining](https://github.com/microsoft/winml-cli/actions/runs/32648982234/job/97217553407) 871 passed / 2 skipped / 1 deselected / 1 warning; and [lint](https://github.com/microsoft/winml-cli/actions/runs/32648982234/job/97217553217) license headers and Ruff PASS with mypy clean across 438 source files. Every one of the six jobs explicitly checked out `ssss141414/winml-cli` at immutable ref `5833e0f8bb3d2b3df95cf813861c7692fa6459af`, asserted `HEAD`, used the candidate-local `.venv`, and synced against the locked `uv.lock` SHA-256 `F6672F52199FA442A7B1414BA943C4ECCC365940206E430777A51A1374B29053`. The [draft validation workflow PR #1337](https://github.com/microsoft/winml-cli/pull/1337) commit is not the model candidate and must never merge. Goal-evidence integrity was independently repaired with an external immutable full SHA-256 snapshot seal covering all referenced Goal roots (226 source files total, zero mismatches); the sealed Goal L0-L3 and analysis values remain unchanged.

#### 4. Per-EP/device/precision results and Functional smoke Eval

| Tier | EP / Device | Precision | Verdict | Mean | p50 | p95 | Throughput | RAM delta |
|---|---|---|---|---:|---:|---:|---:|---:|
| L0 | CPUExecutionProvider / cpu | fp32 | PASS | - | - | - | - | - |
| L0 | CPUExecutionProvider / cpu | fp16 | PASS | - | - | - | - | - |
| L1 | CPUExecutionProvider / cpu | fp32 | PASS | 943.47 ms | 943.94 ms | 981.87 ms | 1.06 samples/s | +389.2 MB |
| L1 | CPUExecutionProvider / cpu | fp16 | PASS | 1294.34 ms | 1290.29 ms | 1338.52 ms | 0.77 samples/s | +406.4 MB |

- L0 fp32: `input_ids` and `attention_mask` INT32 `[1,1024]`; FLOAT logits `[1,1]`; 193 FLOAT, 15 INT64, and 2 BOOL initializers; external data 601,194,496 bytes.
- L0 fp16: the same input/output contract; 193 FLOAT16, 15 INT64, and 2 BOOL initializers; external data 301,126,144 bytes. The fp16/fp32 external-data ratio is `0.5008797419196599`.
- L2 fp32, three pinned model-card pairs: cosine `0.9999999999996143`, max absolute difference `2.6226043701171875e-06`; PyTorch and ONNX descending order both `[1,0,2]`, so order matched. Scores were untransformed raw scalar logits.
- L2 fp16, the same three pairs: cosine `0.9999993407707104`, max absolute difference `0.004093289375305176`; PyTorch and ONNX descending order both `[1,0,2]`, so order matched. Scores were untransformed raw scalar logits.

**Functional smoke Eval:** L3 PASS on final candidate `5833e0f8bb3d2b3df95cf813861c7692fa6459af`, FP32 CPU, using `mteb/scidocs-reranking` test data pinned to revision `56a6d0140cf6356659e2a7c1413286a774468d44`. Deterministic first-N streaming selection processed 2 query groups and 20 query-passage pairs. Caps were 2 groups, 10 candidates per group, 20 total pairs, and sequence length 1024. The schema used `query`, `positive`, and `negative`; positives mapped to relevance 1, negatives to 0; exactly one raw float logit per pair was ranked descending without categorical mapping or softmax. MRR@10 = `1.0`, Recall@1 = `1.0`, and Recall@10 = `1.0`. **This proves end-to-end operability only; it is not representative accuracy or benchmark quality.** FP16 eval was not run because the Tester contract calls for one representative final-SHA FP32 CPU functional smoke. The former blocker was WinML's lack of a reranking evaluator; dependency PR #1322 provides generic task normalization, single-logit evaluation, grouped dataset adaptation, and ranking metrics.

#### 5. Delta

The candidate diff contains exactly these two model-specific recipe files:

- `examples/recipes/Alibaba-NLP_gte-reranker-modernbert-base/cpu/cpu/reranking_fp32_config.json`
- `examples/recipes/Alibaba-NLP_gte-reranker-modernbert-base/cpu/cpu/reranking_fp16_config.json`

| Recipe | JSON pointer | Baseline value | Shipped value |
|---|---|---|---|
| fp32 | `/loader/task` | `text-classification` | `reranking` |
| fp32 | `/eval` | absent | Pinned bounded SciDocs test plan: revision `56a6d0140cf6356659e2a7c1413286a774468d44`, streaming true, shuffle false, samples 2, max candidates 10 |
| fp32 | `/export/compatibility` | `{"transformers_attention":"eager"}` | absent in checked-in source; auto-config resolves to eager |
| fp16 | `/loader/task` | `text-classification` | `reranking` |
| fp16 | `/quant` | `null` | Existing-model fp16 quant block with `mode=fp16` and `task=reranking` |
| fp16 | `/eval` | absent | Pinned bounded SciDocs test plan: revision `56a6d0140cf6356659e2a7c1413286a774468d44`, streaming true, shuffle false, samples 2, max candidates 10 |
| fp16 | `/export/compatibility` | `{"transformers_attention":"eager"}` | absent in checked-in source; auto-config resolves to eager |

Both recipes preserve `AutoModelForSequenceClassification`, `modernbert`, opset 17, eager attention compatibility, INT32 `[1,1024]` inputs, and logits output. The delta is reducibility-consistent with the charter. Recipe-free acceptance passed: published `pipeline_tag=text-ranking` resolves generically to canonical `reranking` with no model-ID hard-coding. Generic source code is owned by dependency PR #1322 at parent `3708969b731425b0c6d4b97920d1b5e6519bb013`; this candidate has no code changes. Existing text-classification recipes and `examples/recipes/README.md` remain untouched.

#### 6. Analyze summary - component level and op level

Static rule analysis completed with `ANALYZE-PARTIAL-SUCCESS` and exit code 1; this is compatibility analysis, not runtime execution. The unresolved overview gap is per-operator input-signature grouping: architecture regions are mapped through hierarchy scopes and tensor boundaries, while an ops-depth breakdown would be needed to resolve that finer grouping.

##### Component-level summary

| Artifact | Architecture coverage | Mapping | Actionable EP findings |
|---|---|---|---|
| fp32 | embeddings; rotary; 22 encoder attention/MLP layers; mean pooling; prediction head; scalar classifier | mapped with explicit overview gaps | QNN partial: Gather and ReduceSum |

The mapped regions cover HTP-tagged attention and MLP scopes across all 22 encoder layers, an 11-node prediction-head region, and the scalar classifier tensor boundary. Embeddings, rotary embeddings, and mean pooling remain architecture-verified overview regions rather than operator-signature mappings.

##### Op-level summary

| Artifact | Graph | Dominant ops | EP roll-up |
|---|---|---|---|
| fp32 | 948 operators / 23 types | MatMul 133; Mul 133; Slice 132; Add 110; Transpose 110 | QNN partial: Gather, ReduceSum; Cast/Slice/Where unknown on rule-backed EPs |

NvTensorRTRTX, OpenVINO GPU, and QNN GPU had rule-backed classifications but no runtime support on the test host; QNN's actionable partial types were `OP/ai.onnx/Gather` and `OP/ai.onnx/ReduceSum`. CUDA, MIGraphX, TensorRT, and DML had no populated rule classification in this handoff. No unsupported operator type was reported.

#### 7. Reproduce commands

Set `$MODEL` to the pinned checkpoint directory and `$OUT` to a writable output directory. These are the tester-recorded build, perf, eval, and analyze command semantics with portable paths.

```powershell
python -m winml.modelkit.cli build -c examples/recipes/Alibaba-NLP_gte-reranker-modernbert-base/cpu/cpu/reranking_fp32_config.json -m $MODEL -o "$OUT/fp32"
python -m winml.modelkit.cli build -c examples/recipes/Alibaba-NLP_gte-reranker-modernbert-base/cpu/cpu/reranking_fp16_config.json -m $MODEL -o "$OUT/fp16" --precision fp16
python -m winml.modelkit.cli perf -m "$OUT/fp32/model.onnx" --ep cpu --device cpu
python -m winml.modelkit.cli perf -m "$OUT/fp16/model.onnx" --ep cpu --device cpu
python -m winml.modelkit.cli eval -m "$OUT/fp32/model.onnx" --model-id $MODEL --task reranking --dataset mteb/scidocs-reranking --dataset-revision 56a6d0140cf6356659e2a7c1413286a774468d44 --split test --streaming --no-shuffle --samples 2 --column query_column=query --column positive_column=positive --column negative_column=negative --column max_candidates=10 --ep cpu --device cpu -o "$OUT/scidocs-fp32.json" --overwrite
python -m winml.modelkit.cli analyze --model "$OUT/fp32/model.onnx" --ep all --output "$OUT/fp32-analyze.json"
```