### PR TITLE
feat(eval): add audio classification evaluation and refresh Gustking deepfake recipes

### DIFF
--- a/examples/recipes/Gustking_wav2vec2-large-xlsr-deepfake-audio-classification/cpu/cpu/audio-classification_fp16_config.json
+++ b/examples/recipes/Gustking_wav2vec2-large-xlsr-deepfake-audio-classification/cpu/cpu/audio-classification_fp16_config.json
@@ -27,7 +27,10 @@
       {
         "name": "logits"
       }
-    ]
+    ],
+    "compatibility": {
+      "transformers_attention": "eager"
+    }
   },
   "optim": {},
   "quant": {

--- a/examples/recipes/Gustking_wav2vec2-large-xlsr-deepfake-audio-classification/cpu/cpu/audio-classification_fp32_config.json
+++ b/examples/recipes/Gustking_wav2vec2-large-xlsr-deepfake-audio-classification/cpu/cpu/audio-classification_fp32_config.json
@@ -27,7 +27,10 @@
       {
         "name": "logits"
       }
-    ]
+    ],
+    "compatibility": {
+      "transformers_attention": "eager"
+    }
   },
   "optim": {},
   "quant": null,

--- a/src/winml/modelkit/commands/eval.py
+++ b/src/winml/modelkit/commands/eval.py
@@ -132,6 +132,12 @@ logger = logging.getLogger(__name__)
     help="Number of dataset samples.",
 )
 @click.option(
+    "--max-duration-seconds",
+    type=click.FloatRange(min=0, min_open=True),
+    default=None,
+    help="Maximum audio duration per sample. Omitted means unbounded.",
+)
+@click.option(
     "--split",
     type=str,
     default="validation",
@@ -265,6 +271,7 @@ def eval(
     runtime: EvalRuntime,
     ep: EPNameOrAlias | None,
     samples: int,
+    max_duration_seconds: float | None,
     split: str,
     shuffle: bool,
     streaming: bool,

--- a/src/winml/modelkit/eval/__init__.py
+++ b/src/winml/modelkit/eval/__init__.py
@@ -19,6 +19,7 @@ from .evaluate import EvalResult, evaluate, get_evaluator_class
 
 
 if TYPE_CHECKING:
+    from .audio_classification_evaluator import WinMLAudioClassificationEvaluator
     from .depth_estimation_evaluator import WinMLDepthEstimationEvaluator
     from .feature_extraction_evaluator import WinMLFeatureExtractionEvaluator
     from .fill_mask_evaluator import WinMLFillMaskEvaluator
@@ -47,6 +48,9 @@ if TYPE_CHECKING:
 
 _LAZY_ATTRS: dict[str, str] = {
     # Evaluators
+    "WinMLAudioClassificationEvaluator": (
+        ".audio_classification_evaluator:WinMLAudioClassificationEvaluator"
+    ),
     "WinMLDepthEstimationEvaluator": ".depth_estimation_evaluator:WinMLDepthEstimationEvaluator",
     "WinMLFeatureExtractionEvaluator": (
         ".feature_extraction_evaluator:WinMLFeatureExtractionEvaluator"
@@ -126,6 +130,7 @@ __all__ = [
     "SpearmanCorrelationMetric",
     "TensorSimilarityEvaluator",
     "TopKAccuracyMetric",
+    "WinMLAudioClassificationEvaluator",
     "WinMLDepthEstimationEvaluator",
     "WinMLEvaluationConfig",
     "WinMLEvaluator",

--- a/src/winml/modelkit/eval/audio_classification_evaluator.py
+++ b/src/winml/modelkit/eval/audio_classification_evaluator.py
@@ -1,0 +1,533 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+"""Generalized evaluation for utterance-level audio classifiers."""
+
+from __future__ import annotations
+
+import logging
+import math
+import random
+from collections import defaultdict
+from collections.abc import Iterator, Mapping
+from copy import copy
+from dataclasses import dataclass
+from io import BytesIO
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+import numpy as np
+import torch
+from scipy.signal import resample_poly
+
+from ..utils.eval_utils import DatasetValidationError, get_default
+from .base_evaluator import WinMLEvaluator
+
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+    from ..models.winml.base import WinMLPreTrainedModel
+    from .config import DatasetConfig, WinMLEvaluationConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _SelectedAudioSample(Mapping[str, Any]):
+    model_id: int
+    row: dict[str, Any]
+
+    def __getitem__(self, key: str) -> Any:
+        return self.row[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.row)
+
+    def __len__(self) -> int:
+        return len(self.row)
+
+
+class _AudioModelAdapter:
+    """Normalize one utterance and run native HF or WinML inference."""
+
+    def __init__(self, config: WinMLEvaluationConfig, model: Any) -> None:
+        from transformers import AutoFeatureExtractor
+
+        if not config.model_id:
+            raise ValueError("model_id is required to load the audio feature extractor.")
+        self.config = config
+        self.model = model
+        self.feature_extractor = AutoFeatureExtractor.from_pretrained(
+            config.model_id,
+            trust_remote_code=config.trust_remote_code,
+        )
+        self.input_contracts = self._resolve_input_contracts()
+        self._validate_output_contract()
+        self.last_was_truncated = False
+        self.last_window_count = 0
+
+    def __call__(self, raw_audio: Any) -> NDArray[np.float32]:
+        if isinstance(raw_audio, (list, tuple, np.ndarray)):
+            waveform = np.asarray(raw_audio, dtype=np.float32)
+            sampling_rate = int(getattr(self.feature_extractor, "sampling_rate", 0))
+            if waveform.ndim != 1:
+                raise ValueError(
+                    f"pre-normalized waveform input must be 1D, got shape {waveform.shape}"
+                )
+        else:
+            waveform, sampling_rate = WinMLAudioClassificationEvaluator._decode_audio(raw_audio)
+
+        waveform = WinMLAudioClassificationEvaluator._to_mono(waveform)
+        if waveform.size == 0:
+            raise ValueError("audio waveform is empty")
+        target_rate = int(getattr(self.feature_extractor, "sampling_rate", sampling_rate))
+        if sampling_rate <= 0 or target_rate <= 0:
+            raise ValueError("audio sampling rate must be positive")
+        if sampling_rate != target_rate:
+            divisor = math.gcd(sampling_rate, target_rate)
+            waveform = resample_poly(
+                waveform,
+                target_rate // divisor,
+                sampling_rate // divisor,
+            ).astype(np.float32)
+
+        self.last_was_truncated = False
+        max_duration = self.config.dataset.max_duration_seconds
+        if max_duration is not None:
+            max_samples = max(1, int(max_duration * target_rate))
+            if waveform.size > max_samples:
+                waveform = waveform[:max_samples]
+                self.last_was_truncated = True
+
+        contract = self.input_contracts.get("input_values")
+        if contract is not None and len(contract) == 2:
+            window_length = contract[1]
+            windows = [
+                waveform[offset : offset + window_length]
+                for offset in range(0, waveform.size, window_length)
+            ]
+        else:
+            windows = [waveform]
+        self.last_window_count = len(windows)
+        return cast(
+            "NDArray[np.float32]",
+            np.mean(np.stack([self._run_window(window) for window in windows]), axis=0),
+        )
+
+    def _run_window(self, waveform: NDArray[np.float32]) -> NDArray[np.float32]:
+        target_rate = int(getattr(self.feature_extractor, "sampling_rate", 0))
+        kwargs: dict[str, Any] = {"sampling_rate": target_rate, "return_tensors": "pt"}
+        contract = self.input_contracts.get("input_values")
+        if contract is not None and len(contract) == 2:
+            kwargs.update(padding="max_length", truncation=True, max_length=contract[1])
+        encoded = self.feature_extractor(waveform, **kwargs)
+        model_inputs = self._select_model_inputs(encoded)
+        device = self.config.pipeline_device if self.config.runtime == "pytorch" else "cpu"
+        model_inputs = {
+            name: value.to(device)
+            if hasattr(value, "to")
+            else torch.as_tensor(value, device=device)
+            for name, value in model_inputs.items()
+        }
+        output = self.model(**model_inputs)
+        logits = (
+            output.get("logits")
+            if isinstance(output, dict)
+            else getattr(output, "logits", None)
+        )
+        if logits is None:
+            raise ValueError("audio-classification model output does not contain logits")
+        if hasattr(logits, "detach"):
+            logits = logits.detach().float().cpu().numpy()
+        array = np.asarray(logits, dtype=np.float32)
+        if array.ndim != 2 or array.shape[0] != 1:
+            raise ValueError(f"expected logits shape [1, classes], got {array.shape}")
+        return cast("NDArray[np.float32]", array[0])
+
+    def _resolve_input_contracts(self) -> dict[str, list[int]]:
+        io_config = getattr(self.model, "io_config", None) or {}
+        names = io_config.get("input_names") or []
+        shapes = io_config.get("input_shapes") or []
+        if not names and not shapes:
+            return {}
+        if len(names) != len(shapes) or len(names) != 1:
+            raise ValueError("audio-classification evaluation requires exactly one model input")
+        shape = list(shapes[0])
+        if len(shape) < 2 or any(not isinstance(value, int) for value in shape[1:]):
+            raise ValueError(
+                "audio-classification evaluation requires static non-batch input shapes"
+            )
+        if isinstance(shape[0], int) and shape[0] != 1:
+            raise ValueError("audio-classification evaluation requires batch size 1")
+        return {str(names[0]): [1, *(int(value) for value in shape[1:])]}
+
+    def _validate_output_contract(self) -> None:
+        io_config = getattr(self.model, "io_config", None) or {}
+        names = io_config.get("output_names") or []
+        shapes = io_config.get("output_shapes") or []
+        if not names and not shapes:
+            return
+        if names != ["logits"] or len(shapes) != 1:
+            raise ValueError("audio-classification evaluation requires exactly one 'logits' output")
+        shape = list(shapes[0])
+        if (
+            len(shape) != 2
+            or (isinstance(shape[0], int) and shape[0] != 1)
+            or not isinstance(shape[1], int)
+            or shape[1] <= 0
+        ):
+            raise ValueError("audio-classification evaluation requires logits shape [1, classes]")
+
+    def _select_model_inputs(self, encoded: Any) -> dict[str, Any]:
+        values = dict(encoded)
+        if not self.input_contracts:
+            if not values:
+                raise ValueError("audio feature extractor produced no model inputs")
+            return values
+        selected: dict[str, Any] = {}
+        for name, expected_shape in self.input_contracts.items():
+            if name not in values:
+                raise ValueError(
+                    f"audio feature extractor output must contain {name!r}; got {sorted(values)}"
+                )
+            actual_shape = list(getattr(values[name], "shape", ()))
+            if actual_shape != expected_shape:
+                raise ValueError(
+                    f"audio feature extractor produced {name} shape {actual_shape}; "
+                    f"expected {expected_shape}"
+                )
+            selected[name] = values[name]
+        return selected
+
+
+class WinMLAudioClassificationEvaluator(WinMLEvaluator):
+    """Evaluate single-label audio classifiers using accuracy and macro-F1."""
+
+    def __init__(self, config: WinMLEvaluationConfig, model: WinMLPreTrainedModel) -> None:
+        mapping = config.dataset.columns_mapping
+        self.audio_column = mapping.get(
+            "input_column", get_default("audio-classification", "input_column")
+        )
+        self.label_column = mapping.get(
+            "label_column", get_default("audio-classification", "label_column")
+        )
+        if self.audio_column is None or self.label_column is None:
+            raise DatasetValidationError(
+                "audio-classification requires input_column and label_column defaults"
+            )
+        self.eligible_count = 0
+        self.selected_count = 0
+        self.dataset_label_to_model_id: dict[int | str, int] = {}
+        self.scalar_string_target = False
+        self.model_id2label, self.model_label2id = self._model_labels(model)
+        super().__init__(config, model)
+
+    def prepare_pipeline(self) -> Any:
+        """Create the shared native-HF/WinML audio adapter."""
+        return _AudioModelAdapter(self.config, self.model)
+
+    def prepare_data(self) -> list[_SelectedAudioSample]:
+        """Load raw media, resolve exact labels, and select balanced rows."""
+        from datasets import load_dataset, load_from_disk
+
+        ds = self.config.dataset
+        try:
+            ds_path = Path(ds.path).expanduser() if ds.path else None
+            dataset = (
+                load_from_disk(str(ds_path))
+                if ds_path and ds_path.is_dir()
+                else load_dataset(
+                    ds.path,
+                    name=ds.name,
+                    split=ds.split,
+                    streaming=ds.streaming,
+                    revision=ds.revision,
+                )
+            )
+            if hasattr(dataset, "keys") and ds.split in dataset:
+                dataset = dataset[ds.split]
+            elif hasattr(dataset, "keys"):
+                raise DatasetValidationError(
+                    f"Dataset split '{ds.split}' was not found; "
+                    f"available splits: {sorted(str(key) for key in dataset)}"
+                )
+        except Exception as error:
+            if isinstance(error, DatasetValidationError):
+                raise
+            raise DatasetValidationError(
+                f"Failed to load dataset '{ds.path}' (name={ds.name!r}, split='{ds.split}'): "
+                f"{error}"
+            ) from error
+
+        self._resolve_labels(dataset, ds)
+        dataset = self._disable_backend_audio_decoding(dataset)
+        if ds.samples <= 0:
+            raise DatasetValidationError("samples must be greater than zero.")
+
+        rows_by_label: dict[int, list[_SelectedAudioSample]] = defaultdict(list)
+        rows = list(dataset) if ds.streaming else [dataset[index] for index in range(len(dataset))]
+        for row in rows:
+            raw_label = row[self.label_column]
+            key: int | str = str(raw_label) if self.scalar_string_target else int(raw_label)
+            model_id = self.dataset_label_to_model_id.get(key)
+            if model_id is None:
+                continue
+            self.eligible_count += 1
+            rows_by_label[model_id].append(_SelectedAudioSample(model_id, row))
+
+        if ds.shuffle:
+            for model_id, bucket in rows_by_label.items():
+                random.Random(ds.seed + model_id).shuffle(bucket)
+        selected: list[_SelectedAudioSample] = []
+        offsets = dict.fromkeys(rows_by_label, 0)
+        while len(selected) < ds.samples:
+            added = False
+            for model_id in sorted(rows_by_label):
+                offset = offsets[model_id]
+                if offset < len(rows_by_label[model_id]):
+                    selected.append(rows_by_label[model_id][offset])
+                    offsets[model_id] += 1
+                    added = True
+                    if len(selected) == ds.samples:
+                        break
+            if not added:
+                break
+        self.selected_count = len(selected)
+        if not selected:
+            raise DatasetValidationError(
+                "No samples remain after label filtering. Dataset and model labels have no overlap."
+            )
+        return selected
+
+    def align_labels(self, dataset: Any, ds_config: DatasetConfig) -> Any:
+        """Preserve raw labels because alignment happens before sampling."""
+        return dataset
+
+    @staticmethod
+    def _model_labels(model: Any) -> tuple[dict[int, str], dict[str, int]]:
+        config = getattr(model, "config", None)
+        raw_id2label = getattr(config, "id2label", None) or {}
+        id2label = {int(index): str(label) for index, label in raw_id2label.items()}
+        if not id2label or sorted(id2label) != list(range(len(id2label))):
+            raise DatasetValidationError(
+                "model.config.id2label must define contiguous class IDs starting at zero."
+            )
+        label2id = {label: index for index, label in id2label.items()}
+        if len(label2id) != len(id2label):
+            raise DatasetValidationError("model.config.id2label contains duplicate label names.")
+        return id2label, label2id
+
+    def _resolve_labels(self, dataset: Any, ds: DatasetConfig) -> None:
+        from datasets import ClassLabel, IterableDataset, Value
+
+        columns = set(dataset.column_names)
+        missing = [
+            column
+            for column in (self.audio_column, self.label_column)
+            if column not in columns
+        ]
+        if missing:
+            raise DatasetValidationError(
+                f"missing required column(s) {missing}; dataset has {sorted(columns)}"
+            )
+        feature = dataset.features[self.label_column]
+        if isinstance(feature, ClassLabel):
+            names = list(feature.names)
+            name_to_raw: dict[str, int | str] = {
+                name: index for index, name in enumerate(names)
+            }
+        elif isinstance(feature, Value) and feature.dtype == "string":
+            self.scalar_string_target = True
+            names = (
+                sorted((ds.label_mapping or self.model_label2id).keys())
+                if isinstance(dataset, IterableDataset)
+                else sorted({str(value) for value in dataset[self.label_column]})
+            )
+            name_to_raw = {name: name for name in names}
+        else:
+            raise DatasetValidationError(
+                f"Column '{self.label_column}' must be a ClassLabel or string Value; "
+                f"got {feature!r}."
+            )
+
+        mapping = ds.label_mapping
+        if mapping is None:
+            mapping = {
+                name: self.model_label2id[name]
+                for name in names
+                if name in self.model_label2id
+            }
+        valid_ids = set(self.model_id2label)
+        for name, model_id in mapping.items():
+            if name not in name_to_raw:
+                continue
+            target = int(model_id)
+            if target not in valid_ids:
+                raise DatasetValidationError(
+                    f"Label mapping target {target} for '{name}' is not present in "
+                    "model.config.id2label."
+                )
+            self.dataset_label_to_model_id[name_to_raw[name]] = target
+        if not self.dataset_label_to_model_id:
+            raise DatasetValidationError(
+                "No samples remain after label filtering. Dataset and model labels have no "
+                "exact overlap; provide --label-mapping with authoritative semantics."
+            )
+
+    def _disable_backend_audio_decoding(self, dataset: Any) -> Any:
+        from datasets import Audio, IterableDataset, Value
+
+        feature = dataset.features[self.audio_column]
+        if not isinstance(feature, Audio):
+            return dataset
+        if isinstance(dataset, IterableDataset):
+            dataset = copy(dataset)
+            dataset._info = dataset._info.copy()
+            dataset._info.features = None
+            return dataset
+        return dataset.cast_column(
+            self.audio_column,
+            {"bytes": Value("binary"), "path": Value("string")},
+        )
+
+    def compute(self) -> dict[str, Any]:
+        """Run one utterance prediction and report metrics plus accounting."""
+        from .metrics.classification import ClassificationMetric
+
+        predictions: list[str] = []
+        references: list[str] = []
+        selected_by_label: dict[str, int] = defaultdict(int)
+        processed_by_label: dict[str, int] = defaultdict(int)
+        confusion: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+        rejected_by_reason: dict[str, int] = defaultdict(int)
+        inference_windows = 0
+        truncated_samples = 0
+
+        adapter = cast("_AudioModelAdapter", self.pipe)
+        for selected in self.data:
+            reference = self.model_id2label[selected.model_id]
+            selected_by_label[reference] += 1
+            try:
+                logits = adapter(selected[self.audio_column])
+                prediction = self.model_id2label[int(np.argmax(logits))]
+            except (TypeError, ValueError, RuntimeError) as error:
+                rejected_by_reason[type(error).__name__] += 1
+                logger.warning("Skipping audio sample: %s", error)
+                continue
+            predictions.append(prediction)
+            references.append(reference)
+            inference_windows += adapter.last_window_count
+            truncated_samples += int(adapter.last_was_truncated)
+            processed_by_label[reference] += 1
+            confusion[reference][prediction] += 1
+
+        if not predictions:
+            raise DatasetValidationError("No audio samples were successfully processed.")
+        insufficient = {
+            label: (processed_by_label[label], min(5, selected_count))
+            for label, selected_count in selected_by_label.items()
+            if processed_by_label[label] < min(5, selected_count)
+        }
+        if insufficient:
+            details = ", ".join(
+                f"{label}={actual}/{required} required"
+                for label, (actual, required) in sorted(insufficient.items())
+            )
+            raise DatasetValidationError(
+                f"Too few usable samples after audio decoding/preprocessing: {details}."
+            )
+
+        represented = sorted(set(references))
+        result = ClassificationMetric().compute(predictions, references, represented)
+        processed = len(predictions)
+        return {
+            "accuracy": result["accuracy"],
+            "macro_f1": result["f1"],
+            "represented_classes": len(represented),
+            "total_classes": len(self.model_id2label),
+            "class_coverage": len(represented) / len(self.model_id2label),
+            "requested_samples": self.config.dataset.samples,
+            "eligible_samples": self.eligible_count,
+            "selected_samples": self.selected_count,
+            "processed_samples": processed,
+            "inference_windows": inference_windows,
+            "truncated_samples": truncated_samples,
+            "rejected_samples": self.selected_count - processed,
+            "rejected_by_reason": dict(sorted(rejected_by_reason.items())),
+            "per_label_processed": dict(sorted(processed_by_label.items())),
+            "confusion_matrix": {
+                reference: dict(sorted(values.items()))
+                for reference, values in sorted(confusion.items())
+            },
+        }
+
+    @staticmethod
+    def _decode_audio(audio: Any) -> tuple[np.ndarray, int]:
+        encoded_bytes = None
+        encoded_path = None
+        if isinstance(audio, dict):
+            if audio.get("array") is not None and audio.get("sampling_rate") is not None:
+                return np.asarray(audio["array"], dtype=np.float32), int(audio["sampling_rate"])
+            encoded_bytes = audio.get("bytes")
+            encoded_path = audio.get("path")
+            if encoded_bytes is None and not encoded_path:
+                raise ValueError(
+                    "audio dict requires array and sampling_rate, or encoded bytes/path"
+                )
+        elif isinstance(audio, (bytes, bytearray, memoryview)):
+            encoded_bytes = bytes(audio)
+        elif isinstance(audio, (str, Path)):
+            encoded_path = str(audio)
+
+        if encoded_bytes is not None or encoded_path:
+            try:
+                import soundfile as sf
+                from datasets.download.streaming_download_manager import xopen
+            except ImportError as error:
+                raise RuntimeError(
+                    "Decoding encoded audio requires the 'audio' extra "
+                    "(install winml-cli[audio])."
+                ) from error
+            try:
+                if encoded_bytes is not None:
+                    waveform, sampling_rate = sf.read(
+                        BytesIO(encoded_bytes), dtype="float32", always_2d=False
+                    )
+                else:
+                    with xopen(str(encoded_path), "rb") as source:
+                        waveform, sampling_rate = sf.read(
+                            source, dtype="float32", always_2d=False
+                        )
+            except (OSError, RuntimeError) as error:
+                raise ValueError(f"failed to decode audio: {error}") from error
+            if waveform.ndim == 2:
+                waveform = waveform.T
+            return np.asarray(waveform, dtype=np.float32), int(sampling_rate)
+
+        get_all_samples = getattr(audio, "get_all_samples", None)
+        if callable(get_all_samples):
+            decoded = get_all_samples()
+            data = getattr(decoded, "data", getattr(decoded, "samples", None))
+            rate = getattr(decoded, "sample_rate", getattr(decoded, "sampling_rate", None))
+            if data is None or rate is None:
+                raise ValueError("decoded audio does not expose samples and sampling rate")
+            if hasattr(data, "detach"):
+                data = data.detach().cpu().numpy()
+            return np.asarray(data, dtype=np.float32), int(rate)
+        raise TypeError(f"Unsupported audio value: {type(audio).__name__}")
+
+    @staticmethod
+    def _to_mono(waveform: np.ndarray) -> NDArray[np.float32]:
+        waveform = np.asarray(waveform, dtype=np.float32)
+        if waveform.ndim == 1:
+            return cast("NDArray[np.float32]", waveform)
+        if waveform.ndim != 2:
+            raise ValueError(f"audio must be 1D or 2D, got shape {waveform.shape}")
+        if waveform.shape[0] <= 8:
+            return cast("NDArray[np.float32]", waveform.mean(axis=0).astype(np.float32))
+        if waveform.shape[1] <= 8:
+            return cast("NDArray[np.float32]", waveform.mean(axis=1).astype(np.float32))
+        raise ValueError(f"cannot determine channel axis for audio shape {waveform.shape}")

--- a/src/winml/modelkit/eval/config.py
+++ b/src/winml/modelkit/eval/config.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from math import isfinite
 from pathlib import Path
 from typing import Any, Literal
 
@@ -40,6 +41,8 @@ class DatasetConfig:
             ``--output <path>`` before the dataset is loaded.
         label_mapping_file: Path to a JSON file with label mapping.
             Resolved into ``label_mapping`` at eval time.
+        max_duration_seconds: Optional positive audio duration cap. When omitted,
+            evaluators preserve the full input duration.
     """
 
     path: str | None = field(default=None, metadata={"cli_name": "dataset_path"})
@@ -54,6 +57,13 @@ class DatasetConfig:
     revision: str | None = field(default=None, metadata={"cli_name": "dataset_revision"})
     build_script: str | None = field(default=None, metadata={"cli_name": "dataset_script"})
     label_mapping_file: str | None = None
+    max_duration_seconds: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.max_duration_seconds is not None and (
+            not isfinite(self.max_duration_seconds) or self.max_duration_seconds <= 0
+        ):
+            raise ValueError("max_duration_seconds must be a finite value greater than zero.")
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for serialization."""
@@ -79,6 +89,8 @@ class DatasetConfig:
             result["build_script"] = self.build_script
         if self.label_mapping_file is not None:
             result["label_mapping_file"] = self.label_mapping_file
+        if self.max_duration_seconds is not None:
+            result["max_duration_seconds"] = self.max_duration_seconds
         return result
 
 
@@ -267,10 +279,12 @@ class WinMLEvaluationConfig:
             shuffle=ds_data.get("shuffle", True),
             seed=ds_data.get("seed", 42),
             columns_mapping=ds_data.get("columns_mapping", {}),
+            label_mapping=ds_data.get("label_mapping"),
             streaming=ds_data.get("streaming", False),
             revision=ds_data.get("revision"),
             build_script=ds_data.get("build_script"),
             label_mapping_file=ds_data.get("label_mapping_file"),
+            max_duration_seconds=ds_data.get("max_duration_seconds"),
         )
         return cls(
             model_id=data.get("model_id"),

--- a/src/winml/modelkit/eval/evaluate.py
+++ b/src/winml/modelkit/eval/evaluate.py
@@ -60,6 +60,8 @@ def _select_model_loader(config: WinMLEvaluationConfig) -> _ModelLoaderKind:
 # default formatter layout) yields >100-char lines that trip E501.
 # fmt: off
 _EVALUATOR_REGISTRY: dict[str, str] = {
+    "audio-classification":
+        "winml.modelkit.eval.audio_classification_evaluator:WinMLAudioClassificationEvaluator",
     "image-classification":
         "winml.modelkit.eval.base_evaluator:WinMLEvaluator",
     "text-classification":

--- a/src/winml/modelkit/utils/eval_utils.py
+++ b/src/winml/modelkit/utils/eval_utils.py
@@ -57,6 +57,23 @@ _IMAGE_CLASSIFICATION_SCHEMA = TaskSchema(
     ),
 )
 
+_AUDIO_CLASSIFICATION_SCHEMA = TaskSchema(
+    columns=(
+        SchemaItem(
+            "input_column",
+            "decoded audio with sampling rate, or pre-normalized 1D waveform",
+            default="audio",
+            remap_hint="<your_audio_column>",
+        ),
+        SchemaItem(
+            "label_column",
+            "audio class label (ClassLabel)",
+            default="label",
+            remap_hint="<your_label_column>",
+        ),
+    ),
+)
+
 _TEXT_CLASSIFICATION_SCHEMA = TaskSchema(
     columns=(
         SchemaItem(
@@ -449,6 +466,7 @@ _TEXT_GENERATION_SCHEMA = TaskSchema(
 )
 
 TASK_SCHEMAS: dict[str, TaskSchema] = {
+    "audio-classification": _AUDIO_CLASSIFICATION_SCHEMA,
     "image-classification": _IMAGE_CLASSIFICATION_SCHEMA,
     "text-classification": _TEXT_CLASSIFICATION_SCHEMA,
     "sequence-classification": _TEXT_CLASSIFICATION_SCHEMA,

--- a/tests/unit/eval/test_audio_classification_evaluator.py
+++ b/tests/unit/eval/test_audio_classification_evaluator.py
@@ -1,0 +1,232 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from io import BytesIO
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import torch
+
+from winml.modelkit.eval import DatasetConfig, WinMLEvaluationConfig
+from winml.modelkit.eval.audio_classification_evaluator import (
+    WinMLAudioClassificationEvaluator,
+    _AudioModelAdapter,
+)
+from winml.modelkit.utils.eval_utils import DatasetValidationError
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _model() -> MagicMock:
+    model = MagicMock()
+    model.config = SimpleNamespace(
+        id2label={0: "real", 1: "fake"},
+        label2id={"real": 0, "fake": 1},
+    )
+    model.io_config = {
+        "input_names": ["input_values"],
+        "input_shapes": [[1, 16000]],
+        "output_names": ["logits"],
+        "output_shapes": [[1, 2]],
+    }
+    return model
+
+
+def _config(**dataset_kwargs: object) -> WinMLEvaluationConfig:
+    return WinMLEvaluationConfig(
+        model_id="test/audio-classifier",
+        task="audio-classification",
+        dataset=DatasetConfig(path="test/audio", shuffle=False, **dataset_kwargs),
+    )
+
+
+def test_dataset_config_roundtrip_preserves_audio_options() -> None:
+    config = _config(
+        label_mapping={"bonafide": 0, "spoof": 1},
+        max_duration_seconds=2.0,
+    )
+
+    restored = WinMLEvaluationConfig.from_dict(config.to_dict())
+
+    assert restored.dataset.label_mapping == {"bonafide": 0, "spoof": 1}
+    assert restored.dataset.max_duration_seconds == 2.0
+
+
+@pytest.mark.parametrize("value", [0.0, -1.0, float("inf"), float("nan")])
+def test_dataset_config_rejects_invalid_duration(value: float) -> None:
+    with pytest.raises(ValueError, match="finite value greater than zero"):
+        DatasetConfig(max_duration_seconds=value)
+
+
+def test_decode_audio_supports_flac_bytes_and_path(tmp_path: Path) -> None:
+    import soundfile as sf
+
+    waveform = np.linspace(-0.5, 0.5, 800, dtype=np.float32)
+    buffer = BytesIO()
+    sf.write(buffer, waveform, 16000, format="FLAC")
+    encoded = buffer.getvalue()
+    path = tmp_path / "sample.flac"
+    path.write_bytes(encoded)
+
+    decoded_bytes, bytes_rate = WinMLAudioClassificationEvaluator._decode_audio(encoded)
+    decoded_path, path_rate = WinMLAudioClassificationEvaluator._decode_audio(str(path))
+
+    assert bytes_rate == path_rate == 16000
+    np.testing.assert_allclose(decoded_bytes, decoded_path)
+    assert decoded_bytes.shape == (800,)
+
+
+def test_adapter_resamples_stereo_caps_windows_and_averages_logits() -> None:
+    feature_extractor = MagicMock()
+    feature_extractor.sampling_rate = 16000
+    seen: list[np.ndarray] = []
+
+    def encode(waveform: np.ndarray, **_kwargs: object) -> dict[str, torch.Tensor]:
+        seen.append(np.asarray(waveform))
+        padded = np.pad(waveform, (0, 16000 - len(waveform)))
+        return {"input_values": torch.from_numpy(padded[None, :].astype(np.float32))}
+
+    feature_extractor.side_effect = encode
+    model = _model()
+    model.side_effect = [
+        {"logits": torch.tensor([[2.0, 0.0]])},
+        {"logits": torch.tensor([[0.0, 4.0]])},
+    ]
+    config = _config(max_duration_seconds=2.0)
+    stereo = np.stack([
+        np.linspace(-1.0, 1.0, 44100 * 3, dtype=np.float32),
+        np.linspace(1.0, -1.0, 44100 * 3, dtype=np.float32),
+    ])
+
+    with patch(
+        "transformers.AutoFeatureExtractor.from_pretrained",
+        return_value=feature_extractor,
+    ):
+        adapter = _AudioModelAdapter(config, model)
+        logits = adapter({"array": stereo, "sampling_rate": 44100})
+
+    np.testing.assert_allclose(logits, [1.0, 2.0])
+    assert [len(window) for window in seen] == [16000, 16000]
+    assert adapter.last_window_count == 2
+    assert adapter.last_was_truncated is True
+
+
+def test_prepare_data_preserves_metadata_and_balances_exact_classlabels() -> None:
+    from datasets import Audio, ClassLabel, Dataset, Features, Value
+
+    features = Features({
+        "audio": {"bytes": Value("binary"), "path": Value("string")},
+        "label": ClassLabel(names=["real", "fake", "other"]),
+        "archive_member": Value("string"),
+    })
+    dataset = Dataset.from_dict(
+        {
+            "audio": [
+                {"bytes": b"real", "path": "archive.zip::real.flac"},
+                {"bytes": b"fake", "path": "archive.zip::fake.flac"},
+                {"bytes": b"other", "path": "archive.zip::other.flac"},
+            ],
+            "label": [0, 1, 2],
+            "archive_member": ["real.flac", "fake.flac", "other.flac"],
+        },
+        features=features,
+    ).cast_column("audio", Audio(decode=False))
+    evaluator = WinMLAudioClassificationEvaluator.__new__(WinMLAudioClassificationEvaluator)
+    evaluator.config = _config(samples=2)
+    evaluator.model = _model()
+    evaluator.audio_column = "audio"
+    evaluator.label_column = "label"
+    evaluator.eligible_count = 0
+    evaluator.selected_count = 0
+    evaluator.dataset_label_to_model_id = {}
+    evaluator.scalar_string_target = False
+    evaluator.model_id2label, evaluator.model_label2id = evaluator._model_labels(evaluator.model)
+
+    with patch("datasets.load_dataset", return_value=dataset):
+        selected = evaluator.prepare_data()
+
+    assert [sample.model_id for sample in selected] == [0, 1]
+    assert [sample["archive_member"] for sample in selected] == ["real.flac", "fake.flac"]
+    assert evaluator.eligible_count == 2
+    assert evaluator.selected_count == 2
+
+
+def test_string_targets_require_exact_or_explicit_mapping() -> None:
+    from datasets import Dataset
+
+    dataset = Dataset.from_dict({
+        "audio": [np.zeros(10, dtype=np.float32), np.ones(10, dtype=np.float32)],
+        "label": ["bonafide", "spoof"],
+    })
+    evaluator = WinMLAudioClassificationEvaluator.__new__(WinMLAudioClassificationEvaluator)
+    evaluator.audio_column = "audio"
+    evaluator.label_column = "label"
+    evaluator.model = _model()
+    evaluator.model_id2label, evaluator.model_label2id = evaluator._model_labels(evaluator.model)
+    evaluator.dataset_label_to_model_id = {}
+    evaluator.scalar_string_target = False
+
+    with pytest.raises(DatasetValidationError, match="no exact overlap"):
+        evaluator._resolve_labels(dataset, DatasetConfig())
+
+    evaluator._resolve_labels(
+        dataset,
+        DatasetConfig(label_mapping={"bonafide": 0, "spoof": 1}),
+    )
+    assert evaluator.dataset_label_to_model_id == {"bonafide": 0, "spoof": 1}
+
+
+def test_compute_reports_metrics_and_bounded_accounting() -> None:
+    evaluator = WinMLAudioClassificationEvaluator.__new__(WinMLAudioClassificationEvaluator)
+    evaluator.config = _config(samples=2, max_duration_seconds=2.0)
+    evaluator.model_id2label = {0: "real", 1: "fake"}
+    evaluator.eligible_count = 2
+    evaluator.selected_count = 2
+    evaluator.audio_column = "audio"
+    adapter = MagicMock(side_effect=[np.array([3.0, 1.0]), np.array([0.0, 2.0])])
+    adapter.last_window_count = 1
+    adapter.last_was_truncated = False
+    evaluator.pipe = adapter
+
+    # SimpleNamespace special methods are resolved on the type, so use mappings here.
+    evaluator.data = [
+        type("Selected", (), {"model_id": 0, "__getitem__": lambda self, key: [0.0]})(),
+        type("Selected", (), {"model_id": 1, "__getitem__": lambda self, key: [1.0]})(),
+    ]
+    metrics = evaluator.compute()
+
+    assert metrics["accuracy"] == 1.0
+    assert metrics["macro_f1"] == 1.0
+    assert metrics["requested_samples"] == metrics["processed_samples"] == 2
+    assert metrics["inference_windows"] == 2
+    assert metrics["rejected_samples"] == 0
+    assert metrics["confusion_matrix"] == {"fake": {"fake": 1}, "real": {"real": 1}}
+
+
+def test_compute_fails_closed_when_a_selected_class_cannot_decode() -> None:
+    evaluator = WinMLAudioClassificationEvaluator.__new__(WinMLAudioClassificationEvaluator)
+    evaluator.config = _config(samples=2)
+    evaluator.model_id2label = {0: "real", 1: "fake"}
+    evaluator.eligible_count = 2
+    evaluator.selected_count = 2
+    evaluator.audio_column = "audio"
+    evaluator.data = [
+        type("Selected", (), {"model_id": 0, "__getitem__": lambda self, key: [0.0]})(),
+        type("Selected", (), {"model_id": 1, "__getitem__": lambda self, key: [1.0]})(),
+    ]
+    adapter = MagicMock(side_effect=[np.array([3.0, 1.0]), ValueError("bad audio")])
+    adapter.last_window_count = 1
+    adapter.last_was_truncated = False
+    evaluator.pipe = adapter
+
+    with pytest.raises(DatasetValidationError, match="fake=0/1 required"):
+        evaluator.compute()

--- a/tests/unit/recipes/test_cpu_recipes.py
+++ b/tests/unit/recipes/test_cpu_recipes.py
@@ -42,13 +42,46 @@ recipes = [
         "opset_version": 17,
         "quant_mode": "fp16",
     },
+    {
+        "path": REPO_ROOT
+        / "examples"
+        / "recipes"
+        / "Gustking_wav2vec2-large-xlsr-deepfake-audio-classification"
+        / "cpu"
+        / "cpu"
+        / "audio-classification_fp32_config.json",
+        "loader_task": "audio-classification",
+        "loader_model_class": "AutoModelForAudioClassification",
+        "loader_model_type": "wav2vec2",
+        "opset_version": 17,
+        "quant_mode": None,
+    },
+    {
+        "path": REPO_ROOT
+        / "examples"
+        / "recipes"
+        / "Gustking_wav2vec2-large-xlsr-deepfake-audio-classification"
+        / "cpu"
+        / "cpu"
+        / "audio-classification_fp16_config.json",
+        "loader_task": "audio-classification",
+        "loader_model_class": "AutoModelForAudioClassification",
+        "loader_model_type": "wav2vec2",
+        "opset_version": 17,
+        "quant_mode": "fp16",
+    },
 ]
 
 
 @pytest.mark.parametrize(
     "rec",
     recipes,
-    ids=["audeering-wav2vec2-emotion-fp32", "audeering-wav2vec2-emotion-fp16"],
+    ids=[
+        "audeering-wav2vec2-emotion-fp32",
+        "audeering-wav2vec2-emotion-fp16",
+        "gustking-wav2vec2-deepfake-fp32",
+        "gustking-wav2vec2-deepfake-fp16",
+    ],
 )
 def test_cpu_recipes(rec):
     path: Path = rec["path"]
@@ -71,6 +104,13 @@ def test_cpu_recipes(rec):
     assert config.loader.task == rec["loader_task"]
     assert config.loader.model_class == rec["loader_model_class"]
     assert config.loader.model_type == rec["loader_model_type"]
+
+    if rec["loader_model_class"] == "AutoModelForAudioClassification":
+        assert config.export.input_tensors[0].name == "input_values"
+        assert config.export.input_tensors[0].shape == (1, 16000)
+        assert config.export.input_tensors[0].value_range == (-1, 1)
+        assert config.export.output_tensors[0].name == "logits"
+        assert config.export.compatibility.transformers_attention == "eager"
 
     if rec["quant_mode"] is None:
         assert config.quant is None


### PR DESCRIPTION
# Summary

This L2 contribution adds generalized `audio-classification` Eval support and refreshes the existing FP32 and FP16 CPU recipes for `Gustking/wav2vec2-large-xlsr-deepfake-audio-classification`. It enables bounded, semantically checked real-versus-fake audio evaluation while preserving exact recipe tuple identities. Candidate `c76c0eff5c99dd9fddfbd550e19dd91d3776a058` reached Goal L3 PASS with full coverage and no deferred tuples; the shipped Outcome remains L2.

# Model metadata

## What the model does

This checkpoint accepts speech waveforms and emits two sequence-classification logits interpreted as real human speech or fake/synthetic speech for deepfake-audio detection. Evidence: the pinned config declares `Wav2Vec2ForSequenceClassification` and `id2label={0: real, 1: fake}`; the pinned model card states deepfake audio classification and reports ASVspoof2019 evaluation; and the graph is `input_values[1,16000] -> logits[1,2]`. Confidence: `verified`.

## Primary user stories

- A user supplies a speech recording to obtain real-versus-fake logits for screening synthetic or manipulated audio. Evidence: pinned model-card purpose and real/fake label map. Confidence: `verified`.

## Supported tasks

- `audio-classification` across checkpoint, Transformers, and WinML support surfaces. Evidence: Hub `pipeline_tag=audio-classification`, Transformers `AutoModelForAudioClassification`, and WinML inspect resolving `audio-classification` with `Wav2Vec2OnnxConfig`. Confidence: `verified`.

## Model architecture

```text
Wav2Vec2ForSequenceClassification
|-- Wav2Vec2Model
|   |-- Convolutional feature encoder x7 (channels 512)
|   |-- Feature projection (512 -> 1024)
|   `-- Stable-LayerNorm encoder stack x24
|       |-- Self-attention (16 heads, hidden 1024)
|       `-- Feed-forward (1024 -> 4096 -> 1024, GELU)
|-- Projector (1024 -> 256)
|-- Temporal mean pooling
`-- Classifier (256 -> 2: real, fake)
```

- Source/confidence: pinned checkpoint `Gustking/wav2vec2-large-xlsr-deepfake-audio-classification@f7050b586236dc910d1157f430def2d0647b02b4`, pinned config dimensions, Transformers `Wav2Vec2ForSequenceClassification` source, and hierarchy metadata (409 modules, 315,701,634 parameters, 118 traced modules); `verified`.

# Validation and support evidence

## Baseline

- Authoritative base is `main` at `be3e59dd412d4918c5a852aa4d8f0207c34aaf6f`, WinML `0.0.1.dev0`. Main advanced from `8d631f6f1e5db26a04e8c13045280408c6f984dc`; Planner issued a fail-closed PARTIAL-RERUN because `src/winml/modelkit/__init__.py` changed ONNX Runtime initialization and its paired test was deleted.
- Planner reused only the frozen model profile, inspect/config diagnosis, dataset selection and semantics, and E/G/O scope. The previous baseline measured build PASS in 156.0 s for `Wav2Vec2ForSequenceClassification`, 315.7M parameters, with FLOAT `input_values[1,16000] -> logits[1,2]`; perf mean 139.492 ms, p50 134.010 ms, throughput 7.17 samples/s, total RSS delta 91.05 MB; and pinned-PyTorch parity cosine 0.9999999985074244, maximum absolute error 0.000011314637959003448, top-1 match. These baseline measurements remain explicitly bound to the prior main evidence commit and are not presented as current-candidate results.
- Auto-config resolved `audio-classification`, `AutoModelForAudioClassification`, and `transformers_attention=eager`. Optimum 2 had no vendor Wav2Vec2 registrations until WinML registration; verdict `WINML-ONLY`.
- Baseline Eval was CLI-BLOCKED before dataset loading because `audio-classification` was absent from WinML Eval. Baseline Analyze was CLI-BLOCKED because runtime rule Parquets were absent; an independent graph census found 873 nodes / 14 op types, dominated by Add=227, MatMul=194, Transpose=111, Reshape=96, and Mul=88.
- The candidate patch remained equivalent after rebase, but package-level runtime reach invalidated build, perf, parity, Eval, Analyze, and quality evidence. Tester freshly reran that complete closure on `c76c0eff5c99dd9fddfbd550e19dd91d3776a058`; no superseded-candidate measurement is used below.

## Goal

- Effort: L2.
- Committed Goal ceiling: L3, marching through build, perf, pinned-PyTorch numeric parity, and bounded task-metric functional smoke.
- Outcome: L2, comprising generalized task-family evaluator support, regression coverage, and target recipe refreshes.
- Success required both CPU/cpu precisions to pass L0 build, L1 perf, and L2 parity, plus one final-candidate FP32 CPU L3 functional smoke with exact dataset/checkpoint semantics and bounded fan-out. No replacement ceiling was issued.

## Outcome

- Shipped tier: L2. Highest Goal verdict: L3 PASS. Coverage: full. Deferred tuples: none.
- Candidate: `c76c0eff5c99dd9fddfbd550e19dd91d3776a058`; tree `c2beedf4dee41579cd4323f43934be761daca897`; base `be3e59dd412d4918c5a852aa4d8f0207c34aaf6f`.
- Shared generalized support is isolated in droppable commit `bf781055f334676ba8dc6af6981347d48b866792`; target-only recipe refresh and recipe regression coverage are isolated in `c76c0eff5c99dd9fddfbd550e19dd91d3776a058`.
- Refreshed Learner findings `wav2vec2-027..030` capture artifact/architecture facts, CPU precision tradeoffs, exact bounded real/fake semantics, and static Analyze interpretation. They are published separately in Lane A draft PR #312 at head `8d010b1dbc646b41aabf006a57b15b231bbba32a`.
- Draft PRs #1388 and #1389 were open, draft, and unmerged at the last authoritative check. This branch is independently based on current main and does not stack on either. The two-commit split makes overlap removal mechanical: `bf781055` owns shared evaluator support, while `c76c0eff` owns only the Model14 recipes and recipe regression. If either PR merges before shipment or review, stop; Planner must rebase and compare the merged implementation, drop or reconcile `bf781055`, retain/rebase the target-only commit only when still needed, and route every impacted stage back to Tester before this body may be used.

## Per-EP/device/precision results and Functional smoke Eval

| Tier | EP / Device | Precision | Verdict | Mean | p50 | Throughput | RAM delta |
|---|---|---|---|---:|---:|---:|---:|
| L0 | CPUExecutionProvider / cpu | fp32 | PASS | - | - | - | - |
| L0 | CPUExecutionProvider / cpu | fp16 | PASS | - | - | - | - |
| L1 | CPUExecutionProvider / cpu | fp32 | PASS | 148.523 ms | 152.364 ms | 6.73 samples/s | +91.23 MB |
| L1 | CPUExecutionProvider / cpu | fp16 | PASS | 162.778 ms | 163.186 ms | 6.14 samples/s | +43.45 MB |
| L2 | CPUExecutionProvider / cpu | fp32 | PASS | - | - | - | - |
| L2 | CPUExecutionProvider / cpu | fp16 | PASS | - | - | - | - |
| L3 | CPUExecutionProvider / cpu | fp32 | PASS | - | - | - | - |

### L0 artifact and graph signatures

- FP32: ONNX 293,409 bytes plus external data 1,262,801,920 bytes; initializers FLOAT=425 and INT64=11. Input `input_values` FLOAT `[1,16000]`; output `logits` FLOAT `[1,2]`; CPUExecutionProvider output `[1,2]` was finite.
- FP16: ONNX 293,716 bytes plus external data 631,400,448 bytes; initializers FLOAT16=425 and INT64=11; FP16/FP32 external-data ratio 0.4999995945524061. I/O remains FP32: `input_values` FLOAT `[1,16000]` and `logits` FLOAT `[1,2]`; CPUExecutionProvider output `[1,2]` was finite.

### L1 memory details

- FP32: RSS baseline 1689.14 MB; after compile 1689.45 MB; after inference and checkpoint peak 1780.38 MB; model-load delta 0.30 MB; inference delta 90.93 MB; total delta 91.23 MB. Local/shared VRAM baseline, after compile, after inference, checkpoint peak, and all load/inference/total deltas were 0.0 MB.
- FP16: RSS baseline 1746.40 MB; after compile 1746.70 MB; after inference and checkpoint peak 1789.86 MB; model-load delta 0.30 MB; inference delta 43.15 MB; total delta 43.45 MB. Local/shared VRAM baseline, after compile, after inference, checkpoint peak, and all load/inference/total deltas were 0.0 MB.

### L2 numeric parity

- FP32 PASS: cosine 0.9999999983582369; maximum absolute error 0.000011951662600040436; reference logits `[0.008207489736378193, -0.007818397134542465]`; ONNX logits `[0.008219093084335327, -0.007830348797142506]`; reference and ONNX class 0 (`real`). Bounds: cosine >= 0.99999, maximum absolute error <= 0.001, predicted-class match required. Provider: CPUExecutionProvider; input `input_values` `[1,16000]` `tensor(float)`.
- FP16 PASS: cosine 0.9999545270207585; maximum absolute error 0.002589728683233261; reference logits `[0.008207489736378193, -0.007818397134542465]`; ONNX logits `[0.010719520039856434, -0.010408125817775726]`; reference and ONNX class 0 (`real`). Bounds: cosine >= 0.999, maximum absolute error <= 0.02, predicted-class match required. Provider: CPUExecutionProvider; input `input_values` `[1,16000]` `tensor(float)`.

### Functional smoke Eval

FP32 CPU Eval PASS on candidate `c76c0eff5c99dd9fddfbd550e19dd91d3776a058` using public, ungated CC-BY-4.0 dataset `garystafford/deepfake-audio-detection@fcf5344bb7f82b54b6b932291326d29750ef1e82`, config `default`, split `train`, with deterministic first usable row per ClassLabel. Dataset and checkpoint labels matched exactly as raw scalar/ClassLabel IDs: `0=real`, `1=fake`; media came from embedded FLAC bytes/path and was decoded with SoundFile rather than inferred from filenames.

The selected real row was `yt_0000_p2_part_167.flac`: 477,353 bytes, 44,100 Hz, stereo, 230,951 frames, 5.236984126984127 seconds. The selected fake row was `el_0001_c_part_002.flac`: 131,470 bytes, 16,000 Hz, mono, 57,792 frames, 3.612 seconds.

Accounting was exact: scan 934, eligible 1,866, selected 2, processed 2, inference windows 4, truncated 2, rejected 0. Each utterance was converted to mono, resampled to 16,000 Hz, normalized through the feature extractor, capped at 2 seconds / 32,000 samples, split into at most two 16,000-sample windows, and reduced once per utterance by arithmetic mean of window logits; total inference was capped at 4 windows. Targets and predictions were `real -> real` once and `fake -> fake` once. Accuracy was 1.0 and macro-F1 was 1.0, with 2/2 represented classes and class coverage 1.0.

This is functional-smoke evidence of end-to-end operability only. Two selected utterances are not representative accuracy or benchmark-quality evidence, and no Eval accuracy claim is made for FP16 or another EP.

### Quality gates

- Focused: 15 passed in 23.02 s.
- Affected Eval/recipe partitions: 678 passed, 1 warning in 64.63 s (0:01:04).
- Analyze: 1,529 passed, 45 skipped in 334.89 s (0:05:34).
- Models: 1,541 passed, 7 skipped, 1 xfailed in 63.26 s (0:01:03).
- Optim: 876 passed, 16 skipped, 1 xfailed in 54.88 s.
- Commands/config/build/compiler/session/Eval: 3,697 passed, 9 skipped, 2 warnings in 343.79 s (0:05:43).
- Remaining core/ONNX/cache/utils/helpers/sysinfo/inspect/optracing/serve/regression/CLI: 964 passed, 2 skipped, 1 deselected, 1 warning in 639.74 s (0:10:39).
- Partition marker exclusions: `not e2e and not npu and not gpu`.
- Mypy baseline parent and candidate each reported `Success: no issues found in 442 source files`; both also noted unused pyproject sections for `onnxruntime_genai.*`, `openvino.*`, `tests`, and `tests.*`.
- Ruff: PASS. License: PASS.

## Delta

### Recipe refresh

Both existing exact-tuple recipe files change only JSON pointer `/export/compatibility/transformers_attention` from `null` to `"eager"`:

- `examples/recipes/Gustking_wav2vec2-large-xlsr-deepfake-audio-classification/cpu/cpu/audio-classification_fp16_config.json`.
- `examples/recipes/Gustking_wav2vec2-large-xlsr-deepfake-audio-classification/cpu/cpu/audio-classification_fp32_config.json`.

The delta is reducibility-consistent with the charter. Recipe authority was verified without recipe-owned CLI overrides. The production `examples/recipes/README.md` remains untouched.

### Complete changed paths

Droppable shared evaluator commit `bf781055f334676ba8dc6af6981347d48b866792`:

- `src/winml/modelkit/commands/eval.py`
- `src/winml/modelkit/eval/__init__.py`
- `src/winml/modelkit/eval/audio_classification_evaluator.py`
- `src/winml/modelkit/eval/config.py`
- `src/winml/modelkit/eval/evaluate.py`
- `src/winml/modelkit/utils/eval_utils.py`
- `tests/unit/eval/test_audio_classification_evaluator.py`

Target-only commit `c76c0eff5c99dd9fddfbd550e19dd91d3776a058`:

- `examples/recipes/Gustking_wav2vec2-large-xlsr-deepfake-audio-classification/cpu/cpu/audio-classification_fp16_config.json`
- `examples/recipes/Gustking_wav2vec2-large-xlsr-deepfake-audio-classification/cpu/cpu/audio-classification_fp32_config.json`
- `tests/unit/recipes/test_cpu_recipes.py`

No other-model recipe, recipe README, or checkpoint-hardcoded behavior is included.

### Bug fix explanation

1. **User-visible symptom and trigger:** baseline `winml eval --task audio-classification` failed before dataset loading because the task was absent from the Eval registry; an explicit audio dataset and a standard single-logits audio classifier were sufficient to trigger the missing path.
2. **Root cause:** Eval had no audio-classification registry/schema entry, raw-media adapter, waveform preprocessing/window aggregation, exact target mapping, prediction decoder, or classification metric path. Existing evaluators could not safely reinterpret raw audio rows or preserve their label semantics.
3. **Changed symbols and mechanism:** `WinMLAudioClassificationEvaluator`, `_AudioModelAdapter`, `DatasetConfig.max_duration_seconds`, `_EVALUATOR_REGISTRY`, and `TASK_SCHEMAS` add raw bytes/path decoding, mono conversion, rational resampling, feature-extractor normalization, bounded static windows, utterance-mean logits, exact scalar/ClassLabel mapping, predictions, accuracy/macro-F1, errors, and accounting.
4. **General/data-driven rule:** activation is derived from `task=audio-classification`, one static audio input, and one rank-2 `[batch,classes]` logits output. Dataset/checkpoint label namespaces must match exactly. No checkpoint ID, filename, model-specific recipe, or positional-label inference controls evaluator behavior.
5. **Compatibility and blast radius:** existing Eval tasks, schemas, mappings, and metrics remain unchanged; audio evaluation requires an explicit semantically compatible dataset and introduces no universal default. Runtime/decode errors still fail, malformed rows are counted, zero processed rows fails closed, and the only intentional public change is support for explicit-dataset audio classification. Existing Gustking tuple identities remain unchanged except for derived attention compatibility metadata.
6. **Regression evidence:** focused audio tests passed 15/15; affected Eval/recipe tests passed 678 with 1 warning; all listed quality partitions passed; both FP32/FP16 build, perf, and parity tuples passed; and the FP32 bounded functional smoke processed exact raw real/fake rows with 1.0 accuracy and macro-F1.

## Analyze summary - component level and op level

Analyze completed with `ANALYZE-PARTIAL-SUCCESS` and exit code 1 for each artifact because four requested EPs had no shipped rule data. This is static rule compatibility analysis, not accelerator runtime execution.

### Component-level summary

| Artifact | Architecture coverage | Mapping | Actionable EP findings |
|---|---|---:|---|
| FP32 | convolutional feature encoder; feature projection; 24-layer stable-LayerNorm encoder; projector; temporal mean pool; real/fake classifier | 747/747 mapped, 0 unmapped | None in rule-backed data |
| FP16 | same regions | 748/749 mapped, 1 unmapped (`graph_input_cast0`) | No rule-backed op issue; one input-Cast component-mapping gap |

Mapping confidence is `mapped`. FP16 has 749 graph operators but 748 mapped component nodes: its classifier region includes one Cast, while the separate graph-input Cast remains unmapped. That gap is retained rather than promoted to full component coverage.

### Op-level summary

| Artifact | Graph | Dominant operators | Rule-backed EP roll-up |
|---|---|---|---|
| FP32 | 747 operators / 13 unique types | Reshape 244; Gemm 147; Transpose 111; LayerNormalization 57; Add 49 | NvTensorRTRTX, QNN, and OpenVINO: all 13 types supported; no partial, unsupported, or unknown types |
| FP16 | 749 operators / 14 unique types | Reshape 244; Gemm 147; Transpose 111; LayerNormalization 57; Add 49; Cast 2 | NvTensorRTRTX, QNN, and OpenVINO: all 14 types supported; no partial, unsupported, or unknown types |

The complete FP32 inventory is Unsqueeze 1, Conv 8, Transpose 111, LayerNormalization 57, Gelu 32, Reshape 244, Gemm 147, Slice 1, Add 49, MatMul 48, Mul 24, Softmax 24, and ReduceMean 1. FP16 adds Cast 2.

CUDAExecutionProvider, MIGraphXExecutionProvider, TensorrtExecutionProvider, and DmlExecutionProvider have no check results because no rule data is shipped for them. These are absent-rule results, not unsupported operators, and they provide no runtime-support claim.

## Reproduce commands

```powershell
$OUT='temp/gustking-wav2vec2-deepfake'
python -m winml.modelkit.cli build -c examples/recipes/Gustking_wav2vec2-large-xlsr-deepfake-audio-classification/cpu/cpu/audio-classification_fp32_config.json -m Gustking/wav2vec2-large-xlsr-deepfake-audio-classification -o $OUT/fp32
python -m winml.modelkit.cli build -c examples/recipes/Gustking_wav2vec2-large-xlsr-deepfake-audio-classification/cpu/cpu/audio-classification_fp16_config.json -m Gustking/wav2vec2-large-xlsr-deepfake-audio-classification -o $OUT/fp16
python -m winml.modelkit.cli perf -m $OUT/fp32/model.onnx --ep cpu --device cpu --iterations 10 --warmup 3
python -m winml.modelkit.cli perf -m $OUT/fp16/model.onnx --ep cpu --device cpu --iterations 10 --warmup 3
python -m winml.modelkit.cli analyze --model $OUT/fp32/model.onnx --ep all --output $OUT/analyze-fp32.json
python -m winml.modelkit.cli analyze --model $OUT/fp16/model.onnx --ep all --output $OUT/analyze-fp16.json
python -m winml.modelkit.cli eval -m $OUT/fp32/model.onnx --model-id Gustking/wav2vec2-large-xlsr-deepfake-audio-classification --dataset garystafford/deepfake-audio-detection --dataset-name default --dataset-revision fcf5344bb7f82b54b6b932291326d29750ef1e82 --task audio-classification --device cpu --ep cpu --samples 2 --max-duration-seconds 2 --split train --no-shuffle --output $OUT/eval-fp32.json
```