### PR TITLE
feat(eval): add audio classification evaluation and music genre recipes

### DIFF
--- a/examples/recipes/dima806_music_genres_classification/cpu/cpu/audio-classification_fp16_config.json
+++ b/examples/recipes/dima806_music_genres_classification/cpu/cpu/audio-classification_fp16_config.json
@@ -21,7 +21,10 @@
       {
         "name": "logits"
       }
-    ]
+    ],
+    "compatibility": {
+      "transformers_attention": "eager"
+    }
   },
   "optim": {},
   "quant": {

--- a/examples/recipes/dima806_music_genres_classification/cpu/cpu/audio-classification_fp32_config.json
+++ b/examples/recipes/dima806_music_genres_classification/cpu/cpu/audio-classification_fp32_config.json
@@ -21,7 +21,10 @@
       {
         "name": "logits"
       }
-    ]
+    ],
+    "compatibility": {
+      "transformers_attention": "eager"
+    }
   },
   "optim": {},
   "quant": null,

--- a/src/winml/modelkit/commands/eval.py
+++ b/src/winml/modelkit/commands/eval.py
@@ -132,6 +132,12 @@ logger = logging.getLogger(__name__)
     help="Number of dataset samples.",
 )
 @click.option(
+    "--max-duration-seconds",
+    type=click.FloatRange(min=0, min_open=True),
+    default=None,
+    help="Maximum audio duration per sample. Omitted means unbounded.",
+)
+@click.option(
     "--split",
     type=str,
     default="validation",
@@ -265,6 +271,7 @@ def eval(
     runtime: EvalRuntime,
     ep: EPNameOrAlias | None,
     samples: int,
+    max_duration_seconds: float | None,
     split: str,
     shuffle: bool,
     streaming: bool,

--- a/src/winml/modelkit/eval/__init__.py
+++ b/src/winml/modelkit/eval/__init__.py
@@ -19,6 +19,7 @@ from .evaluate import EvalResult, evaluate, get_evaluator_class
 
 
 if TYPE_CHECKING:
+    from .audio_classification_evaluator import WinMLAudioClassificationEvaluator
     from .depth_estimation_evaluator import WinMLDepthEstimationEvaluator
     from .feature_extraction_evaluator import WinMLFeatureExtractionEvaluator
     from .fill_mask_evaluator import WinMLFillMaskEvaluator
@@ -45,8 +46,13 @@ if TYPE_CHECKING:
     from .zero_shot_image_classification_evaluator import WinMLZeroShotImageClassificationEvaluator
 
 
+# Keep the key/value-per-line layout consistent with the evaluator registry.
+# fmt: off
 _LAZY_ATTRS: dict[str, str] = {
     # Evaluators
+    "WinMLAudioClassificationEvaluator": (
+        ".audio_classification_evaluator:WinMLAudioClassificationEvaluator"
+    ),
     "WinMLDepthEstimationEvaluator": ".depth_estimation_evaluator:WinMLDepthEstimationEvaluator",
     "WinMLFeatureExtractionEvaluator": (
         ".feature_extraction_evaluator:WinMLFeatureExtractionEvaluator"
@@ -92,6 +98,7 @@ _LAZY_ATTRS: dict[str, str] = {
     "SpearmanCorrelationMetric": ".metrics.spearman_correlation:SpearmanCorrelationMetric",
     "TopKAccuracyMetric": ".metrics.top_k_accuracy:TopKAccuracyMetric",
 }
+# fmt: on
 
 
 def __getattr__(name: str) -> Any:
@@ -126,6 +133,7 @@ __all__ = [
     "SpearmanCorrelationMetric",
     "TensorSimilarityEvaluator",
     "TopKAccuracyMetric",
+    "WinMLAudioClassificationEvaluator",
     "WinMLDepthEstimationEvaluator",
     "WinMLEvaluationConfig",
     "WinMLEvaluator",

--- a/src/winml/modelkit/eval/audio_classification_evaluator.py
+++ b/src/winml/modelkit/eval/audio_classification_evaluator.py
@@ -1,0 +1,866 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+"""Audio classification evaluation for scalar and multi-label targets.
+
+The evaluator deliberately has no built-in dataset. Audio-classification
+labels can represent languages, speakers, emotions, intents, or arbitrary
+acoustic events, so callers must provide a labeled dataset whose semantics
+match the checkpoint.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import random
+from collections import defaultdict
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
+from io import BytesIO
+from itertools import islice
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+import numpy as np
+import torch
+from scipy.signal import resample_poly
+
+from ..utils.eval_utils import DatasetValidationError
+from .base_evaluator import WinMLEvaluator
+
+
+if TYPE_CHECKING:
+    from datasets import Dataset
+    from numpy.typing import NDArray
+
+    from ..models.winml.base import WinMLPreTrainedModel
+    from .config import DatasetConfig, WinMLEvaluationConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _SelectedAudioSample(Mapping[str, Any]):
+    model_id: int
+    row: dict[str, Any]
+
+    def __getitem__(self, key: str) -> Any:
+        return self.row[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.row)
+
+    def __len__(self) -> int:
+        return len(self.row)
+
+
+class _AudioModelAdapter:
+    """Decode, preprocess, and run one audio row for native HF or WinML models."""
+
+    def __init__(self, config: WinMLEvaluationConfig, model: Any) -> None:
+        from transformers import AutoFeatureExtractor
+
+        if not config.model_id:
+            raise ValueError("model_id is required to load the audio feature extractor.")
+        self._config = config
+        self.model = model
+        self._feature_extractor = AutoFeatureExtractor.from_pretrained(
+            config.model_id,
+            trust_remote_code=getattr(config, "trust_remote_code", False),
+        )
+        self._input_contracts = self._resolve_input_contracts()
+        self._validate_output_contract()
+        self.last_was_truncated = False
+        self.last_window_count = 0
+
+    def __call__(self, raw_audio: Any) -> NDArray[np.float32]:
+        """Return utterance logits, averaging fixed-shape waveform windows."""
+        if isinstance(raw_audio, (list, tuple, np.ndarray)):
+            waveform = np.asarray(raw_audio, dtype=np.float32)
+            sampling_rate = int(getattr(self._feature_extractor, "sampling_rate", 0))
+            if waveform.ndim != 1:
+                raise ValueError(
+                    f"pre-normalized waveform input must be 1D, got shape {waveform.shape}",
+                )
+        else:
+            waveform, sampling_rate = WinMLAudioClassificationEvaluator._decode_audio(raw_audio)
+
+        waveform = WinMLAudioClassificationEvaluator._to_mono(waveform)
+        if waveform.size == 0:
+            raise ValueError("audio waveform is empty")
+        target_rate = int(
+            getattr(self._feature_extractor, "sampling_rate", sampling_rate),
+        )
+        if sampling_rate <= 0 or target_rate <= 0:
+            raise ValueError("audio sampling rate must be positive")
+        if sampling_rate != target_rate:
+            divisor = math.gcd(sampling_rate, target_rate)
+            waveform = resample_poly(
+                waveform,
+                target_rate // divisor,
+                sampling_rate // divisor,
+            ).astype(np.float32)
+
+        self.last_was_truncated = False
+        max_duration = self._config.dataset.max_duration_seconds
+        if max_duration is not None:
+            max_samples = max(1, int(max_duration * target_rate))
+            if waveform.size > max_samples:
+                waveform = waveform[:max_samples]
+                self.last_was_truncated = True
+
+        waveform_contract = self._input_contracts.get("input_values")
+        if waveform_contract is not None and len(waveform_contract) == 2:
+            window_length = waveform_contract[1]
+            windows = [
+                waveform[offset : offset + window_length]
+                for offset in range(0, waveform.size, window_length)
+            ]
+        else:
+            windows = [waveform]
+        self.last_window_count = len(windows)
+        return cast(
+            "NDArray[np.float32]",
+            np.mean(np.stack([self._run_window(window) for window in windows]), axis=0),
+        )
+
+    def _run_window(self, waveform: NDArray[np.float32]) -> NDArray[np.float32]:
+        """Preprocess and run one waveform window."""
+        target_rate = int(getattr(self._feature_extractor, "sampling_rate", 0))
+        extractor_kwargs: dict[str, Any] = {
+            "sampling_rate": target_rate,
+            "return_tensors": "pt",
+        }
+        waveform_contract = self._input_contracts.get("input_values")
+        if waveform_contract is not None and len(waveform_contract) == 2:
+            extractor_kwargs.update(
+                padding="max_length",
+                truncation=True,
+                max_length=waveform_contract[1],
+            )
+        encoded = self._feature_extractor(waveform, **extractor_kwargs)
+        model_inputs = self._select_model_inputs(encoded)
+        device = (
+            getattr(self._config, "pipeline_device", "cpu")
+            if getattr(self._config, "runtime", None) == "pytorch"
+            else "cpu"
+        )
+        model_inputs = {
+            name: value.to(device)
+            if hasattr(value, "to")
+            else torch.as_tensor(value, device=device)
+            for name, value in model_inputs.items()
+        }
+        output = self.model(**model_inputs)
+        logits = (
+            output.get("logits")
+            if isinstance(output, dict)
+            else getattr(output, "logits", None)
+        )
+        if logits is None:
+            raise ValueError("audio-classification model output does not contain logits")
+        if hasattr(logits, "detach"):
+            logits = logits.detach().float().cpu().numpy()
+        array = np.asarray(logits, dtype=np.float32)
+        if array.ndim != 2 or array.shape[0] != 1:
+            raise ValueError(f"expected logits shape [1, classes], got {array.shape}")
+        return cast("NDArray[np.float32]", np.asarray(array[0], dtype=np.float32))
+
+    def _resolve_input_contracts(self) -> dict[str, list[int]]:
+        io_config = getattr(self.model, "io_config", None) or {}
+        names = io_config.get("input_names") or []
+        shapes = io_config.get("input_shapes") or []
+        if not names and not shapes:
+            return {}
+        if len(names) != len(shapes) or not names:
+            raise ValueError(
+                "audio-classification input names and shapes must have equal non-zero lengths",
+            )
+        if len(names) != 1:
+            raise ValueError("audio-classification evaluation requires exactly one model input")
+        contracts: dict[str, list[int]] = {}
+        for name, raw_shape in zip(names, shapes, strict=True):
+            shape = list(raw_shape)
+            if len(shape) < 2 or any(not isinstance(value, int) for value in shape[1:]):
+                raise ValueError(
+                    "audio-classification evaluation requires static non-batch input shapes",
+                )
+            if isinstance(shape[0], int) and shape[0] != 1:
+                raise ValueError("audio-classification evaluation requires batch size 1")
+            contracts[str(name)] = [1, *(int(value) for value in shape[1:])]
+        return contracts
+
+    def _validate_output_contract(self) -> None:
+        io_config = getattr(self.model, "io_config", None) or {}
+        names = io_config.get("output_names") or []
+        shapes = io_config.get("output_shapes") or []
+        if not names and not shapes:
+            return
+        if names != ["logits"] or len(shapes) != 1:
+            raise ValueError(
+                "audio-classification evaluation requires exactly one 'logits' output"
+            )
+        shape = list(shapes[0])
+        if (
+            len(shape) != 2
+            or (isinstance(shape[0], int) and shape[0] != 1)
+            or not isinstance(shape[1], int)
+            or shape[1] <= 0
+        ):
+            raise ValueError(
+                "audio-classification evaluation requires logits shape [1, classes]"
+            )
+
+    def _select_model_inputs(self, encoded: Any) -> dict[str, Any]:
+        values = dict(encoded)
+        if not self._input_contracts:
+            if not values:
+                raise ValueError("audio feature extractor produced no model inputs")
+            return values
+        selected: dict[str, Any] = {}
+        for name, expected_shape in self._input_contracts.items():
+            if name not in values:
+                raise ValueError(
+                    f"audio feature extractor output must contain {name!r}; got {sorted(values)}",
+                )
+            actual_shape = list(getattr(values[name], "shape", ()))
+            if actual_shape != expected_shape:
+                raise ValueError(
+                    f"audio feature extractor produced {name} shape {actual_shape}; "
+                    f"expected {expected_shape}",
+                )
+            selected[name] = values[name]
+        return selected
+
+
+class WinMLAudioClassificationEvaluator(WinMLEvaluator):
+    """Evaluate utterance-level audio classifiers using accuracy and macro-F1."""
+
+    def __init__(
+        self,
+        config: WinMLEvaluationConfig,
+        model: WinMLPreTrainedModel,
+    ) -> None:
+        from ..utils.eval_utils import get_default
+
+        mapping = config.dataset.columns_mapping
+        task = "audio-classification"
+        audio_col = mapping.get("input_column", get_default(task, "input_column"))
+        label_col = mapping.get("label_column", get_default(task, "label_column"))
+        if audio_col is None or label_col is None:
+            raise DatasetValidationError(
+                "audio-classification requires input_column and label_column defaults",
+            )
+        self._audio_col = audio_col
+        self._label_col = label_col
+        self._eligible_count = 0
+        self._selected_count = 0
+        self._dataset_id_to_model_id: dict[int, int] = {}
+        self._eligible_model_labels: list[str] = []
+        self._indexed_dataset: Any = None
+        self._target_kind = ""
+        self._label_feature: Any = None
+        self._label_name_col = mapping.get("label_name_column", "human_labels")
+        self._model_id2label, self._model_label2id = self._model_labels(model)
+        super().__init__(config, model)
+
+    def prepare_pipeline(self) -> Any:
+        """Create the shared native-HF/WinML callable audio adapter."""
+        return _AudioModelAdapter(self.config, self.model)
+
+    def prepare_data(self) -> list[_SelectedAudioSample] | list[dict[str, Any]]:
+        """Load, label-filter, then select a seeded stratified sample.
+
+        Filtering happens before sampling so unsupported classes cannot consume
+        the requested sample budget. Shuffled streaming datasets use bounded
+        per-class reservoir sampling over the complete stream. Deterministic
+        streams stop once every authoritative overlapping class has supplied
+        its balanced quota.
+        """
+        from datasets import load_dataset, load_from_disk
+
+        ds = self.config.dataset
+        try:
+            ds_path = Path(ds.path).expanduser() if ds.path else None
+            if ds_path and ds_path.is_dir():
+                dataset = load_from_disk(str(ds_path))
+            else:
+                dataset = load_dataset(
+                    ds.path,
+                    name=ds.name,
+                    split=ds.split,
+                    streaming=ds.streaming,
+                    revision=ds.revision,
+                )
+            if hasattr(dataset, "keys") and ds.split in dataset:
+                dataset = dataset[ds.split]
+            elif hasattr(dataset, "keys"):
+                available = sorted(str(split) for split in dataset)
+                raise DatasetValidationError(
+                    f"Dataset split '{ds.split}' was not found; available splits: {available}",
+                )
+        except Exception as error:
+            if isinstance(error, DatasetValidationError):
+                raise
+            raise DatasetValidationError(
+                f"Failed to load dataset '{ds.path}' "
+                f"(name={ds.name!r}, split='{ds.split}'): {error}",
+            ) from error
+
+        self._validate_target_schema(dataset, ds)
+        dataset = self._disable_backend_audio_decoding(dataset)
+        if ds.samples <= 0:
+            raise DatasetValidationError("samples must be greater than zero.")
+
+        if self._target_kind == "multi-label":
+            if ds.streaming:
+                if ds.shuffle:
+                    dataset = dataset.shuffle(seed=ds.seed)
+                selected_rows = list(islice(iter(dataset), ds.samples))
+                self._eligible_count = len(selected_rows)
+            else:
+                if ds.shuffle:
+                    dataset = dataset.shuffle(seed=ds.seed)
+                count = min(ds.samples, len(dataset))
+                selected_rows = [dataset[index] for index in range(count)]
+                self._eligible_count = len(dataset)
+            self._selected_count = len(selected_rows)
+            if not selected_rows:
+                raise DatasetValidationError("No samples were selected for evaluation.")
+            return selected_rows
+
+        if ds.streaming:
+            rows_by_label = self._streaming_reservoirs(
+                dataset,
+                ds.samples,
+                ds.seed,
+                ds.shuffle,
+            )
+        else:
+            self._indexed_dataset = dataset
+            rows_by_label = self._indexed_rows(dataset, ds.seed, ds.shuffle)
+
+        selected = self._balanced_take(rows_by_label, ds.samples)
+        self._selected_count = len(selected)
+        if not selected:
+            raise DatasetValidationError(
+                "No samples remain after label filtering. "
+                "Dataset and model labels have no overlap.",
+            )
+        return selected
+
+    def align_labels(self, dataset: Dataset, ds_config: DatasetConfig) -> Dataset:
+        """Keep base-class construction compatible; alignment is done before sampling."""
+        return dataset
+
+    def _validate_target_schema(self, dataset: Any, ds: DatasetConfig) -> None:
+        """Validate scalar or sequence label semantics before selecting rows."""
+        from datasets import ClassLabel, Sequence, Value
+
+        columns = set(dataset.column_names)
+        missing = [col for col in (self._audio_col, self._label_col) if col not in columns]
+        if missing:
+            raise DatasetValidationError(
+                f"missing required column(s) {missing}; dataset has {sorted(columns)}",
+            )
+        feature = dataset.features[self._label_col]
+        self._label_feature = feature
+        if isinstance(feature, ClassLabel):
+            self._target_kind = "single-label"
+            self._validate_and_resolve_labels(dataset, ds)
+        elif isinstance(feature, Sequence) and isinstance(feature.feature, (ClassLabel, Value)):
+            self._target_kind = "multi-label"
+        else:
+            raise DatasetValidationError(
+                f"Column '{self._label_col}' must be ClassLabel or a sequence of "
+                f"ClassLabel/string values; got {feature!r}.",
+            )
+
+    @staticmethod
+    def _model_labels(model: Any) -> tuple[dict[int, str], dict[str, int]]:
+        config = getattr(model, "config", None)
+        raw_id2label = getattr(config, "id2label", None) or {}
+        id2label = {int(index): str(label) for index, label in raw_id2label.items()}
+        if not id2label or sorted(id2label) != list(range(len(id2label))):
+            raise DatasetValidationError(
+                "model.config.id2label must define contiguous class IDs starting at zero.",
+            )
+        label2id = {label: index for index, label in id2label.items()}
+        if len(label2id) != len(id2label):
+            raise DatasetValidationError("model.config.id2label contains duplicate label names.")
+        return id2label, label2id
+
+    def _validate_and_resolve_labels(self, dataset: Any, ds: DatasetConfig) -> None:
+        """Validate required columns and resolve exact dataset-name to model-ID mapping."""
+        from datasets import ClassLabel
+
+        columns = set(dataset.column_names)
+        missing = [col for col in (self._audio_col, self._label_col) if col not in columns]
+        if missing:
+            raise DatasetValidationError(
+                f"missing required column(s) {missing}; dataset has {sorted(columns)}",
+            )
+
+        label_feature = dataset.features[self._label_col]
+        if not isinstance(label_feature, ClassLabel):
+            raise DatasetValidationError(
+                f"Column '{self._label_col}' must be a ClassLabel so label semantics "
+                "can be aligned explicitly.",
+            )
+
+        model_label2id = getattr(self.model.config, "label2id", None) or {}
+        model_id2label = getattr(self.model.config, "id2label", None) or {}
+        if not model_id2label:
+            raise DatasetValidationError("model.config.id2label is required for evaluation.")
+        if not model_label2id:
+            model_label2id = {str(name): int(model_id) for model_id, name in model_id2label.items()}
+
+        # A user mapping is authoritative. Without one, only exact label-name
+        # identity is accepted; no locale, case, punctuation, or region inference.
+        label_mapping = ds.label_mapping
+        if label_mapping is None:
+            label_mapping = {
+                name: int(model_label2id[name])
+                for name in label_feature.names
+                if name in model_label2id
+            }
+
+        name_to_dataset_id = {name: index for index, name in enumerate(label_feature.names)}
+        valid_model_ids = {int(key) for key in model_id2label}
+        resolved: dict[int, int] = {}
+        for dataset_name, model_id in label_mapping.items():
+            if dataset_name not in name_to_dataset_id:
+                continue
+            target_id = int(model_id)
+            if target_id not in valid_model_ids:
+                raise DatasetValidationError(
+                    f"Label mapping target {target_id} for '{dataset_name}' is not present "
+                    "in model.config.id2label.",
+                )
+            resolved[name_to_dataset_id[dataset_name]] = target_id
+
+        if not resolved:
+            raise DatasetValidationError(
+                "No samples remain after label filtering. Dataset and model labels have "
+                "no exact overlap; provide --label-mapping with authoritative semantics.",
+            )
+
+        self._dataset_id_to_model_id = resolved
+        self._eligible_model_labels = sorted(
+            {self._decode_model_label(model_id) for model_id in resolved.values()},
+        )
+
+    def _disable_backend_audio_decoding(self, dataset: Any) -> Any:
+        """Keep dataset audio as bytes/path so decoding does not require TorchCodec."""
+        from datasets import Audio
+
+        audio_feature = dataset.features[self._audio_col]
+        if isinstance(audio_feature, Audio) and audio_feature.decode:
+            return dataset.cast_column(
+                self._audio_col,
+                Audio(sampling_rate=audio_feature.sampling_rate, decode=False),
+            )
+        return dataset
+
+    def _indexed_rows(
+        self,
+        dataset: Any,
+        seed: int,
+        shuffle: bool,
+    ) -> dict[int, list[_SelectedAudioSample]]:
+        """Collect shuffled eligible row indices without decoding the audio column."""
+        indices: dict[int, list[int]] = defaultdict(list)
+        for index, raw_label in enumerate(dataset[self._label_col]):
+            dataset_id = int(raw_label)
+            if dataset_id in self._dataset_id_to_model_id:
+                indices[self._dataset_id_to_model_id[dataset_id]].append(index)
+        self._eligible_count = sum(len(items) for items in indices.values())
+
+        rows: dict[int, list[_SelectedAudioSample]] = {}
+        for model_id, label_indices in sorted(indices.items()):
+            if shuffle:
+                random.Random(seed + model_id).shuffle(label_indices)
+            selected_indices = label_indices[: self.config.dataset.samples]
+            rows[model_id] = [
+                _SelectedAudioSample(model_id=model_id, row=dataset[index])
+                for index in selected_indices
+            ]
+        return rows
+
+    def _streaming_reservoirs(
+        self,
+        dataset: Any,
+        limit: int,
+        seed: int,
+        shuffle: bool,
+    ) -> dict[int, list[_SelectedAudioSample]]:
+        """Select streaming rows without weakening requested shuffle semantics."""
+        if not shuffle:
+            return self._streaming_balanced_prefix(dataset, limit)
+
+        # True reservoir sampling requires visiting the complete stream. Keep
+        # this path separate from deterministic bounded selection so --shuffle
+        # never presents a prefix as a random sample.
+        reservoirs: dict[int, list[_SelectedAudioSample]] = defaultdict(list)
+        seen: dict[int, int] = defaultdict(int)
+        rng = random.Random(seed)
+        for row in dataset:
+            dataset_id = int(row[self._label_col])
+            model_id = self._dataset_id_to_model_id.get(dataset_id)
+            if model_id is None:
+                continue
+            self._eligible_count += 1
+            seen[model_id] += 1
+            bucket = reservoirs[model_id]
+            selected = _SelectedAudioSample(model_id=model_id, row=row)
+            if len(bucket) < limit:
+                bucket.append(selected)
+            else:
+                replacement = rng.randrange(seen[model_id])
+                if replacement < limit:
+                    bucket[replacement] = selected
+        return dict(reservoirs)
+
+    def _streaming_balanced_prefix(
+        self,
+        dataset: Any,
+        limit: int,
+    ) -> dict[int, list[_SelectedAudioSample]]:
+        """Collect a deterministic balanced prefix and stop when quotas are full.
+
+        Quotas are based on the unique model classes resolved from the
+        authoritative exact label mapping, not on labels encountered so far.
+        Consequently an absent or short class forces stream exhaustion and a
+        short selection instead of silently redistributing its quota.
+        """
+        quotas = self._balanced_quotas(self._dataset_id_to_model_id.values(), limit)
+        rows: dict[int, list[_SelectedAudioSample]] = defaultdict(list)
+        pending = sum(quota > 0 for quota in quotas.values())
+
+        for row in dataset:
+            dataset_id = int(row[self._label_col])
+            model_id = self._dataset_id_to_model_id.get(dataset_id)
+            if model_id is None:
+                continue
+            self._eligible_count += 1
+            bucket = rows[model_id]
+            quota = quotas[model_id]
+            if len(bucket) >= quota:
+                continue
+            bucket.append(_SelectedAudioSample(model_id=model_id, row=row))
+            if len(bucket) == quota:
+                pending -= 1
+                if pending == 0:
+                    break
+        return dict(rows)
+
+    @staticmethod
+    def _balanced_quotas(model_ids: Any, limit: int) -> dict[int, int]:
+        """Assign deterministic per-class quotas whose sum is ``limit``."""
+        labels = sorted({int(model_id) for model_id in model_ids})
+        if not labels:
+            return {}
+        base, remainder = divmod(limit, len(labels))
+        return {label: base + (index < remainder) for index, label in enumerate(labels)}
+
+    @staticmethod
+    def _balanced_take(
+        rows_by_label: dict[int, list[_SelectedAudioSample]],
+        limit: int,
+    ) -> list[_SelectedAudioSample]:
+        """Round-robin classes to form a balanced sample and redistribute shortages."""
+        selected: list[_SelectedAudioSample] = []
+        offsets = dict.fromkeys(rows_by_label, 0)
+        labels = sorted(rows_by_label)
+        while len(selected) < limit:
+            added = False
+            for label in labels:
+                offset = offsets[label]
+                if offset < len(rows_by_label[label]):
+                    selected.append(rows_by_label[label][offset])
+                    offsets[label] += 1
+                    added = True
+                    if len(selected) == limit:
+                        break
+            if not added:
+                break
+        return selected
+
+    def compute(self) -> dict[str, Any]:
+        """Run exactly one forward per selected row and report task metrics."""
+        logits: list[np.ndarray] = []
+        targets: list[Any] = []
+        confusion: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+        processed_by_label: dict[str, int] = defaultdict(int)
+        selected_by_label: dict[str, int] = defaultdict(int)
+        rejected_by_reason: dict[str, int] = defaultdict(int)
+        inference_windows = 0
+        truncated_samples = 0
+
+        for selected in self.data:
+            if isinstance(selected, _SelectedAudioSample):
+                reference_id = selected.model_id
+                reference = self._decode_model_label(reference_id)
+                selected_by_label[reference] += 1
+            else:
+                reference_id = None
+                reference = None
+            try:
+                if isinstance(selected, _SelectedAudioSample) and selected.row is not None:
+                    sample = selected.row
+                elif isinstance(selected, dict):
+                    sample = selected
+                else:
+                    raise ValueError("selected audio sample has no row or dataset index")
+                target = (
+                    reference_id
+                    if reference_id is not None
+                    else self._target_for_row(sample)
+                )
+                adapter = cast("_AudioModelAdapter", self.pipe)
+                prediction_logits = adapter(sample[self._audio_col])
+                inference_windows += adapter.last_window_count
+                truncated_samples += int(adapter.last_was_truncated)
+            except (TypeError, ValueError, RuntimeError) as error:
+                rejected_by_reason[type(error).__name__] += 1
+                logger.warning("Skipping audio sample: %s", error)
+                continue
+            logits.append(prediction_logits)
+            targets.append(target)
+            if reference is not None:
+                prediction = self._decode_model_label(int(np.argmax(prediction_logits)))
+                confusion[reference][prediction] += 1
+                processed_by_label[reference] += 1
+
+        if not logits:
+            raise DatasetValidationError("No audio samples were successfully processed.")
+
+        if self._target_kind == "single-label":
+            insufficient = {
+                label: (processed_by_label[label], min(5, selected_count))
+                for label, selected_count in selected_by_label.items()
+                if processed_by_label[label] < min(5, selected_count)
+            }
+            if insufficient:
+                details = ", ".join(
+                    f"{label}={actual}/{required} required"
+                    for label, (actual, required) in sorted(insufficient.items())
+                )
+                raise DatasetValidationError(
+                    f"Too few usable samples after audio decoding/preprocessing: {details}.",
+                )
+
+        scores = np.stack(logits)
+        if scores.shape[1] != len(self._model_id2label):
+            raise DatasetValidationError(
+                f"model returned {scores.shape[1]} classes but config defines "
+                f"{len(self._model_id2label)} labels.",
+            )
+        metrics: dict[str, Any] = (
+            self._multi_label_metrics(scores, targets)
+            if self._target_kind == "multi-label"
+            else self._single_label_metrics(scores, targets)
+        )
+        processed = len(targets)
+        metrics.update({
+            "requested_samples": self.config.dataset.samples,
+            "eligible_samples": self._eligible_count,
+            "selected_samples": self._selected_count,
+            "processed_samples": processed,
+            "inference_windows": inference_windows,
+            "truncated_samples": truncated_samples,
+            "rejected_samples": self._selected_count - processed,
+            "rejected_by_reason": dict(sorted(rejected_by_reason.items())),
+            "per_label_processed": dict(sorted(processed_by_label.items())),
+            "confusion_matrix": {
+                reference: dict(sorted(predictions.items()))
+                for reference, predictions in sorted(confusion.items())
+            },
+        })
+        return metrics
+
+    def _target_for_row(self, row: dict[str, Any]) -> int | list[int]:
+        from datasets import ClassLabel
+
+        raw_target = row[self._label_col]
+        if self._target_kind == "single-label":
+            return self._resolve_label(self._label_feature.int2str(int(raw_target)))
+
+        values = list(raw_target)
+        feature = self._label_feature.feature
+        decoded = (
+            [feature.int2str(int(value)) for value in values]
+            if isinstance(feature, ClassLabel)
+            else [str(value) for value in values]
+        )
+        parallel_names = row.get(self._label_name_col)
+        if parallel_names is not None and len(parallel_names) != len(decoded):
+            raise DatasetValidationError(
+                f"Columns '{self._label_col}' and '{self._label_name_col}' must contain "
+                "the same number of labels.",
+            )
+        resolved = [
+            self._resolve_label(
+                value,
+                fallback_name=parallel_names[index] if parallel_names is not None else None,
+            )
+            for index, value in enumerate(decoded)
+        ]
+        if not resolved:
+            raise DatasetValidationError("Multi-label targets must contain at least one label.")
+        return sorted(set(resolved))
+
+    def _resolve_label(self, value: str, *, fallback_name: Any = None) -> int:
+        mapping = self.config.dataset.label_mapping or {}
+        if value in mapping:
+            model_id = int(mapping[value])
+        elif value in self._model_label2id:
+            model_id = self._model_label2id[value]
+        elif fallback_name is not None and str(fallback_name) in self._model_label2id:
+            model_id = self._model_label2id[str(fallback_name)]
+        else:
+            raise DatasetValidationError(
+                f"Dataset label {value!r} has no exact model-label match; provide an "
+                "authoritative label mapping or parallel exact label-name column.",
+            )
+        if model_id not in self._model_id2label:
+            raise DatasetValidationError(
+                f"Label mapping target {model_id} is absent from model.config.id2label.",
+            )
+        return model_id
+
+    def _single_label_metrics(
+        self,
+        logits: np.ndarray,
+        targets: list[int],
+    ) -> dict[str, Any]:
+        from .metrics.classification import ClassificationMetric
+
+        predictions = [self._model_id2label[int(index)] for index in np.argmax(logits, axis=1)]
+        references = [self._model_id2label[int(index)] for index in targets]
+        represented = sorted(set(references))
+        result = ClassificationMetric().compute(predictions, references, represented)
+        return {
+            "accuracy": result["accuracy"],
+            "macro_f1": result["f1"],
+            "represented_classes": len(represented),
+            "total_classes": len(self._model_id2label),
+            "class_coverage": len(represented) / len(self._model_id2label),
+        }
+
+    @staticmethod
+    def _multi_label_metrics(
+        logits: np.ndarray,
+        targets: list[list[int]],
+    ) -> dict[str, float]:
+        from sklearn.metrics import average_precision_score
+
+        references = np.zeros_like(logits, dtype=np.int8)
+        for row_index, model_ids in enumerate(targets):
+            references[row_index, model_ids] = 1
+        probabilities = 1.0 / (1.0 + np.exp(-logits))
+        sample_ap = float(average_precision_score(references, probabilities, average="samples"))
+        micro_ap = float(average_precision_score(references, probabilities, average="micro"))
+        if not np.isfinite(sample_ap) or not np.isfinite(micro_ap):
+            raise DatasetValidationError("Multi-label average precision must be finite.")
+        return {
+            "sample_average_precision": sample_ap,
+            "micro_average_precision": micro_ap,
+        }
+
+    @staticmethod
+    def _decode_audio(audio: Any) -> tuple[np.ndarray, int]:
+        """Decode common datasets Audio values without assuming one backend version."""
+        if isinstance(audio, dict):
+            if audio.get("array") is not None and audio.get("sampling_rate") is not None:
+                return np.asarray(audio["array"], dtype=np.float32), int(
+                    audio["sampling_rate"]
+                )
+
+            encoded_bytes = audio.get("bytes")
+            encoded_path = audio.get("path")
+            if encoded_bytes is not None or encoded_path:
+                try:
+                    import soundfile as sf
+                    from datasets.download.streaming_download_manager import xopen
+                except ImportError as error:
+                    raise RuntimeError(
+                        "Decoding encoded audio requires the 'audio' extra "
+                        "(install winml-cli[audio])."
+                    ) from error
+                try:
+                    if encoded_bytes is not None:
+                        waveform, sampling_rate = sf.read(
+                            BytesIO(encoded_bytes),
+                            dtype="float32",
+                            always_2d=False,
+                        )
+                    else:
+                        with xopen(str(encoded_path), "rb") as source:
+                            waveform, sampling_rate = sf.read(
+                                source,
+                                dtype="float32",
+                                always_2d=False,
+                            )
+                except (OSError, RuntimeError) as error:
+                    raise ValueError(f"failed to decode audio: {error}") from error
+                # SoundFile returns [frames, channels]. Normalize its known
+                # layout explicitly instead of guessing the channel axis for
+                # very short clips later in preprocessing.
+                if waveform.ndim == 2:
+                    waveform = waveform.T
+                return np.asarray(waveform, dtype=np.float32), int(sampling_rate)
+
+            raise ValueError(
+                "audio dict requires array and sampling_rate, or encoded bytes/path"
+            )
+
+        get_all_samples = getattr(audio, "get_all_samples", None)
+        if callable(get_all_samples):
+            decoded = get_all_samples()
+            data = getattr(decoded, "data", getattr(decoded, "samples", None))
+            rate = getattr(decoded, "sample_rate", getattr(decoded, "sampling_rate", None))
+            if data is None or rate is None:
+                raise ValueError("decoded audio does not expose samples and sampling rate")
+            if hasattr(data, "detach"):
+                data = data.detach().cpu().numpy()
+            return np.asarray(data, dtype=np.float32), int(rate)
+
+        array = getattr(audio, "array", None)
+        rate = getattr(audio, "sampling_rate", None)
+        if array is not None and rate is not None:
+            return np.asarray(array, dtype=np.float32), int(rate)
+        raise TypeError(f"Unsupported audio value: {type(audio).__name__}")
+
+    @staticmethod
+    def _to_mono(waveform: np.ndarray) -> NDArray[np.float32]:
+        """Return one float32 channel from mono or common stereo layouts."""
+        waveform = np.asarray(waveform, dtype=np.float32)
+        if waveform.ndim == 1:
+            return cast("NDArray[np.float32]", waveform)
+        if waveform.ndim != 2:
+            raise ValueError(f"audio must be 1D or 2D, got shape {waveform.shape}")
+        if waveform.shape[0] <= 8:
+            return cast(
+                "NDArray[np.float32]",
+                np.asarray(waveform.mean(axis=0), dtype=np.float32),
+            )
+        if waveform.shape[1] <= 8:
+            return cast(
+                "NDArray[np.float32]",
+                np.asarray(waveform.mean(axis=1), dtype=np.float32),
+            )
+        raise ValueError(f"cannot determine channel axis for audio shape {waveform.shape}")
+
+    def _decode_model_label(self, model_id: int) -> str:
+        """Decode a class ID through checkpoint id2label."""
+        model = cast("WinMLPreTrainedModel", self.model)
+        config = model.config
+        if config is None:
+            return str(model_id)
+        id2label = cast("dict[Any, Any]", config.id2label or {})
+        label = id2label.get(model_id, id2label.get(str(model_id)))
+        return str(label) if label is not None else str(model_id)

--- a/src/winml/modelkit/eval/audio_classification_evaluator.py
+++ b/src/winml/modelkit/eval/audio_classification_evaluator.py
@@ -259,10 +259,11 @@ class WinMLAudioClassificationEvaluator(WinMLEvaluator):
         self._label_col = label_col
         self._eligible_count = 0
         self._selected_count = 0
-        self._dataset_id_to_model_id: dict[int, int] = {}
+        self._dataset_label_to_model_id: dict[int | str, int] = {}
         self._eligible_model_labels: list[str] = []
         self._indexed_dataset: Any = None
         self._target_kind = ""
+        self._scalar_string_target = False
         self._label_feature: Any = None
         self._label_name_col = mapping.get("label_name_column", "human_labels")
         self._model_id2label, self._model_label2id = self._model_labels(model)
@@ -372,12 +373,16 @@ class WinMLAudioClassificationEvaluator(WinMLEvaluator):
         if isinstance(feature, ClassLabel):
             self._target_kind = "single-label"
             self._validate_and_resolve_labels(dataset, ds)
+        elif isinstance(feature, Value) and feature.dtype == "string":
+            self._target_kind = "single-label"
+            self._scalar_string_target = True
+            self._validate_and_resolve_labels(dataset, ds)
         elif isinstance(feature, Sequence) and isinstance(feature.feature, (ClassLabel, Value)):
             self._target_kind = "multi-label"
         else:
             raise DatasetValidationError(
-                f"Column '{self._label_col}' must be ClassLabel or a sequence of "
-                f"ClassLabel/string values; got {feature!r}.",
+                f"Column '{self._label_col}' must be ClassLabel, a string Value, or a "
+                f"sequence of ClassLabel/string values; got {feature!r}.",
             )
 
     @staticmethod
@@ -396,7 +401,7 @@ class WinMLAudioClassificationEvaluator(WinMLEvaluator):
 
     def _validate_and_resolve_labels(self, dataset: Any, ds: DatasetConfig) -> None:
         """Validate required columns and resolve exact dataset-name to model-ID mapping."""
-        from datasets import ClassLabel
+        from datasets import ClassLabel, Value
 
         columns = set(dataset.column_names)
         missing = [col for col in (self._audio_col, self._label_col) if col not in columns]
@@ -406,10 +411,12 @@ class WinMLAudioClassificationEvaluator(WinMLEvaluator):
             )
 
         label_feature = dataset.features[self._label_col]
-        if not isinstance(label_feature, ClassLabel):
+        if not isinstance(label_feature, ClassLabel) and not (
+            isinstance(label_feature, Value) and label_feature.dtype == "string"
+        ):
             raise DatasetValidationError(
-                f"Column '{self._label_col}' must be a ClassLabel so label semantics "
-                "can be aligned explicitly.",
+                f"Column '{self._label_col}' must be a ClassLabel or string Value so "
+                "label semantics can be aligned explicitly.",
             )
 
         model_label2id = getattr(self.model.config, "label2id", None) or {}
@@ -423,17 +430,26 @@ class WinMLAudioClassificationEvaluator(WinMLEvaluator):
         # identity is accepted; no locale, case, punctuation, or region inference.
         label_mapping = ds.label_mapping
         if label_mapping is None:
+            candidate_names = (
+                label_feature.names
+                if isinstance(label_feature, ClassLabel)
+                else model_label2id.keys()
+            )
             label_mapping = {
                 name: int(model_label2id[name])
-                for name in label_feature.names
+                for name in candidate_names
                 if name in model_label2id
             }
 
-        name_to_dataset_id = {name: index for index, name in enumerate(label_feature.names)}
+        name_to_dataset_label: dict[str, int | str] = (
+            {name: index for index, name in enumerate(label_feature.names)}
+            if isinstance(label_feature, ClassLabel)
+            else {str(name): str(name) for name in label_mapping}
+        )
         valid_model_ids = {int(key) for key in model_id2label}
-        resolved: dict[int, int] = {}
+        resolved: dict[int | str, int] = {}
         for dataset_name, model_id in label_mapping.items():
-            if dataset_name not in name_to_dataset_id:
+            if dataset_name not in name_to_dataset_label:
                 continue
             target_id = int(model_id)
             if target_id not in valid_model_ids:
@@ -441,7 +457,7 @@ class WinMLAudioClassificationEvaluator(WinMLEvaluator):
                     f"Label mapping target {target_id} for '{dataset_name}' is not present "
                     "in model.config.id2label.",
                 )
-            resolved[name_to_dataset_id[dataset_name]] = target_id
+            resolved[name_to_dataset_label[dataset_name]] = target_id
 
         if not resolved:
             raise DatasetValidationError(
@@ -449,10 +465,13 @@ class WinMLAudioClassificationEvaluator(WinMLEvaluator):
                 "no exact overlap; provide --label-mapping with authoritative semantics.",
             )
 
-        self._dataset_id_to_model_id = resolved
+        self._dataset_label_to_model_id = resolved
         self._eligible_model_labels = sorted(
             {self._decode_model_label(model_id) for model_id in resolved.values()},
         )
+
+    def _dataset_label_key(self, raw_label: Any) -> int | str:
+        return str(raw_label) if self._scalar_string_target else int(raw_label)
 
     def _disable_backend_audio_decoding(self, dataset: Any) -> Any:
         """Keep dataset audio as bytes/path so decoding does not require TorchCodec."""
@@ -480,9 +499,9 @@ class WinMLAudioClassificationEvaluator(WinMLEvaluator):
         """Collect shuffled eligible row indices without decoding the audio column."""
         indices: dict[int, list[int]] = defaultdict(list)
         for index, raw_label in enumerate(dataset[self._label_col]):
-            dataset_id = int(raw_label)
-            if dataset_id in self._dataset_id_to_model_id:
-                indices[self._dataset_id_to_model_id[dataset_id]].append(index)
+            dataset_label = self._dataset_label_key(raw_label)
+            if dataset_label in self._dataset_label_to_model_id:
+                indices[self._dataset_label_to_model_id[dataset_label]].append(index)
         self._eligible_count = sum(len(items) for items in indices.values())
 
         rows: dict[int, list[_SelectedAudioSample]] = {}
@@ -514,8 +533,8 @@ class WinMLAudioClassificationEvaluator(WinMLEvaluator):
         seen: dict[int, int] = defaultdict(int)
         rng = random.Random(seed)
         for row in dataset:
-            dataset_id = int(row[self._label_col])
-            model_id = self._dataset_id_to_model_id.get(dataset_id)
+            dataset_label = self._dataset_label_key(row[self._label_col])
+            model_id = self._dataset_label_to_model_id.get(dataset_label)
             if model_id is None:
                 continue
             self._eligible_count += 1
@@ -542,13 +561,13 @@ class WinMLAudioClassificationEvaluator(WinMLEvaluator):
         Consequently an absent or short class forces stream exhaustion and a
         short selection instead of silently redistributing its quota.
         """
-        quotas = self._balanced_quotas(self._dataset_id_to_model_id.values(), limit)
+        quotas = self._balanced_quotas(self._dataset_label_to_model_id.values(), limit)
         rows: dict[int, list[_SelectedAudioSample]] = defaultdict(list)
         pending = sum(quota > 0 for quota in quotas.values())
 
         for row in dataset:
-            dataset_id = int(row[self._label_col])
-            model_id = self._dataset_id_to_model_id.get(dataset_id)
+            dataset_label = self._dataset_label_key(row[self._label_col])
+            model_id = self._dataset_label_to_model_id.get(dataset_label)
             if model_id is None:
                 continue
             self._eligible_count += 1

--- a/src/winml/modelkit/eval/audio_classification_evaluator.py
+++ b/src/winml/modelkit/eval/audio_classification_evaluator.py
@@ -18,6 +18,7 @@ import math
 import random
 from collections import defaultdict
 from collections.abc import Iterator, Mapping
+from copy import copy
 from dataclasses import dataclass
 from io import BytesIO
 from itertools import islice
@@ -455,10 +456,15 @@ class WinMLAudioClassificationEvaluator(WinMLEvaluator):
 
     def _disable_backend_audio_decoding(self, dataset: Any) -> Any:
         """Keep dataset audio as bytes/path so decoding does not require TorchCodec."""
-        from datasets import Audio, Value
+        from datasets import Audio, IterableDataset, Value
 
         audio_feature = dataset.features[self._audio_col]
         if isinstance(audio_feature, Audio):
+            if isinstance(dataset, IterableDataset):
+                dataset = copy(dataset)
+                dataset._info = dataset._info.copy()
+                dataset._info.features = None
+                return dataset
             return dataset.cast_column(
                 self._audio_col,
                 {"bytes": Value("binary"), "path": Value("string")},
@@ -774,6 +780,8 @@ class WinMLAudioClassificationEvaluator(WinMLEvaluator):
     @staticmethod
     def _decode_audio(audio: Any) -> tuple[np.ndarray, int]:
         """Decode common datasets Audio values without assuming one backend version."""
+        encoded_bytes = None
+        encoded_path = None
         if isinstance(audio, dict):
             if audio.get("array") is not None and audio.get("sampling_rate") is not None:
                 return np.asarray(audio["array"], dtype=np.float32), int(
@@ -782,41 +790,46 @@ class WinMLAudioClassificationEvaluator(WinMLEvaluator):
 
             encoded_bytes = audio.get("bytes")
             encoded_path = audio.get("path")
-            if encoded_bytes is not None or encoded_path:
-                try:
-                    import soundfile as sf
-                    from datasets.download.streaming_download_manager import xopen
-                except ImportError as error:
-                    raise RuntimeError(
-                        "Decoding encoded audio requires the 'audio' extra "
-                        "(install winml-cli[audio])."
-                    ) from error
-                try:
-                    if encoded_bytes is not None:
+            if encoded_bytes is None and not encoded_path:
+                raise ValueError(
+                    "audio dict requires array and sampling_rate, or encoded bytes/path"
+                )
+        elif isinstance(audio, (bytes, bytearray, memoryview)):
+            encoded_bytes = bytes(audio)
+        elif isinstance(audio, (str, Path)):
+            encoded_path = str(audio)
+
+        if encoded_bytes is not None or encoded_path:
+            try:
+                import soundfile as sf
+                from datasets.download.streaming_download_manager import xopen
+            except ImportError as error:
+                raise RuntimeError(
+                    "Decoding encoded audio requires the 'audio' extra "
+                    "(install winml-cli[audio])."
+                ) from error
+            try:
+                if encoded_bytes is not None:
+                    waveform, sampling_rate = sf.read(
+                        BytesIO(encoded_bytes),
+                        dtype="float32",
+                        always_2d=False,
+                    )
+                else:
+                    with xopen(str(encoded_path), "rb") as source:
                         waveform, sampling_rate = sf.read(
-                            BytesIO(encoded_bytes),
+                            source,
                             dtype="float32",
                             always_2d=False,
                         )
-                    else:
-                        with xopen(str(encoded_path), "rb") as source:
-                            waveform, sampling_rate = sf.read(
-                                source,
-                                dtype="float32",
-                                always_2d=False,
-                            )
-                except (OSError, RuntimeError) as error:
-                    raise ValueError(f"failed to decode audio: {error}") from error
-                # SoundFile returns [frames, channels]. Normalize its known
-                # layout explicitly instead of guessing the channel axis for
-                # very short clips later in preprocessing.
-                if waveform.ndim == 2:
-                    waveform = waveform.T
-                return np.asarray(waveform, dtype=np.float32), int(sampling_rate)
-
-            raise ValueError(
-                "audio dict requires array and sampling_rate, or encoded bytes/path"
-            )
+            except (OSError, RuntimeError) as error:
+                raise ValueError(f"failed to decode audio: {error}") from error
+            # SoundFile returns [frames, channels]. Normalize its known
+            # layout explicitly instead of guessing the channel axis for
+            # very short clips later in preprocessing.
+            if waveform.ndim == 2:
+                waveform = waveform.T
+            return np.asarray(waveform, dtype=np.float32), int(sampling_rate)
 
         get_all_samples = getattr(audio, "get_all_samples", None)
         if callable(get_all_samples):

--- a/src/winml/modelkit/eval/audio_classification_evaluator.py
+++ b/src/winml/modelkit/eval/audio_classification_evaluator.py
@@ -455,13 +455,13 @@ class WinMLAudioClassificationEvaluator(WinMLEvaluator):
 
     def _disable_backend_audio_decoding(self, dataset: Any) -> Any:
         """Keep dataset audio as bytes/path so decoding does not require TorchCodec."""
-        from datasets import Audio
+        from datasets import Audio, Value
 
         audio_feature = dataset.features[self._audio_col]
-        if isinstance(audio_feature, Audio) and audio_feature.decode:
+        if isinstance(audio_feature, Audio):
             return dataset.cast_column(
                 self._audio_col,
-                Audio(sampling_rate=audio_feature.sampling_rate, decode=False),
+                {"bytes": Value("binary"), "path": Value("string")},
             )
         return dataset
 

--- a/src/winml/modelkit/eval/config.py
+++ b/src/winml/modelkit/eval/config.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from math import isfinite
 from pathlib import Path
 from typing import Any, Literal
 
@@ -40,6 +41,8 @@ class DatasetConfig:
             ``--output <path>`` before the dataset is loaded.
         label_mapping_file: Path to a JSON file with label mapping.
             Resolved into ``label_mapping`` at eval time.
+        max_duration_seconds: Optional positive audio duration cap. When omitted,
+            evaluators preserve the full input duration.
     """
 
     path: str | None = field(default=None, metadata={"cli_name": "dataset_path"})
@@ -54,6 +57,13 @@ class DatasetConfig:
     revision: str | None = field(default=None, metadata={"cli_name": "dataset_revision"})
     build_script: str | None = field(default=None, metadata={"cli_name": "dataset_script"})
     label_mapping_file: str | None = None
+    max_duration_seconds: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.max_duration_seconds is not None and (
+            not isfinite(self.max_duration_seconds) or self.max_duration_seconds <= 0
+        ):
+            raise ValueError("max_duration_seconds must be a finite value greater than zero.")
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for serialization."""
@@ -79,6 +89,8 @@ class DatasetConfig:
             result["build_script"] = self.build_script
         if self.label_mapping_file is not None:
             result["label_mapping_file"] = self.label_mapping_file
+        if self.max_duration_seconds is not None:
+            result["max_duration_seconds"] = self.max_duration_seconds
         return result
 
 
@@ -267,10 +279,12 @@ class WinMLEvaluationConfig:
             shuffle=ds_data.get("shuffle", True),
             seed=ds_data.get("seed", 42),
             columns_mapping=ds_data.get("columns_mapping", {}),
+            label_mapping=ds_data.get("label_mapping"),
             streaming=ds_data.get("streaming", False),
             revision=ds_data.get("revision"),
             build_script=ds_data.get("build_script"),
             label_mapping_file=ds_data.get("label_mapping_file"),
+            max_duration_seconds=ds_data.get("max_duration_seconds"),
         )
         return cls(
             model_id=data.get("model_id"),

--- a/src/winml/modelkit/eval/evaluate.py
+++ b/src/winml/modelkit/eval/evaluate.py
@@ -60,6 +60,8 @@ def _select_model_loader(config: WinMLEvaluationConfig) -> _ModelLoaderKind:
 # default formatter layout) yields >100-char lines that trip E501.
 # fmt: off
 _EVALUATOR_REGISTRY: dict[str, str] = {
+    "audio-classification":
+        "winml.modelkit.eval.audio_classification_evaluator:WinMLAudioClassificationEvaluator",
     "image-classification":
         "winml.modelkit.eval.base_evaluator:WinMLEvaluator",
     "text-classification":

--- a/src/winml/modelkit/utils/eval_utils.py
+++ b/src/winml/modelkit/utils/eval_utils.py
@@ -57,6 +57,23 @@ _IMAGE_CLASSIFICATION_SCHEMA = TaskSchema(
     ),
 )
 
+_AUDIO_CLASSIFICATION_SCHEMA = TaskSchema(
+    columns=(
+        SchemaItem(
+            "input_column",
+            "decoded audio with sampling rate, or pre-normalized 1D waveform",
+            default="audio",
+            remap_hint="<your_audio_column>",
+        ),
+        SchemaItem(
+            "label_column",
+            "audio class label (ClassLabel)",
+            default="label",
+            remap_hint="<your_label_column>",
+        ),
+    ),
+)
+
 _TEXT_CLASSIFICATION_SCHEMA = TaskSchema(
     columns=(
         SchemaItem(
@@ -449,6 +466,7 @@ _TEXT_GENERATION_SCHEMA = TaskSchema(
 )
 
 TASK_SCHEMAS: dict[str, TaskSchema] = {
+    "audio-classification": _AUDIO_CLASSIFICATION_SCHEMA,
     "image-classification": _IMAGE_CLASSIFICATION_SCHEMA,
     "text-classification": _TEXT_CLASSIFICATION_SCHEMA,
     "sequence-classification": _TEXT_CLASSIFICATION_SCHEMA,

--- a/tests/unit/eval/test_audio_classification_evaluator.py
+++ b/tests/unit/eval/test_audio_classification_evaluator.py
@@ -1,0 +1,996 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import json
+from io import BytesIO
+from types import SimpleNamespace
+from typing import ClassVar
+from unittest.mock import patch
+
+import numpy as np
+import onnx
+import pytest
+import soundfile as sf
+import torch
+from click.testing import CliRunner
+from datasets import (
+    Audio,
+    ClassLabel,
+    Dataset,
+    DatasetDict,
+    Features,
+    IterableDataset,
+    Sequence,
+    Value,
+)
+from onnx import TensorProto, helper
+from transformers import Wav2Vec2Config
+
+from winml.modelkit.commands.eval import eval as eval_command
+from winml.modelkit.eval import DatasetConfig, WinMLEvaluationConfig
+from winml.modelkit.eval.audio_classification_evaluator import (
+    WinMLAudioClassificationEvaluator,
+    _AudioModelAdapter,
+)
+from winml.modelkit.utils.eval_utils import DatasetValidationError
+
+
+class _IdentityFeatureExtractor:
+    sampling_rate = 16_000
+    padding_value = 0.0
+
+    def __call__(self, waveform, *, sampling_rate, return_tensors, **kwargs):
+        assert sampling_rate == self.sampling_rate
+        assert return_tensors in {"np", "pt"}
+        values = np.asarray(waveform, dtype=np.float32)
+        if kwargs.get("padding") == "max_length":
+            max_length = kwargs["max_length"]
+            values = values[:max_length]
+            values = np.pad(values, (0, max_length - values.size))
+        tensor = values[None, :]
+        return {
+            "input_values": torch.from_numpy(tensor) if return_tensors == "pt" else tensor,
+        }
+
+
+class _SignClassifier:
+    io_config: ClassVar = {
+        "input_names": ["input_values"],
+        "input_shapes": [[1, 8]],
+        "output_names": ["logits"],
+        "output_shapes": [[1, 3]],
+    }
+    config = SimpleNamespace(
+        label2id={"cat": 0, "dog": 1, "other": 2},
+        id2label={0: "cat", 1: "dog", 2: "other"},
+    )
+
+    def __call__(self, **kwargs):
+        values = kwargs["input_values"].cpu().numpy()
+        score = float(values.mean())
+        return {"logits": torch.tensor([[score, -score, -10.0]])}
+
+
+class _RecordingClassifier(_SignClassifier):
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+        return super().__call__(**kwargs)
+
+
+class _TwoInputFeatureExtractor:
+    sampling_rate = 16_000
+
+    def __init__(self):
+        self.kwargs = None
+        self.waveforms = []
+
+    def __call__(self, waveform, *, sampling_rate, return_tensors, **kwargs):
+        self.kwargs = kwargs
+        self.waveforms.append(np.asarray(waveform, dtype=np.float32))
+        assert sampling_rate == self.sampling_rate
+        assert return_tensors == "pt"
+        length = kwargs.get("max_length", len(waveform))
+        values = np.asarray(waveform, dtype=np.float32)[:length]
+        values = np.pad(values, (0, length - values.size))
+        return {
+            "input_values": torch.from_numpy(values[None, :]),
+            "attention_mask": torch.ones((1, length), dtype=torch.int64),
+            "extra": torch.zeros((1, length), dtype=torch.int64),
+        }
+
+
+class _TwoInputClassifier:
+    io_config: ClassVar = {
+        "input_names": ["input_values", "attention_mask"],
+        "input_shapes": [[1, 8], [1, 8]],
+        "output_names": ["logits"],
+        "output_shapes": [[1, 3]],
+    }
+    config = _SignClassifier.config
+
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"logits": torch.tensor([[5.0, 0.0, -5.0]])}
+
+
+class _SpectrogramFeatureExtractor:
+    sampling_rate = 16_000
+
+    def __call__(self, waveform, *, sampling_rate, return_tensors):
+        assert waveform.size > 0
+        assert sampling_rate == self.sampling_rate
+        assert return_tensors == "pt"
+        return {"input_values": torch.ones((1, 4, 3), dtype=torch.float32)}
+
+
+class _SpectrogramClassifier:
+    io_config: ClassVar = {
+        "input_names": ["input_values"],
+        "input_shapes": [[1, 4, 3]],
+        "output_names": ["logits"],
+        "output_shapes": [[1, 3]],
+    }
+    config = _SignClassifier.config
+
+    def __call__(self, **kwargs):
+        assert kwargs["input_values"].shape == (1, 4, 3)
+        return {"logits": torch.tensor([[1.0, 0.0, -1.0]])}
+
+
+class _CountingStreamingDataset:
+    def __init__(self, rows):
+        self.column_names = ["audio", "label"]
+        self.features = {
+            "audio": Value("string"),
+            "label": ClassLabel(names=["cat", "dog", "en_us"]),
+        }
+        self._rows = rows
+        self.rows_yielded = 0
+
+    def __iter__(self):
+        for row in self._rows:
+            self.rows_yielded += 1
+            yield row
+
+
+class _EncodingMustNotRunAudio(Audio):
+    def encode_example(self, value):
+        raise AssertionError("bounded selection must not re-encode raw audio")
+
+
+class _RawAudioIterableDataset(IterableDataset):
+    def __init__(self, rows, features):
+        self._rows = rows
+        self._raw_features = features
+
+    @property
+    def features(self):
+        return self._raw_features
+
+    @property
+    def column_names(self):
+        return list(self._raw_features)
+
+    def __iter__(self):
+        return iter(self._rows)
+
+
+def _audio_dataset(rows):
+    features = Features(
+        {
+            "audio": {
+                "array": Sequence(Value("float32")),
+                "sampling_rate": Value("int32"),
+            },
+            "label": ClassLabel(names=["cat", "dog", "en_us"]),
+        }
+    )
+    return Dataset.from_list(rows, features=features)
+
+
+def _config(
+    samples=4,
+    label_mapping=None,
+    *,
+    streaming=False,
+    shuffle=True,
+    max_duration_seconds=None,
+):
+    return WinMLEvaluationConfig(
+        model_id="example/audio-classifier",
+        task="audio-classification",
+        dataset=DatasetConfig(
+            path="example/audio-dataset",
+            split="test",
+            samples=samples,
+            shuffle=shuffle,
+            seed=42,
+            label_mapping=label_mapping,
+            streaming=streaming,
+            max_duration_seconds=max_duration_seconds,
+        ),
+    )
+
+
+def _save_sign_classifier(path):
+    input_info = helper.make_tensor_value_info("input_values", TensorProto.FLOAT, [1, 8])
+    output_info = helper.make_tensor_value_info("logits", TensorProto.FLOAT, [1, 2])
+    graph = helper.make_graph(
+        [
+            helper.make_node("ReduceMean", ["input_values"], ["score"], axes=[1], keepdims=1),
+            helper.make_node("Neg", ["score"], ["negative_score"]),
+            helper.make_node("Concat", ["score", "negative_score"], ["logits"], axis=1),
+        ],
+        "sign_classifier",
+        [input_info],
+        [output_info],
+    )
+    model = helper.make_model(
+        graph,
+        opset_imports=[helper.make_opsetid("", 17)],
+        ir_version=9,
+    )
+    onnx.save(model, path)
+
+
+class TestAudioPreprocessing:
+    def test_decodes_encoded_audio_bytes_without_torchcodec(self):
+        encoded = BytesIO()
+        sf.write(encoded, np.array([0.25, -0.5], dtype=np.float32), 16_000, format="WAV")
+
+        waveform, sampling_rate = WinMLAudioClassificationEvaluator._decode_audio(
+            {"bytes": encoded.getvalue(), "path": None}
+        )
+
+        assert sampling_rate == 16_000
+        np.testing.assert_allclose(waveform, [0.25, -0.5], atol=4e-5)
+
+    def test_decodes_path_audio_through_dataset_opener(self, tmp_path):
+        audio_path = tmp_path / "clip.wav"
+        frames_first = np.array([[0.25, 0.5], [-0.25, -0.5]], dtype=np.float32)
+        sf.write(audio_path, frames_first, 16_000)
+
+        waveform, sampling_rate = WinMLAudioClassificationEvaluator._decode_audio(
+            {"bytes": None, "path": str(audio_path)}
+        )
+
+        assert sampling_rate == 16_000
+        assert waveform.shape == (2, 2)
+        np.testing.assert_allclose(waveform, frames_first.T, atol=4e-5)
+
+    def test_mono_and_both_stereo_layouts(self):
+        mono = np.array([1.0, 3.0], dtype=np.float32)
+        channels_first = np.array([[1.0, 3.0], [3.0, 5.0]], dtype=np.float32)
+        channels_last = channels_first.T
+        one_frame_channels_first = np.array([[1.0], [0.5]], dtype=np.float32)
+
+        np.testing.assert_array_equal(
+            WinMLAudioClassificationEvaluator._to_mono(mono),
+            mono,
+        )
+        np.testing.assert_array_equal(
+            WinMLAudioClassificationEvaluator._to_mono(channels_first),
+            np.array([2.0, 4.0], dtype=np.float32),
+        )
+        np.testing.assert_array_equal(
+            WinMLAudioClassificationEvaluator._to_mono(channels_last),
+            np.array([2.0, 4.0], dtype=np.float32),
+        )
+        np.testing.assert_array_equal(
+            WinMLAudioClassificationEvaluator._to_mono(one_frame_channels_first),
+            np.array([0.75], dtype=np.float32),
+        )
+
+class TestAudioLabelAlignmentAndSampling:
+    def test_saved_dataset_dict_selects_requested_split(self, tmp_path):
+        train = _audio_dataset(
+            [{"audio": {"array": [-1.0] * 8, "sampling_rate": 16_000}, "label": 1}]
+        )
+        test = _audio_dataset(
+            [{"audio": {"array": [1.0] * 8, "sampling_rate": 16_000}, "label": 0}]
+        )
+        dataset_path = tmp_path / "audio-dataset"
+        DatasetDict({"train": train, "test": test}).save_to_disk(dataset_path)
+        config = _config(samples=1, label_mapping={"cat": 0})
+        config.dataset.path = str(dataset_path)
+
+        with patch(
+            "transformers.AutoFeatureExtractor.from_pretrained",
+            return_value=_IdentityFeatureExtractor(),
+        ):
+            evaluator = WinMLAudioClassificationEvaluator(config, _SignClassifier())
+
+        assert evaluator._eligible_count == 1
+        assert [sample.model_id for sample in evaluator.data] == [0]
+
+    def test_saved_dataset_dict_missing_split_is_clear(self, tmp_path):
+        dataset_path = tmp_path / "audio-dataset"
+        DatasetDict(
+            {
+                "train": _audio_dataset(
+                    [
+                        {
+                            "audio": {"array": [1.0] * 8, "sampling_rate": 16_000},
+                            "label": 0,
+                        }
+                    ]
+                )
+            }
+        ).save_to_disk(dataset_path)
+        config = _config(samples=1)
+        config.dataset.path = str(dataset_path)
+
+        with pytest.raises(
+            DatasetValidationError,
+            match=r"Dataset split 'test' was not found; available splits: \['train'\]",
+        ):
+            WinMLAudioClassificationEvaluator(config, _SignClassifier())
+
+    def test_filters_authoritative_labels_before_stratified_sampling(self):
+        rows = [
+            {"audio": {"array": [1.0] * 8, "sampling_rate": 16_000}, "label": 0},
+            {"audio": {"array": [2.0] * 8, "sampling_rate": 16_000}, "label": 0},
+            {"audio": {"array": [-1.0] * 8, "sampling_rate": 16_000}, "label": 1},
+            {"audio": {"array": [-2.0] * 8, "sampling_rate": 16_000}, "label": 1},
+            *[
+                {
+                    "audio": {"array": [9.0] * 8, "sampling_rate": 16_000},
+                    "label": 2,
+                }
+                for _ in range(20)
+            ],
+        ]
+        dataset = _audio_dataset(rows)
+        config = _config(samples=4, label_mapping={"cat": 0, "dog": 1})
+
+        with (
+            patch("datasets.load_dataset", return_value=dataset),
+            patch(
+                "transformers.AutoFeatureExtractor.from_pretrained",
+                return_value=_IdentityFeatureExtractor(),
+            ),
+        ):
+            evaluator = WinMLAudioClassificationEvaluator(config, _SignClassifier())
+
+        assert evaluator._eligible_count == 4
+        assert [sample.model_id for sample in evaluator.data].count(0) == 2
+        assert [sample.model_id for sample in evaluator.data].count(1) == 2
+        assert all(sample.model_id != 2 for sample in evaluator.data)
+
+    def test_does_not_infer_cross_region_or_other_near_match(self):
+        dataset = _audio_dataset(
+            [
+                {
+                    "audio": {"array": [1.0] * 8, "sampling_rate": 16_000},
+                    "label": 2,
+                }
+            ]
+        )
+        model = _SignClassifier()
+        model.config = SimpleNamespace(
+            label2id={"en-IN": 0},
+            id2label={0: "en-IN"},
+        )
+
+        with (
+            patch("datasets.load_dataset", return_value=dataset),
+            patch(
+                "transformers.AutoFeatureExtractor.from_pretrained",
+                return_value=_IdentityFeatureExtractor(),
+            ),
+            pytest.raises(DatasetValidationError, match="no exact overlap"),
+        ):
+            WinMLAudioClassificationEvaluator(_config(samples=1), model)
+
+    def test_zero_overlap_mapping_fails_closed(self):
+        dataset = _audio_dataset(
+            [
+                {
+                    "audio": {"array": [1.0] * 8, "sampling_rate": 16_000},
+                    "label": 0,
+                }
+            ]
+        )
+        with (
+            patch("datasets.load_dataset", return_value=dataset),
+            patch(
+                "transformers.AutoFeatureExtractor.from_pretrained",
+                return_value=_IdentityFeatureExtractor(),
+            ),
+            pytest.raises(DatasetValidationError, match="no exact overlap"),
+        ):
+            WinMLAudioClassificationEvaluator(
+                _config(samples=1, label_mapping={"missing": 0}),
+                _SignClassifier(),
+            )
+
+    def test_no_shuffle_streaming_stops_after_balanced_quota(self):
+        rows = [{"audio": f"cat-{index}", "label": 0} for index in range(3)] + [
+            {"audio": f"dog-{index}", "label": 1} for index in range(20)
+        ]
+        dataset = _CountingStreamingDataset(rows)
+        config = _config(
+            samples=6,
+            label_mapping={"cat": 0, "dog": 1},
+            streaming=True,
+            shuffle=False,
+        )
+
+        with (
+            patch("datasets.load_dataset", return_value=dataset),
+            patch(
+                "transformers.AutoFeatureExtractor.from_pretrained",
+                return_value=_IdentityFeatureExtractor(),
+            ),
+        ):
+            evaluator = WinMLAudioClassificationEvaluator(config, _SignClassifier())
+
+        assert dataset.rows_yielded == 6
+        assert dataset.rows_yielded < len(rows)
+        assert [sample.model_id for sample in evaluator.data] == [0, 1, 0, 1, 0, 1]
+        assert [sample.row["audio"] for sample in evaluator.data] == [
+            "cat-0",
+            "dog-0",
+            "cat-1",
+            "dog-1",
+            "cat-2",
+            "dog-2",
+        ]
+
+    @pytest.mark.parametrize(
+        ("labels", "expected_counts"),
+        [
+            ([0, 0, 0, 1, 1, 1], {0: 2, 1: 2}),
+            ([0, 1, 1, 2, 2, 2], {0: 1, 1: 2, 2: 2}),
+        ],
+        ids=["absent-authoritative-class", "uneven-class"],
+    )
+    def test_no_shuffle_streaming_exhausts_and_reports_short_quota(
+        self,
+        labels,
+        expected_counts,
+    ):
+        rows = [{"audio": str(index), "label": label} for index, label in enumerate(labels)]
+        dataset = _CountingStreamingDataset(rows)
+        config = _config(
+            samples=6,
+            label_mapping={"cat": 0, "dog": 1, "en_us": 2},
+            streaming=True,
+            shuffle=False,
+        )
+
+        with (
+            patch("datasets.load_dataset", return_value=dataset),
+            patch(
+                "transformers.AutoFeatureExtractor.from_pretrained",
+                return_value=_IdentityFeatureExtractor(),
+            ),
+        ):
+            evaluator = WinMLAudioClassificationEvaluator(config, _SignClassifier())
+
+        actual_counts = {
+            model_id: [sample.model_id for sample in evaluator.data].count(model_id)
+            for model_id in expected_counts
+        }
+        assert dataset.rows_yielded == len(rows)
+        assert actual_counts == expected_counts
+        assert evaluator._selected_count == sum(expected_counts.values())
+        assert evaluator._selected_count < config.dataset.samples
+
+    def test_shuffle_streaming_still_scans_complete_stream(self):
+        rows = [{"audio": f"cat-{index}", "label": 0} for index in range(20)] + [
+            {"audio": f"dog-{index}", "label": 1} for index in range(20)
+        ]
+        dataset = _CountingStreamingDataset(rows)
+        config = _config(
+            samples=6,
+            label_mapping={"cat": 0, "dog": 1},
+            streaming=True,
+            shuffle=True,
+        )
+
+        with (
+            patch("datasets.load_dataset", return_value=dataset),
+            patch(
+                "transformers.AutoFeatureExtractor.from_pretrained",
+                return_value=_IdentityFeatureExtractor(),
+            ),
+        ):
+            evaluator = WinMLAudioClassificationEvaluator(config, _SignClassifier())
+
+        assert dataset.rows_yielded == len(rows)
+        assert evaluator._eligible_count == len(rows)
+        assert [sample.model_id for sample in evaluator.data].count(0) == 3
+        assert [sample.model_id for sample in evaluator.data].count(1) == 3
+
+
+class TestAudioPredictionAndMetrics:
+    def test_pre_normalized_waveform_must_be_one_dimensional(self):
+        with patch(
+            "transformers.AutoFeatureExtractor.from_pretrained",
+            return_value=_IdentityFeatureExtractor(),
+        ):
+            adapter = _AudioModelAdapter(_config(samples=1), _SignClassifier())
+            with pytest.raises(ValueError, match="must be 1D"):
+                adapter(np.ones((1, 8), dtype=np.float32))
+
+    def test_rank_three_spectrogram_runs_through_adapter(self):
+        with patch(
+            "transformers.AutoFeatureExtractor.from_pretrained",
+            return_value=_SpectrogramFeatureExtractor(),
+        ):
+            logits = _AudioModelAdapter(_config(samples=1), _SpectrogramClassifier())(
+                {"array": np.ones(16, dtype=np.float32), "sampling_rate": 16_000}
+            )
+
+        np.testing.assert_array_equal(logits, [1.0, 0.0, -1.0])
+
+    def test_overlength_waveform_aggregates_all_fixed_shape_windows_by_default(self):
+        model = _RecordingClassifier()
+        extractor = _TwoInputFeatureExtractor()
+        with patch(
+            "transformers.AutoFeatureExtractor.from_pretrained",
+            return_value=extractor,
+        ):
+            adapter = _AudioModelAdapter(_config(samples=1), model)
+            logits = adapter([1.0] * 24)
+
+        assert adapter.model is model
+        assert len(model.calls) == 3
+        assert all(set(call) == {"input_values"} for call in model.calls)
+        assert all(call["input_values"].shape == (1, 8) for call in model.calls)
+        assert adapter.last_was_truncated is False
+        assert adapter.last_window_count == 3
+        assert extractor.kwargs == {
+            "padding": "max_length",
+            "truncation": True,
+            "max_length": 8,
+        }
+        np.testing.assert_array_equal(logits, [1.0, -1.0, -10.0])
+
+    def test_explicit_duration_cap_truncates_before_bounded_windowing(self):
+        model = _RecordingClassifier()
+        with patch(
+            "transformers.AutoFeatureExtractor.from_pretrained",
+            return_value=_TwoInputFeatureExtractor(),
+        ):
+            adapter = _AudioModelAdapter(
+                _config(samples=1, max_duration_seconds=0.001),
+                model,
+            )
+            adapter({"array": np.ones(40, dtype=np.float32), "sampling_rate": 16_000})
+
+        assert len(model.calls) == 2
+        assert adapter.last_was_truncated is True
+        assert adapter.last_window_count == 2
+
+    def test_resamples_22050_hz_audio_to_feature_extractor_rate(self):
+        extractor = _TwoInputFeatureExtractor()
+        with patch(
+            "transformers.AutoFeatureExtractor.from_pretrained",
+            return_value=extractor,
+        ):
+            _AudioModelAdapter(_config(samples=1), _RecordingClassifier())(
+                {"array": np.ones(22_050, dtype=np.float32), "sampling_rate": 22_050}
+            )
+
+        assert sum(waveform.size for waveform in extractor.waveforms) == 16_000
+
+    def test_rejects_multiple_static_model_inputs(self):
+        with (
+            patch(
+                "transformers.AutoFeatureExtractor.from_pretrained",
+                return_value=_TwoInputFeatureExtractor(),
+            ),
+            pytest.raises(ValueError, match="exactly one model input"),
+        ):
+            _AudioModelAdapter(_config(samples=1), _TwoInputClassifier())
+
+    def test_rejects_dynamic_audio_shape(self):
+        model = _SignClassifier()
+        model.io_config = {
+            **model.io_config,
+            "input_shapes": [[1, "audio_length"]],
+        }
+        with (
+            patch(
+                "transformers.AutoFeatureExtractor.from_pretrained",
+                return_value=_IdentityFeatureExtractor(),
+            ),
+            pytest.raises(ValueError, match="static non-batch input shapes"),
+        ):
+            _AudioModelAdapter(_config(samples=1), model)
+
+    @pytest.mark.parametrize(
+        ("output_names", "output_shapes", "message"),
+        [
+            (["logits", "aux"], [[1, 3], [1, 3]], "exactly one 'logits' output"),
+            (["logits"], [[1, 3, 1]], r"logits shape \[1, classes\]"),
+        ],
+    )
+    def test_rejects_invalid_output_contract(self, output_names, output_shapes, message):
+        model = _SignClassifier()
+        model.io_config = {
+            **model.io_config,
+            "output_names": output_names,
+            "output_shapes": output_shapes,
+        }
+        with (
+            patch(
+                "transformers.AutoFeatureExtractor.from_pretrained",
+                return_value=_IdentityFeatureExtractor(),
+            ),
+            pytest.raises(ValueError, match=message),
+        ):
+            _AudioModelAdapter(_config(samples=1), model)
+
+    def test_native_model_without_io_config_receives_all_extractor_outputs(self):
+        class _NativeModel:
+            config = _SignClassifier.config
+
+            def __init__(self):
+                self.inputs = None
+
+            def __call__(self, **kwargs):
+                self.inputs = kwargs
+                return SimpleNamespace(logits=torch.tensor([[1.0, 0.0, -1.0]]))
+
+        model = _NativeModel()
+        extractor = _TwoInputFeatureExtractor()
+        with patch(
+            "transformers.AutoFeatureExtractor.from_pretrained",
+            return_value=extractor,
+        ):
+            logits = _AudioModelAdapter(_config(samples=1), model)([1.0] * 8)
+
+        assert set(model.inputs) == {"input_values", "attention_mask", "extra"}
+        np.testing.assert_array_equal(logits, [1.0, 0.0, -1.0])
+
+    @pytest.mark.parametrize(
+        ("label_feature", "labels", "names", "label_mapping"),
+        [
+            (
+                Sequence(ClassLabel(names=["cat", "dog", "other"])),
+                [[0, 1], [1, 2]],
+                None,
+                None,
+            ),
+            (
+                Sequence(Value("string")),
+                [["/cat", "/dog"], ["/dog", "/other"]],
+                [["cat", "dog"], ["dog", "other"]],
+                None,
+            ),
+        ],
+        ids=["sequence-classlabel", "sequence-value-with-label-names"],
+    )
+    def test_multi_label_targets_have_finite_sigmoid_average_precision(
+        self,
+        label_feature,
+        labels,
+        names,
+        label_mapping,
+    ):
+        feature_map = {
+            "audio": {
+                "array": Sequence(Value("float32")),
+                "sampling_rate": Value("int32"),
+            },
+            "labels": label_feature,
+        }
+        rows = [
+            {
+                "audio": {"array": [1.0] * 8, "sampling_rate": 16_000},
+                "labels": labels[0],
+            },
+            {
+                "audio": {"array": [-1.0] * 8, "sampling_rate": 16_000},
+                "labels": labels[1],
+            },
+        ]
+        columns_mapping = {"label_column": "labels"}
+        if names is not None:
+            feature_map["names"] = Sequence(Value("string"))
+            rows[0]["names"] = names[0]
+            rows[1]["names"] = names[1]
+            columns_mapping["label_name_column"] = "names"
+        dataset = Dataset.from_list(rows, features=Features(feature_map))
+        config = WinMLEvaluationConfig(
+            model_id="example/audio-classifier",
+            task="audio-classification",
+            dataset=DatasetConfig(
+                path="example/audio-dataset",
+                split="test",
+                samples=2,
+                shuffle=False,
+                columns_mapping=columns_mapping,
+                label_mapping=label_mapping,
+            ),
+        )
+        model = _RecordingClassifier()
+
+        with (
+            patch("datasets.load_dataset", return_value=dataset),
+            patch(
+                "transformers.AutoFeatureExtractor.from_pretrained",
+                return_value=_TwoInputFeatureExtractor(),
+            ),
+        ):
+            metrics = WinMLAudioClassificationEvaluator(config, model).compute()
+
+        assert len(model.calls) == 2
+        assert np.isfinite(metrics["sample_average_precision"])
+        assert np.isfinite(metrics["micro_average_precision"])
+
+    def test_streaming_selection_preserves_raw_audio_without_reencoding(self):
+        encoded = BytesIO()
+        sf.write(encoded, np.ones(8, dtype=np.float32), 16_000, format="WAV")
+        raw_audio = {"bytes": encoded.getvalue(), "path": None}
+        dataset = _RawAudioIterableDataset(
+            [{"audio": raw_audio, "labels": ["cat"]}],
+            Features(
+                {
+                    "audio": _EncodingMustNotRunAudio(decode=False),
+                    "labels": Sequence(Value("string")),
+                }
+            ),
+        )
+        config = WinMLEvaluationConfig(
+            model_id="example/audio-classifier",
+            task="audio-classification",
+            dataset=DatasetConfig(
+                path="example/audio-dataset",
+                split="test",
+                samples=1,
+                shuffle=False,
+                streaming=True,
+                columns_mapping={"label_column": "labels"},
+            ),
+        )
+
+        with (
+            patch("datasets.load_dataset", return_value=dataset),
+            patch(
+                "transformers.AutoFeatureExtractor.from_pretrained",
+                return_value=_TwoInputFeatureExtractor(),
+            ),
+        ):
+            evaluator = WinMLAudioClassificationEvaluator(config, _SignClassifier())
+            assert evaluator.data[0]["audio"]["bytes"] == raw_audio["bytes"]
+            metrics = evaluator.compute()
+
+        assert metrics["processed_samples"] == 1
+        assert np.isfinite(metrics["sample_average_precision"])
+
+    def test_end_to_end_fixed_shape_evaluator_reports_accounting(self):
+        rows = [
+            {"audio": {"array": [1.0] * 8, "sampling_rate": 16_000}, "label": 0},
+            {"audio": {"array": [2.0] * 8, "sampling_rate": 16_000}, "label": 0},
+            {"audio": {"array": [-1.0] * 8, "sampling_rate": 16_000}, "label": 1},
+            {"audio": {"array": [-2.0] * 8, "sampling_rate": 16_000}, "label": 1},
+        ]
+        dataset = _audio_dataset(rows)
+        config = _config(samples=4, label_mapping={"cat": 0, "dog": 1})
+
+        with (
+            patch("datasets.load_dataset", return_value=dataset),
+            patch(
+                "transformers.AutoFeatureExtractor.from_pretrained",
+                return_value=_IdentityFeatureExtractor(),
+            ),
+        ):
+            metrics = WinMLAudioClassificationEvaluator(config, _SignClassifier()).compute()
+
+        assert metrics == {
+            "accuracy": 1.0,
+            "macro_f1": 1.0,
+            "represented_classes": 2,
+            "total_classes": 3,
+            "class_coverage": 2 / 3,
+            "requested_samples": 4,
+            "eligible_samples": 4,
+            "selected_samples": 4,
+            "processed_samples": 4,
+            "inference_windows": 4,
+            "truncated_samples": 0,
+            "rejected_samples": 0,
+            "rejected_by_reason": {},
+            "per_label_processed": {"cat": 2, "dog": 2},
+            "confusion_matrix": {"cat": {"cat": 2}, "dog": {"dog": 2}},
+        }
+
+    def test_duration_truncation_is_reported(self):
+        dataset = _audio_dataset(
+            [{"audio": {"array": [1.0] * 16, "sampling_rate": 16_000}, "label": 0}]
+        )
+        config = _config(
+            samples=1,
+            label_mapping={"cat": 0},
+            shuffle=False,
+            max_duration_seconds=0.0005,
+        )
+
+        with (
+            patch("datasets.load_dataset", return_value=dataset),
+            patch(
+                "transformers.AutoFeatureExtractor.from_pretrained",
+                return_value=_IdentityFeatureExtractor(),
+            ),
+        ):
+            metrics = WinMLAudioClassificationEvaluator(config, _SignClassifier()).compute()
+
+        assert metrics["inference_windows"] == 1
+        assert metrics["truncated_samples"] == 1
+
+    def test_rejected_audio_is_accounted_after_selection(self):
+        rows = [
+            {"audio": {"array": [], "sampling_rate": 16_000}, "label": 0},
+            *[
+                {"audio": {"array": [1.0] * 8, "sampling_rate": 16_000}, "label": 0}
+                for _ in range(5)
+            ],
+            *[
+                {"audio": {"array": [-1.0] * 8, "sampling_rate": 16_000}, "label": 1}
+                for _ in range(6)
+            ],
+        ]
+        dataset = _audio_dataset(rows)
+        config = _config(samples=12, label_mapping={"cat": 0, "dog": 1})
+
+        with (
+            patch("datasets.load_dataset", return_value=dataset),
+            patch(
+                "transformers.AutoFeatureExtractor.from_pretrained",
+                return_value=_IdentityFeatureExtractor(),
+            ),
+        ):
+            metrics = WinMLAudioClassificationEvaluator(config, _SignClassifier()).compute()
+
+        assert metrics["eligible_samples"] == 12
+        assert metrics["selected_samples"] == 12
+        assert metrics["processed_samples"] == 11
+        assert metrics["rejected_samples"] == 1
+        assert metrics["rejected_by_reason"] == {"ValueError": 1}
+        assert metrics["per_label_processed"] == {"cat": 5, "dog": 6}
+
+    def test_prediction_outside_reference_labels_is_an_accuracy_error(self):
+        class _OtherClassifier(_SignClassifier):
+            def __call__(self, **_kwargs):
+                return {"logits": torch.tensor([[0.0, 0.0, 10.0]])}
+
+        dataset = _audio_dataset(
+            [
+                {
+                    "audio": {"array": [1.0] * 8, "sampling_rate": 16_000},
+                    "label": 0,
+                }
+            ]
+        )
+        with (
+            patch("datasets.load_dataset", return_value=dataset),
+            patch(
+                "transformers.AutoFeatureExtractor.from_pretrained",
+                return_value=_IdentityFeatureExtractor(),
+            ),
+        ):
+            metrics = WinMLAudioClassificationEvaluator(
+                _config(samples=1, label_mapping={"cat": 0}),
+                _OtherClassifier(),
+            ).compute()
+
+        assert metrics["accuracy"] == 0.0
+        assert metrics["macro_f1"] == 0.0
+        assert metrics["represented_classes"] == 1
+        assert metrics["total_classes"] == 3
+        assert metrics["class_coverage"] == pytest.approx(1 / 3)
+        assert metrics["confusion_matrix"] == {"cat": {"other": 1}}
+
+    def test_cli_with_saved_dataset_and_fixed_shape_onnx_reports_metrics(self, tmp_path):
+        dataset_path = tmp_path / "dataset"
+        model_path = tmp_path / "classifier.onnx"
+        output_path = tmp_path / "result.json"
+        label_mapping_path = tmp_path / "labels.json"
+        rows = [
+            {"audio": {"array": [1.0] * 8, "sampling_rate": 16_000}, "label": 0},
+            {"audio": {"array": [2.0] * 8, "sampling_rate": 16_000}, "label": 0},
+            {"audio": {"array": [-1.0] * 8, "sampling_rate": 16_000}, "label": 1},
+            {"audio": {"array": [-2.0] * 8, "sampling_rate": 16_000}, "label": 1},
+        ]
+        _audio_dataset(rows).save_to_disk(dataset_path)
+        _save_sign_classifier(model_path)
+        label_mapping_path.write_text(json.dumps({"cat": 0, "dog": 1}), encoding="utf-8")
+        hf_config = Wav2Vec2Config(
+            id2label={0: "cat", 1: "dog"},
+            label2id={"cat": 0, "dog": 1},
+        )
+
+        with (
+            patch("winml.modelkit.loader.load_hf_config", return_value=hf_config),
+            patch(
+                "transformers.AutoFeatureExtractor.from_pretrained",
+                return_value=_IdentityFeatureExtractor(),
+            ),
+        ):
+            result = CliRunner().invoke(
+                eval_command,
+                [
+                    "-m",
+                    str(model_path),
+                    "--model-id",
+                    "example/audio-classifier",
+                    "--task",
+                    "audio-classification",
+                    "--dataset",
+                    str(dataset_path),
+                    "--split",
+                    "train",
+                    "--samples",
+                    "4",
+                    "--max-duration-seconds",
+                    "0.00025",
+                    "--device",
+                    "cpu",
+                    "--label-mapping",
+                    str(label_mapping_path),
+                    "--output",
+                    str(output_path),
+                ],
+                obj={"debug": False},
+            )
+
+        assert result.exit_code == 0, result.output
+        metrics = json.loads(output_path.read_text(encoding="utf-8"))["metrics"]
+        assert metrics["accuracy"] == 1.0
+        assert metrics["macro_f1"] == 1.0
+        assert metrics["requested_samples"] == 4
+        assert metrics["eligible_samples"] == 4
+        assert metrics["processed_samples"] == 4
+        assert metrics["truncated_samples"] == 4
+        assert metrics["rejected_samples"] == 0
+
+    def test_cli_rejects_nonpositive_max_duration(self):
+        result = CliRunner().invoke(
+            eval_command,
+            ["--max-duration-seconds", "0"],
+            obj={"debug": False},
+        )
+
+        assert result.exit_code == 2
+        assert "0 is not in the range x>0" in result.output
+
+
+class TestAudioRegistryCompatibility:
+    def test_audio_schema_and_evaluator_registered_without_changing_sibling(self):
+        from winml.modelkit.eval.evaluate import _DEFAULT_DATASETS, get_evaluator_class
+        from winml.modelkit.eval.text_classification_evaluator import (
+            WinMLTextClassificationEvaluator,
+        )
+        from winml.modelkit.utils.eval_utils import TASK_SCHEMAS
+
+        audio_schema = TASK_SCHEMAS["audio-classification"]
+        assert [item.default for item in audio_schema.columns] == ["audio", "label"]
+        assert "audio-classification" not in _DEFAULT_DATASETS
+        assert get_evaluator_class(_config()).__name__ == "WinMLAudioClassificationEvaluator"
+        assert (
+            get_evaluator_class(WinMLEvaluationConfig(task="text-classification"))
+            is WinMLTextClassificationEvaluator
+        )
+
+        schema_result = CliRunner().invoke(
+            eval_command,
+            ["--schema", "--task", "audio-classification"],
+            obj={},
+        )
+        assert schema_result.exit_code == 0
+        assert "default: audio" in schema_result.output
+        assert "default: label" in schema_result.output

--- a/tests/unit/eval/test_audio_classification_evaluator.py
+++ b/tests/unit/eval/test_audio_classification_evaluator.py
@@ -28,7 +28,6 @@ from datasets import (
     Sequence,
     Value,
 )
-from onnx import TensorProto, helper
 from transformers import Wav2Vec2Config
 
 from winml.modelkit.commands.eval import eval as eval_command
@@ -202,21 +201,29 @@ def _config(
 
 
 def _save_sign_classifier(path):
-    input_info = helper.make_tensor_value_info("input_values", TensorProto.FLOAT, [1, 8])
-    output_info = helper.make_tensor_value_info("logits", TensorProto.FLOAT, [1, 2])
-    graph = helper.make_graph(
+    input_info = onnx.helper.make_tensor_value_info(
+        "input_values", onnx.TensorProto.FLOAT, [1, 8]
+    )
+    output_info = onnx.helper.make_tensor_value_info(
+        "logits", onnx.TensorProto.FLOAT, [1, 2]
+    )
+    graph = onnx.helper.make_graph(
         [
-            helper.make_node("ReduceMean", ["input_values"], ["score"], axes=[1], keepdims=1),
-            helper.make_node("Neg", ["score"], ["negative_score"]),
-            helper.make_node("Concat", ["score", "negative_score"], ["logits"], axis=1),
+            onnx.helper.make_node(
+                "ReduceMean", ["input_values"], ["score"], axes=[1], keepdims=1
+            ),
+            onnx.helper.make_node("Neg", ["score"], ["negative_score"]),
+            onnx.helper.make_node(
+                "Concat", ["score", "negative_score"], ["logits"], axis=1
+            ),
         ],
         "sign_classifier",
         [input_info],
         [output_info],
     )
-    model = helper.make_model(
+    model = onnx.helper.make_model(
         graph,
-        opset_imports=[helper.make_opsetid("", 17)],
+        opset_imports=[onnx.helper.make_opsetid("", 17)],
         ir_version=9,
     )
     onnx.save(model, path)

--- a/tests/unit/eval/test_audio_classification_evaluator.py
+++ b/tests/unit/eval/test_audio_classification_evaluator.py
@@ -163,28 +163,6 @@ class _CountingStreamingDataset:
             yield row
 
 
-class _EncodingMustNotRunAudio(Audio):
-    def encode_example(self, value):
-        raise AssertionError("bounded selection must not re-encode raw audio")
-
-
-class _RawAudioIterableDataset(IterableDataset):
-    def __init__(self, rows, features):
-        self._rows = rows
-        self._raw_features = features
-
-    @property
-    def features(self):
-        return self._raw_features
-
-    @property
-    def column_names(self):
-        return list(self._raw_features)
-
-    def __iter__(self):
-        return iter(self._rows)
-
-
 def _audio_dataset(rows):
     features = Features(
         {
@@ -736,13 +714,10 @@ class TestAudioPredictionAndMetrics:
         encoded = BytesIO()
         sf.write(encoded, np.ones(8, dtype=np.float32), 16_000, format="WAV")
         raw_audio = {"bytes": encoded.getvalue(), "path": None}
-        dataset = _RawAudioIterableDataset(
-            [{"audio": raw_audio, "labels": ["cat"]}],
-            Features(
-                {
-                    "audio": _EncodingMustNotRunAudio(decode=False),
-                    "labels": Sequence(Value("string")),
-                }
+        dataset = IterableDataset.from_generator(
+            lambda: iter([{"audio": raw_audio, "labels": ["cat"]}]),
+            features=Features(
+                {"audio": Audio(), "labels": Sequence(Value("string"))}
             ),
         )
         config = WinMLEvaluationConfig(
@@ -760,6 +735,11 @@ class TestAudioPredictionAndMetrics:
 
         with (
             patch("datasets.load_dataset", return_value=dataset),
+            patch.object(
+                Audio,
+                "encode_example",
+                side_effect=AssertionError("streaming audio must remain raw"),
+            ),
             patch(
                 "transformers.AutoFeatureExtractor.from_pretrained",
                 return_value=_TwoInputFeatureExtractor(),

--- a/tests/unit/eval/test_audio_classification_evaluator.py
+++ b/tests/unit/eval/test_audio_classification_evaluator.py
@@ -10,6 +10,7 @@ from io import BytesIO
 from types import SimpleNamespace
 from typing import ClassVar
 from unittest.mock import patch
+from zipfile import ZipFile
 
 import numpy as np
 import onnx
@@ -747,6 +748,52 @@ class TestAudioPredictionAndMetrics:
         ):
             evaluator = WinMLAudioClassificationEvaluator(config, _SignClassifier())
             assert evaluator.data[0]["audio"]["bytes"] == raw_audio["bytes"]
+            metrics = evaluator.compute()
+
+        assert metrics["processed_samples"] == 1
+        assert np.isfinite(metrics["sample_average_precision"])
+
+    def test_streaming_selection_decodes_raw_virtual_archive_path(self, tmp_path):
+        encoded = BytesIO()
+        sf.write(encoded, np.ones(8, dtype=np.float32), 16_000, format="WAV")
+        archive_path = tmp_path / "audio.zip"
+        member_path = "genres/example.wav"
+        with ZipFile(archive_path, "w") as archive:
+            archive.writestr(member_path, encoded.getvalue())
+        raw_audio = f"zip://{member_path}::{archive_path.as_posix()}"
+        dataset = IterableDataset.from_generator(
+            lambda: iter([{"audio": raw_audio, "labels": ["cat"]}]),
+            features=Features(
+                {"audio": Audio(), "labels": Sequence(Value("string"))}
+            ),
+        )
+        config = WinMLEvaluationConfig(
+            model_id="example/audio-classifier",
+            task="audio-classification",
+            dataset=DatasetConfig(
+                path="example/audio-dataset",
+                split="test",
+                samples=1,
+                shuffle=False,
+                streaming=True,
+                columns_mapping={"label_column": "labels"},
+            ),
+        )
+
+        with (
+            patch("datasets.load_dataset", return_value=dataset),
+            patch.object(
+                Audio,
+                "encode_example",
+                side_effect=AssertionError("streaming audio must remain raw"),
+            ),
+            patch(
+                "transformers.AutoFeatureExtractor.from_pretrained",
+                return_value=_TwoInputFeatureExtractor(),
+            ),
+        ):
+            evaluator = WinMLAudioClassificationEvaluator(config, _SignClassifier())
+            assert evaluator.data[0]["audio"] == raw_audio
             metrics = evaluator.compute()
 
         assert metrics["processed_samples"] == 1

--- a/tests/unit/eval/test_audio_classification_evaluator.py
+++ b/tests/unit/eval/test_audio_classification_evaluator.py
@@ -271,6 +271,45 @@ class TestAudioPreprocessing:
         )
 
 class TestAudioLabelAlignmentAndSampling:
+    def test_embedded_audio_with_scalar_string_label_mapping(self):
+        encoded = BytesIO()
+        sf.write(encoded, np.ones(8, dtype=np.float32), 16_000, format="WAV")
+        dataset = Dataset.from_list(
+            [{"audio": {"bytes": encoded.getvalue(), "path": "clip.wav"}, "genre": "feline"}],
+            features=Features(
+                {
+                    "audio": {"bytes": Value("binary"), "path": Value("string")},
+                    "genre": Value("string"),
+                }
+            ),
+        )
+        config = WinMLEvaluationConfig(
+            model_id="example/audio-classifier",
+            task="audio-classification",
+            dataset=DatasetConfig(
+                path="example/audio-dataset",
+                split="test",
+                samples=1,
+                shuffle=False,
+                columns_mapping={"label_column": "genre"},
+                label_mapping={"feline": 0},
+            ),
+        )
+
+        with (
+            patch("datasets.load_dataset", return_value=dataset),
+            patch(
+                "transformers.AutoFeatureExtractor.from_pretrained",
+                return_value=_IdentityFeatureExtractor(),
+            ),
+        ):
+            evaluator = WinMLAudioClassificationEvaluator(config, _SignClassifier())
+            metrics = evaluator.compute()
+
+        assert evaluator.data[0].model_id == 0
+        assert metrics["processed_samples"] == 1
+        assert metrics["per_label_processed"] == {"cat": 1}
+
     def test_saved_dataset_dict_selects_requested_split(self, tmp_path):
         train = _audio_dataset(
             [{"audio": {"array": [-1.0] * 8, "sampling_rate": 16_000}, "label": 1}]

--- a/tests/unit/eval/test_eval.py
+++ b/tests/unit/eval/test_eval.py
@@ -72,12 +72,14 @@ class TestEvaluationConfig:
                 split="test",
                 samples=20,
                 columns_mapping={"label_column": "lbl"},
+                label_mapping={"blues": 3},
             ),
         )
         restored = WinMLEvaluationConfig.from_dict(config.to_dict())
         assert restored.model_id == config.model_id
         assert restored.dataset.path == config.dataset.path
         assert restored.dataset.columns_mapping == config.dataset.columns_mapping
+        assert restored.dataset.label_mapping == config.dataset.label_mapping
 
     def test_config_roundtrip_preserves_revision(self):
         """DatasetConfig.revision survives to_dict/from_dict roundtrip."""
@@ -97,6 +99,27 @@ class TestEvaluationConfig:
         ds = DatasetConfig(path="some-dataset")
         assert ds.revision is None
         assert "revision" not in ds.to_dict()
+
+    def test_dataset_config_max_duration_seconds_roundtrip(self):
+        dataset = DatasetConfig(path="audio-dataset", max_duration_seconds=2.0)
+
+        restored = WinMLEvaluationConfig.from_dict(
+            WinMLEvaluationConfig(dataset=dataset).to_dict()
+        )
+
+        assert restored.dataset.max_duration_seconds == 2.0
+        assert dataset.to_dict()["max_duration_seconds"] == 2.0
+
+    def test_dataset_config_max_duration_seconds_defaults_to_unbounded(self):
+        dataset = DatasetConfig(path="audio-dataset")
+
+        assert dataset.max_duration_seconds is None
+        assert "max_duration_seconds" not in dataset.to_dict()
+
+    @pytest.mark.parametrize("value", [0.0, -1.0, float("nan"), float("inf")])
+    def test_dataset_config_rejects_nonpositive_max_duration(self, value: float):
+        with pytest.raises(ValueError, match="finite value greater than zero"):
+            DatasetConfig(max_duration_seconds=value)
 
     def test_input_data_default_is_none(self):
         """input_data defaults to None and is omitted from to_dict."""

--- a/tests/unit/recipes/test_cpu_recipes.py
+++ b/tests/unit/recipes/test_cpu_recipes.py
@@ -18,6 +18,36 @@ recipes = [
         "path": REPO_ROOT
         / "examples"
         / "recipes"
+        / "dima806_music_genres_classification"
+        / "cpu"
+        / "cpu"
+        / "audio-classification_fp32_config.json",
+        "loader_task": "audio-classification",
+        "loader_model_class": "AutoModelForAudioClassification",
+        "loader_model_type": "wav2vec2",
+        "opset_version": 17,
+        "quant_mode": None,
+        "transformers_attention": "eager",
+    },
+    {
+        "path": REPO_ROOT
+        / "examples"
+        / "recipes"
+        / "dima806_music_genres_classification"
+        / "cpu"
+        / "cpu"
+        / "audio-classification_fp16_config.json",
+        "loader_task": "audio-classification",
+        "loader_model_class": "AutoModelForAudioClassification",
+        "loader_model_type": "wav2vec2",
+        "opset_version": 17,
+        "quant_mode": "fp16",
+        "transformers_attention": "eager",
+    },
+    {
+        "path": REPO_ROOT
+        / "examples"
+        / "recipes"
         / "audeering_wav2vec2-large-robust-12-ft-emotion-msp-dim"
         / "cpu"
         / "cpu"
@@ -48,7 +78,12 @@ recipes = [
 @pytest.mark.parametrize(
     "rec",
     recipes,
-    ids=["audeering-wav2vec2-emotion-fp32", "audeering-wav2vec2-emotion-fp16"],
+    ids=[
+        "dima806-music-genres-fp32",
+        "dima806-music-genres-fp16",
+        "audeering-wav2vec2-emotion-fp32",
+        "audeering-wav2vec2-emotion-fp16",
+    ],
 )
 def test_cpu_recipes(rec):
     path: Path = rec["path"]
@@ -66,6 +101,12 @@ def test_cpu_recipes(rec):
     # export.opset_version exact
     assert config.export is not None
     assert config.export.opset_version == rec["opset_version"]
+    assert config.export.input_tensors[0].dtype == "float32"
+    if "transformers_attention" in rec:
+        assert (
+            config.export.compatibility.transformers_attention
+            == rec["transformers_attention"]
+        )
 
     # loader routes to the emotion-regression head
     assert config.loader.task == rec["loader_task"]


### PR DESCRIPTION
## Summary

This contribution adds generalized `audio-classification` evaluation and refreshes CPU FP32/FP16 recipes for `dima806/music_genres_classification`. The L2 outcome adds task-family evaluator, configuration, CLI, and regression-test support rather than checkpoint-specific production logic. Goal L3 remains PASS for repaired candidate `caefc9ccde629d2596f26ccde41fb5dfdb5092ec` through the exact execution/reuse provenance below; the two-row result is functional-smoke evidence only, not representative accuracy or benchmark quality.

## Model metadata

### What the model does

A Wav2Vec2 music-genre classifier that accepts mono waveform samples at 16 kHz and emits ten logits for the GTZAN genres.

- Evidence/confidence: pinned checkpoint `dima806/music_genres_classification@5f71fb1e2c6bedcddb2bfb1e929fc70655780902`; its model card identifies GTZAN music genre classification, exact config selects `Wav2Vec2ForSequenceClassification` with ten `id2label` entries, exact preprocessor config sets 16,000 Hz and normalization, and the exported ONNX contract is `input_values[1,16000] -> logits[1,10]` (`verified`).

### Primary user stories

- A music catalog supplies an audio clip to obtain a genre label for recommendation, organization, discovery, or metadata enrichment (`verified` from the pinned model card).
- A broadcaster, licensing workflow, or researcher supplies recorded music to obtain a coarse genre classification for programming or analysis (`verified` from the pinned model card).

### Supported tasks

- `audio-classification` across the checkpoint, Transformers, Optimum ONNX, and WinML surfaces. The Hub pipeline tag, Optimum Wav2Vec2 vendor registry, and WinML inspect/config/build resolution agree (`verified`). Optimum already registers Wav2Vec2 audio classification; WinML adds no vendor-registry alias.

### Model architecture

```text
Wav2Vec2ForSequenceClassification
|- Wav2Vec2Model
|  |- Convolutional feature encoder x 7 (total stride 320)
|  |- Feature projection (512 -> 768)
|  |- Positional convolution embedding
|  `- Transformer encoder x 12
|     |- Self-attention (12 heads)
|     `- Feed-forward (768 -> 3072 -> 768, GELU)
|- Linear projector (768 -> 256)
|- Time mean pooling
`- Linear classifier (256 -> 10 logits)
```

- Source/confidence: exact pinned Wav2Vec2 config, Transformers 4.57.6 `Wav2Vec2ForSequenceClassification` source, a 94,571,146-parameter trace, and the exported ONNX graph (`verified`).

## Validation and support evidence

### Baseline

Baseline was current `main` commit `8d631f6f1e5db26a04e8c13045280408c6f984dc` with `winml, version 0.0.1.dev0`. Auto-config resolved `audio-classification`. CPU build passed in 61.2 s (33.7 s export, 16.4 s optimize); baseline perf was 61.63 ms mean, 62.29 ms p50, 64.19 ms p90, 16.23 samples/s, and +62.2 MB RAM. Baseline Eval failed because `audio-classification` was not registered. The observed `--no-optimize` behavior is owned separately and is not changed here. Optimum's pinned Wav2Vec2 registry already listed `audio-classification`, `audio-frame-classification`, `audio-xvector`, `automatic-speech-recognition`, and `feature-extraction`; WinML added no registry entries.

### Goal

- Effort: **L2**, a generalized task-family implementation plus exact-model recipes.
- Goal ceiling: **L3**, requiring L0 FP32/FP16 structural proof, L1 CPU perf, L2 numerical parity against pinned PyTorch, and one bounded final-SHA FP32 CPU task-metric smoke.
- Outcome: **L2**.
- Success definition: both CPU precisions build with their realized graph precision, both record perf, both preserve frozen parity bounds and top-1, and final-SHA FP32 Eval processes two semantically verified rows under explicit duration/window caps and emits accuracy and macro-F1.

### Outcome

The highest reached verdict is **L3 PASS** with full planned CPU FP32/FP16 coverage and no deferred tuples. The shipped Lane B delta contains two refreshed recipes, generalized evaluator/config/CLI registration, and regression tests. Model findings `wav2vec2-018` through `wav2vec2-022` and methodology finding `_meta-115` were published separately in Lane A PR [gim-home/ModelKitArtifacts#307](https://github.com/gim-home/ModelKitArtifacts/pull/307), head `837b125a4e60372c2b446fd8003a366645fec95a`; those skill/knowledge files are not part of this `winml-cli` change.

PR [#1388](https://github.com/microsoft/winml-cli/pull/1388) already exists as a draft with the `model-scale-by-skill` label, but it still points to prior head `95506e515042b10567c4392ada4481df079f2dfd`. Repaired candidate `caefc9ccde629d2596f26ccde41fb5dfdb5092ec` is clean and one commit ahead of the remote branch; this report does not claim it has been pushed or that the PR has been updated.

L0, L1, L2, and Analyze were executed on `4eb6900fa1857a1feaa565a3774e054e3a2f06d0`. They were first **REUSE-REBIND** evidence for `95506e515042b10567c4392ada4481df079f2dfd`, not relabeled final-SHA executions; L3 and its then-current quality gates were run fresh on `95506e515042b10567c4392ada4481df079f2dfd`. For repaired candidate `caefc9ccde629d2596f26ccde41fb5dfdb5092ec`, L0-L3, Analyze, Models, Optim, mypy, Remaining, and license evidence are again **REUSE-REBIND**, preserving those original execution SHAs. The exact `95506e515042b10567c4392ada4481df079f2dfd..caefc9ccde629d2596f26ccde41fb5dfdb5092ec` diff changes only `tests/unit/eval/test_audio_classification_evaluator.py`: it removes the mixed ONNX from-import and qualifies the same `TensorProto` and `helper` objects through `onnx`, with identical fixture graph operations, arguments, opset, IR, save behavior, and no production, recipe, dependency, artifact, or runtime-path change. Fresh repaired-head checks found no `from onnx import`, passed the import/runtime probe, passed 34 focused tests, passed Ruff, and passed Commands with 3726 tests and 9 skips.

### Per-EP/device/precision results and Functional smoke Eval

| Tier | EP / device | Precision | Verdict | Mean | p50 | Throughput | RAM delta |
|---|---|---|---|---:|---:|---:|---:|
| L0 | CPU / cpu | fp32 | PASS | - | - | - | - |
| L0 | CPU / cpu | fp16 | PASS | - | - | - | - |
| L1 | CPU / cpu | fp32 | PASS | 49.85 ms | 49.94 ms | 20.06 samples/s | +62.5 MB |
| L1 | CPU / cpu | fp16 | PASS | 59.48 ms | 59.17 ms | 16.81 samples/s | +41.3 MB |

Both L1 rows used 3 warmups and 10 measured iterations. FP16 was slower than FP32 in this short CPU run; no speed threshold applies.

**L0 structural validation.** Both artifacts passed ONNX load/checker at IR 8 and opset 17, with FP32 graph I/O `input_values[1,16000] FLOAT -> logits[1,10] FLOAT`. FP32 has 385 nodes, 276 initializers (216 FLOAT, 60 INT64), and 378,438,918 total bytes (153,862-byte model plus 378,285,056-byte external data). FP16 has 387 nodes, 276 initializers (216 FLOAT16, 60 INT64), and 189,296,375 total bytes (154,359-byte model plus 189,142,016-byte external data). This proves true FP16 initializer conversion while preserving FP32 I/O; both use eager attention and local external data.

**L2 numerical parity.** One real 1,323,632-byte WAV was decoded from mono 22,050 Hz / 661,794 frames, resampled to 16,000 Hz, reduced to 16,000 normalized samples, and supplied as `input_values[1,16000] float32` to pinned PyTorch and ONNX. Frozen FP32 bounds were cosine >= 0.9999 and maximum absolute error <= 0.01; observed cosine was 1.0, maximum absolute error `1.0371208190917969e-05`, and reference/candidate top-1 were both 6. Frozen FP16 bounds were cosine >= 0.999 and maximum absolute error <= 0.05; observed cosine was `0.9999998211860657`, maximum absolute error `0.0035549402236938477`, and reference/candidate top-1 were both 6.

**Functional smoke Eval.** This L3 run executed on `95506e515042b10567c4392ada4481df079f2dfd` and is REUSE-REBIND evidence for repaired candidate `caefc9ccde629d2596f26ccde41fb5dfdb5092ec`; it passed using FP32 ONNX Runtime CPU and pinned `danilotpnta/GTZAN_genre_classification@77564793c44e244eaff98a267bb7ba7cc1bda0b1`, config/split `gtzan/train`. Exactly 2 samples were requested, 101 eligible rows were examined, 2 were selected/decoded/processed, 4 inference windows ran, 2 samples were truncated, and 0 were rejected. The authoritative scalar labels mapped exactly and case-sensitively: `blues -> 3` and `classical -> 5`. Both embedded PCM_16 WAVs were mono 22,050 Hz with 661,794 decoded float32 frames; each was resampled to 16,000 Hz, capped at 2.0 seconds / 32,000 samples, and split into exactly two 16,000-sample windows. Mean logits were aggregated once per utterance before argmax and pinned `id2label` decoding. Predictions were `blues -> jazz` and `classical -> classical`; accuracy was **0.5** and macro-F1 was **0.5**. This proves bounded end-to-end operability only and is not representative accuracy or benchmark quality.

The evaluator supports raw audio bytes and ordinary paths, preserves virtual archive paths for `xopen`, and decodes with SoundFile without requiring TorchCodec or FFmpeg. It converts decoded float32 audio to mono, resamples to the checkpoint rate, applies optional duration and static-window caps, requires one static audio input and one rank-2 class-logits output, maps scalar labels exactly through configured metadata, and computes utterance accuracy/macro-F1 after mean-logit aggregation.

Fresh repaired-head evidence on `caefc9ccde629d2596f26ccde41fb5dfdb5092ec`: ONNX import/runtime probe **PASS** with no `from onnx import`; focused audio regressions **34 passed, 1 warning**; touched-file Ruff **PASS**; Commands **3726 passed, 9 skipped, 2 warnings**. Reused evidence retains its original execution SHA: invalidated Eval/schema/recipe tests **173 passed, 1 warning**, full Ruff and license headers PASS, L3, Analyze **1529 passed, 45 skipped**, Models **1541 passed, 7 skipped, 1 xfailed**, Optim **876 passed, 16 skipped, 1 xfailed**, and Remaining **964 passed, 2 skipped, 1 deselected** were established on `95506e515042b10567c4392ada4481df079f2dfd` or its explicitly cited source chain. Mypy remains provenance-bound at **441 files, 0 issues** on baseline and **442 files, 0 issues** on `95506e515042b10567c4392ada4481df079f2dfd`; it was not rerun or relabeled as a `caefc9ccde629d2596f26ccde41fb5dfdb5092ec` execution.

### Delta

The base-to-candidate range is `8d631f6f1e5db26a04e8c13045280408c6f984dc..caefc9ccde629d2596f26ccde41fb5dfdb5092ec`: 11 files changed, 2089 insertions(+), 3 deletions(-) across five commits. `examples/recipes/README.md` is untouched.

| File | Exact delta |
|---|---|
| `examples/recipes/dima806_music_genres_classification/cpu/cpu/audio-classification_fp32_config.json` | Refreshes `/export/compatibility/transformers_attention` from absent to `"eager"`; retains FP32 recipe semantics. |
| `examples/recipes/dima806_music_genres_classification/cpu/cpu/audio-classification_fp16_config.json` | Refreshes `/export/compatibility/transformers_attention` from absent to `"eager"`; retains FP16 recipe semantics. |
| `src/winml/modelkit/commands/eval.py` | Plumbs additive audio duration configuration through Eval CLI handling. |
| `src/winml/modelkit/eval/__init__.py` | Adds lazy export of the audio-classification evaluator. |
| `src/winml/modelkit/eval/audio_classification_evaluator.py` | Adds generalized bytes/path/virtual-path decoding, SoundFile preprocessing, mono/resampling, duration/window bounds, static-shape validation, exact label mapping, mean-logit decoding, accuracy, and macro-F1. |
| `src/winml/modelkit/eval/config.py` | Adds optional finite positive `DatasetConfig.max_duration_seconds` with null/unbounded default and label-mapping round-trip. |
| `src/winml/modelkit/eval/evaluate.py` | Registers the generalized `audio-classification` evaluator. |
| `src/winml/modelkit/utils/eval_utils.py` | Adds the audio-classification task schema and dataset/config fields. |
| `tests/unit/eval/test_audio_classification_evaluator.py` | Adds focused coverage for raw bytes, paths and virtual paths, decoding/preprocessing, caps, mappings, aggregation/metrics, and invalid model shapes; the reviewer repair normalizes ONNX imports by using `onnx.TensorProto` and `onnx.helper` exclusively. |
| `tests/unit/eval/test_eval.py` | Adds registry/config/CLI integration regressions while preserving existing tasks. |
| `tests/unit/recipes/test_cpu_recipes.py` | Refreshes exact FP32/FP16 recipe expectations. |

**Bug fix explanation.**

1. **Symptom/minimal trigger:** generalized audio Eval could reject or backend-decode valid streaming rows before SoundFile saw their raw bytes/virtual path, and the replacement public dataset's authoritative scalar `Value('string')` genre labels were rejected before configured mapping.
2. **Root cause:** the old flow did not preserve every pre-encoding bytes/path representation and restricted accepted target feature shapes too early, ahead of exact label mapping and bounded sample selection.
3. **Changed symbols/mechanism:** `WinMLAudioClassificationEvaluator`, `_AudioModelAdapter`, `DatasetConfig`, Eval registry/schema, and CLI plumbing now preserve embedded bytes or `xopen`-readable virtual paths, decode through SoundFile, normalize audio shape/rate, validate static model contracts, retain scalar string keys for explicit mapping, aggregate window logits, and emit accuracy/macro-F1.
4. **General rule:** dispatch is derived from canonical task, row media representation, model input/output metadata, feature extractor settings, and caller-supplied label mapping. The production delta adds no checkpoint ID or dataset literal.
5. **Compatibility/blast radius:** existing Eval tasks and CLI defaults remain unchanged; duration is unbounded unless explicitly capped; explicit mapping is required rather than inferred from paths or ordering; FP32/FP16 recipes preserve FP32 I/O and precision semantics. Unsupported multi-input, dynamic audio-shape, multi-head, and non-rank-2 logits models fail clearly instead of being guessed.
6. **Regression evidence:** `95506e515042b10567c4392ada4481df079f2dfd` established the pinned two-row smoke, 173 invalidated schema/recipe tests, L0-L3, Analyze, full Ruff/license, mypy, and the non-Commands partitions through the stated provenance chain. `caefc9ccde629d2596f26ccde41fb5dfdb5092ec` freshly passed the import/runtime probe with no `from onnx import`, 34 focused tests, touched-file Ruff, and Commands at 3726 passed / 9 skipped. The exact test-only alias-qualification diff has no behavior impact, so the prior model/runtime evidence is REUSE-REBIND rather than relabeled as freshly executed.

The class-wide code fix is recipe-free and metadata-driven; the recipes only record exact checkpoint/precision compatibility. Reducibility is consistent with the L2 charter.

### Analyze summary - component level and op level

Analyze was **ANALYZE-PARTIAL-SUCCESS** for both artifacts; each command exited 1 because some requested EPs had no rule data. This is static rule analysis, not runtime execution or an accelerator support claim.

#### Component-level summary

| Artifact | Architecture coverage | Mapping | Actionable EP findings |
|---|---|---|---|
| fp32 | convolutional feature encoder; feature projection; 12x encoder; projector; mean pooling; classifier | 246 mapped, 139 partial/unmapped of 385; partial confidence | No operator-rule issue; optimization removed scope from 139 fused/support nodes, which remain explicitly unmapped rather than guessed. |
| fp16 | same regions | 246 mapped, 141 partial/unmapped of 387; partial confidence | Same mapping gap, including two graph-boundary Cast nodes. |

#### Op-level summary

| Artifact | Graph | Dominant ops | Static EP roll-up |
|---|---|---|---|
| fp32 | 385 ops / 14 types | Reshape 126; Gemm 75; Transpose 51; Add 26; LayerNormalization 26 | TensorRT RTX, QNN GPU, and OpenVINO GPU rules classify all 385 supported. |
| fp16 | 387 ops / 15 types | Reshape 126; Gemm 75; Transpose 51; Add 26; LayerNormalization 26; Cast 2 | TensorRT RTX, QNN GPU, and OpenVINO GPU rules classify all 387 supported. |

CUDA, MIGraphX, legacy TensorRT, and DirectML had no loaded rule data and were skipped/unknown; that static limitation caused the nonzero Analyze status. No runtime inference was performed on those EPs.

### Reproduce commands

The commands below preserve the Tester invocations with portable variables in place of machine-local interpreter, model-cache, and output paths. `label-map.json` contains `{ "blues": 3, "classical": 5 }`.

```powershell
$PYTHON = "python"
$MODEL_ID = "dima806/music_genres_classification"
$REVISION = "5f71fb1e2c6bedcddb2bfb1e929fc70655780902"
$OUT = Join-Path $PWD "model12-output"
New-Item -ItemType Directory -Force $OUT | Out-Null

& $PYTHON -m winml.modelkit build -c examples/recipes/dima806_music_genres_classification/cpu/cpu/audio-classification_fp32_config.json -m $MODEL_ID -o "$OUT/fp32"
& $PYTHON -m winml.modelkit build -c examples/recipes/dima806_music_genres_classification/cpu/cpu/audio-classification_fp16_config.json -m $MODEL_ID -o "$OUT/fp16"

& $PYTHON -m winml.modelkit perf -m "$OUT/fp32/model.onnx" --ep cpu --device cpu --warmup 3 --iterations 10
& $PYTHON -m winml.modelkit perf -m "$OUT/fp16/model.onnx" --ep cpu --device cpu --warmup 3 --iterations 10

& $PYTHON -m winml.modelkit analyze --model "$OUT/fp32/model.onnx" --ep all --output "$OUT/analysis-fp32.json"
& $PYTHON -m winml.modelkit analyze --model "$OUT/fp16/model.onnx" --ep all --output "$OUT/analysis-fp16.json"

'{ "blues": 3, "classical": 5 }' | Set-Content -Encoding utf8 "$OUT/label-map.json"
& $PYTHON -m winml.modelkit eval -m "$OUT/fp32/model.onnx" --model-id $MODEL_ID --task audio-classification --dataset danilotpnta/GTZAN_genre_classification --dataset-name gtzan --dataset-revision 77564793c44e244eaff98a267bb7ba7cc1bda0b1 --split train --samples 2 --no-shuffle --streaming --column label_column=genre --label-mapping "$OUT/label-map.json" --max-duration-seconds 2.0 --ep cpu --device cpu --skip-build --format json -o "$OUT/l3-eval.json"

& $PYTHON -m pytest tests/unit/eval/test_audio_classification_evaluator.py tests/unit/eval/test_eval.py tests/unit/recipes/test_cpu_recipes.py -q
```

The Tester used Python 3.11.15, uv 0.12.5, Transformers 4.57.6, ONNX 1.18.0, `onnxruntime-windowsml` 1.27.1.202607110137, Datasets 5.0.1, SoundFile 0.14.0, and Torch 2.14.0 with lock digest `8353285ee649c5df37f15e8129c1bcc3d24f178e38c88dafcc18b95a16ee86d8`.