### PR TITLE
Fix VitisAI compilation cache permissions

### DIFF
--- a/src/winml/modelkit/compiler/configs.py
+++ b/src/winml/modelkit/compiler/configs.py
@@ -269,11 +269,18 @@ class WinMLCompileConfig:
         when available (target=X1, xclbin=<install>/voe-4.0-win_amd64/
         xclbins/phoenix/4x4.xclbin, xlnx_enable_py3_round=0). VitisAI EP
         ignores ``device_type``; the correct device hint is the xclbin path.
+        The cache is placed under WinML's user-writable cache root instead of
+        VitisAI's installation-relative default, which may resolve through the
+        protected WindowsApps directory and fail during model compilation.
         """
         import os
         from pathlib import Path as _Path
 
-        provider_options: dict[str, str] = {}
+        from ..cache import get_cache_dir
+
+        vaip_cache_dir = (get_cache_dir() / "vitisai").resolve()
+        vaip_cache_dir.mkdir(parents=True, exist_ok=True)
+        provider_options: dict[str, str] = {"cache_dir": str(vaip_cache_dir)}
         ryzen_ai = os.environ.get("RYZEN_AI_INSTALLATION_PATH")
         if ryzen_ai:
             xclbin = _Path(ryzen_ai) / "voe-4.0-win_amd64" / "xclbins" / "phoenix" / "4x4.xclbin"

--- a/tests/unit/compiler/test_compiler_configs.py
+++ b/tests/unit/compiler/test_compiler_configs.py
@@ -99,11 +99,14 @@ class TestCompileConfig:
         assert config.ep_config.provider == "openvino"
         assert config.ep_config.enable_ep_context is True
 
-    def test_for_vitisai(self):
+    def test_for_vitisai(self, tmp_path, monkeypatch):
         """Test Vitis AI factory method."""
+        monkeypatch.setenv("WINML_CACHE_DIR", str(tmp_path))
         config = WinMLCompileConfig.for_vitisai()
         assert config.ep_config.provider == "vitisai"
         assert config.ep_config.enable_ep_context is True
+        assert config.ep_config.provider_options["cache_dir"] == str(tmp_path / "vitisai")
+        assert (tmp_path / "vitisai").is_dir()
 
     def test_for_migraphx(self):
         """Test MIGraphX factory method."""


### PR DESCRIPTION
## Summary

- configure VitisAI to use a user-writable cache under the WinML cache root
- avoid installation-relative cache resolution through protected WindowsApps paths
- verify that the cache directory is created and forwarded as a provider option

Related to #1224.

## Validation

- `uv run --no-sync pytest tests/unit/compiler/test_compiler_configs.py --basetemp C:\Users\yuesu\winml-cli\temp\pytest_tmp\compiler-configs-final` (54 passed)
- `uv run --no-sync pytest tests/e2e/test_eval_e2e.py::TestEvalPerTask::test_fill_mask -m e2e --basetemp C:\Users\yuesu\winml-cli\temp\pytest_tmp\fill-mask-v031-vaip-cache-fix` (1 passed on VitisAI NPU)
- `uv run --no-sync ruff check --fix src/winml/modelkit/compiler/configs.py tests/unit/compiler/test_compiler_configs.py tests/e2e/test_eval_e2e.py`