### PR TITLE
recipe(layoutlm): add QNN NPU document QA configs

### DIFF
--- a/examples/recipes/impira_layoutlm-document-qa/qnn/npu/question-answering_fp16_config.json
+++ b/examples/recipes/impira_layoutlm-document-qa/qnn/npu/question-answering_fp16_config.json
@@ -1,0 +1,125 @@
+{
+  "auto": false,
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          50265
+        ]
+      },
+      {
+        "name": "bbox",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512,
+          4
+        ],
+        "value_range": [
+          0,
+          1000
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      },
+      {
+        "name": "token_type_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "start_logits"
+      },
+      {
+        "name": "end_logits"
+      }
+    ],
+    "compatibility": {
+      "transformers_attention": "eager"
+    }
+  },
+  "optim": {
+    "clamp_constant_values": true,
+    "gelu_fusion": false,
+    "matmul_add_fusion": false
+  },
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "question-answering",
+    "model_id": "impira/layoutlm-document-qa",
+    "model_type": "layoutlm",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": {
+    "execution_provider": "qnn",
+    "provider_options": {
+      "device_type": "NPU",
+      "htp_performance_mode": "burst",
+      "htp_graph_finalization_optimization_mode": "3"
+    },
+    "provider_option_file_keys": [],
+    "enable_ep_context": true,
+    "embed_context": false,
+    "compiler": "ort",
+    "qnn_sdk_root": null,
+    "device": "npu",
+    "ep_device": null,
+    "validate": false
+  },
+  "loader": {
+    "task": "question-answering",
+    "model_class": "LayoutLMForQuestionAnswering",
+    "model_type": "layoutlm"
+  }
+}

--- a/examples/recipes/impira_layoutlm-document-qa/qnn/npu/question-answering_w8a16_config.json
+++ b/examples/recipes/impira_layoutlm-document-qa/qnn/npu/question-answering_w8a16_config.json
@@ -1,0 +1,123 @@
+{
+  "auto": false,
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          50265
+        ]
+      },
+      {
+        "name": "bbox",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512,
+          4
+        ],
+        "value_range": [
+          0,
+          1000
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      },
+      {
+        "name": "token_type_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          1
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "start_logits"
+      },
+      {
+        "name": "end_logits"
+      }
+    ],
+    "compatibility": {
+      "transformers_attention": "eager"
+    }
+  },
+  "optim": {
+    "clamp_constant_values": true,
+    "gelu_fusion": true,
+    "matmul_add_fusion": false
+  },
+  "quant": {
+    "mode": "static",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint16",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": 42,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "question-answering",
+    "model_id": "impira/layoutlm-document-qa",
+    "model_type": "layoutlm"
+  },
+  "compile": {
+    "execution_provider": "qnn",
+    "provider_options": {
+      "device_type": "NPU",
+      "htp_performance_mode": "burst",
+      "htp_graph_finalization_optimization_mode": "3"
+    },
+    "provider_option_file_keys": [],
+    "enable_ep_context": true,
+    "embed_context": false,
+    "compiler": "ort",
+    "qnn_sdk_root": null,
+    "device": "npu",
+    "ep_device": null,
+    "validate": false
+  },
+  "loader": {
+    "task": "question-answering",
+    "model_class": "LayoutLMForQuestionAnswering",
+    "model_type": "layoutlm"
+  }
+}


### PR DESCRIPTION
## Summary

Adds two deterministic QNN NPU recipes for `impira/layoutlm-document-qa`:

- fp16
- W8A16

This is intentionally recipe-only. It does not change shared source code, tests, or `examples/recipes/README.md`. Each recipe owns its exact LayoutLM input contract, optimization choices, quantization, and QNN compile settings. Top-level `"auto": false` prevents autoconf from changing the evidenced graph.

The confirmed W8A16 optimization lowers paired p50 latency by **65.2747%** (95% CI `[65.1316%, 65.4115%]`) against the correctness-valid W8A16 baseline, from about 45.443 ms to 15.734 ms. A fresh latest-main recipe-only build measured 15.9689 ms p50 in a 100-iteration smoke run.

## Model metadata

### What the model does

This English LayoutLM v1 checkpoint performs extractive question answering over documents. Its neural forward path consumes tokenized question/document text, OCR-derived normalized token bounding boxes, an attention mask, and token-type IDs, then emits per-token start and end logits for an answer span. Image/PDF decoding, OCR, word-to-box alignment, and final answer decoding are outside this model forward path.

### Primary user stories

- Extract a requested field such as an invoice number from an invoice.
- Extract a requested amount or clause from a contract or financial document.

### Supported tasks

- `document-question-answering`: checkpoint and Transformers pipeline intent.
- `question-answering`: the neural span-scoring task used by WinML export and these recipes.

### Model architecture

```text
LayoutLMForQuestionAnswering
|-- LayoutLMModel backbone
|   |-- word + 1D position + 2D layout + token-type embeddings (hidden 768)
|   `-- 12 encoder layers
|       |-- 12-head self-attention
|       `-- 768 -> 3072 -> 768 GELU feed-forward block
`-- QA span head
    |-- start_logits [batch, sequence]
    `-- end_logits [batch, sequence]
```

Checkpoint evidence is pinned at [beed3c4d02d86017ebca5bd0fdf210046b907aa6](https://huggingface.co/impira/layoutlm-document-qa/tree/beed3c4d02d86017ebca5bd0fdf210046b907aa6).

## Validation and support evidence

### 1. Baseline

- Current base: `2472d56165871cba2f56a04397c1f56a9558f239`; WinML version `0.3.0`.
- Original measurement base: `6b16162816121bec4f1610726dc0769b2df5a703`.
- The previous PR base was `f5ee1267a9a6ec32639c15f3cac3006f56d5b46b`. The two subsequent main commits changed E2E timeout handling, dependency/workflow configuration, and unrelated runtime/model surfaces. Fresh latest-main builds, four-sample QNN parity, and fixed-input performance were rerun for both retained recipes.
- Recipe-free baseline build: **FAIL**, exit 2. Automatic task resolution selected `AutoModelForNextSentencePrediction`, which rejects `LayoutLMConfig`; no ONNX or latency result was produced.
- The explicit-task starting config used sequence length 514, token-type range `[0,2)`, no compile target, and autoconf enabled. The checked-in recipes own the valid fixed contract instead.

### 2. Goal

- Contribution effort/outcome: **recipe-only (L0)**.
- Validation ceiling: **L2**.
- A retained tuple must build one QNN EPContext, run fixed-input QNN NPU performance, and pass four-sample tensor/span parity.
- The recipes must preserve four inputs and two outputs, use sequence length 512, constrain bbox coordinates to `[0,1000)`, constrain token types to `[0,1)`, and retain the exact QNN provider options.

### 3. Outcome

- **L2 PASS** for QNN/NPU fp16 and W8A16.
- Coverage is `required-tuples-contain-exhausted-failures`, not full or partial.
- Shipped tuples: `qnn/npu/fp16`, `qnn/npu/w8a16`.
- Reachable exhausted tuples: `qnn/npu/fp32`, `qnn/npu/w8a8`.
- Deferred tuples: none.
- Final diff: exactly these two recipe JSON files; production README unchanged.

### 4. Per-EP/device/precision results and Functional smoke Eval

| EP / Device | Precision | Verdict | Confirmed mean | Confirmed p50 | Confirmed throughput |
|---|---|---|---:|---:|---:|
| QNNExecutionProvider / NPU | fp32 | EXHAUSTED-FAIL | - | - | - |
| QNNExecutionProvider / NPU | fp16 | PASS | 30.8760 ms | 29.8871 ms | 32.3876 samples/s |
| QNNExecutionProvider / NPU | W8A8 | EXHAUSTED-FAIL | - | - | - |
| QNNExecutionProvider / NPU | W8A16 | PASS | 16.0221 ms | 15.8387 ms | 62.4138 samples/s |

Confirmed protocol for each PASS row: two fresh sessions, 10 warmups plus 100 measured iterations per session, 200 measured samples total, fixed valid input, QNN burst mode, and graph-finalization mode 3.

Fresh recipe-only validation on current main:

| Precision | Build | EPContext | Four-sample parity | Fresh p50 (100 iterations) | Fresh throughput |
|---|---:|---:|---|---:|---:|
| fp16 | 87.6 s | 1 | PASS | 30.1476 ms | 32.6950 samples/s |
| W8A16 | 105.9 s | 1 | PASS | 15.9689 ms | 61.9105 samples/s |

- fp16 parity: minimum cosine `0.9996343229625595`, maximum normalized RMSE `0.027264006657588272`, 8/8 output argmax values exact. The pre-compile artifact contains 208 FLOAT16 initializers; external payload is 254,401,536 bytes versus 508,803,072 bytes before fp16 conversion.
- W8A16 parity: minimum cosine `0.9961441275182744`, maximum normalized RMSE `0.09754994049065031`, 8/8 output argmax values exact. The recipe uses UINT8 learned weights and UINT16 activations.
- fp32 exhaustion: native-GELU and Erf graphs produced the same QNN result; disabling HTP fp16 precision did not restore the reference span ordering. No fp32 recipe is shipped.
- W8A8 exhaustion: default calibration and four valid NPZ calibration samples both failed all four parity samples. No W8A8 recipe is shipped.

**Functional smoke Eval:** `CLI-BLOCKED`, exit 2 on current main. `winml eval` does not support `document-question-answering`, and text-only QA is not a valid substitute for the image/OCR/bbox contract. L2 therefore validates the neural span scorer without claiming document-QA task accuracy.

### 5. Delta

The recipes differ from the explicit-task starting config at 27 RFC 6901 paths in total.

Common changes in both recipes:

- `/auto`: implicit `true` -> `false`, freezing the evidenced graph.
- `/compile`: `null` -> QNN/NPU EPContext compilation with burst mode, graph-finalization mode 3, and `validate=false`.
- `/export/input_tensors/{0,1,2,3}/shape/1`: `514` -> `512`.
- `/export/input_tensors/1/value_range/1`: `1` -> `1000` for bbox coordinates.
- `/export/input_tensors/3/value_range/1`: `2` -> `1` for this checkpoint's single token type.
- `/optim/clamp_constant_values`: missing -> `true`.
- `/optim/matmul_add_fusion`: missing -> `false` to preserve span ordering.

fp16-only changes:

- `/optim/gelu_fusion`: missing -> `false`.
- `/quant/mode`: `static` -> `fp16`.
- `/quant/activation_type`: `uint16` -> `uint8` (inactive calibration metadata for fp16 mode).
- `/quant/fp16_keep_io_types`: missing -> `true`.
- `/quant/fp16_op_block_list`: missing -> `null`.

W8A16-only changes:

- `/optim/gelu_fusion`: missing -> `true`; this collapses the QNN topology from 13 EPContext partitions to one and drives the confirmed 65.2747% paired p50 reduction.
- `/quant/seed`: `null` -> `42`.

### 6. Analyze summary - component level and op level

Static analysis is `ANALYZE-PARTIAL-SUCCESS` with complete parseable requested-EP data.

| Artifact | Architecture mapping | Graph summary | Actionable static findings |
|---|---|---|---|
| fp16 | 442/444 nodes mapped | 444 ops / 16 types | QNN NPU partial Add/Div/Erf/Mul; OpenVINO NPU partial Slice; no unsupported types |
| W8A16 | 1156/1374 nodes mapped | 1374 ops / 17 types | QNN NPU partial MatMul (QDQ); no unsupported types |

Dominant fp16 operators are Add 129, MatMul 97, Reshape 48, Transpose 48, Mul 37, and LayerNormalization 25. Dominant W8A16 operators are DequantizeLinear 593, QuantizeLinear 387, Add 117, MatMul 97, Reshape 48, Transpose 48, and LayerNormalization 25. This is compatibility-rule analysis, not runtime support or performance evidence.

### 7. Reproduce commands

No semantic device, EP, precision, optimization, or compile override is needed; each recipe is self-contained.

```powershell
$OUT='temp/layoutlm-document-qa-qnn-npu'
$INPUT='path/to/sample_02.npz'
$TOOLS='path/to/tester-tools'

winml build -c examples/recipes/impira_layoutlm-document-qa/qnn/npu/question-answering_fp16_config.json -m impira/layoutlm-document-qa -o $OUT/fp16 --rebuild --no-color
winml build -c examples/recipes/impira_layoutlm-document-qa/qnn/npu/question-answering_w8a16_config.json -m impira/layoutlm-document-qa -o $OUT/w8a16 --rebuild --no-color

python $TOOLS/benchmark_fixed_input.py --model $OUT/fp16/model.onnx --input $INPUT --label fp16 --session 1 --warmup 10 --iterations 100 --protocol-reference path/to/perf.json --output $OUT/fp16-perf.json
python $TOOLS/benchmark_fixed_input.py --model $OUT/w8a16/model.onnx --input $INPUT --label w8a16 --session 1 --warmup 10 --iterations 100 --protocol-reference path/to/perf.json --output $OUT/w8a16-perf.json

winml eval --schema --task document-question-answering --no-color
```
