### PR TITLE
Add WinML reranking recipes for cross-encoder/ms-marco-MiniLM-L4-v2

### DIFF
--- a/examples/recipes/cross-encoder_ms-marco-MiniLM-L4-v2/cpu/cpu/reranking_fp16_config.json
+++ b/examples/recipes/cross-encoder_ms-marco-MiniLM-L4-v2/cpu/cpu/reranking_fp16_config.json
@@ -1,0 +1,65 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [1, 512],
+        "value_range": [0, 30522]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [1, 512],
+        "value_range": [0, 2]
+      },
+      {
+        "name": "token_type_ids",
+        "dtype": "int32",
+        "shape": [1, 512],
+        "value_range": [0, 2]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "reranking",
+    "model_class": "AutoModelForSequenceClassification",
+    "model_type": "bert"
+  }
+}

--- a/examples/recipes/cross-encoder_ms-marco-MiniLM-L4-v2/cpu/cpu/reranking_fp32_config.json
+++ b/examples/recipes/cross-encoder_ms-marco-MiniLM-L4-v2/cpu/cpu/reranking_fp32_config.json
@@ -1,0 +1,46 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [1, 512],
+        "value_range": [0, 30522]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [1, 512],
+        "value_range": [0, 2]
+      },
+      {
+        "name": "token_type_ids",
+        "dtype": "int32",
+        "shape": [1, 512],
+        "value_range": [0, 2]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "logits"
+      }
+    ]
+  },
+  "optim": {},
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "reranking",
+    "model_class": "AutoModelForSequenceClassification",
+    "model_type": "bert"
+  }
+}


### PR DESCRIPTION
## Summary

Adds two CPU reranking recipes for `cross-encoder/ms-marco-MiniLM-L4-v2`, a compact English passage cross-encoder. This is an L0 recipe-only contribution with full fp32 and true-fp16 CPU coverage. The committed Goal ceiling was L3, and the fresh immutable recovery run reached **L3 PASS** without any candidate change.

## Model metadata

### What the model does

An English cross-encoder passage reranker that jointly encodes one query-document pair and emits one raw scalar relevance logit; candidates are ordered by decreasing score without softmax, sigmoid, or instruction prefixes. **Confidence: verified.**

Evidence: the model card and `config.json` at pinned checkpoint revision `777b2f369bc1c2f850df8bd367ed1654bda4497b` describe MS MARCO passage reranking, decreasing-score sorting, `BertForSequenceClassification`, one `LABEL_0` output, and Identity activation. Current-main export resolves logits from the sequence-classification head.

### Primary user stories

- A user supplies a search query and a bounded candidate passage list to obtain one relevance score per pair and reorder retrieval results. Evidence: pinned model-card usage and retrieve-and-rerank description. **Confidence: verified.**
- A retrieval or RAG pipeline supplies first-stage candidates to obtain a stronger final ordering before presenting or using the evidence. Evidence: the pinned model card links the checkpoint to information retrieval and retrieve-and-rerank usage. **Confidence: mapped.**

### Supported tasks

- **reranking** (`checkpoint`, `transformers`): the published pipeline tag is `text-ranking`, with pinned pair-scoring examples; `AutoModelForSequenceClassification` is the published Transformers class. **Confidence: verified.**
- **text-classification** (`transformers`, `optimum-onnx`, `winml`): current-main inspect and recipe-free build resolve through `BertIOConfig` and `AutoModelForSequenceClassification`; the pinned checkpoint exports successfully at opset 17. **Confidence: verified.**

### Model architecture

```text
BertForSequenceClassification
|-- BertEmbeddings (vocab 30,522 -> hidden 384; positions 512)
|-- BertEncoder layer x 4
|   |-- Bidirectional self-attention (12 heads)
|   |-- Feed-forward (384 -> 1,536 -> 384, GELU)
|   `-- Residual + LayerNorm
|-- BertPooler (first-token hidden state)
`-- Sequence-classification head (384 -> 1 raw relevance logit)
```

- Source/confidence: pinned checkpoint dimensions and `BertForSequenceClassification`, corroborated by current-main hierarchy metadata for 19,164,673 parameters, 87 modules, 33 traced modules, 66 execution steps, four `BertLayer` children, and 215/215 tagged ONNX nodes (**verified**).

## Validation and support evidence

### 1. Baseline

The fresh baseline used current `main` commit `774dd6e0811f6947eaf2bd8fb721d5f6e718b0c0` and WinML `0.0.1.dev0`. Planner classified the move from `0876e5ae1c98a169a6137e092e0d7b30bf9cee33` as **FULL-RERUN**, not a SHA-only attestation: the intervening changes directly affect shared Perf EP/device selection and monitoring, session exports, Analyze missing-schema behavior, CLI constants, and their quality gates. Planner therefore reran inspect, default and reranking config, build, perf, Eval, and Analyze fail-closed on current `main`; only the unchanged model profile and dependency-alias evidence were reused.

Recipe-free `BertForSequenceClassification` / `text-classification` build passed at IR 8/opset 17 in 11.0 s, producing a 76,714,266-byte model with three `int32 [1,512]` inputs, `float [1,1]` logits, and FLOAT initializers. The CLI still emitted an Optimize stage despite `--no-optimize`. Baseline CPU perf over 10 measured iterations after 2 warmups was 37.30 ms mean, 37.94 ms p50, 43.70 ms p95, 26.81 samples/s, and +79.2 MB inference RAM. Baseline reranking Eval remained at the unsupported floor: it exited 1 and emitted no metric. Default config resolved `text-classification`; explicit reranking config exited 2 as unsupported. Baseline Analyze returned the expected partial-success contract with exit 1 and retained JSON containing 152 operators, 17 operator types, and 12 provider rows; this is static compatibility evidence, not a command crash or non-CPU runtime proof.

Optimum probing was **VENDOR-ONLY**: the exact L4 import probe failed because installed Optimum imports a removed Transformers 5.14.1 private symbol. The accepted exact-runtime BERT probe exposed the same six vendor and post-WinML tasks (`feature-extraction`, `fill-mask`, `multiple-choice`, `question-answering`, `text-classification`, `token-classification`) with `added_by_winml=[]`; fresh L4 inspect/build independently verified the same model class and exporter path.

This PR is intentionally stacked on draft dependency PR #1322, branch `producer/ms-marco-minilm-l6-v2-reranking`, at `3708969b731425b0c6d4b97920d1b5e6519bb013`. On that dependency, `text-ranking` and `reranking` config both exit 0, normalize to `loader.task=reranking`, and are parsed-JSON identical. Current `main` (`774dd6e0811f6947eaf2bd8fb721d5f6e718b0c0`) and the dependency head are divergent: current `main` is used only for the refreshed baseline, while candidate `d951fccaba37275540cdf2757bfb6b3cf60e8ec8` has the dependency SHA as its exact sole parent. The candidate therefore does not incorporate current-main commits; it contributes exactly two recipe files on top of #1322 and depends on #1322's generic reranking normalization and Eval support.

### 2. Goal

- **Effort:** L0, recipe-only CPU precision coverage.
- **Goal ceiling:** L3.
- **Outcome:** L0 shipped with full required coverage.
- **Success definition:** march L0-L3 with complete CPU fp32/fp16 perf, parity, functional smoke, analysis, and CI-parity gates.

No ceiling change or re-issued charter occurred.

### 3. Outcome

The shipped tier is **L0**, the highest reached Goal verdict is **L3 PASS**, coverage is **full**, and there are no deferred tuples. The contribution contains only:

- `examples/recipes/cross-encoder_ms-marco-MiniLM-L4-v2/cpu/cpu/reranking_fp32_config.json`
- `examples/recipes/cross-encoder_ms-marco-MiniLM-L4-v2/cpu/cpu/reranking_fp16_config.json`

Quality gates passed: license-header check; Ruff; mypy over 444 source files; 1,526 analyze tests; 1,534 model/loader/dataset/export tests; 848 optimization tests; 3,641 command/config/build/compiler/session/eval tests; and 892 remaining unit/regression/CLI tests, with only the recorded skips, xfails, deselection, and warnings.

Learner v3 preserves model findings `bert-024` through `bert-029`, which capture exact L4 build structure, HTP hierarchy, component/op analysis, CPU performance, raw-logit parity, and the bounded SciDocs smoke. It refreshes `bert-024` and `bert-027` from the Planner v2 baseline and Tester v2 fp16 evidence. Methodology friction `_meta-114` records that precision-size validation must compare realized model payloads rather than aggregate build directories. The focused Lane A [compare](https://github.com/gim-home/ModelKitArtifacts/compare/main...ssss141414/learner-l4-bert-knowledge-20260824?expand=1) was pushed and verified at final commit [`e125b318d74a1319cedf5215b92f6bdd0ead9140`](https://github.com/gim-home/ModelKitArtifacts/commit/e125b318d74a1319cedf5215b92f6bdd0ead9140); it preserves the separate authoritative `_meta-113` finding.

Final PASS retains the exact-candidate evidence from immutable recovery run `32695311485` and refreshes only fp16 L1 in immutable hosted run `32701875911`, as authorized by the Tester v2 preserved-evidence manifest. Preserved L0, fp32 L1, L2, L3, Analyze, and quality evidence remains tied to the unchanged candidate and dependency. The preserved first run failed because the tester harness compared aggregate build-directory sizes containing retained fp32 intermediates (230,182,646 bytes fp32 vs 230,235,020 bytes fp16), rather than realized `model.onnx` payloads (76,710,324 bytes fp32 vs 38,381,076 bytes fp16). This was a tester-harness defect; the correction changed the size assertion to compare final payload bytes, and the candidate commit did not change.

The fp16 refresh also preserves two failed hosted harness attempts truthfully: run `32701127519` referenced a nonexistent top-level materialized-config model key, and run `32701514334` found that raw CLI Perf passed but did not invoke its disconnected Model Precision display helper. The final harness printed initializer-derived `Model Precision: fp16` before invoking the same bounded CLI Perf command. These were evidence-harness incidents, not candidate failures; the final artifact was byte-identical and the candidate remained `d951fccaba37275540cdf2757bfb6b3cf60e8ec8`.

### 4. Per-EP/device/precision results and Functional smoke Eval

#### Goal ladder

| Tier | Verdict | Evidence |
|---|---|---|
| L0 | PASS | Both required CPU precision tuples built and passed structure/precision checks. |
| L1 | PASS | Fresh CPU perf completed for both required tuples. |
| L2 | PASS | Raw scalar-logit parity and descending order passed on three pinned query-passage pairs. |
| L3 | PASS | Final-candidate fp32 CPU bounded SciDocs reranking Eval completed. |

#### Build, perf, and parity

| EP / Device | Precision | Verdict | Model / initializer proof | Mean | p50 | p95 | Throughput | RAM before | RAM inference / total delta |
|---|---|---|---|---:|---:|---:|---:|---:|---:|
| CPUExecutionProvider / cpu | fp32 | PASS | 76,710,324 bytes; 76 FLOAT, 1 BOOL, 24 INT64 initializers | 66.65 ms | 62.37 ms | 92.52 ms | 15.0 samples/s | 674.7 MB | +78.2 / +78.2 MB |
| CPUExecutionProvider / cpu | fp16 | PASS | **Model Precision: fp16**; 38,381,076 bytes; 76 FLOAT16, 1 BOOL, 24 INT64 initializers | 97.02 ms | 96.45 ms | 120.96 ms | 10.31 samples/s | 699.9 MB | +87.9 / +87.9 MB |

Both artifacts expose `input_ids`, `attention_mask`, and `token_type_ids` as `INT32 [1,512]`, with `logits` as `FLOAT [1,1]`. FP32 also measured p90/p99/max 92.52 ms and min 62.03 ms. Fresh fp16 measured p90/p99/max 120.96 ms and min 85.85 ms, with explicit initializer-derived runtime output `Model Precision: fp16`. Its exact realized payload is 38,381,076 bytes, including 38,329,352 raw FLOAT16 payload bytes across 76 FLOAT16 initializers. VRAM delta was not applicable for CPU.

| Precision | PyTorch logits | ONNX logits | Cosine | Max abs | Required floor / ceiling | Descending order | Verdict |
|---|---|---|---:|---:|---|---|---|
| fp32 | `[8.320240020751953, 1.2873587608337402, -11.603301048278809]` | `[8.320236206054688, 1.2873551845550537, -11.603301048278809]` | 0.9999999999999492 | 0.000003814697265625 | >=0.99999 / <=0.001 | `[0,1,2]` preserved | PASS |
| fp16 | `[8.320240020751953, 1.2873587608337402, -11.603301048278809]` | `[8.31916618347168, 1.2839525938034058, -11.603437423706055]` | 0.9999999705508874 | 0.0034061670303344727 | >=0.999 / <=0.1 | `[0,1,2]` preserved | PASS |

#### Functional smoke Eval

**PASS, operability evidence only; not representative accuracy or benchmark quality.** The final candidate fp32 CPU artifact ran `mteb/scidocs-reranking` test split at pinned revision `56a6d0140cf6356659e2a7c1413286a774468d44`. Deterministic first-N streaming selected and processed 2 of 2 query groups with no shuffle. Schema, positive/negative label semantics, and one-raw-logit-per-pair descending-score prediction semantics were verified.

Caps were 2 groups, 10 candidates per group, at least 1 positive per group, 20 pairs total, and sequence length 512; candidate labels/prompts were capped at 10, with beams and frames/crops not applicable. Raw metrics were MRR@10 **1.0**, Recall@1 **1.0**, and Recall@10 **1.0**. No other precision or EP received an accuracy claim. Current `main` formerly rejected the `reranking` task; dependency #1322 supplies generic task normalization, paired-input raw-scalar evaluation, grouped-text adaptation, candidate caps, and ranking metrics.

### 5. Delta

The production recipe README is untouched. No product source, generic tests, skill files, or existing L2/L6/L12 recipes changed in this model contribution.

| Recipe | JSON pointer | Baseline | Shipped | Classification |
|---|---|---|---|---|
| fp32 | `/loader/task` | `text-classification` | `reranking` | Consumes generic normalization owned by dependency #1322. |
| fp16 | `/loader/task` | `text-classification` | `reranking` | Consumes generic normalization owned by dependency #1322. |
| fp16 | `/quant` | `null` | `{"mode":"fp16","fp16_keep_io_types":true,"samples":10}` | Required checkpoint CPU fp16 coverage; remaining fields are accepted explicit schema defaults. |
| both | `/export/compatibility` | `{"transformers_attention":"eager"}` | omitted | Sparse-template omission; materialized configs restore `transformers_attention=eager`. |
| both | `/optim/clamp_constant_values` | `true` | omitted | Sparse-template omission; optimization is auto-resolved. |

The dependency-generated `text-ranking` and `reranking` configs are parsed-JSON identical. The fp32 and fp16 recipes have the same sparse structure except for the required fp16 `/quant` declaration. Reducibility is consistent with the charter: only per-checkpoint CPU precision coverage is authored; all metadata-derived reranking normalization and evaluation remains in dependency #1322. Recipe-free acceptance is not required for this per-model coverage contribution, and no checkpoint-hardcoded code exists.

### 6. Analyze summary - component level and op level

Static analysis returned **ANALYZE-PARTIAL-SUCCESS** for both artifacts: `analyze` exited 1 because provider-bridge initialization failed, while retaining complete JSON for all seven requested EPs. This is static rule analysis, not runtime execution proof for non-CPU EPs.

#### Component-level summary

| Artifact | Architecture coverage | Mapping | Confidence | Actionable finding |
|---|---|---|---|---|
| fp32 | embeddings; 4x encoder attention/FFN; pooler; scalar classifier | 89 mapped, 47 unmapped | mapped | QNN partial `Gather` in embeddings/pooler; no unsupported types. |
| fp16 | embeddings; 4x encoder attention/FFN; pooler; scalar classifier | 89 mapped, 48 unmapped | mapped | QNN partial `Gather` in embeddings/pooler; no unsupported types. |

The explicit unmapped nodes are backbone mask/shape glue outside the frozen component regions.

#### Op-level summary

| Artifact | Graph | Dominant operators |
|---|---|---|
| fp32 | 136 operators / 16 types | Reshape 41; Gemm 26; Transpose 16; Add 14; LayerNormalization 9; MatMul 8; Cast 1 |
| fp16 | 137 operators / 16 types | Reshape 41; Gemm 26; Transpose 16; Add 14; LayerNormalization 9; MatMul 8; Cast 2 |

The other counts are identical in both graphs: Gather 4, Mul 4, Flatten 1, And 1, Expand 1, Where 1, Softmax 4, Gelu 4, and Tanh 1.

| Static EP row | fp32 semantics | fp16 semantics |
|---|---|---|
| NvTensorRTRTXExecutionProvider | 15 types supported; `Where` unknown; none partial/unsupported | 15 types listed supported; `Where` and `Cast` unknown; none partial/unsupported |
| CUDAExecutionProvider | No classifications emitted | No classifications emitted |
| MIGraphXExecutionProvider | No classifications emitted | No classifications emitted |
| QNNExecutionProvider | 15 types listed supported; `Gather` partial; `Where` unknown; none unsupported | 15 types listed supported; `Gather` partial; `Where` and `Cast` unknown; none unsupported |
| OpenVINOExecutionProvider | 15 types supported; `Where` unknown; none partial/unsupported | 15 types listed supported; `Where` and `Cast` unknown; none partial/unsupported |
| TensorrtExecutionProvider | No classifications emitted | No classifications emitted |
| DmlExecutionProvider | No classifications emitted | No classifications emitted |

### 7. Reproduce commands

```powershell
$OUT='temp/model-support-repro'
winml build -c examples/recipes/cross-encoder_ms-marco-MiniLM-L4-v2/cpu/cpu/reranking_fp32_config.json -m cross-encoder/ms-marco-MiniLM-L4-v2 -o $OUT/fp32
winml build -c examples/recipes/cross-encoder_ms-marco-MiniLM-L4-v2/cpu/cpu/reranking_fp16_config.json -m cross-encoder/ms-marco-MiniLM-L4-v2 -o $OUT/fp16 --precision fp16
winml perf -m $OUT/fp32/model.onnx --device cpu --ep cpu --warmup 2 --iterations 10
winml perf -m $OUT/fp16/model.onnx --device cpu --ep cpu --warmup 2 --iterations 10
winml analyze --model $OUT/fp32/model.onnx --ep all --output $OUT/analyze-fp32.json
winml eval -m $OUT/fp32/model.onnx --model-id cross-encoder/ms-marco-MiniLM-L4-v2 --task reranking --dataset mteb/scidocs-reranking --dataset-revision 56a6d0140cf6356659e2a7c1413286a774468d44 --split test --streaming --no-shuffle --samples 2 --column query_column=query --column positive_column=positive --column negative_column=negative --column max_candidates=10 --ep cpu --device cpu -o $OUT/eval.json --overwrite
```