### PR TITLE
chore: Move perf runtime names to shared constants

### DIFF
--- a/src/winml/modelkit/commands/_perf_genai.py
+++ b/src/winml/modelkit/commands/_perf_genai.py
@@ -57,7 +57,7 @@ if TYPE_CHECKING:
 
     from rich.console import Console
 
-    from ..utils.constants import EPName
+    from ..utils.constants import EPName, RuntimeName
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +66,7 @@ logger = logging.getLogger(__name__)
 # Constants
 # =============================================================================
 
-RUNTIME_TYPE = "winml-genai"
+RUNTIME_TYPE: RuntimeName = "winml-genai"
 _HW_POLL_INTERVAL_MS = 200
 
 # Built-in benchmark prompt.  Mirrored by the ``--prompt`` CLI default and the

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -23,7 +23,7 @@ import time
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import click
 import numpy as np
@@ -37,7 +37,6 @@ from ..utils.constants import (
     RUNTIME_NAMES,
     EPName,
     EPNameOrAlias,
-    RuntimeName,
 )
 from ..utils.logging import (
     configure_logging,
@@ -53,6 +52,7 @@ from ._pre_bench import print_pre_bench_block
 if TYPE_CHECKING:
     import contextlib
     from collections.abc import Iterator
+    from typing import Literal
 
     from rich.console import Console
 
@@ -62,6 +62,7 @@ if TYPE_CHECKING:
     from ..session.monitor.ep_monitor import WinMLEPMonitor
     from ..session.monitor.op_metrics import TraceFallbackReason
     from ..session.stats import PerfStats
+    from ..utils.constants import RuntimeName
 
 logger = logging.getLogger(__name__)
 
@@ -72,6 +73,7 @@ logger = logging.getLogger(__name__)
 
 # Hardware monitor polling interval (milliseconds)
 _HW_POLL_INTERVAL_MS = 200
+_RUNTIME_TYPE: RuntimeName = "winml"
 
 
 def _resolve_runtime(runtime: RuntimeName, model: str) -> RuntimeName:
@@ -437,7 +439,7 @@ class BenchmarkResult:
         result: dict[str, Any] = {
             "schema_version": 2,
             "benchmark_info": {
-                "runtime": "winml",
+                "runtime": _RUNTIME_TYPE,
                 "model_id": self.config.model_id,
                 "running_model_path": self.running_model_path,
                 "task": self.actual_task,

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -23,7 +23,7 @@ import time
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, cast, get_args
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import click
 import numpy as np
@@ -32,7 +32,13 @@ from rich.table import Table
 
 from ..utils import cli as cli_utils
 from ..utils.console import SafeConsole
-from ..utils.constants import ACCELERATOR_DEVICE_TYPES, EPName, EPNameOrAlias
+from ..utils.constants import (
+    ACCELERATOR_DEVICE_TYPES,
+    RUNTIME_NAMES,
+    EPName,
+    EPNameOrAlias,
+    RuntimeName,
+)
 from ..utils.logging import (
     configure_logging,
     suppress_huggingface_warning_logs,
@@ -66,15 +72,6 @@ logger = logging.getLogger(__name__)
 
 # Hardware monitor polling interval (milliseconds)
 _HW_POLL_INTERVAL_MS = 200
-
-
-# Inference runtimes selectable via ``--runtime`` (closed set; mirrors the
-# ``--compiler`` / ``COMPILER_NAMES`` convention in utils.constants):
-#   "auto"        -> select from the local model folder contents (default)
-#   "winml"       -> single-shot ONNX inference
-#   "winml-genai" -> onnxruntime-genai decoder-pipeline generation
-RuntimeName = Literal["auto", "winml", "winml-genai"]
-RUNTIME_NAMES: tuple[RuntimeName, ...] = get_args(RuntimeName)
 
 
 def _resolve_runtime(runtime: RuntimeName, model: str) -> RuntimeName:

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -23,7 +23,7 @@ import time
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import click
 import numpy as np
@@ -52,7 +52,6 @@ from ._pre_bench import print_pre_bench_block
 if TYPE_CHECKING:
     import contextlib
     from collections.abc import Iterator
-    from typing import Literal
 
     from rich.console import Console
 
@@ -74,6 +73,7 @@ logger = logging.getLogger(__name__)
 # Hardware monitor polling interval (milliseconds)
 _HW_POLL_INTERVAL_MS = 200
 _RUNTIME_TYPE: RuntimeName = "winml"
+_OpTracingLevel = Literal["basic", "detail"]
 
 
 def _resolve_runtime(runtime: RuntimeName, model: str) -> RuntimeName:
@@ -252,7 +252,7 @@ def _resolve_ep_monitor(
                     "with QNN runtime, or run `wmk perf` without --op-tracing."
                 )
             return QNNMonitor(
-                level=cast('Literal["basic", "detail"]', op_tracing),
+                level=cast("_OpTracingLevel", op_tracing),
                 output_dir=output_dir,
             )
 

--- a/src/winml/modelkit/commands/perf.py
+++ b/src/winml/modelkit/commands/perf.py
@@ -73,7 +73,6 @@ logger = logging.getLogger(__name__)
 # Hardware monitor polling interval (milliseconds)
 _HW_POLL_INTERVAL_MS = 200
 _RUNTIME_TYPE: RuntimeName = "winml"
-_OpTracingLevel = Literal["basic", "detail"]
 
 
 def _resolve_runtime(runtime: RuntimeName, model: str) -> RuntimeName:
@@ -252,7 +251,7 @@ def _resolve_ep_monitor(
                     "with QNN runtime, or run `wmk perf` without --op-tracing."
                 )
             return QNNMonitor(
-                level=cast("_OpTracingLevel", op_tracing),
+                level=cast(Literal["basic", "detail"], op_tracing),  # noqa: TC006
                 output_dir=output_dir,
             )
 

--- a/src/winml/modelkit/utils/constants.py
+++ b/src/winml/modelkit/utils/constants.py
@@ -20,6 +20,7 @@ __all__ = [
     "EP_NAMES",
     "EP_SUPPORTED_DEVICES",
     "ORT_SESSION_COMPILER",
+    "RUNTIME_NAMES",
     "SUPPORTED_DEVICES",
     "SUPPORTED_EPS",
     "CompilerName",
@@ -27,6 +28,7 @@ __all__ = [
     "EPAlias",
     "EPName",
     "EPNameOrAlias",
+    "RuntimeName",
     "extract_ep_options",
     "normalize_ep_name",
 ]
@@ -77,6 +79,11 @@ ORT_SESSION_COMPILER: CompilerName = "ort_session"
 
 # Runtime-iterable form of ``CompilerName`` (e.g. for the CLI choice list).
 COMPILER_NAMES: tuple[CompilerName, ...] = get_args(CompilerName)
+
+
+# Inference runtimes selectable via ``winml perf --runtime``.
+RuntimeName = Literal["auto", "winml", "winml-genai"]
+RUNTIME_NAMES: tuple[RuntimeName, ...] = get_args(RuntimeName)
 
 
 # Supported execution providers — derived from the ``EPName`` Literal above so

--- a/tests/unit/utils/test_runtime_constants.py
+++ b/tests/unit/utils/test_runtime_constants.py
@@ -1,0 +1,16 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+"""Tests for inference runtime constants."""
+
+from __future__ import annotations
+
+from typing import get_args
+
+from winml.modelkit.utils.constants import RUNTIME_NAMES, RuntimeName
+
+
+def test_runtime_names_match_runtime_name_literal() -> None:
+    assert get_args(RuntimeName) == RUNTIME_NAMES
+    assert RUNTIME_NAMES == ("auto", "winml", "winml-genai")


### PR DESCRIPTION
## Summary
- move `RuntimeName` and `RUNTIME_NAMES` from the perf command into `utils.constants`
- use the shared type for perf runtime annotations and CLI choices
- add unit coverage ensuring the runtime tuple stays derived from the literal