### PR TITLE
Fix Transformers 4.57 export compatibility

### DIFF
--- a/src/winml/modelkit/export/htp/exporter.py
+++ b/src/winml/modelkit/export/htp/exporter.py
@@ -256,7 +256,10 @@ class HTPExporter:
                 # are traced with the same inputs they are exported with. The export
                 # in Step 4 re-enters the patcher; the contexts are sequential, not
                 # nested.
-                with self._get_optimum_patcher(model, task):
+                with (
+                    self._get_optimum_patcher(model, task),
+                    self._export_compatibility_context(model, export_config),
+                ):
                     self._trace_model_hierarchy(model, inputs)
 
                 execution_steps = (
@@ -416,8 +419,14 @@ class HTPExporter:
 
         self._hierarchy_builder = TracingHierarchyBuilder(exceptions=exceptions)
 
-        # Pass inputs to tracer
-        input_args = inputs
+        # Models with an explicit positional export protocol must use the same
+        # binding for hierarchy tracing and ONNX export. This is particularly
+        # important for wrappers whose ``forward`` accepts only ``*args``.
+        input_args = (
+            model.get_export_args(inputs)  # type: ignore[operator]
+            if hasattr(model, "get_export_args")
+            else inputs
+        )
 
         self._hierarchy_builder.trace_model_execution(model, input_args)
 

--- a/src/winml/modelkit/models/hf/blip.py
+++ b/src/winml/modelkit/models/hf/blip.py
@@ -265,15 +265,14 @@ class BlipDecoderWrapper(WinMLDecoderWrapper):
             dtype=torch.long,
             device=encoder_hidden_states.device,
         )
-        decoder_mask = (1 - inputs["decoder_attention_mask"]).to(dtype=encoder_hidden_states.dtype)
-        decoder_mask = decoder_mask.unsqueeze(1).unsqueeze(1)
-        decoder_mask = decoder_mask * torch.finfo(encoder_hidden_states.dtype).min
+        # Transformers 4.57 accepts a 2-D or 3-D binary attention mask and
+        # expands it to additive form internally. Preserve the explicit query
+        # dimension required by this one-token static-cache decoder step.
+        decoder_mask = inputs["decoder_attention_mask"].unsqueeze(1)
         # self.model is nn.Module; torch's __getattr__ types text_decoder as
         # Tensor | Module, so narrow to a callable Module.
         outputs = cast("nn.Module", self.model.text_decoder)(
             input_ids=inputs["decoder_input_ids"],
-            # HF's causal-mask reconstruction traces as ops the NPU analyzer
-            # doesn't support; pass an additive 4-D mask to bypass reconstruction.
             attention_mask=decoder_mask,
             # Without explicit position_ids, BlipTextModel would derive them
             # from past_kv_len=0 (a frozen constant in the trace), giving every

--- a/src/winml/modelkit/transformers_compat.py
+++ b/src/winml/modelkit/transformers_compat.py
@@ -309,7 +309,7 @@ def _install_impl() -> None:
 
 
 def _patch_model_patcher(module: Any) -> None:
-    """Replace ``sdpa_mask_without_vmap`` on an already-loaded model_patcher module.
+    """Apply attention compatibility patches to an already-loaded model patcher.
 
     Must only be called after ``module`` has finished executing its own
     top-level code (its own definition is assigned near the end of the
@@ -367,6 +367,43 @@ def _patch_model_patcher(module: Any) -> None:
         return causal_mask.expand(batch_size, -1, q_length, kv_length)
 
     module.sdpa_mask_without_vmap = _sdpa_mask_without_vmap_tf5
+
+    original_sdpa = module.original_scaled_dot_product_attention
+    if not getattr(original_sdpa, "_winml_integral_mask_compat", False):
+
+        def _scaled_dot_product_attention_with_compatible_mask(
+            query: Any,
+            key: Any,
+            value: Any,
+            attn_mask: Any | None = None,
+            dropout_p: float = 0.0,
+            is_causal: bool = False,
+            **kwargs: Any,
+        ) -> Any:
+            """Convert integral visibility masks to the boolean SDPA contract."""
+            if (
+                attn_mask is not None
+                and attn_mask.dtype != torch.bool
+                and not torch.is_floating_point(attn_mask)
+                and not torch.is_complex(attn_mask)
+            ):
+                attn_mask = attn_mask.to(torch.bool)
+            return original_sdpa(
+                query=query,
+                key=key,
+                value=value,
+                attn_mask=attn_mask,
+                dropout_p=dropout_p,
+                is_causal=is_causal,
+                **kwargs,
+            )
+
+        _scaled_dot_product_attention_with_compatible_mask._winml_integral_mask_compat = (  # type: ignore[attr-defined]
+            True
+        )
+        module.original_scaled_dot_product_attention = (
+            _scaled_dot_product_attention_with_compatible_mask
+        )
 
 
 class _PatchModelPatcherLoader(Loader):

--- a/tests/unit/export/test_blip_onnx_config.py
+++ b/tests/unit/export/test_blip_onnx_config.py
@@ -136,7 +136,7 @@ class TestBlipDecoderIO:
         assert tuple(inputs["past_0_key"].shape) == expected
         assert tuple(inputs["past_0_value"].shape) == expected
 
-    def test_decoder_passes_four_dimensional_additive_attention_mask(self, monkeypatch) -> None:
+    def test_decoder_passes_three_dimensional_binary_attention_mask(self, monkeypatch) -> None:
         from types import SimpleNamespace
         from unittest.mock import MagicMock
 
@@ -165,10 +165,9 @@ class TestBlipDecoderIO:
         wrapper._invoke_hf(object(), inputs)
 
         mask = captured["attention_mask"]
-        assert mask.shape == (1, 1, 1, 2)
-        assert mask.is_floating_point()
-        assert mask[0, 0, 0, 0] == 0
-        assert mask[0, 0, 0, 1] == torch.finfo(mask.dtype).min
+        assert mask.shape == (1, 1, 2)
+        assert mask.dtype == torch.int64
+        torch.testing.assert_close(mask, inputs["decoder_attention_mask"].unsqueeze(1))
 
     def test_decoder_cache_uses_position_input_when_model_omits_cache_kwargs(
         self, blip_config

--- a/tests/unit/export/test_pytorch_export.py
+++ b/tests/unit/export/test_pytorch_export.py
@@ -103,6 +103,19 @@ class PositionalExportOrderModel(nn.Module):
         return torch.cat((wide, narrow), dim=1)
 
 
+class PositionalOnlyHierarchyModel(nn.Module):
+    """Model whose positional protocol differs from input insertion order."""
+
+    def get_export_args(self, inputs):
+        return inputs["narrow"], inputs["wide"]
+
+    def forward(self, *args):
+        narrow, wide = args
+        if narrow.shape[1] >= wide.shape[1]:
+            raise ValueError("positional export protocol was not honored")
+        return torch.cat((narrow, wide), dim=1)
+
+
 # =============================================================================
 # TestInputTensorSpecToTensor
 # =============================================================================
@@ -437,6 +450,22 @@ class TestExportPytorch:
             for tensor in onnx_model.graph.input
         }
         assert input_shapes == {"narrow": (1, 3), "wide": (1, 5)}
+
+    def test_hierarchy_trace_honors_get_export_args(self) -> None:
+        """Hierarchy tracing uses the same positional protocol as ONNX export."""
+        from winml.modelkit.export.htp import HTPExporter
+
+        model = PositionalOnlyHierarchyModel()
+        inputs = {
+            "wide": torch.ones(1, 5),
+            "narrow": torch.ones(1, 3),
+        }
+        exporter = HTPExporter()
+
+        exporter._trace_model_hierarchy(model, inputs)
+
+        assert exporter._hierarchy_builder is not None
+        assert exporter._hierarchy_builder.model_outputs.shape == (1, 8)
 
 
 class TestStaleExternalDataCleanup:

--- a/tests/unit/test_transformers_compat.py
+++ b/tests/unit/test_transformers_compat.py
@@ -19,6 +19,7 @@ import inspect
 import sys
 
 import pytest
+import torch
 
 from winml.modelkit import transformers_compat
 
@@ -115,3 +116,41 @@ def test_install_is_idempotent_and_reentrant_safe():
     transformers_compat.install()
 
     assert _is_transformers5_patched(model_patcher)
+
+
+def test_traceable_sdpa_accepts_integral_visibility_mask() -> None:
+    """Optimum must normalize the integral masks emitted by Transformers 4.57."""
+    import optimum.exporters.onnx.model_patcher as model_patcher
+
+    query = torch.randn(1, 2, 3, 4)
+    key = torch.randn(1, 2, 3, 4)
+    value = torch.randn(1, 2, 3, 4)
+    integral_mask = torch.tensor(
+        [[[[1, 1, 0], [1, 1, 0], [1, 1, 1]]]],
+        dtype=torch.int64,
+    )
+
+    expected = torch.nn.functional.scaled_dot_product_attention(
+        query,
+        key,
+        value,
+        attn_mask=integral_mask.to(torch.bool),
+    )
+    actual = model_patcher.traceable_scaled_dot_product_attention(
+        query,
+        key,
+        value,
+        attn_mask=integral_mask,
+    )
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_integral_sdpa_mask_patch_is_idempotent() -> None:
+    """Repeated compatibility setup must not stack SDPA wrappers."""
+    import optimum.exporters.onnx.model_patcher as model_patcher
+
+    first = model_patcher.original_scaled_dot_product_attention
+    transformers_compat._patch_model_patcher(model_patcher)
+
+    assert model_patcher.original_scaled_dot_product_attention is first


### PR DESCRIPTION
## Summary

- normalize integral attention masks before Optimum calls PyTorch SDPA
- use the model's positional export protocol during HTP hierarchy tracing
- pass a Transformers 4.57-compatible 3-D binary mask to the BLIP decoder

## Validation

- 54 focused unit tests passed
- DistilBERT fill-mask evaluation passed on OpenVINO NPU
- BLIP FP16 image-to-text evaluation passed on OpenVINO NPU
- both affected eval E2E cases passed in 445.90s
- Ruff passed