### PR TITLE
fix(build): honor --no-optimize and add multilingual similarity recipes

### DIFF
--- a/examples/recipes/dell-research-harvard_lt-wikidata-comp-multi/cpu/cpu/sentence-similarity_fp16_config.json
+++ b/examples/recipes/dell-research-harvard_lt-wikidata-comp-multi/cpu/cpu/sentence-similarity_fp16_config.json
@@ -1,0 +1,79 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          250002
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ],
+    "compatibility": {
+      "transformers_attention": "eager"
+    }
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": {
+    "mode": "fp16",
+    "samples": 10,
+    "calibration_method": "minmax",
+    "weight_type": "uint8",
+    "activation_type": "uint8",
+    "per_channel": false,
+    "symmetric": false,
+    "weight_symmetric": null,
+    "activation_symmetric": null,
+    "save_calibration": false,
+    "distribution": "uniform",
+    "seed": null,
+    "calibration_load_path": null,
+    "calibration_save_path": null,
+    "op_types_to_quantize": null,
+    "nodes_to_exclude": null,
+    "task": "sentence-similarity",
+    "model_id": "dell-research-harvard/lt-wikidata-comp-multi",
+    "model_type": "xlm-roberta",
+    "fp16_keep_io_types": true,
+    "fp16_op_block_list": null
+  },
+  "compile": null,
+  "loader": {
+    "task": "sentence-similarity",
+    "model_class": "AutoModel",
+    "model_type": "xlm-roberta"
+  }
+}

--- a/examples/recipes/dell-research-harvard_lt-wikidata-comp-multi/cpu/cpu/sentence-similarity_fp32_config.json
+++ b/examples/recipes/dell-research-harvard_lt-wikidata-comp-multi/cpu/cpu/sentence-similarity_fp32_config.json
@@ -1,0 +1,57 @@
+{
+  "export": {
+    "opset_version": 17,
+    "batch_size": 1,
+    "export_params": true,
+    "do_constant_folding": true,
+    "verbose": false,
+    "dynamo": false,
+    "enable_hierarchy_tags": true,
+    "clean_onnx": false,
+    "hierarchy_tag_format": "full",
+    "input_tensors": [
+      {
+        "name": "input_ids",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          250002
+        ]
+      },
+      {
+        "name": "attention_mask",
+        "dtype": "int32",
+        "shape": [
+          1,
+          512
+        ],
+        "value_range": [
+          0,
+          2
+        ]
+      }
+    ],
+    "output_tensors": [
+      {
+        "name": "last_hidden_state"
+      }
+    ],
+    "compatibility": {
+      "transformers_attention": "eager"
+    }
+  },
+  "optim": {
+    "clamp_constant_values": true
+  },
+  "quant": null,
+  "compile": null,
+  "loader": {
+    "task": "sentence-similarity",
+    "model_class": "AutoModel",
+    "model_type": "xlm-roberta"
+  }
+}

--- a/src/winml/modelkit/commands/build.py
+++ b/src/winml/modelkit/commands/build.py
@@ -2068,6 +2068,7 @@ def _build_hf_pipeline(
 
     max_iters: int = extra_kwargs.pop("hack_max_optim_iterations", 3)
     allow_unsupported_nodes: bool = extra_kwargs.pop("allow_unsupported_nodes", False)
+    skip_optimize = extra_kwargs.pop("skip_optimize", False) or config.skip_optimize
     model_label = model_id or "random-init"
 
     # ── Validate + setup ─────────────────────────────────────────
@@ -2142,18 +2143,19 @@ def _build_hf_pipeline(
     stage_timings.append(("Export", _export_elapsed))
 
     # ── Optimize stage ───────────────────────────────────────────
-    current_path, _ = _run_optimize_stage(
-        config=config,
-        model_path=current_path,
-        optimized_path=optimized_path,
-        ep=ep,
-        device=device,
-        max_iters=max_iters,
-        stage_timings=stage_timings,
-        show_io_first=False,
-        analyze_output_path=analyze_result_path,
-        allow_unsupported_nodes=allow_unsupported_nodes,
-    )
+    if not skip_optimize:
+        current_path, _ = _run_optimize_stage(
+            config=config,
+            model_path=current_path,
+            optimized_path=optimized_path,
+            ep=ep,
+            device=device,
+            max_iters=max_iters,
+            stage_timings=stage_timings,
+            show_io_first=False,
+            analyze_output_path=analyze_result_path,
+            allow_unsupported_nodes=allow_unsupported_nodes,
+        )
 
     # Persist config after autoconf
     config_path.write_text(json.dumps(config.to_dict(), indent=2))
@@ -2209,6 +2211,7 @@ def _build_onnx_pipeline(
 
     max_iters: int = extra_kwargs.pop("hack_max_optim_iterations", 3)
     allow_unsupported_nodes: bool = extra_kwargs.pop("allow_unsupported_nodes", False)
+    skip_optimize = extra_kwargs.pop("skip_optimize", False)
 
     # ── Validate + setup ─────────────────────────────────────────
     if not onnx_path.exists():
@@ -2251,21 +2254,22 @@ def _build_onnx_pipeline(
     # config before any stage reads it, otherwise the optimize stage will still
     # run on integer ops and the quantize stage may try to re-quantize.
     ensure_pre_quantized_stamped(config, current_path)
+    skip_optimize = skip_optimize or config.skip_optimize
 
     # ── Optimize stage (first stage for ONNX — show I/O here) ────
-    current_path, _ = _run_optimize_stage(
-        config=config,
-        model_path=current_path,
-        optimized_path=optimized_path,
-        ep=ep,
-        device=device,
-        max_iters=max_iters,
-        stage_timings=stage_timings,
-        show_io_first=True,
-        analyze_output_path=analyze_result_path,
-        allow_unsupported_nodes=allow_unsupported_nodes,
-        skip_optimize=config.skip_optimize,
-    )
+    if not skip_optimize:
+        current_path, _ = _run_optimize_stage(
+            config=config,
+            model_path=current_path,
+            optimized_path=optimized_path,
+            ep=ep,
+            device=device,
+            max_iters=max_iters,
+            stage_timings=stage_timings,
+            show_io_first=True,
+            analyze_output_path=analyze_result_path,
+            allow_unsupported_nodes=allow_unsupported_nodes,
+        )
 
     config_path.write_text(json.dumps(config.to_dict(), indent=2))
 

--- a/tests/unit/commands/test_build.py
+++ b/tests/unit/commands/test_build.py
@@ -2021,6 +2021,185 @@ class TestBuildHfPipelineModelType:
         mock_quantize.assert_called_once()
 
 
+class TestBuildPipelineSkipOptimize:
+    """Concrete CLI pipelines must consume the no-optimize build control."""
+
+    @pytest.mark.parametrize("quant_mode", [None, "fp16"])
+    @patch("winml.modelkit.onnx.copy_onnx_model")
+    @patch("winml.modelkit.commands.build._run_compile_stage")
+    @patch("winml.modelkit.commands.build._run_quantize_stage")
+    @patch("winml.modelkit.commands.build._run_optimize_stage")
+    @patch("winml.modelkit.utils.console.StageLive")
+    @patch("winml.modelkit.export.export_onnx")
+    @patch("winml.modelkit.build.hf._load_model")
+    def test_hf_skip_optimize_preserves_quantize(
+        self,
+        mock_load_model: MagicMock,
+        mock_export_onnx: MagicMock,
+        mock_stage_live: MagicMock,
+        mock_optimize: MagicMock,
+        mock_quantize: MagicMock,
+        mock_compile: MagicMock,
+        mock_copy: MagicMock,
+        quant_mode: str | None,
+        tmp_path: Path,
+    ) -> None:
+        from winml.modelkit.commands.build import _build_hf_pipeline
+
+        mock_stage_live.return_value.__enter__ = MagicMock(return_value=MagicMock())
+        mock_stage_live.return_value.__exit__ = MagicMock(return_value=False)
+        output_dir = tmp_path / "out"
+        export_path = output_dir / "export.onnx"
+        quantized_path = output_dir / "quantized.onnx"
+        mock_quantize.return_value = quantized_path if quant_mode else export_path
+        mock_compile.side_effect = lambda **kwargs: kwargs["current_path"]
+
+        config = MagicMock()
+        config.skip_optimize = False
+        config.loader.model_type = "xlm-roberta"
+        config.loader.task = "sentence-similarity"
+        config.loader.model_class = "AutoModel"
+        config.export = MagicMock()
+        config.quant = None if quant_mode is None else MagicMock(mode=quant_mode)
+        if config.quant is not None:
+            config.quant.model_type = None
+        config.to_dict.return_value = {}
+
+        result = _build_hf_pipeline(
+            config=config,
+            model_id="example/model",
+            output_dir=output_dir,
+            rebuild=True,
+            cache_key=None,
+            ep="cpu",
+            device="cpu",
+            extra_kwargs={"skip_optimize": True},
+        )
+
+        assert result is not None
+        assert [name for name, _ in result] == ["Export"]
+        mock_optimize.assert_not_called()
+        assert mock_quantize.call_args.kwargs["current_path"] == export_path
+        expected_final_source = quantized_path if quant_mode else export_path
+        mock_copy.assert_called_once_with(expected_final_source, output_dir / "model.onnx")
+
+    @pytest.mark.parametrize("quant_mode", [None, "fp16"])
+    @patch("winml.modelkit.onnx.copy_onnx_model")
+    @patch("winml.modelkit.commands.build._run_compile_stage")
+    @patch("winml.modelkit.commands.build._run_quantize_stage")
+    @patch("winml.modelkit.commands.build._run_optimize_stage")
+    def test_onnx_skip_optimize_preserves_quantize(
+        self,
+        mock_optimize: MagicMock,
+        mock_quantize: MagicMock,
+        mock_compile: MagicMock,
+        mock_copy: MagicMock,
+        quant_mode: str | None,
+        tmp_path: Path,
+    ) -> None:
+        from winml.modelkit.commands.build import _build_onnx_pipeline
+
+        onnx_path = tmp_path / "input.onnx"
+        onnx_path.write_bytes(b"fake-onnx-data")
+        output_dir = tmp_path / "out"
+        copied_input = output_dir / onnx_path.name
+        quantized_path = output_dir / "input_quantized.onnx"
+        mock_quantize.return_value = quantized_path if quant_mode else copied_input
+        mock_compile.side_effect = lambda **kwargs: kwargs["current_path"]
+
+        config = MagicMock()
+        config.skip_optimize = False
+        config.quant = None if quant_mode is None else MagicMock(mode=quant_mode)
+        config.to_dict.return_value = {}
+
+        with patch("winml.modelkit.build.common.ensure_pre_quantized_stamped"):
+            result = _build_onnx_pipeline(
+                config=config,
+                onnx_path=onnx_path,
+                output_dir=output_dir,
+                rebuild=True,
+                ep="cpu",
+                device="cpu",
+                extra_kwargs={"skip_optimize": True},
+            )
+
+        assert result == []
+        mock_optimize.assert_not_called()
+        assert mock_quantize.call_args.kwargs["current_path"] == copied_input
+        expected_final_source = quantized_path if quant_mode else copied_input
+        assert mock_copy.call_args_list[-1].args == (
+            expected_final_source,
+            output_dir / "model.onnx",
+        )
+
+    @pytest.mark.parametrize("pipeline", ["hf", "onnx"])
+    @patch("winml.modelkit.commands.build._run_compile_stage")
+    @patch("winml.modelkit.commands.build._run_quantize_stage")
+    @patch("winml.modelkit.commands.build._run_optimize_stage")
+    def test_default_pipeline_still_optimizes(
+        self,
+        mock_optimize: MagicMock,
+        mock_quantize: MagicMock,
+        mock_compile: MagicMock,
+        pipeline: str,
+        tmp_path: Path,
+    ) -> None:
+        from winml.modelkit.commands.build import _build_hf_pipeline, _build_onnx_pipeline
+
+        output_dir = tmp_path / "out"
+        optimized_name = "optimized.onnx" if pipeline == "hf" else "input_optimized.onnx"
+        optimized_path = output_dir / optimized_name
+        mock_optimize.return_value = (optimized_path, 0.1)
+        mock_quantize.side_effect = lambda **kwargs: kwargs["current_path"]
+        mock_compile.side_effect = lambda **kwargs: kwargs["current_path"]
+        config = MagicMock()
+        config.skip_optimize = False
+        config.quant = None
+        config.to_dict.return_value = {}
+
+        if pipeline == "hf":
+            config.loader.model_type = "xlm-roberta"
+            config.loader.task = "sentence-similarity"
+            config.loader.model_class = "AutoModel"
+            config.export = MagicMock()
+            with (
+                patch("winml.modelkit.build.hf._load_model"),
+                patch("winml.modelkit.export.export_onnx"),
+                patch("winml.modelkit.utils.console.StageLive") as mock_stage_live,
+                patch("winml.modelkit.onnx.copy_onnx_model"),
+            ):
+                mock_stage_live.return_value.__enter__ = MagicMock(return_value=MagicMock())
+                mock_stage_live.return_value.__exit__ = MagicMock(return_value=False)
+                _build_hf_pipeline(
+                    config=config,
+                    model_id="example/model",
+                    output_dir=output_dir,
+                    rebuild=True,
+                    cache_key=None,
+                    ep="cpu",
+                    device="cpu",
+                    extra_kwargs={},
+                )
+        else:
+            onnx_path = tmp_path / "input.onnx"
+            onnx_path.write_bytes(b"fake-onnx-data")
+            with (
+                patch("winml.modelkit.build.common.ensure_pre_quantized_stamped"),
+                patch("winml.modelkit.onnx.copy_onnx_model"),
+            ):
+                _build_onnx_pipeline(
+                    config=config,
+                    onnx_path=onnx_path,
+                    output_dir=output_dir,
+                    rebuild=True,
+                    ep="cpu",
+                    device="cpu",
+                    extra_kwargs={},
+                )
+
+        mock_optimize.assert_called_once()
+
+
 class TestBuildEpResolution:
     """--ep forwarding into config generation + the compile EP-availability gate."""
 
@@ -2330,11 +2509,11 @@ class TestBuildOnnxPipelineRegressions:
         assert timings and timings[0][0] == "Quantize"
         mock_quantize.assert_called_once()
 
-    def test_pre_quantized_stamp_runs_before_optimize(self, tmp_path: Path) -> None:
-        """_build_onnx_pipeline must stamp config before optimize/quantize stages.
+    def test_pre_quantized_stamp_runs_before_stage_dispatch(self, tmp_path: Path) -> None:
+        """_build_onnx_pipeline must stamp config before optimize/quantize dispatch.
 
         This ensures pre-quantized ONNX inputs can set skip_optimize and clear
-        quant before stage dispatch, preventing optimize/quantize double-work.
+        quant before stage dispatch, bypassing optimize/quantize double-work.
         """
         from winml.modelkit.commands.build import _build_onnx_pipeline
 
@@ -2382,7 +2561,7 @@ class TestBuildOnnxPipelineRegressions:
 
         assert result is not None
         mock_stamp.assert_called_once()
-        assert mock_opt.call_args.kwargs["skip_optimize"] is True
+        mock_opt.assert_not_called()
         assert mock_quant.call_args.kwargs["config"].quant is None
 
 

--- a/tests/unit/commands/test_build.py
+++ b/tests/unit/commands/test_build.py
@@ -2051,8 +2051,9 @@ class TestBuildPipelineSkipOptimize:
         output_dir = tmp_path / "out"
         export_path = output_dir / "export.onnx"
         quantized_path = output_dir / "quantized.onnx"
+        compiled_path = output_dir / "compiled.onnx"
         mock_quantize.return_value = quantized_path if quant_mode else export_path
-        mock_compile.side_effect = lambda **kwargs: kwargs["current_path"]
+        mock_compile.return_value = compiled_path
 
         config = MagicMock()
         config.skip_optimize = False
@@ -2061,6 +2062,7 @@ class TestBuildPipelineSkipOptimize:
         config.loader.model_class = "AutoModel"
         config.export = MagicMock()
         config.quant = None if quant_mode is None else MagicMock(mode=quant_mode)
+        config.compile = MagicMock()
         if config.quant is not None:
             config.quant.model_type = None
         config.to_dict.return_value = {}
@@ -2080,8 +2082,10 @@ class TestBuildPipelineSkipOptimize:
         assert [name for name, _ in result] == ["Export"]
         mock_optimize.assert_not_called()
         assert mock_quantize.call_args.kwargs["current_path"] == export_path
-        expected_final_source = quantized_path if quant_mode else export_path
-        mock_copy.assert_called_once_with(expected_final_source, output_dir / "model.onnx")
+        expected_compile_source = quantized_path if quant_mode else export_path
+        mock_compile.assert_called_once()
+        assert mock_compile.call_args.kwargs["current_path"] == expected_compile_source
+        mock_copy.assert_called_once_with(compiled_path, output_dir / "model.onnx")
 
     @pytest.mark.parametrize("quant_mode", [None, "fp16"])
     @patch("winml.modelkit.onnx.copy_onnx_model")
@@ -2104,12 +2108,14 @@ class TestBuildPipelineSkipOptimize:
         output_dir = tmp_path / "out"
         copied_input = output_dir / onnx_path.name
         quantized_path = output_dir / "input_quantized.onnx"
+        compiled_path = output_dir / "input_compiled.onnx"
         mock_quantize.return_value = quantized_path if quant_mode else copied_input
-        mock_compile.side_effect = lambda **kwargs: kwargs["current_path"]
+        mock_compile.return_value = compiled_path
 
         config = MagicMock()
         config.skip_optimize = False
         config.quant = None if quant_mode is None else MagicMock(mode=quant_mode)
+        config.compile = MagicMock()
         config.to_dict.return_value = {}
 
         with patch("winml.modelkit.build.common.ensure_pre_quantized_stamped"):
@@ -2126,9 +2132,11 @@ class TestBuildPipelineSkipOptimize:
         assert result == []
         mock_optimize.assert_not_called()
         assert mock_quantize.call_args.kwargs["current_path"] == copied_input
-        expected_final_source = quantized_path if quant_mode else copied_input
+        expected_compile_source = quantized_path if quant_mode else copied_input
+        mock_compile.assert_called_once()
+        assert mock_compile.call_args.kwargs["current_path"] == expected_compile_source
         assert mock_copy.call_args_list[-1].args == (
-            expected_final_source,
+            compiled_path,
             output_dir / "model.onnx",
         )
 


### PR DESCRIPTION
## Summary

This L2 contribution adds CPU FP32 and FP16 sentence-similarity recipes for `dell-research-harvard/lt-wikidata-comp-multi` and fixes shared build-stage control for Hugging Face and direct-ONNX inputs. The candidate reached the committed L3 goal with full planned CPU coverage: both precisions passed structural, performance, and bounded numeric validation, and FP32 passed the bounded multilingual functional smoke Eval. A test-only follow-up now proves that configured compile returns a distinct output and that finalization consumes it in both concrete no-optimize paths. The current candidate is `3cd22269dfbfaac8baef63cb221c44c9e803af91`, with parent `a4ad838ecb83d103ee2a338dda5746a72492262b`.

## Model metadata

### What the model does

A multilingual text-embedding checkpoint for company-alias record linkage and sentence similarity across 12 advertised languages; it exports contextual token states consumed by downstream mean pooling into 768-dimensional embeddings.

- Evidence: pinned checkpoint `dell-research-harvard/lt-wikidata-comp-multi@129b41d6e02494453aef06108baec55d85c6ad8c`, its model card, `config.model_type=xlm-roberta`, `architectures=[XLMRobertaModel]`, and `1_Pooling/config.json` with `pooling_mode_mean_tokens=true`.
- Confidence: `verified`.

### Primary user stories

- A user supplies multilingual company names or descriptions to obtain embedding similarity for record linkage, deduplication, clustering, or semantic search. Evidence: the pinned checkpoint model card. Confidence: `verified`.

### Supported tasks

- `sentence-similarity` on the checkpoint and WinML surfaces. Evidence: Hub `pipeline_tag=sentence-similarity`; `winml eval --schema --task sentence-similarity` exits 0. Confidence: `verified`.
- `feature-extraction` on Transformers, Optimum ONNX, and WinML surfaces. Evidence: `winml inspect` resolves feature extraction through `XLMRobertaIOConfig`; current main contains exact-model FP32/FP16 feature-extraction recipes. Confidence: `verified`.

### Model architecture

```text
XLMRobertaModel
|- Embeddings (250002 vocab, position + token type, width 768)
|- Encoder stack x 12
|  |- Bidirectional self-attention (12 heads)
|  |- Feed-forward (768 -> 3072 -> 768, GELU)
|  `- Residual + LayerNorm
|- Exported output: last_hidden_state [1, sequence, 768]
`- Downstream sentence-transformers mean pooling -> 768-d embedding
```

- Source/confidence: exact pinned config dimensions, locked Transformers 5.14.1 `modeling_xlm_roberta.py`, pinned pooling config, and built ONNX graph structure (`verified`).

## Validation and support evidence

### Baseline

Baseline was freshly measured on main commit `6b16162816121bec4f1610726dc0769b2df5a703` with `winml, version 0.0.1.dev0`. Auto-config generated a sentence-similarity recipe. A no-optimize CPU build exited 0 in 124.8 s (Export 69.0 s, Optimize 30.0 s), but still emitted an Optimize stage and optimized artifact, proving that `--no-optimize` was ignored by the concrete HF pipeline. The resulting baseline perf was 310.26 ms mean, 312.81 ms p50, 314.20 ms p90, 3.22 samples/s, and +105.0 MB RAM over three measured iterations. Baseline Eval evidence contained only Python REPL startup and established no task metric.

The Optimum registry probe found the vendor and WinML surfaces both advertising feature extraction, fill-mask, multiple choice, question answering, text classification, and token classification; WinML added no task. The aggregate probe exceeded its 10-minute wall-time and was terminated (`probe_exit_code=-1`), so no probe PASS is inferred. The baseline goal floor was L1.

### Goal

- Effort: L2.
- Goal ceiling: L3, reached with PASS.
- Outcome: L2.
- Success definition: no-recipe XLM-R build acceptance; concrete HF and ONNX `--no-optimize` behavior with quantization and defaults preserved; independent FP32/FP16 CPU recipe validation with true-FP16 evidence; and one final-SHA, two-row, pinned English-German functional smoke Eval with all fan-out caps retained.

No charter re-issue or ceiling change occurred.

### Outcome

The shipped tier is L2 and the highest goal verdict is `L3 PASS`. Coverage is `full` for the planned CPU/cpu FP32 and FP16 tuples, with no deferred tuples. The contribution adds two sentence-similarity recipes, changes shared build behavior, and adds concrete-sink regression tests.

The follow-up from `a4ad838ecb83d103ee2a338dda5746a72492262b` to `3cd22269dfbfaac8baef63cb221c44c9e803af91` changes only `tests/unit/commands/test_build.py`. Fresh testing at `3cd22269...` covered the four concrete HF/ONNX sink cases, the complete commands partition, and touched-file Ruff. Because production code, recipes, `uv.lock`, model artifacts, evaluator, compiler, optimizer, and workflows are unchanged, the Tester made an explicit `REUSE-REBIND` decision for L0 builds/structure, L1 perf, L2 parity, L3 Eval, component/op Analyze, models/optim/remaining partitions, full Ruff, and mypy. Those values below were executed at `a4ad838e...` and are preserved as provenance-bound evidence; they were not rerun or relabeled as executions at `3cd22269...`.

Learner findings `xlm-roberta-005` through `xlm-roberta-010` and methodology finding `_meta-114` were published separately in Lane A PR [gim-home/ModelKitArtifacts#289](https://github.com/gim-home/ModelKitArtifacts/pull/289) at commit `6b485ff17aeb128651335f0d53301479b06f3151`, based on prerequisite PR #288 at commit `63e0bb74b4b79a394d5aaffef496d3d83404447b`. Those skill and knowledge files are not part of this winml-cli contribution.

### Per-EP/device/precision results and Functional smoke Eval

The following L0-L3 model values are `REUSE-REBIND` evidence executed at `a4ad838e...`; no production or artifact-producing input changed in the test-only follow-up.

| Tier | EP / Device | Precision | Verdict | Mean | p50 | Throughput | RAM delta | Precision evidence |
|---|---|---|---|---|---|---|---|---|
| L0 | CPUExecutionProvider / cpu | fp32 | PASS | - | - | - | - | 383 nodes; 200 FLOAT initializers; 1,109,820,432-byte external data; FLOAT output |
| L0 | CPUExecutionProvider / cpu | fp16 | PASS | - | - | - | - | 384 nodes; 200 FLOAT16 initializers; 554,914,320-byte external data; FP32 I/O preserved; FP16/FP32 size ratio 0.5000036978955168 |
| L1 | CPUExecutionProvider / cpu | fp32 | PASS | 424.85 ms | 373.55 ms | 2.35 samples/s | +105.0 MB | printed output precision float32 |
| L1 | CPUExecutionProvider / cpu | fp16 | PASS | 314.49 ms | 316.34 ms | 3.18 samples/s | +122.0 MB | requested FP16; printed output precision float32 because I/O is preserved; true FP16 artifact evidence above |

The L1 figures are short-run measurements with one warmup and three measured iterations; they are not a stable benchmark claim.

| L2 artifact | Verdict | Frozen bounds | Observed values |
|---|---|---|---|
| fp32 | PASS | minimum cosine 0.9999; maximum absolute error 0.0005 | minimum cosine 0.9999999403953552; maximum absolute error 1.2293457984924316e-07 |
| fp16 | PASS | minimum cosine 0.999; maximum absolute error 0.02 | minimum cosine 0.9999995231628418; maximum absolute error 0.00013403967022895813 |

**Functional smoke Eval:** `L3 PASS`, executed at candidate `a4ad838ecb83d103ee2a338dda5746a72492262b` and retained for `3cd22269...` by the Tester's explicit `REUSE-REBIND` decision. It used FP32 CPU and `mteb/sts17-crosslingual-sts` at requested and resolved revision `bb1de64ee6fd9ccd66e0bdbadcafe990f652d887`, config `en-de`, split `test`. Deterministic first-N selection requested and processed two English-German sentence pairs. Schema was verified; labels are STS relatedness scores; predictions are cosine similarities of attention-mask mean-pooled, L2-normalized `last_hidden_state` embeddings; pooling was verified against the pinned configuration. Fan-out was capped at two sentence pairs, one `en-de` language direction, sequence length 512, no beams, and no candidate labels or prompts. The raw `spearman_correlation` was `0.9999999999999999` (approximately 1.0). With only two rows, this is functional end-to-end operability evidence only, not representative accuracy or benchmark-quality evidence.

### Delta

Changed winml-cli files across the full current candidate:

- `src/winml/modelkit/commands/build.py`
- `tests/unit/commands/test_build.py`
- `examples/recipes/dell-research-harvard_lt-wikidata-comp-multi/cpu/cpu/sentence-similarity_fp32_config.json`
- `examples/recipes/dell-research-harvard_lt-wikidata-comp-multi/cpu/cpu/sentence-similarity_fp16_config.json`

The FP32 recipe is identical to the Planner's starting auto-config. The FP16 recipe changes only JSON pointer `/quant`, from `null` to explicit FP16 configuration: mode `fp16`, samples `10`, calibration method `minmax`, weight and activation types `uint8`, `per_channel=false`, `symmetric=false`, uniform distribution, model/task/type identity, and `fp16_keep_io_types=true`; optional symmetry, paths, op lists, block lists, and seed remain null. The production recipe README is untouched. Recipe-free acceptance passed, and the delta is reducibility-consistent with the charter.

The repair commit changes only `tests/unit/commands/test_build.py`: its HF and ONNX no-optimize tests now configure compile to return a path distinct from the quantized or exported input, assert compile ordering, and assert that finalization consumes that compiled path. It changes no production behavior, recipes, lock data, or artifacts.

**Bug fix explanation**

1. **Symptom and trigger:** `winml build ... --no-optimize` propagated the flag but still ran Optimize on a concrete Hugging Face build; direct-ONNX builds had the same sink-level gap.
2. **Root cause:** the command layer placed `skip_optimize` in `build_pipeline_extra_kwargs`, but `_build_hf_pipeline` and `_build_onnx_pipeline` did not consume it before unconditionally invoking the optimize helper. Existing propagation-only tests mocked the concrete sink and could not detect this.
3. **Mechanism:** `_build_hf_pipeline` and `_build_onnx_pipeline` consume `skip_optimize` and bypass only the Optimize helper. Requested FP16/other quantization, compile, and finalize stages continue to run.
4. **General rule:** the fix is driven by the existing stage-control flag at both concrete pipeline sinks. It contains no model ID, checkpoint, or XLM-R special case.
5. **Compatibility:** default builds still optimize; skipping optimization does not suppress requested quantization; lower HF/ONNX semantics, recipe behavior, compile, and finalization are preserved. There are no intentional behavior changes beyond making `--no-optimize` honor its documented meaning.
6. **Regression evidence:** at current candidate `3cd22269...`, four concrete HF/ONNX sink cases passed in 4.83 s. They cover quantized and no-quant paths, make compile output distinct, assert compile receives the quantized or exported output, and assert finalization receives the compiled output while Optimize alone is skipped. The complete commands partition passed with 3648 passed, 9 skipped, 1 warning in 317.31 s (0:05:17), and touched-file Ruff reported `All checks passed!`.

### Analyze summary - component level and op level

`ANALYZE-PARTIAL-SUCCESS`: Analyze emitted complete seven-EP JSON and exited `1`; the nonzero status is retained because findings include partial/unknown support and EPs without rule data. This is static rule analysis of the FP32 graph, not runtime execution. No all-EP runtime support was measured, and no FP16 all-EP Analyze run was supplied. This section is `REUSE-REBIND` evidence executed at `a4ad838e...`, not a fresh Analyze run at `3cd22269...`.

#### Component-level summary

| Artifact | Architecture coverage | Mapping | Confidence / unresolved gaps |
|---|---|---|---|
| fp32 | embeddings; 12 encoder layers with self-attention and MLP; `last_hidden_state` boundary; downstream mean pooling | 383 mapped, 0 unmapped | hierarchy tags plus frozen tensor-boundary mapping; output is a tensor boundary, pooling is outside the graph, and optimized Gemm nodes cannot be uniquely split between attention and MLP |

#### Op-level summary

| Artifact | Graph | Dominant ops | Actionable static EP findings |
|---|---|---|---|
| fp32 | 383 operators / 19 types | Reshape 121; Gemm 72; Transpose 48; Add 39; LayerNormalization 25; MatMul 24; Mul 13; Softmax 12 | QNN GPU: partial Gather and GatherElements, unknown Where; NvTensorRTRTX/OpenVINO GPU: unknown Where |

CUDA and MIGraphX classifications had ambiguous type-derived counts (380 supported nodes, 2 partial, 1 unknown). TensorRT and DML had no rule data, leaving all 383 nodes unclassified. None of these static rows claims provider runtime execution.

#### CI quality partitions

Fresh local evidence at `3cd22269...`:

- Focused concrete HF/ONNX sink partition: 4 passed in 4.83 s.
- Commands partition: 3648 passed, 9 skipped, 1 warning in 317.31 s (0:05:17).
- Touched-file Ruff: All checks passed.

Live PR #1370 CI at head `3cd22269dfbfaac8baef63cb221c44c9e803af91`: all nine reported checks completed successfully: Analyze (Python), lint, test (analyze), test (models), test (optim), test (commands), test (remaining), CodeQL, and license/cla.

Preserved `REUSE-REBIND` evidence executed at `a4ad838e...`:

- `insert-license`: Passed.
- `ruff-full`: All checks passed.
- `mypy-full`: Success, no issues in 441 source files.
- Analyze partition: 1529 passed, 45 skipped.
- Models partition: 1538 passed, 6 skipped, 2 xfailed.
- Optim partition: 876 passed, 16 skipped, 1 xfailed.
- Remaining partition: 936 passed, 2 skipped, 1 deselected, 2 warnings in 559.69 s (0:09:19).
- Compatibility-focused partition: HF/ONNX no-optimize, quant preservation, and defaults passed.

The prior remaining-partition attempt was environment-blocked because Node 22 was absent; the final supplemental run used Node v22.23.2 on `PATH` and passed.

### Reproduce commands

Run from a winml-cli checkout after installing its frozen environment. These are the Tester-supplied portable public commands retained from the original model-validation handoff:

```powershell
$OUT='temp/lt-wikidata-comp-multi-test'
winml build -c examples/recipes/dell-research-harvard_lt-wikidata-comp-multi/cpu/cpu/sentence-similarity_fp32_config.json -m dell-research-harvard/lt-wikidata-comp-multi -o $OUT/fp32
winml build -c examples/recipes/dell-research-harvard_lt-wikidata-comp-multi/cpu/cpu/sentence-similarity_fp16_config.json -m dell-research-harvard/lt-wikidata-comp-multi -o $OUT/fp16 --precision fp16
winml perf -m $OUT/fp32/model.onnx --ep cpu --device cpu --warmup 1 --iterations 3
WINMLCLI_RULES_DIR=<rules-root> winml analyze --model $OUT/fp32/model.onnx --ep all --output $OUT/analyze.json
```

This body is ready to replace the description of existing draft PR #1370, which carries the `model-scale-by-skill` label. This refresh does not mutate the PR.