### PR TITLE
revert: relax onnxruntime-windowsml version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
   # form of what WinML's wasdk metadata pins as `1.24.5.post202604171637` (PEP 440
   # normalized) — an exact `==` can't reconcile the two. A bounded range keeps the
   # 1.24.x series while resolving to the published wheel.
-  "onnxruntime-windowsml==1.24.5.202604171637 ; sys_platform == 'win32'",
+  "onnxruntime-windowsml>=1.24.5,<1.25 ; sys_platform == 'win32'",
   "onnxscript>=0.2",
   "opentelemetry-sdk>=1.39.1",
   "optimum>=2",


### PR DESCRIPTION
## Summary

- Revert the exact onnxruntime-windowsml version pin to the previous bounded range (>=1.24.5,<1.25).
- The exact pin was introduced because winml sys failed without it, but that issue is no longer reproducible.
- Restore flexible resolution within the supported 1.24.x release line.