### PR TITLE
fix(export): support LayoutLM QA and BLIP decoder

### DIFF
--- a/src/winml/modelkit/models/hf/__init__.py
+++ b/src/winml/modelkit/models/hf/__init__.py
@@ -48,6 +48,7 @@ from .convnext import ConvNextIOConfig as _ConvNextIOConfig  # triggers registra
 from .depth_anything import DepthAnythingIOConfig as _DepthAnythingIOConfig  # triggers registration
 from .depth_pro import DepthProIOConfig as _DepthProIOConfig  # triggers registration
 from .detr import DETR_CONFIG
+from .layoutlm import MODEL_CLASS_MAPPING as _LAYOUTLM_CLASS_MAPPING
 from .layoutlm import LayoutLMQAIOConfig as _LayoutLMQAIOConfig  # triggers registration
 from .layoutlmv3 import LAYOUTLMV3_CONFIG
 from .layoutlmv3 import LayoutLMv3IOConfig as _LayoutLMv3IOConfig  # triggers registration
@@ -132,6 +133,7 @@ MODEL_CLASS_MAPPING: dict[tuple[str, str | None], type] = {
         _BART_CLASS_MAPPING,
         _BLIP_CLASS_MAPPING,
         _CLIP_CLASS_MAPPING,
+        _LAYOUTLM_CLASS_MAPPING,
         _MARIAN_CLASS_MAPPING,
         _MU2_CLASS_MAPPING,
         _QWEN_CLASS_MAPPING,

--- a/src/winml/modelkit/models/hf/blip.py
+++ b/src/winml/modelkit/models/hf/blip.py
@@ -265,15 +265,13 @@ class BlipDecoderWrapper(WinMLDecoderWrapper):
             dtype=torch.long,
             device=encoder_hidden_states.device,
         )
-        decoder_mask = (1 - inputs["decoder_attention_mask"]).to(dtype=encoder_hidden_states.dtype)
-        decoder_mask = decoder_mask.unsqueeze(1).unsqueeze(1)
-        decoder_mask = decoder_mask * torch.finfo(encoder_hidden_states.dtype).min
+        decoder_mask = inputs["decoder_attention_mask"].unsqueeze(1)
         # self.model is nn.Module; torch's __getattr__ types text_decoder as
         # Tensor | Module, so narrow to a callable Module.
         outputs = cast("nn.Module", self.model.text_decoder)(
             input_ids=inputs["decoder_input_ids"],
             # HF's causal-mask reconstruction traces as ops the NPU analyzer
-            # doesn't support; pass an additive 4-D mask to bypass reconstruction.
+            # doesn't support; pass a 3-D mask to bypass reconstruction.
             attention_mask=decoder_mask,
             # Without explicit position_ids, BlipTextModel would derive them
             # from past_kv_len=0 (a frozen constant in the trace), giving every

--- a/src/winml/modelkit/models/hf/layoutlm.py
+++ b/src/winml/modelkit/models/hf/layoutlm.py
@@ -46,7 +46,7 @@ class ZeroTokenTypeLayoutLMTextInputGenerator(MaxLengthTextInputGenerator):
                     dtype=int_dtype,
                 ),
             )
-        tensor = cast(
+        return cast(
             "torch.Tensor",
             super().generate(
                 input_name,
@@ -55,7 +55,6 @@ class ZeroTokenTypeLayoutLMTextInputGenerator(MaxLengthTextInputGenerator):
                 float_dtype=float_dtype,
             ),
         )
-        return tensor
 
 
 @register_onnx_overwrite("layoutlm", "question-answering", library_name="transformers")

--- a/src/winml/modelkit/models/hf/layoutlm.py
+++ b/src/winml/modelkit/models/hf/layoutlm.py
@@ -11,12 +11,18 @@ from typing import TYPE_CHECKING, Any, cast
 from optimum.exporters.onnx.model_configs import LayoutLMOnnxConfig
 from optimum.utils import NormalizedTextConfig
 from optimum.utils.input_generators import DummyBboxInputGenerator, DummyVisionInputGenerator
+from transformers import LayoutLMForQuestionAnswering
 
 from ...export import MaxLengthTextInputGenerator, register_onnx_overwrite
 
 
 if TYPE_CHECKING:
     import torch
+
+
+MODEL_CLASS_MAPPING: dict[tuple[str, str], type] = {
+    ("layoutlm", "question-answering"): LayoutLMForQuestionAnswering,
+}
 
 
 class ZeroTokenTypeLayoutLMTextInputGenerator(MaxLengthTextInputGenerator):
@@ -30,6 +36,16 @@ class ZeroTokenTypeLayoutLMTextInputGenerator(MaxLengthTextInputGenerator):
         float_dtype: str = "fp32",
     ) -> torch.Tensor:
         """Generate LayoutLM text inputs, replacing token_type_ids with zeros."""
+        if input_name == "token_type_ids":
+            return cast(
+                "torch.Tensor",
+                self.random_int_tensor(
+                    (self.batch_size, self.sequence_length),
+                    max_value=1,
+                    framework=framework,
+                    dtype=int_dtype,
+                ),
+            )
         tensor = cast(
             "torch.Tensor",
             super().generate(
@@ -39,8 +55,6 @@ class ZeroTokenTypeLayoutLMTextInputGenerator(MaxLengthTextInputGenerator):
                 float_dtype=float_dtype,
             ),
         )
-        if input_name == "token_type_ids":
-            return tensor.new_zeros(tensor.shape)
         return tensor
 
 

--- a/tests/unit/export/test_blip_onnx_config.py
+++ b/tests/unit/export/test_blip_onnx_config.py
@@ -136,7 +136,7 @@ class TestBlipDecoderIO:
         assert tuple(inputs["past_0_key"].shape) == expected
         assert tuple(inputs["past_0_value"].shape) == expected
 
-    def test_decoder_passes_four_dimensional_additive_attention_mask(self, monkeypatch) -> None:
+    def test_decoder_passes_three_dimensional_attention_mask(self, monkeypatch) -> None:
         from types import SimpleNamespace
         from unittest.mock import MagicMock
 
@@ -165,10 +165,9 @@ class TestBlipDecoderIO:
         wrapper._invoke_hf(object(), inputs)
 
         mask = captured["attention_mask"]
-        assert mask.shape == (1, 1, 1, 2)
-        assert mask.is_floating_point()
-        assert mask[0, 0, 0, 0] == 0
-        assert mask[0, 0, 0, 1] == torch.finfo(mask.dtype).min
+        assert mask.shape == (1, 1, 2)
+        assert mask.dtype == torch.int64
+        assert torch.equal(mask, torch.tensor([[[1, 0]]], dtype=torch.int64))
 
     def test_decoder_cache_uses_position_input_when_model_omits_cache_kwargs(
         self, blip_config

--- a/tests/unit/export/test_blip_onnx_config.py
+++ b/tests/unit/export/test_blip_onnx_config.py
@@ -169,6 +169,43 @@ class TestBlipDecoderIO:
         assert mask.dtype == torch.int64
         assert torch.equal(mask, torch.tensor([[[1, 0]]], dtype=torch.int64))
 
+    def test_decoder_runs_with_real_model_and_binary_mask(self, blip_config) -> None:
+        import torch
+        from transformers import BlipForConditionalGeneration
+
+        from winml.modelkit.models.hf import blip as blip_module
+
+        wrapper = blip_module.BlipDecoderWrapper()
+        wrapper.model = BlipForConditionalGeneration(blip_config)
+        wrapper.config = blip_config
+        wrapper.onnx_config = blip_module.BlipDecoderIOConfig(
+            blip_config,
+            task="text2text-generation",
+        )
+        wrapper.num_layers = blip_config.text_config.num_hidden_layers
+        wrapper.eval()
+
+        inputs = generate_dummy_inputs("blip", "text2text-generation", blip_config)
+        inputs["cache_position"] = torch.tensor([1], dtype=torch.int64)
+        inputs["decoder_attention_mask"].zero_()
+        inputs["decoder_attention_mask"][:, :2] = 1
+
+        with torch.inference_mode():
+            logits, *present = wrapper(*wrapper.get_export_args(inputs))
+
+        text_config = blip_config.text_config
+        expected_kv_shape = (
+            1,
+            text_config.num_attention_heads,
+            1,
+            text_config.hidden_size // text_config.num_attention_heads,
+        )
+        assert logits.shape == (1, 1, text_config.vocab_size)
+        assert len(present) == 2 * text_config.num_hidden_layers
+        assert all(tuple(tensor.shape) == expected_kv_shape for tensor in present)
+        assert torch.isfinite(logits).all()
+        assert all(torch.isfinite(tensor).all() for tensor in present)
+
     def test_decoder_cache_uses_position_input_when_model_omits_cache_kwargs(
         self, blip_config
     ) -> None:

--- a/tests/unit/export/test_onnx_config_overrides.py
+++ b/tests/unit/export/test_onnx_config_overrides.py
@@ -186,6 +186,7 @@ class TestLayoutLMQuestionAnsweringOverride:
         ]
         assert specs["input_shapes"] == [(1, 32), (1, 32, 4), (1, 32), (1, 32)]
         assert specs["output_names"] == ["start_logits", "end_logits"]
+        assert specs["value_ranges"]["token_type_ids"] == (0, 1)
 
 
 class TestLayoutLMv3QuestionAnsweringOverride:

--- a/tests/unit/loader/test_hf_model_class_mapping.py
+++ b/tests/unit/loader/test_hf_model_class_mapping.py
@@ -70,6 +70,16 @@ class TestHFModelClassMappingDesign:
         )
         assert result.__name__ == "AutoModelForSemanticSegmentation"
 
+    def test_layoutlm_question_answering_returns_concrete_model(self):
+        """LayoutLM QA must bypass the incompatible AutoModel mapping."""
+        from winml.modelkit.loader.resolution import _get_custom_model_class
+
+        result = _get_custom_model_class(
+            model_type="layoutlm",
+            task="question-answering",
+        )
+        assert result.__name__ == "LayoutLMForQuestionAnswering"
+
     # =========================================================================
     # Level 2: Task Defaults (tasks not in TasksManager)
     # =========================================================================


### PR DESCRIPTION
## Summary

- resolve LayoutLM question answering with `LayoutLMForQuestionAnswering` instead of the incompatible AutoModel mapping
- generate LayoutLM `token_type_ids` directly in `[0, 1)` so checkpoints with `type_vocab_size=1` remain valid in generated build configs
- pass a 3D binary attention mask to the BLIP decoder to match the current Transformers contract
- add regression coverage for model resolution, LayoutLM value ranges, and BLIP mask shape/dtype

Fixes #1391

## Validation

- `38 passed` across the related LayoutLM/BLIP unit tests
- `impira/layoutlm-document-qa` / `question-answering`: real build PASS; TRT-RTX perf PASS at 6.014 ms mean
- `Salesforce/blip-image-captioning-base` / `image-to-text`: encoder and decoder real builds PASS; TRT-RTX perf PASS at 7.468 ms / 6.748 ms mean

Full `--eval-type both` additionally exposed accuracy-evaluator issues outside this export fix: the generic QA evaluator does not produce LayoutLM `bbox` inputs, and the image-to-text evaluator passes an unsupported `text` keyword and skips all BLIP samples.