### PR TITLE
recipe(mmarco-mMiniLMv2-L12-H384-v1): add CPU reranking recipes

### DIFF
--- a/examples/recipes/cross-encoder_mmarco-mMiniLMv2-L12-H384-v1/cpu/cpu/reranking_fp16_config.json
+++ b/examples/recipes/cross-encoder_mmarco-mMiniLMv2-L12-H384-v1/cpu/cpu/reranking_fp16_config.json
@@ -1,0 +1,94 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          250002
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "reranking",
+    "model_id": "cross-encoder/mmarco-mMiniLMv2-L12-H384-v1",
+    "model_type": "xlm-roberta",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "reranking",
+    "model_class": "AutoModelForSequenceClassification",
+    "model_type": "xlm-roberta"
+  },
+  "eval": {
+    "task": "reranking",
+    "dataset": {
+      "path": "C-MTEB/Mmarco-reranking",
+      "name": "default",
+      "split": "dev",
+      "samples": 2,
+      "shuffle": false,
+      "streaming": true,
+      "revision": "8e0c766dbe9e16e1d221116a3f36795fbade07f6",
+      "columns_mapping": {
+        "query_column": "query",
+        "positive_column": "positive",
+        "negative_column": "negative",
+        "max_candidates": "10"
+      }
+    }
+  }
+}

--- a/examples/recipes/cross-encoder_mmarco-mMiniLMv2-L12-H384-v1/cpu/cpu/reranking_fp32_config.json
+++ b/examples/recipes/cross-encoder_mmarco-mMiniLMv2-L12-H384-v1/cpu/cpu/reranking_fp32_config.json
@@ -1,0 +1,72 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          250002
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "reranking",
+    "model_class": "AutoModelForSequenceClassification",
+    "model_type": "xlm-roberta"
+  },
+  "eval": {
+    "task": "reranking",
+    "dataset": {
+      "path": "C-MTEB/Mmarco-reranking",
+      "name": "default",
+      "split": "dev",
+      "samples": 2,
+      "shuffle": false,
+      "streaming": true,
+      "revision": "8e0c766dbe9e16e1d221116a3f36795fbade07f6",
+      "columns_mapping": {
+        "query_column": "query",
+        "positive_column": "positive",
+        "negative_column": "negative",
+        "max_candidates": "10"
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Summary

This adds CPU fp32 and fp16 reranking recipes for `cross-encoder/mmarco-mMiniLMv2-L12-H384-v1`, a multilingual cross-encoder that emits one raw relevance logit per query-passage pair. The shipped Effort and Outcome are L0, layered on the generic reranking capability owned by dependency PR #1322. Candidate evidence reaches L3 PASS with full CPU fp32/fp16 coverage; exact current-main hosted evidence establishes the recipe-free fp32 baseline while confirming that current-main reranking config and Eval are unsupported.

### Model metadata

#### What the model does

A multilingual cross-encoder reranker that jointly tokenizes a query and candidate passage, then emits one raw relevance logit used to sort passages in descending order.

- Evidence: the [pinned checkpoint](https://huggingface.co/cross-encoder/mmarco-mMiniLMv2-L12-H384-v1/tree/1427fd652930e4ba29e8149678df786c240d8825) model card documents paired-query usage and decreasing-score ordering; its configuration selects `XLMRobertaForSequenceClassification` with one label and Identity activation; Transformers v5.14.1 supplies the one-logit sequence-classification path. Confidence: `verified`.

#### Primary user stories

- A user supplies a search query and retrieved candidate passages to obtain relevance scores for second-stage passage reranking. Evidence: pinned model card Information Retrieval and retrieve-and-rerank usage. Confidence: `verified`.
- A user supplies multilingual query-passage pairs to rank candidates in any of the 14 mMARCO languages advertised by the checkpoint. Evidence: pinned model card training statement and checkpoint language tags. Confidence: `verified`.

#### Supported tasks

- `reranking` on the checkpoint and Transformers surfaces. Evidence: checkpoint `pipeline_tag=text-ranking` and the paired-input raw-logit model-card example. Confidence: `verified`.
- `text-classification` on the Transformers and WinML surfaces. Evidence: checkpoint Transformers metadata selects `AutoModelForSequenceClassification`; the existing exact-model text-classification fp16 recipe remains unchanged. Confidence: `mapped`.

#### Model architecture

```text
XLMRobertaForSequenceClassification
|-- XLM-R embeddings (250002 vocab, 384 hidden, learned absolute positions)
|-- Encoder stack x 12
|   |-- Self-attention (12 heads x 32 dimensions)
|   |-- Feed-forward (384 -> 1536 -> 384, GELU)
|   `-- Residual connections + LayerNorm
`-- Classification head on <s> (384 -> 384, tanh -> 1 raw logit)
```

- Source/confidence: pinned checkpoint configuration and Transformers v5.14.1 `XLMRobertaForSequenceClassification` source (`verified`).

### Validation and support evidence

#### 1. Baseline

- Pinned `main`: `0876e5ae1c98a169a6137e092e0d7b30bf9cee33`.
- WinML version: `winml, version 0.3.0`. Hosted recovery supplied an exact-lock current-main environment after the earlier local hydration attempt was blocked.
- Recipe-free build: **PASS** in 111.313 seconds with auto-config, CPU, no analyze/optimize/quantize/compile, producing fp32 opset 17 with `input_ids` and `attention_mask` INT32 `[1,512]`, FLOAT `logits` `[1,1]`, 435 nodes, and external data.
- CPU perf: **PASS** over 3 iterations after 1 warmup: mean `210.972 ms`, p50 `211.587 ms`, throughput `4.74 samples/s`, and RSS total delta `+80.81 MB`.
- Starting auto-config resolves `AutoModelForSequenceClassification`, `xlm-roberta`, and `text-classification`. Explicit `text-ranking` and `reranking` config requests both exit 2. Current-main reranking Eval is **UNSUPPORTED-TASK**, exits 1, and emits no metrics.
- Optimum statically advertises vendor `text-classification`, and WinML adds no task: `VENDOR-ONLY`. The exact-lock live probe could not import Optimum's ONNX model-config module because the locked Optimum/Transformers pair is incompatible (`_CAN_RECORD_REGISTRY` import failure), so its evidence remains `STATIC-MAPPED; LIVE-PROBE-LOCK-INCOMPATIBILITY`; this does not become a claim that WinML added reranking support.
- Goal floor: L0 is the first required tier. The hosted run is actual current-main baseline evidence, not candidate evidence.

#### 2. Goal

- Committed Effort: **L0**.
- Committed Goal ceiling: **L3**.
- Committed Outcome: **L0**.
- Success definition: CPU fp32/fp16 reranking build, perf, multilingual raw-logit parity and ordering, and a pinned bounded smoke through the shipped reranking evaluator.
- No ceiling change or re-issued charter occurred. Candidate evidence reached L3 PASS with full coverage and no deferred tuples; this does not change the shipped L0 Outcome.

#### 3. Outcome

The shipped Outcome is **L0**: exactly two model-specific CPU reranking recipes declare verified fp32 and fp16 coverage while generic reranking remains owned by dependency PR #1322. The highest reached Goal verdict is **L3 PASS** on candidate `bc7377782d96a4788e565ff3acf0a6c2f06ae56d`, with full required-tuple coverage and no deferred tuples.

Learner findings `xlm-roberta-005` through `xlm-roberta-009` retain the resolved autoconf/HTP facts, complete static analysis, fp32/fp16 structure and bounded perf, raw-logit parity/order, and pinned Chinese functional-smoke evidence. They are separate Lane A knowledge changes, as is methodology finding `_meta-113` ([Lane A commit `113413ae`](https://github.com/gim-home/ModelKitArtifacts/commit/113413ae5580e1c78c0afce20c5b14b0436f8d14), [compare](https://github.com/gim-home/ModelKitArtifacts/compare/main...ssss141414/learner-mmarco-xlmr-knowledge-20260824?expand=1)); none is included in this model PR.

**Exact-candidate quality:** Ruff passed, mypy reported no issues in 438 source files, and the five candidate test partitions passed an aggregate **8420 tests**: models 1534 passed / 6 skipped / 2 xfailed; optim 848 passed / 16 skipped / 1 xfailed; commands 3641 passed / 9 skipped / 1 warning; analyze 1526 passed / 45 skipped; remaining 871 passed / 2 skipped / 1 deselected / 1 warning. Aggregate non-pass accounting was 78 skipped, 3 xfailed, and 1 deselected.

The original [exact-head validation workflow](https://github.com/microsoft/winml-cli/actions/runs/32655153048) concluded **failure**: its model job stopped when `winml analyze` returned exit 1 for partial/unknown static findings, so the wrapper skipped its summarizer even though complete JSON had already been emitted and was independently validated. This was a harness false negative and a non-candidate blocker, not a candidate change or a claim that the original workflow was green.

Methodology finding `_meta-113` is now **mechanism confirmed** by validation-only [run 32660811255](https://github.com/microsoft/winml-cli/actions/runs/32660811255) on unchanged candidate `bc7377782d96a4788e565ff3acf0a6c2f06ae56d`, through closed, unmerged draft [PR #1341](https://github.com/microsoft/winml-cli/pull/1341). The repaired control flow captured analyze exit 1, continued to the summarizer, validated the complete `ANALYZE-PARTIAL-SUCCESS` result with 387 operators, 20 unique types, and all 7 requested EP rows, then returned wrapper exit 0 with both validator and final job successful. This exercises the repair without changing the candidate.

#### 4. Per-EP/device/precision results and Functional smoke Eval

| Tier | EP / Device | Precision | Verdict | Mean | p50 | Throughput | RAM delta |
|---|---|---|---|---:|---:|---:|---:|
| L0 | CPUExecutionProvider / cpu | fp32 | PASS | - | - | - | - |
| L0 | CPUExecutionProvider / cpu | fp16 | PASS | - | - | - | - |
| L1 | CPUExecutionProvider / cpu | fp32 | PASS | 234.276 ms | 227.901 ms | 4.27 samples/s | +80.53 MB |
| L1 | CPUExecutionProvider / cpu | fp16 | PASS (bounded: 1 iteration, 0 warmups) | 282.673 ms | 282.673 ms | 3.54 samples/s | +44.33 MB |

- L0 fp32: `input_ids` and `attention_mask` INT32 `[1,512]`; FLOAT `logits` `[1,1]`; 204 FLOAT initializers; artifact size 470724506 bytes.
- L0 fp16: `input_ids` and `attention_mask` INT32 `[1,512]`; FLOAT `logits` `[1,1]`; 204 FLOAT16 initializers; artifact size 235435418 bytes.
- L2 fp32: cosine `0.9999999999999137`, max absolute difference `0.0000057220458984375`; reference and ONNX descending order `[0,1,2]`.
- L2 fp16: cosine `0.9999999857145679`, max absolute difference `0.0023097991943359375`; reference and ONNX descending order `[0,1,2]`.
- L2 scope: exactly three pairs at sequence length 512, with English, German, and unrelated Chinese passages. Scores were Identity-activated raw scalar logits with no postprocessing.

**Functional smoke Eval:** L3 PASS on final candidate `bc7377782d96a4788e565ff3acf0a6c2f06ae56d`, FP32 CPU, using `C-MTEB/Mmarco-reranking`, configuration `default`, split `dev`, pinned revision `8e0c766dbe9e16e1d221116a3f36795fbade07f6`. Deterministic first-N selection with no shuffle retained source candidate order and processed/scored **2/2 groups**, **20/20 expanded pairs**, with **zero skipped groups** and zero groups without a positive. Caps were 2 groups, 10 candidates per group, 20 total pairs, and sequence length 512. Schema (`query`, `positive`, `negative`), positive/negative relevance labels, and descending raw-logit prediction semantics were verified. MRR@10 = `0.333333`, Recall@1 = `0.0`, and Recall@10 = `1.0`. **This Chinese run is functional smoke only: it proves end-to-end evaluator operability, not benchmark accuracy or multilingual quality.** No fp16 or accelerator Eval claim is made. The former blocker was the absence of a WinML reranking evaluator; dependency PR #1322 supplies generic task resolution, paired-input inference, raw-logit evaluation, grouped relevance metrics, and dataset adaptation.

#### 5. Delta

The candidate diff contains exactly these two model-specific recipes:

- `examples/recipes/cross-encoder_mmarco-mMiniLMv2-L12-H384-v1/cpu/cpu/reranking_fp32_config.json`
- `examples/recipes/cross-encoder_mmarco-mMiniLMv2-L12-H384-v1/cpu/cpu/reranking_fp16_config.json`

| Recipe | JSON pointer | Existing legacy value | Shipped value |
|---|---|---|---|
| fp32 | `/loader/task` | `text-classification` | `reranking` |
| fp32 | `/quant` | fp16 quantization block | `null` |
| fp32 | `/eval` | absent | Pinned C-MTEB default/dev plan; revision `8e0c766dbe9e16e1d221116a3f36795fbade07f6`; samples 2; shuffle false; streaming true; query/positive/negative columns; max candidates 10 |
| fp16 | `/loader/task` | `text-classification` | `reranking` |
| fp16 | `/quant/task` | `text-classification` | `reranking` |
| fp16 | `/eval` | absent | Pinned C-MTEB default/dev plan; revision `8e0c766dbe9e16e1d221116a3f36795fbade07f6`; samples 2; shuffle false; streaming true; query/positive/negative columns; max candidates 10 |

The current-main generated auto-config was recovered and compared field by field after stripping note-only fields:

| Shipped recipe | Identical | Different | Precision-specific |
|---|---:|---:|---:|
| fp32 | 27 | 14 | 0 |
| fp16 | 26 | 14 | 22 |

- The 14 differences for each recipe are complete: 12 shipped `/eval` leaves absent from auto-config (task; dataset path/name/revision/split/samples/shuffle/streaming; query/positive/negative/max-candidates mappings), `/loader/task` changes `text-classification` to `reranking`, and auto-config-only `/export/compatibility/transformers_attention=eager` is omitted. The eval block encodes the Producer-owned pinned bounded smoke plan; the loader delta selects dependency PR #1322's paired-input reranking semantics; omitting the compatibility hint preserves the existing exact-model recipe contract.
- The common identical fields cover `/compile`; `/optim/clamp_constant_values`; loader model class/type; export batch, cleanup, folding, dynamo, hierarchy, parameter, verbosity and opset settings; both named INT32 input shapes and value ranges; and the `logits` output name. fp32 also has identical `/quant=null`.
- The 22 fp16 precision-specific pointers are complete: `/quant` itself plus `/quant/{activation_symmetric,activation_type,calibration_load_path,calibration_method,calibration_save_path,distribution,fp16_keep_io_types,fp16_op_block_list,mode,model_id,model_type,nodes_to_exclude,op_types_to_quantize,per_channel,samples,save_calibration,seed,symmetric,task,weight_symmetric,weight_type}`. They have no like-for-like value because current-main auto-config was generated without a precision flag; this is a precision realization, not an auto-config regression.

Relative to the existing exact-model legacy recipe, export, optimization, and compile configuration are identical; the recipes preserve `AutoModelForSequenceClassification`, `xlm-roberta`, opset 17, INT32 `[1,512]` named inputs, no `token_type_ids`, and one logits output. The existing text-classification recipe is unchanged. No source, tests, workflow files, or production recipe README are changed. Current-main recipe-free fp32 acceptance passes, while current-main reranking config/Eval remain unsupported; generic reranking behavior and acceptance remain dependency PR #1322 ownership. The two-recipe delta is reducibility-consistent with the charter and contains no checkpoint-specific shared-code behavior.

#### 6. Analyze summary - component level and op level

Static rule analysis completed as **`ANALYZE-PARTIAL-SUCCESS` with exit code 1**; complete JSON was emitted and independently validated. This is static compatibility analysis, not accelerator runtime execution.

##### Component-level summary

| Artifact | Architecture coverage | Mapping | Actionable EP findings |
|---|---|---|---|
| fp32 | embeddings 16; 12-layer self-attention 192; feed-forward 48; classifier 4 | 260 mapped, 127 explicitly unmapped, 387 total; mapped with explicit unmapped bucket | QNN partial Gather/GatherElements affects embeddings; Gather also affects classifier; Where is in the unmapped bucket |

The unresolved mapping gap is 127 optimizer-generated/helper nodes in fp32; repeated encoder layers are collapsed above.

##### Op-level summary

| Artifact | Graph | Dominant ops | EP roll-up |
|---|---|---|---|
| fp32 | 387 operators / 20 types | Reshape 121; Gemm 74; Transpose 48; Add 39; MatMul 24 | NvTensorRTRTX and OpenVINO: 19 supported types, Where unknown; QNN: 17 supported types, Gather/GatherElements partial, Where unknown |

No unsupported operator type was reported. CUDA, MIGraphX, TensorRT, and DML have no rule classifications. These are complete per-EP static findings, not runtime support claims.

#### 7. Reproduce commands

```powershell
$OUT='temp/mmarco-mminilmv2-l12-h384-v1-test'
uv run winml build -c examples/recipes/cross-encoder_mmarco-mMiniLMv2-L12-H384-v1/cpu/cpu/reranking_fp32_config.json -m cross-encoder/mmarco-mMiniLMv2-L12-H384-v1 -o $OUT/fp32
uv run winml build -c examples/recipes/cross-encoder_mmarco-mMiniLMv2-L12-H384-v1/cpu/cpu/reranking_fp16_config.json -m cross-encoder/mmarco-mMiniLMv2-L12-H384-v1 -o $OUT/fp16 --precision fp16
uv run winml analyze --model $OUT/fp32/model.onnx --ep all --output $OUT/analyze-all.json
uv run winml perf -m $OUT/fp32/model.onnx --device cpu --ep cpu --iterations 3 --warmup 1
uv run winml eval -m $OUT/fp32/model.onnx --model-id cross-encoder/mmarco-mMiniLMv2-L12-H384-v1 --task reranking --dataset C-MTEB/Mmarco-reranking --dataset-name default --dataset-revision 8e0c766dbe9e16e1d221116a3f36795fbade07f6 --split dev --samples 2 --no-shuffle --streaming --column query_column=query --column positive_column=positive --column negative_column=negative --column max_candidates=10 --ep cpu --device cpu
```