### PR TITLE
Fix uv version in release pipelines

### DIFF
--- a/.pipelines/templates/e2e-test-jobs.yml
+++ b/.pipelines/templates/e2e-test-jobs.yml
@@ -136,17 +136,16 @@ jobs:
 
       - powershell: |
           $uvBin = "$env:USERPROFILE\.local\bin"
-          if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
-            Invoke-RestMethod https://astral.sh/uv/0.10.12/install.ps1 | Invoke-Expression
-            $env:PATH = "$uvBin;$env:PATH"
-          }
+          Invoke-RestMethod https://astral.sh/uv/0.11.25/install.ps1 | Invoke-Expression
+          $env:PATH = "$uvBin;$env:PATH"
+          uv --version
           uv python install 3.11
           Remove-Item -Recurse -Force "$(Build.SourcesDirectory)\.venv" -ErrorAction SilentlyContinue
           uv venv $(Build.SourcesDirectory)\.venv --python 3.11
           $venvDir = "$(Build.SourcesDirectory)\.venv\Scripts"
           Write-Host "##vso[task.prependpath]$uvBin"
           Write-Host "##vso[task.prependpath]$venvDir"
-        displayName: 'Install uv 0.10.12 and Python'
+        displayName: 'Install uv 0.11.25 and Python'
 
       - script: python --version
         displayName: 'Check Python version'

--- a/.pipelines/templates/eval-report-jobs.yml
+++ b/.pipelines/templates/eval-report-jobs.yml
@@ -88,17 +88,16 @@ jobs:
 
       - powershell: |
           $uvBin = "$env:USERPROFILE\.local\bin"
-          if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
-            Invoke-RestMethod https://astral.sh/uv/0.10.12/install.ps1 | Invoke-Expression
-            $env:PATH = "$uvBin;$env:PATH"
-          }
+          Invoke-RestMethod https://astral.sh/uv/0.11.25/install.ps1 | Invoke-Expression
+          $env:PATH = "$uvBin;$env:PATH"
+          uv --version
           uv python install 3.11
           Remove-Item -Recurse -Force "$(Build.SourcesDirectory)\.venv" -ErrorAction SilentlyContinue
           uv venv $(Build.SourcesDirectory)\.venv --python 3.11
           $venvDir = "$(Build.SourcesDirectory)\.venv\Scripts"
           Write-Host "##vso[task.prependpath]$uvBin"
           Write-Host "##vso[task.prependpath]$venvDir"
-        displayName: 'Install uv 0.10.12 and Python'
+        displayName: 'Install uv 0.11.25 and Python'
 
       - script: python --version
         displayName: 'Check Python version'


### PR DESCRIPTION
## Summary

- Pin Azure Pipelines to uv 0.11.25 to support scoped dependency exclusions.
- Always install the pinned version and print the active version to avoid reusing an older agent-provided uv.

## Validation

- Verified uv 0.11.25 parses the project configuration successfully.
- Confirmed git diff --check passes.