### PR TITLE
fix(sys): enumerate DXCore hardware attributes

### DIFF
--- a/src/winml/modelkit/sysinfo/dxcore_adapters.py
+++ b/src/winml/modelkit/sysinfo/dxcore_adapters.py
@@ -64,16 +64,14 @@ _IID_FACTORY1 = _GUID.from_string("d5682e19-6d21-401c-827a-9a51a4ea35d7")
 _IID_ADAPTER_LIST = _GUID.from_string("526c7776-40e9-459b-b711-f32ad76dfc28")
 _IID_ADAPTER = _GUID.from_string("f0db4c7f-fe5a-42a2-bd62-f2a6cf6fc83e")
 
+_ATTRIBUTE_GPU = _GUID.from_string("b69eb219-3ded-4464-979f-a00bd4687006")
+_ATTRIBUTE_NPU = _GUID.from_string("d46140c4-add7-451b-9e56-06fe8c3b58ed")
+
 _PROPERTY_INSTANCE_LUID = 0
 _PROPERTY_DRIVER_DESCRIPTION = 2
 _PROPERTY_HARDWARE_ID = 3
 _PROPERTY_HARDWARE_ID_PARTS = 14
 _PROPERTY_IS_HARDWARE = 11
-
-_WORKLOAD_MACHINE_LEARNING = 3
-_HARDWARE_TYPE_GPU = 0x1
-_HARDWARE_TYPE_NPU = 0x4
-
 
 def _method(
     instance: ctypes.c_void_p,
@@ -165,28 +163,26 @@ def _format_luid(luid: _LUID) -> str:
 def _enumerate_for_type(
     factory: ctypes.c_void_p,
     device_type: str,
-    hardware_filter: int,
+    attribute: _GUID,
 ) -> list[DXCoreAdapterInfo]:
     adapter_list = ctypes.c_void_p()
     create_list = _method(
         factory,
-        8,
+        3,
         ctypes.c_long,
         ctypes.c_uint32,
-        ctypes.c_uint32,
-        ctypes.c_uint32,
+        ctypes.POINTER(_GUID),
         ctypes.POINTER(_GUID),
         ctypes.POINTER(ctypes.c_void_p),
     )
     result = create_list(
         factory,
-        _WORKLOAD_MACHINE_LEARNING,
-        0,
-        hardware_filter,
+        1,
+        ctypes.byref(attribute),
         ctypes.byref(_IID_ADAPTER_LIST),
         ctypes.byref(adapter_list),
     )
-    _check_hresult(result, "IDXCoreAdapterFactory1.CreateAdapterListByWorkload")
+    _check_hresult(result, "IDXCoreAdapterFactory.CreateAdapterList")
 
     adapters: list[DXCoreAdapterInfo] = []
     try:
@@ -256,8 +252,8 @@ def enumerate_compute_adapters() -> list[DXCoreAdapterInfo]:
     )
     try:
         return [
-            *_enumerate_for_type(factory, "NPU", _HARDWARE_TYPE_NPU),
-            *_enumerate_for_type(factory, "GPU", _HARDWARE_TYPE_GPU),
+            *_enumerate_for_type(factory, "NPU", _ATTRIBUTE_NPU),
+            *_enumerate_for_type(factory, "GPU", _ATTRIBUTE_GPU),
         ]
     finally:
         _release(factory)

--- a/tests/unit/sysinfo/test_dxcore_adapters.py
+++ b/tests/unit/sysinfo/test_dxcore_adapters.py
@@ -6,10 +6,17 @@
 
 from __future__ import annotations
 
+import ctypes
 from typing import TYPE_CHECKING
 
 from winml.modelkit.sysinfo import dxcore_adapters
-from winml.modelkit.sysinfo.dxcore_adapters import _LUID, _format_luid
+from winml.modelkit.sysinfo.dxcore_adapters import (
+    _ATTRIBUTE_NPU,
+    _GUID,
+    _LUID,
+    _enumerate_for_type,
+    _format_luid,
+)
 
 
 if TYPE_CHECKING:
@@ -31,3 +38,42 @@ def test_enumeration_is_empty_off_windows(
     monkeypatch.setattr(dxcore_adapters.sys, "platform", "linux")
 
     assert dxcore_adapters.enumerate_compute_adapters() == []
+
+
+def test_enumeration_filters_by_hardware_type_attribute(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[int, int, bytes]] = []
+
+    def fake_method(
+        instance: ctypes.c_void_p,
+        index: int,
+        restype: object,
+        *argtypes: object,
+    ):
+        del instance, restype, argtypes
+
+        if index == 3:
+
+            def create_list(
+                factory: ctypes.c_void_p,
+                attribute_count: int,
+                attributes: object,
+                iid: object,
+                adapter_list: object,
+            ) -> int:
+                del factory, iid, adapter_list
+                guid = ctypes.cast(attributes, ctypes.POINTER(_GUID)).contents
+                calls.append((index, attribute_count, bytes(guid)))
+                return 0
+
+            return create_list
+        if index == 4:
+            return lambda adapter_list: 0
+        raise AssertionError(f"unexpected vtable method {index}")
+
+    monkeypatch.setattr(dxcore_adapters, "_method", fake_method)
+    monkeypatch.setattr(dxcore_adapters, "_release", lambda instance: None)
+
+    assert _enumerate_for_type(ctypes.c_void_p(1), "NPU", _ATTRIBUTE_NPU) == []
+    assert calls == [(3, 1, bytes(_ATTRIBUTE_NPU))]


### PR DESCRIPTION
## Summary
- enumerate DXCore adapters with the official GPU and NPU hardware-type attributes
- use `IDXCoreAdapterFactory.CreateAdapterList`, matching the Vortice.DXCore path that discovers Intel NPUs correctly
- retain architecture-agnostic adapter metadata and add focused coverage for the attribute filter call

## Hardware result
On Intel Core Ultra 7 258V, native discovery now returns:

- Intel(R) AI Boost NPU: `0x00000000_0x0001030D`
- Intel(R) Arc(TM) 140V GPU: `0x00000000_0x0000FED2`

The NPU previously disappeared from `enumerate_compute_adapters()`, leaving the top-level `winml sys` NPU LUID null.

## Validation
- 23 targeted sysinfo/CLI unit tests passed
- 21 hardware sys E2E tests passed
- focused mypy and Ruff checks passed
- direct DXCore probe returned both the Intel NPU and GPU
