### PR TITLE
feat(eval): add translation evaluation and refresh opus-mt-en-ru recipes

### DIFF
--- a/examples/recipes/Helsinki-NLP_opus-mt-en-ru/cpu/cpu/translation_fp16_decoder_config.json
+++ b/examples/recipes/Helsinki-NLP_opus-mt-en-ru/cpu/cpu/translation_fp16_decoder_config.json
@@ -36,7 +36,10 @@
       {"name": "present_3_key"}, {"name": "present_3_value"},
       {"name": "present_4_key"}, {"name": "present_4_value"},
       {"name": "present_5_key"}, {"name": "present_5_value"}
-    ]
+    ],
+    "compatibility": {
+      "transformers_attention": "eager"
+    }
   },
   "optim": {
     "clamp_constant_values": true,

--- a/examples/recipes/Helsinki-NLP_opus-mt-en-ru/cpu/cpu/translation_fp16_encoder_config.json
+++ b/examples/recipes/Helsinki-NLP_opus-mt-en-ru/cpu/cpu/translation_fp16_encoder_config.json
@@ -13,7 +13,10 @@
       {"name": "input_ids", "dtype": "int32", "shape": [1, 512], "value_range": [0, 62518]},
       {"name": "attention_mask", "dtype": "int32", "shape": [1, 512], "value_range": [0, 2]}
     ],
-    "output_tensors": [{"name": "encoder_hidden_states"}]
+    "output_tensors": [{"name": "encoder_hidden_states"}],
+    "compatibility": {
+      "transformers_attention": "eager"
+    }
   },
   "optim": {
     "clamp_constant_values": true,

--- a/examples/recipes/Helsinki-NLP_opus-mt-en-ru/cpu/cpu/translation_fp32_decoder_config.json
+++ b/examples/recipes/Helsinki-NLP_opus-mt-en-ru/cpu/cpu/translation_fp32_decoder_config.json
@@ -36,7 +36,10 @@
       {"name": "present_3_key"}, {"name": "present_3_value"},
       {"name": "present_4_key"}, {"name": "present_4_value"},
       {"name": "present_5_key"}, {"name": "present_5_value"}
-    ]
+    ],
+    "compatibility": {
+      "transformers_attention": "eager"
+    }
   },
   "optim": {
     "clamp_constant_values": true,

--- a/examples/recipes/Helsinki-NLP_opus-mt-en-ru/cpu/cpu/translation_fp32_encoder_config.json
+++ b/examples/recipes/Helsinki-NLP_opus-mt-en-ru/cpu/cpu/translation_fp32_encoder_config.json
@@ -13,7 +13,10 @@
       {"name": "input_ids", "dtype": "int32", "shape": [1, 512], "value_range": [0, 62518]},
       {"name": "attention_mask", "dtype": "int32", "shape": [1, 512], "value_range": [0, 2]}
     ],
-    "output_tensors": [{"name": "encoder_hidden_states"}]
+    "output_tensors": [{"name": "encoder_hidden_states"}],
+    "compatibility": {
+      "transformers_attention": "eager"
+    }
   },
   "optim": {
     "clamp_constant_values": true,

--- a/src/winml/modelkit/eval/__init__.py
+++ b/src/winml/modelkit/eval/__init__.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
     from .text_classification_evaluator import WinMLTextClassificationEvaluator
     from .text_generation_evaluator import WinMLTextGenerationEvaluator
     from .token_classification_evaluator import WinMLTokenClassificationEvaluator
+    from .translation_evaluator import WinMLTranslationEvaluator
     from .zero_shot_classification_evaluator import WinMLZeroShotClassificationEvaluator
     from .zero_shot_image_classification_evaluator import WinMLZeroShotImageClassificationEvaluator
 
@@ -73,6 +74,7 @@ _LAZY_ATTRS: dict[str, str] = {
     "WinMLTokenClassificationEvaluator": (
         ".token_classification_evaluator:WinMLTokenClassificationEvaluator"
     ),
+    "WinMLTranslationEvaluator": ".translation_evaluator:WinMLTranslationEvaluator",
     "WinMLZeroShotClassificationEvaluator": (
         ".zero_shot_classification_evaluator:WinMLZeroShotClassificationEvaluator"
     ),
@@ -140,6 +142,7 @@ __all__ = [
     "WinMLTextClassificationEvaluator",
     "WinMLTextGenerationEvaluator",
     "WinMLTokenClassificationEvaluator",
+    "WinMLTranslationEvaluator",
     "WinMLZeroShotClassificationEvaluator",
     "WinMLZeroShotImageClassificationEvaluator",
     "evaluate",

--- a/src/winml/modelkit/eval/evaluate.py
+++ b/src/winml/modelkit/eval/evaluate.py
@@ -84,6 +84,8 @@ _EVALUATOR_REGISTRY: dict[str, str] = {
         "winml.modelkit.eval.image_feature_extraction_evaluator:WinMLImageFeatureExtractionEvaluator",
     "image-to-text":
         "winml.modelkit.eval.image_to_text_evaluator:WinMLImageToTextEvaluator",
+    "translation":
+        "winml.modelkit.eval.translation_evaluator:WinMLTranslationEvaluator",
     "fill-mask":
         "winml.modelkit.eval.fill_mask_evaluator:WinMLFillMaskEvaluator",
     "zero-shot-classification":

--- a/src/winml/modelkit/eval/metrics/translation.py
+++ b/src/winml/modelkit/eval/metrics/translation.py
@@ -1,0 +1,53 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+"""Corpus-level machine-translation metrics."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class TranslationMetric:
+    """Aggregate corpus SacreBLEU-13a and chrF2 on a 0-100 scale."""
+
+    def __init__(self) -> None:
+        self._predictions: list[str] = []
+        self._references: list[list[str]] = []
+
+    def update(self, prediction: str, references: str | list[str]) -> None:
+        """Record one prediction and one or more non-empty references."""
+        refs = [references] if isinstance(references, str) else references
+        cleaned = [reference.strip() for reference in refs if reference and reference.strip()]
+        if not cleaned:
+            raise ValueError("at least one non-empty translation reference is required")
+        self._predictions.append((prediction or "").strip())
+        self._references.append(cleaned)
+
+    def compute(self) -> dict[str, Any]:
+        """Return corpus scores with names that state variant and scale."""
+        if not self._predictions:
+            return {
+                "sacrebleu_13a_0_100": None,
+                "chrf2_0_100": None,
+                "n_samples": 0,
+            }
+
+        from torchmetrics.text import CHRFScore, SacreBLEUScore
+
+        sacrebleu = SacreBLEUScore(tokenize="13a")(
+            self._predictions,
+            self._references,
+        )
+        chrf = CHRFScore(n_char_order=6, n_word_order=0, beta=2.0)(
+            self._predictions,
+            self._references,
+        )
+
+        return {
+            "sacrebleu_13a_0_100": round(float(sacrebleu) * 100, 4),
+            "chrf2_0_100": round(float(chrf) * 100, 4),
+            "n_samples": len(self._predictions),
+        }

--- a/src/winml/modelkit/eval/translation_evaluator.py
+++ b/src/winml/modelkit/eval/translation_evaluator.py
@@ -1,0 +1,213 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+"""Evaluator for text-to-text machine translation models."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
+
+from .base_evaluator import WinMLEvaluator
+
+
+if TYPE_CHECKING:
+    from datasets import Dataset
+
+    from ..models.winml.composite_model import WinMLCompositeModel
+    from .config import DatasetConfig, WinMLEvaluationConfig
+
+
+logger = logging.getLogger(__name__)
+
+
+def _positive_int(mapping: Mapping[str, str], name: str, default: int) -> int:
+    from ..utils.eval_utils import DatasetValidationError
+
+    raw_value = mapping.get(name, str(default))
+    try:
+        value = int(raw_value)
+    except (TypeError, ValueError) as error:
+        raise DatasetValidationError(f"{name} must be a positive integer") from error
+    if value < 1:
+        raise DatasetValidationError(f"{name} must be a positive integer")
+    return value
+
+
+class WinMLTranslationEvaluator(WinMLEvaluator):
+    """Evaluate translations with bounded generation and corpus metrics."""
+
+    def __init__(
+        self,
+        config: WinMLEvaluationConfig,
+        model: WinMLCompositeModel,
+    ) -> None:
+        from ..utils.eval_utils import DatasetValidationError, get_default
+
+        mapping = config.dataset.columns_mapping
+        self._source_col = mapping.get(
+            "source_column",
+            get_default("translation", "source_column") or "translation",
+        )
+        self._reference_col = mapping.get(
+            "reference_column",
+            get_default("translation", "reference_column") or "translation",
+        )
+        self._source_lang = mapping.get("source_lang")
+        self._target_lang = mapping.get("target_lang")
+        self._tokenizer_source_lang = mapping.get("tokenizer_source_lang", self._source_lang)
+        self._tokenizer_target_lang = mapping.get("tokenizer_target_lang", self._target_lang)
+        self._source_prefix = mapping.get("source_prefix", "")
+        max_source_tokens = _positive_int(mapping, "max_source_tokens", 128)
+        max_new_tokens = _positive_int(mapping, "max_new_tokens", 64)
+        num_beams = _positive_int(mapping, "num_beams", 1)
+        num_return_sequences = _positive_int(mapping, "num_return_sequences", 1)
+        if num_beams != 1 or num_return_sequences != 1:
+            raise DatasetValidationError(
+                "translation evaluation requires num_beams=1 and num_return_sequences=1 "
+                "for the static batch-one generation contract"
+            )
+
+        super().__init__(config, model)
+        self._pipeline_kwargs: dict[str, Any] = {
+            "do_sample": False,
+            "max_new_tokens": max_new_tokens,
+            "num_beams": 1,
+            "num_return_sequences": 1,
+            "truncation": True,
+        }
+        if self._tokenizer_source_lang:
+            self._pipeline_kwargs["src_lang"] = self._tokenizer_source_lang
+        if self._tokenizer_target_lang:
+            self._pipeline_kwargs["tgt_lang"] = self._tokenizer_target_lang
+
+        max_encoder_length = getattr(model, "max_encoder_length", None)
+        if isinstance(max_encoder_length, int) and max_encoder_length > 0:
+            max_source_tokens = min(max_source_tokens, max_encoder_length)
+        if self.pipe.tokenizer is not None:
+            self.pipe.tokenizer.model_max_length = max_source_tokens
+
+        max_decode_length = getattr(model, "max_decode_length", None)
+        if isinstance(max_decode_length, int):
+            if max_decode_length <= 1:
+                raise DatasetValidationError(
+                    "decoder static cache must leave capacity for at least one generated token"
+                )
+            self._pipeline_kwargs["max_new_tokens"] = min(
+                max_new_tokens,
+                max_decode_length - 1,
+            )
+            self.pipe.generation_config.max_length = max_decode_length
+            self.pipe.generation_config.max_new_tokens = None
+            self.pipe.generation_config.num_beams = 1
+            self.pipe.generation_config.num_return_sequences = 1
+            self.pipe.generation_config.do_sample = False
+
+    def align_labels(self, dataset: Dataset, ds_config: DatasetConfig) -> Dataset:
+        """Return free-text references unchanged."""
+        return dataset
+
+    @staticmethod
+    def _extract_text(value: Any, language: str | None, field: str) -> str:
+        """Extract one text value from a flat string or language-keyed mapping."""
+        from ..utils.eval_utils import DatasetValidationError
+
+        if isinstance(value, Mapping):
+            if not language:
+                language_option = "source_lang" if field == "source" else "target_lang"
+                raise DatasetValidationError(
+                    f"{field} contains a translation dict; provide --column "
+                    f"{language_option}=<language key>"
+                )
+            if language not in value:
+                raise DatasetValidationError(
+                    f"{field} translation dict has no language key '{language}'; "
+                    f"available keys: {sorted(str(key) for key in value)}"
+                )
+            value = value[language]
+        if not isinstance(value, str) or not value.strip():
+            raise DatasetValidationError(f"{field} must resolve to a non-empty string")
+        return value.strip()
+
+    def _extract_references(self, value: Any) -> str | list[str]:
+        """Extract one or more reference translations."""
+        if isinstance(value, list):
+            if not value:
+                from ..utils.eval_utils import DatasetValidationError
+
+                raise DatasetValidationError("reference must contain at least one translation")
+            return [self._extract_text(item, self._target_lang, "reference") for item in value]
+        return self._extract_text(value, self._target_lang, "reference")
+
+    @staticmethod
+    def _prediction_text(output: Any) -> str:
+        """Normalize Hugging Face translation pipeline output shapes."""
+        from ..utils.eval_utils import DatasetValidationError
+
+        if isinstance(output, list):
+            if not output:
+                raise DatasetValidationError("pipeline returned no translations")
+            output = output[0]
+        if isinstance(output, Mapping):
+            prediction = output.get("translation_text", output.get("generated_text", ""))
+            if isinstance(prediction, str) and prediction.strip():
+                return prediction.strip()
+            raise DatasetValidationError("pipeline returned an empty translation")
+        if isinstance(output, str) and output.strip():
+            return output.strip()
+        raise DatasetValidationError("pipeline returned an unsupported translation result")
+
+    def _extract_sample(self, sample: Any) -> tuple[str, str | list[str]]:
+        """Extract and validate source/reference values from one dataset row."""
+        from ..utils.eval_utils import DatasetValidationError
+
+        if not isinstance(sample, Mapping):
+            raise DatasetValidationError(
+                f"dataset row must be a mapping, got {type(sample).__name__}"
+            )
+        source = self._extract_text(sample.get(self._source_col), self._source_lang, "source")
+        references = self._extract_references(sample.get(self._reference_col))
+        return f"{self._source_prefix}{source}", references
+
+    def compute(self) -> dict[str, Any]:
+        """Translate each valid row and compute corpus-level metrics."""
+        from tqdm.auto import tqdm
+
+        from ..utils.eval_utils import DatasetValidationError
+        from .metrics.translation import TranslationMetric
+
+        metric = TranslationMetric()
+        skipped = 0
+        first_error: str | None = None
+        attempted = 0
+
+        for sample in tqdm(self.data, desc="Evaluating", unit="sample"):
+            attempted += 1
+            try:
+                source, references = self._extract_sample(sample)
+            except DatasetValidationError as error:
+                logger.warning("Translation sample rejected: %s", error)
+                first_error = first_error or str(error)
+                skipped += 1
+                continue
+
+            output = self.pipe(source, **self._pipeline_kwargs)
+            try:
+                prediction = self._prediction_text(output)
+                metric.update(prediction, references)
+            except (DatasetValidationError, ValueError) as error:
+                logger.warning("Translation output rejected: %s", error)
+                first_error = first_error or str(error)
+                skipped += 1
+
+        result = metric.compute()
+        if result["n_samples"] == 0:
+            detail = f": {first_error}" if first_error else ""
+            raise DatasetValidationError(f"No valid translation samples were evaluated{detail}")
+        result["attempted"] = attempted
+        result["evaluated"] = result["n_samples"]
+        result["skipped"] = skipped
+        return result

--- a/src/winml/modelkit/models/winml/encoder_decoder.py
+++ b/src/winml/modelkit/models/winml/encoder_decoder.py
@@ -193,6 +193,12 @@ class WinMLEncoderDecoderModel(WinMLCompositeModel, GenerationMixin):
         enc_expected = dict(
             zip(enc_io.get("input_names", []), enc_io.get("input_shapes", []), strict=False)
         )
+        input_ids_shape = enc_expected.get("input_ids", [])
+        self._max_enc = (
+            input_ids_shape[1]
+            if len(input_ids_shape) > 1 and isinstance(input_ids_shape[1], int)
+            else None
+        )
         self._encoder_input_names = frozenset(enc_expected)
         # Wrap encoder with auto-padding so all callsites just use self._encoder(...)
         self._encoder = self._EncoderWithInputPadding(raw_encoder, enc_expected)
@@ -203,7 +209,12 @@ class WinMLEncoderDecoderModel(WinMLCompositeModel, GenerationMixin):
         )
 
         # Max decode length and KV dtype from decoder ONNX metadata
-        self._max_dec = self._dec_expected["past_0_key"][2]
+        max_decode_length = self._dec_expected["past_0_key"][2]
+        if not isinstance(max_decode_length, int) or max_decode_length <= 0:
+            raise ValueError(
+                "Decoder input 'past_0_key' must have a positive static cache length"
+            )
+        self._max_dec = max_decode_length
         self._num_kv_layers = sum(
             1 for n in self._dec_expected if n.startswith("past_") and n.endswith("_key")
         )
@@ -221,6 +232,16 @@ class WinMLEncoderDecoderModel(WinMLCompositeModel, GenerationMixin):
             )
         _np_dtype = dec_type_map["past_0_key"]
         self._kv_dtype = torch.from_numpy(np.zeros(1, dtype=_np_dtype)).dtype
+
+    @property
+    def max_encoder_length(self) -> int | None:
+        """Return the encoder's static token capacity, or ``None`` when dynamic."""
+        return self._max_enc
+
+    @property
+    def max_decode_length(self) -> int:
+        """Return the decoder's static output/cache capacity."""
+        return self._max_dec
 
     # ----- Encoder -----
 

--- a/src/winml/modelkit/models/winml/encoder_decoder.py
+++ b/src/winml/modelkit/models/winml/encoder_decoder.py
@@ -407,6 +407,14 @@ class WinMLEncoderDecoderModel(WinMLCompositeModel, GenerationMixin):
                 dtype=torch.int64,
             ),
         )
+        attention_mask = runtime_feeds.get("attention_mask")
+        expected_attention_mask = self._dec_expected.get("attention_mask")
+        if isinstance(attention_mask, torch.Tensor) and expected_attention_mask is not None:
+            runtime_feeds["attention_mask"] = pad_inputs(
+                {"attention_mask": attention_mask},
+                {"attention_mask": expected_attention_mask},
+                mode="right",
+            )["attention_mask"]
         for i in range(self._num_kv_layers):
             layer = cache._layer(i)
             runtime_feeds[f"past_{i}_key"] = cast("torch.Tensor", layer.keys).detach()

--- a/src/winml/modelkit/utils/eval_utils.py
+++ b/src/winml/modelkit/utils/eval_utils.py
@@ -243,6 +243,75 @@ _IMAGE_TO_TEXT_SCHEMA = TaskSchema(
     roles=("encoder", "decoder"),
 )
 
+_TRANSLATION_SCHEMA = TaskSchema(
+    columns=(
+        SchemaItem(
+            "source_column",
+            "source text, or a translation dict containing the source language key",
+            default="translation",
+            remap_hint="<your_source_column>",
+        ),
+        SchemaItem(
+            "reference_column",
+            "reference text(s), or a translation dict containing the target language key",
+            default="translation",
+            remap_hint="<your_reference_column>",
+        ),
+    ),
+    params=(
+        SchemaItem(
+            "source_lang",
+            "source-language key when source_column contains translation dicts",
+            remap_hint="<source_language_key>",
+        ),
+        SchemaItem(
+            "target_lang",
+            "target-language key when reference_column contains translation dicts",
+            remap_hint="<target_language_key>",
+        ),
+        SchemaItem(
+            "tokenizer_source_lang",
+            "source-language identifier for multilingual tokenizers; defaults to source_lang",
+            remap_hint="<tokenizer_source_language>",
+        ),
+        SchemaItem(
+            "tokenizer_target_lang",
+            "target-language identifier for multilingual tokenizers; defaults to target_lang",
+            remap_hint="<tokenizer_target_language>",
+        ),
+        SchemaItem(
+            "source_prefix",
+            "optional task prefix prepended before tokenization",
+            remap_hint="<translation_prefix>",
+        ),
+        SchemaItem(
+            "max_source_tokens",
+            "maximum source tokens, clamped to the encoder capacity",
+            default="128",
+            remap_hint="<positive_integer>",
+        ),
+        SchemaItem(
+            "max_new_tokens",
+            "maximum generated tokens, clamped to the decoder capacity",
+            default="64",
+            remap_hint="<positive_integer>",
+        ),
+        SchemaItem(
+            "num_beams",
+            "beam count; static batch-one models require 1",
+            default="1",
+            remap_hint="<1>",
+        ),
+        SchemaItem(
+            "num_return_sequences",
+            "returned sequences per source; static batch-one models require 1",
+            default="1",
+            remap_hint="<1>",
+        ),
+    ),
+    roles=("encoder", "decoder"),
+)
+
 _FILL_MASK_SCHEMA = TaskSchema(
     columns=(
         SchemaItem(
@@ -461,6 +530,7 @@ TASK_SCHEMAS: dict[str, TaskSchema] = {
     "sentence-similarity": _FEATURE_EXTRACTION_SCHEMA,
     "image-feature-extraction": _IMAGE_FEATURE_EXTRACTION_SCHEMA,
     "image-to-text": _IMAGE_TO_TEXT_SCHEMA,
+    "translation": _TRANSLATION_SCHEMA,
     "fill-mask": _FILL_MASK_SCHEMA,
     "zero-shot-classification": _ZERO_SHOT_CLASSIFICATION_SCHEMA,
     "zero-shot-image-classification": _ZERO_SHOT_IMAGE_CLASSIFICATION_SCHEMA,

--- a/tests/unit/eval/test_translation_evaluator.py
+++ b/tests/unit/eval/test_translation_evaluator.py
@@ -1,0 +1,245 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+"""Unit tests for translation evaluation."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from datasets import Dataset
+
+from winml.modelkit.eval.translation_evaluator import WinMLTranslationEvaluator
+from winml.modelkit.utils.eval_utils import DatasetValidationError
+
+
+def make_evaluator(rows, columns_mapping=None, pipeline=None):
+    from winml.modelkit.eval import DatasetConfig, WinMLEvaluationConfig
+
+    dataset = Dataset.from_list(rows)
+    model = MagicMock()
+    model.config.label2id = None
+    model.max_encoder_length = 512
+    model.max_decode_length = 512
+    config = WinMLEvaluationConfig(
+        model_id="example/translation-model",
+        task="translation",
+        dataset=DatasetConfig(
+            path="example/parallel-corpus",
+            samples=len(rows),
+            shuffle=False,
+            columns_mapping=columns_mapping or {},
+        ),
+    )
+    with (
+        patch("datasets.load_dataset", return_value=dataset),
+        patch(
+            "winml.modelkit.eval.base_evaluator.WinMLEvaluator.prepare_pipeline",
+            return_value=pipeline or MagicMock(),
+        ),
+    ):
+        return WinMLTranslationEvaluator(config, model)
+
+
+class TestTranslationMetric:
+    def test_perfect_corpus_scores_100(self):
+        from winml.modelkit.eval.metrics.translation import TranslationMetric
+
+        metric = TranslationMetric()
+        sentence = "This is a complete test sentence."
+        metric.update(sentence, sentence)
+
+        assert metric.compute() == {
+            "sacrebleu_13a_0_100": 100.0,
+            "chrf2_0_100": 100.0,
+            "n_samples": 1,
+        }
+
+    def test_empty_corpus_has_no_scores(self):
+        from winml.modelkit.eval.metrics.translation import TranslationMetric
+
+        assert TranslationMetric().compute() == {
+            "sacrebleu_13a_0_100": None,
+            "chrf2_0_100": None,
+            "n_samples": 0,
+        }
+
+    def test_multiple_references_use_corpus_metrics(self):
+        from winml.modelkit.eval.metrics.translation import TranslationMetric
+
+        metric = TranslationMetric()
+        prediction = "A sufficiently long reference sentence is here."
+        metric.update(prediction, ["Another complete reference is here.", prediction])
+
+        assert metric.compute()["sacrebleu_13a_0_100"] == 100.0
+
+    def test_empty_references_are_rejected(self):
+        from winml.modelkit.eval.metrics.translation import TranslationMetric
+
+        with pytest.raises(ValueError, match="at least one non-empty"):
+            TranslationMetric().update("prediction", [])
+
+
+class TestTranslationEvaluator:
+    def test_nested_translation_uses_explicit_direction_and_bounded_generation(self):
+        evaluator = make_evaluator(
+            [{"translation": {"source": "Bonjour le monde", "target": "Hello world"}}],
+            {"source_lang": "source", "target_lang": "target"},
+        )
+        assert evaluator.pipe.tokenizer.model_max_length == 128
+        assert evaluator.pipe.generation_config.max_new_tokens is None
+        evaluator.pipe = MagicMock(return_value=[{"translation_text": "Hello world"}])
+
+        result = evaluator.compute()
+
+        evaluator.pipe.assert_called_once_with(
+            "Bonjour le monde",
+            do_sample=False,
+            max_new_tokens=64,
+            num_beams=1,
+            num_return_sequences=1,
+            truncation=True,
+            src_lang="source",
+            tgt_lang="target",
+        )
+        assert result["chrf2_0_100"] == 100.0
+        assert result["attempted"] == result["evaluated"] == 1
+        assert result["skipped"] == 0
+
+    def test_explicit_caps_clamp_to_static_model_capacities(self):
+        pipeline = MagicMock()
+        evaluator = make_evaluator(
+            [{"source": "texte", "reference": "text"}],
+            {
+                "source_column": "source",
+                "reference_column": "reference",
+                "max_source_tokens": "1024",
+                "max_new_tokens": "1024",
+            },
+            pipeline,
+        )
+        evaluator.pipe = MagicMock(return_value={"generated_text": "text"})
+
+        evaluator.compute()
+
+        assert pipeline.tokenizer.model_max_length == 512
+        assert evaluator.pipe.call_args.kwargs["max_new_tokens"] == 511
+
+    @pytest.mark.parametrize(
+        ("name", "value"),
+        [("max_source_tokens", "0"), ("max_new_tokens", "bad")],
+    )
+    def test_invalid_token_bounds_are_rejected(self, name, value):
+        with pytest.raises(DatasetValidationError, match=f"{name} must be a positive integer"):
+            make_evaluator(
+                [{"source": "texte", "reference": "text"}],
+                {"source_column": "source", "reference_column": "reference", name: value},
+            )
+
+    @pytest.mark.parametrize("name", ["num_beams", "num_return_sequences"])
+    def test_static_batch_contract_rejects_generation_fanout(self, name):
+        with pytest.raises(DatasetValidationError, match="static batch-one"):
+            make_evaluator(
+                [{"source": "texte", "reference": "text"}],
+                {"source_column": "source", "reference_column": "reference", name: "2"},
+            )
+
+    def test_pipeline_without_tokenizer_is_supported(self):
+        pipeline = MagicMock()
+        pipeline.tokenizer = None
+
+        evaluator = make_evaluator(
+            [{"source": "texte", "reference": "text"}],
+            {"source_column": "source", "reference_column": "reference"},
+            pipeline,
+        )
+
+        assert evaluator.pipe.tokenizer is None
+
+    def test_flat_columns_and_multiple_references(self):
+        evaluator = make_evaluator(
+            [{"source": "Une phrase source", "references": ["A source sentence", "A sentence"]}],
+            {"source_column": "source", "reference_column": "references"},
+        )
+        evaluator.pipe = MagicMock(return_value={"generated_text": "A source sentence"})
+
+        assert evaluator.compute()["n_samples"] == 1
+
+    def test_missing_language_key_is_skipped_with_exact_accounting(self):
+        evaluator = make_evaluator(
+            [
+                {"translation": {"source": "Valide", "target": "Valid"}},
+                {"translation": {"source": "Invalide", "other": "Invalid"}},
+            ],
+            {"source_lang": "source", "target_lang": "target"},
+        )
+        evaluator.pipe = MagicMock(return_value=[{"translation_text": "Valid"}])
+
+        result = evaluator.compute()
+
+        assert result["attempted"] == 2
+        assert result["evaluated"] == 1
+        assert result["skipped"] == 1
+        evaluator.pipe.assert_called_once()
+
+    def test_nested_translation_requires_explicit_direction(self):
+        evaluator = make_evaluator(
+            [{"translation": {"source": "Bonjour", "target": "Hello"}}]
+        )
+
+        with pytest.raises(DatasetValidationError, match="provide --column source_lang"):
+            evaluator.compute()
+
+    def test_tokenizer_languages_and_prefix_are_independent_of_dataset_keys(self):
+        evaluator = make_evaluator(
+            [{"translation": {"dataset_source": "Bonjour", "dataset_target": "Hello"}}],
+            {
+                "source_lang": "dataset_source",
+                "target_lang": "dataset_target",
+                "tokenizer_source_lang": "tokenizer_source",
+                "tokenizer_target_lang": "tokenizer_target",
+                "source_prefix": "translate: ",
+            },
+        )
+        evaluator.pipe = MagicMock(return_value=[{"translation_text": "Hello"}])
+
+        evaluator.compute()
+
+        assert evaluator.pipe.call_args.args == ("translate: Bonjour",)
+        assert evaluator.pipe.call_args.kwargs["src_lang"] == "tokenizer_source"
+        assert evaluator.pipe.call_args.kwargs["tgt_lang"] == "tokenizer_target"
+
+    def test_runtime_failure_propagates(self):
+        evaluator = make_evaluator(
+            [{"source": "un", "reference": "one"}],
+            {"source_column": "source", "reference_column": "reference"},
+        )
+        evaluator.pipe = MagicMock(side_effect=RuntimeError("decoder failed"))
+
+        with pytest.raises(RuntimeError, match="decoder failed"):
+            evaluator.compute()
+
+    @pytest.mark.parametrize("output", [[], [{}], [{"translation_text": ""}]])
+    def test_invalid_output_fails_closed_when_no_rows_are_evaluated(self, output):
+        evaluator = make_evaluator(
+            [{"source": "texte", "reference": "text"}],
+            {"source_column": "source", "reference_column": "reference"},
+        )
+        evaluator.pipe = MagicMock(return_value=output)
+
+        with pytest.raises(DatasetValidationError, match="No valid translation samples"):
+            evaluator.compute()
+
+
+class TestTranslationRegistration:
+    def test_registry_and_schema_are_present(self):
+        from winml.modelkit.eval import WinMLEvaluationConfig, get_evaluator_class
+        from winml.modelkit.utils.eval_utils import TASK_SCHEMAS
+
+        assert get_evaluator_class(WinMLEvaluationConfig(task="translation")) is (
+            WinMLTranslationEvaluator
+        )
+        assert TASK_SCHEMAS["translation"].roles == ("encoder", "decoder")

--- a/tests/unit/models/winml/test_composite_from_pretrained.py
+++ b/tests/unit/models/winml/test_composite_from_pretrained.py
@@ -355,6 +355,107 @@ def test_encoder_decoder_prefills_every_prompt_token() -> None:
     assert cache.step == 3
 
 
+def test_encoder_decoder_preserves_encoder_alignment_across_independent_rows() -> None:
+    from winml.modelkit.models.winml.encoder_decoder import WinMLEncoderDecoderModel
+
+    class _SourceConditionedDecoder:
+        def __init__(self) -> None:
+            self.io_config = {
+                "input_names": [
+                    "decoder_input_ids",
+                    "encoder_hidden_states",
+                    "attention_mask",
+                    "decoder_attention_mask",
+                    "cache_position",
+                    "past_0_key",
+                    "past_0_value",
+                ],
+                "input_shapes": [
+                    [1, 1],
+                    [1, 4, 2],
+                    [1, 4],
+                    [1, 4],
+                    [1],
+                    [1, 2, 4, 2],
+                    [1, 2, 4, 2],
+                ],
+                "input_types": [
+                    np.int64,
+                    np.float32,
+                    np.int64,
+                    np.int64,
+                    np.int64,
+                    np.float32,
+                    np.float32,
+                ],
+            }
+            self.attention_masks: list[torch.Tensor] = []
+
+        def __call__(self, **feeds):
+            attention_mask = feeds["attention_mask"]
+            self.attention_masks.append(attention_mask.clone())
+            source_token = int(
+                (feeds["encoder_hidden_states"][:, :, 0] * attention_mask).sum().item()
+            )
+            logits = torch.zeros(1, 1, 4)
+            logits[0, 0, source_token] = 1
+            present = torch.full((1, 2, 1, 2), float(source_token))
+            return {
+                "logits": logits,
+                "present_0_key": present,
+                "present_0_value": present.clone(),
+            }
+
+    def make_cache():
+        cache = MagicMock()
+        cache.step = 0
+        cache.layers = [
+            SimpleNamespace(
+                keys=torch.zeros(1, 2, 4, 2),
+                values=torch.zeros(1, 2, 4, 2),
+            )
+        ]
+        cache.build_decoder_mask.return_value = torch.tensor([[1, 0, 0, 0]])
+        cache.get_query_cache_position.return_value = torch.tensor([0])
+
+        def _advance(outputs):
+            cache.step += outputs["present_0_key"].shape[2]
+
+        cache.update_all_layers.side_effect = _advance
+        return cache
+
+    decoder = _SourceConditionedDecoder()
+    model = WinMLEncoderDecoderModel(
+        {"encoder": SimpleNamespace(io_config={}), "decoder": decoder},
+        MagicMock(is_encoder_decoder=True),
+    )
+    first_cache = make_cache()
+    second_cache = make_cache()
+    rows = [
+        (torch.tensor([[[1.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]]]), 1),
+        (torch.tensor([[[2.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]]]), 2),
+    ]
+
+    generated_tokens = []
+    with patch.object(model, "_resolve_cache", side_effect=[first_cache, second_cache]):
+        for hidden_state, _ in rows:
+            result = model.forward(
+                encoder_outputs=BaseModelOutput(last_hidden_state=hidden_state),
+                decoder_input_ids=torch.tensor([[0]]),
+                attention_mask=torch.tensor([[1]]),
+            )
+            generated_tokens.append(int(result.logits[:, -1, :].argmax(dim=-1)[0]))
+
+    assert [mask.tolist() for mask in decoder.attention_masks] == [
+        [[1, 0, 0, 0]],
+        [[1, 0, 0, 0]],
+    ]
+    assert generated_tokens == [1, 2]
+    assert first_cache.step == second_cache.step == 1
+    assert first_cache.update_all_layers.call_count == 1
+    assert second_cache.update_all_layers.call_count == 1
+
+
 def test_static_cache_rejects_out_of_range_query_positions() -> None:
     from winml.modelkit.models.winml.kv_cache import WinMLStaticCache
 


### PR DESCRIPTION
# Summary

This adds generalized translation evaluation for WinML encoder-decoder models, refreshes the four existing Helsinki-NLP/opus-mt-en-ru CPU recipes, and fixes encoder cross-attention mask alignment during generation. The evaluator uses TorchMetrics corpus SacreBLEU with 13a tokenization and standard chrF2; no dependency is added. The contribution is Effort L2 / Outcome L2 and reaches L3 PASS with full planned CPU fp32/fp16 coverage; the two-row Eval is functional-smoke evidence only, not representative translation quality.

# Model metadata

## What the model does

Helsinki-NLP/opus-mt-en-ru accepts English text and autoregressively produces Russian text using a Marian encoder-decoder translation model. Evidence: pinned checkpoint `Helsinki-NLP/opus-mt-en-ru` at revision `bb09c99d180016eac6819df3dae68edb1690fdee`, whose Hub metadata identifies translation, English, Russian, and Apache-2.0; pinned config identifies `MarianMTModel`, `model_type=marian`, and `is_encoder_decoder=true`. Confidence: **verified**.

## Primary user stories

- A user supplies English text to obtain a Russian translation for cross-language communication or downstream text processing. Evidence: checkpoint translation metadata and pinned model-card example inputs. Confidence: **verified**.

## Supported tasks

| Task | Support surface | Evidence | Confidence |
|---|---|---|---|
| translation | checkpoint, Transformers, WinML composite | Hub pipeline tag, `AutoModelForSeq2SeqLM` mapping, and WinML composite registry | verified |
| text2text-generation | Transformers, Optimum ONNX, WinML decoder | Optimum `MarianOnnxConfig` vendor registry and WinML `MarianDecoderIOConfig` override | verified |
| feature-extraction | Optimum ONNX, WinML encoder | Optimum `MarianOnnxConfig` vendor registry and WinML `MarianEncoderIOConfig` override | verified |

## Model architecture

```text
MarianMTModel (vocab 62,518; hidden width 512)
|-- Encoder graph (batch 1, source length 512)
|   |-- Token + sinusoidal position embeddings
|   `-- Encoder layer x6
|       |-- Self-attention (8 heads)
|       `-- Feed-forward + residual + LayerNorm
`-- Cached decoder graph (batch 1, one token per step, cache 512)
    |-- Token + sinusoidal position embeddings
    |-- Decoder layer x6
    |   |-- Masked self-attention (8 heads, static KV cache)
    |   |-- Encoder cross-attention
    |   `-- Feed-forward + residual + LayerNorm
    `-- LM head -> logits [1, 1, 62,518]
```

- Source/confidence: pinned config dimensions, Transformers `MarianMTModel` source, and fresh HTP/ONNX artifacts (**verified**).

# Validation and support evidence

## 1. Baseline

The baseline was fully rerun on `main` commit `be3e59dd412d4918c5a852aa4d8f0207c34aaf6f` with WinML `0.0.1.dev0`; broad runtime, dependency, Marian, generation, Eval, and Analyze changes since the prior baseline made reuse unsafe. CPU fp32 auto-build passed in 137.19 s and emitted opset-17 encoder and cached-decoder artifacts at fixed batch 1, source/cache length 512, and vocabulary 62,518. Baseline perf passed: encoder average/p50 69.76/69.93 ms, 14.34 samples/s, RAM +64.4 MB; decoder average/p50 21.68/20.78 ms, 46.12 samples/s, RAM +21.2 MB. Encoder parity passed on a pinned real row with cosine `0.9999999999993413` and max absolute error `5.245208740234375e-06`.

Baseline two-row generation mechanically ran but collapsed both inputs to the same low-quality short Russian output. Translation Eval was `UNSUPPORTED-TASK` before dataset loading; an ad hoc probe returned SacreBLEU-13a `0.0` and chrF2 `0.012449` raw (`1.2449366` on the 0-100 scale), as functional smoke only. Analyze produced parseable partial-success JSON: encoder 197 nodes / 15 operator types and decoder 378 nodes / 20 operator types. Optimum exposed feature-extraction/text-generation/text2text-generation with and without past; WinML added no keys but replaced vendor feature-extraction and text2text-generation configurations with Marian-specific I/O overrides (`VENDOR+OVERRIDE`).

## 2. Goal

- **Effort:** L2
- **Goal ceiling:** L3
- **Outcome:** L2
- **Committed success definition:** refresh the four existing CPU encoder/decoder fp32/fp16 recipes; add a generalized, explicit-direction translation evaluator with bounded static-batch generation and corpus SacreBLEU-13a/chrF2; preserve existing behavior; then attempt CPU fp32/fp16 L0-L2 and one final-candidate CPU fp32 two-row L3 functional smoke.
- **Required tuples:** CPUExecutionProvider / cpu / fp32 and fp16. No deferred tuples.

No downstream role silently re-tiered the frozen charter.

## 3. Outcome

**L3 PASS**, full planned coverage, no deferred tuples. The final candidate is `3f5f321e4721e3022f7f50514e8cfcfb9ad4570d` (tree `ddf4c7810f2029937798e3ca1c03e4e6595a07af`) on base `be3e59dd412d4918c5a852aa4d8f0207c34aaf6f`; it is clean and unpushed in the sealed handoff.

Shipped product paths comprise the four existing Model25 CPU recipes plus generalized Eval/runtime code and focused tests. There is no hardcoded checkpoint-name branch, no dependency addition, no README change, and no duplicate recipe path. Learner findings `marian-010` through `marian-013` and methodology findings `_meta-117` and `_meta-118` were published separately in Lane A draft PR #314 at commit `2f4c04fa1ff3b427d8bb9c39f7c95c323d178ec3`; no skill files are included in this model contribution.

### Quality gates

- Focused evaluator/model/recipe/regression suite: **72 passed in 32.41 s**.
- Ruff: **All checks passed**. License headers: **Passed**. Translation Eval schema dispatch: **PASS**.
- Mypy: **Success: no issues found in 443 source files**.
- Canonical partitions: **1529 passed, 45 skipped** (Analyze); **1542 passed, 7 skipped, 1 xfailed** (models); **876 passed, 16 skipped, 1 xfailed** (optim); **3706 passed, 9 skipped, 2 warnings** (commands/config/build/compiler/session/Eval); **964 passed, 2 skipped, 1 deselected, 1 warning** (remaining unit/regression/CLI).

## 4. Per-EP/device/precision results and Functional smoke Eval

### Goal ladder and artifact signatures

L0 and L1 are **PRESERVED**, not re-executed on the final runtime-repair SHA. They executed on `92387df1fbe50b628ac38574cdcb0fa992247088` and were reused only after 38 sealed artifact files and all recipes rehashed exactly and the repair was proven evaluator/runtime-only with no config, export, optimizer, recipe, lock, artifact-input, or component-perf impact. The execution SHA remains `92387df1...`; it is not relabeled as final-candidate execution.

| Tier | EP / device | Precision / component | Verdict | Exact artifact signature, size, and realized dtype |
|---|---|---|---|---|
| L0 | CPUExecutionProvider / cpu | fp32 encoder | PASS (preserved) | Inputs `input_ids[1,512]`, `attention_mask[1,512]`; output `encoder_hidden_states`; model 67,274 bytes + `model.onnx.data` 204,742,656 bytes; initializers FLOAT x102, INT64 x29; opset 17 |
| L0 | CPUExecutionProvider / cpu | fp32 decoder | PASS (preserved) | Inputs `decoder_input_ids[1,1]`, `encoder_hidden_states[1,512,512]`, `attention_mask[1,512]`, `decoder_attention_mask[1,512]`, `cache_position[1]`, 12 KV tensors `past_{0..5}_{key,value}[1,8,512,64]`; outputs `logits` + 12 `present_{0..5}_{key,value}`; model 146,157 bytes + `model.onnx.data` 358,291,672 bytes; initializers FLOAT x166, INT64 x43; opset 17 |
| L0 | CPUExecutionProvider / cpu | fp16 encoder | PASS (preserved) | Inputs `input_ids[1,512]`, `attention_mask[1,512]`; output `encoder_hidden_states`; model 102,432,639 bytes; initializers FLOAT16 x102, INT64 x29; opset 17 |
| L0 | CPUExecutionProvider / cpu | fp16 decoder | PASS (preserved) | Same decoder input/output signature as fp32; model 149,324 bytes + `model.onnx.data` 179,156,076 bytes; initializers FLOAT16 x166, INT64 x43; opset 17 |

All four artifact checks also passed co-located external-data, vocabulary 62,518, and realized-precision validation.

### Perf

| Tier | EP / device | Precision / component | Verdict | Mean | p50 | Throughput | RAM total |
|---|---|---|---|---:|---:|---:|---:|
| L1 | CPUExecutionProvider / cpu | fp32 encoder | PASS (preserved) | 69.23 ms | 68.24 ms | 14.45 samples/s | 64.4 MB |
| L1 | CPUExecutionProvider / cpu | fp32 decoder | PASS (preserved) | 22.51 ms | 21.75 ms | 44.42 samples/s | 21.2 MB |
| L1 | CPUExecutionProvider / cpu | fp16 encoder | PASS (preserved) | 89.09 ms | 88.50 ms | 11.22 samples/s | 74.8 MB |
| L1 | CPUExecutionProvider / cpu | fp16 decoder | PASS (preserved) | 24.92 ms | 24.08 ms | 40.13 samples/s | 27.4 MB |

### L2 parity and generation

| Precision | Encoder cosine / max abs | Decoder-logit cosine / max abs | Greedy token parity | Translation parity |
|---|---|---|---|---|
| fp32 | `0.9999999999993413` / `5.245208740234375e-06` | `0.9999999999986515` / `1.71661376953125e-05` | exact | exact |
| fp16 | `0.999998659921451` / `0.007945060729980469` | `0.9999992557247197` / `0.014481067657470703` | exact | exact |

For both fp32 and fp16, ONNX and pinned PyTorch produced these exact, distinct full greedy sequences and decoded texts:

1. Tokens (32): `[62517, 71, 2071, 575, 497, 221, 11, 20840, 30, 164, 3427, 2, 119, 26, 3712, 41, 2207, 806, 8432, 1300, 2, 119, 3983, 234, 38192, 53, 4410, 1046, 17820, 146, 3, 0]`
   Text: `"У нас есть 4-месячные мыши, которые не диабиотичны, которые раньше были диабетиками", добавил он.`
2. Tokens (55): `[62517, 1094, 5192, 1432, 21824, 261, 779, 2, 13172, 25978, 443, 374, 21647, 3085, 48, 1974, 10908, 6, 37750, 43669, 30, 2, 10383, 1561, 806, 6959, 847, 2, 7, 15382, 42, 4421, 10997, 7, 22526, 6876, 40306, 48, 7215, 38192, 41, 28840, 53, 2, 28, 2549, 145, 401, 4275, 6, 4790, 1029, 11078, 3, 0]`
   Text: `Доктор Эхуд Ур, профессор медицины Далхаузийского университета в Галифаксе, Новая Шотландия, и председатель клинического и научного отделения Канадской ассоциации диабета предупредили, что исследования все еще находятся в начале своего существования.`

### Functional smoke Eval

**PASS on final candidate `3f5f321e4721e3022f7f50514e8cfcfb9ad4570d`, FP32 CPU only.** Before this contribution, WinML rejected `translation` as an unsupported Eval task. The generalized evaluator now performs explicit source/reference extraction, bounded composite generation, decoding, exact accounting, and corpus metrics through TorchMetrics `SacreBLEUScore(tokenize='13a')` and `CHRFScore(n_char_order=6, n_word_order=0, beta=2.0)` on a 0-100 scale.

- Dataset: `gsarti/flores_101` source revision `bc58ae43b22607b3e1e2bf3ae1bc5cb053495abb`, immutable Parquet revision `1a45e707ea4b5ea3d6c71341f18bfca6a6e356a3`, config `all`, split `devtest`, deterministic rows 1-2, `sentence_eng` -> `sentence_rus`.
- Caps: max source tokens 128; max new tokens 64; beams 1; return sequences 1; sampling false; two generated sequences; maximum 128 total decoder steps.
- Accounting: attempted 2, evaluated 2, skipped 0.
- Result: **SacreBLEU-13a `9.7950`; chrF2 `56.8509`**. Independent recomputation returned the same values.

| Row | Source | Reference | Prediction | Generated tokens |
|---:|---|---|---|---:|
| 1 | `"We now have 4-month-old mice that are non-diabetic that used to be diabetic," he added.` | `"Теперь у нас есть четырёхмесячные мыши, у которых больше нет диабета", — добавил он.` | `"У нас есть 4-месячные мыши, которые не диабиотичны, которые раньше были диабетиками", добавил он.` | 32 |
| 2 | `Dr. Ehud Ur, professor of medicine at Dalhousie University in Halifax, Nova Scotia and chair of the clinical and scientific division of the Canadian Diabetes Association cautioned that the research is still in its early days.` | `Согласно предупреждению доктора Эхуда Ура (Ehud Ur), профессора медицины в Университете Делхаузи в Галифаксе (Новая Шотландия) и председателя клинико-научного отдела Канадской диабетической ассоциации, исследования все еще находятся на начальной стадии.` | `Доктор Эхуд Ур, профессор медицины Далхаузийского университета в Галифаксе, Новая Шотландия, и председатель клинического и научного отделения Канадской ассоциации диабета предупредили, что исследования все еще находятся в начале своего существования.` | 55 |

This proves end-to-end evaluator operability only. Two adjacent rows from one document are not representative sampling, and these values are not benchmark-quality or representative accuracy claims. Eval was not repeated for fp16 and no fp16 accuracy claim is made.

## 5. Delta

### Commit delta

| Commit | Purpose | Merge-safe disposition |
|---|---|---|
| `caa7dfb972b0c8cc1c5c878defcde790139eaf32` | Generalized bounded translation evaluator | Droppable if PR #1213 or equivalent generalized translation Eval merges first |
| `92387df1fbe50b628ac38574cdcb0fa992247088` | Four Model25 eager-attention recipe refreshes | Retain and rebase independently |
| `3f5f321e4721e3022f7f50514e8cfcfb9ad4570d` | Preserve encoder mask alignment during generation | Retain unless merged runtime already right-pads encoder `attention_mask` equivalently |

### Changed files

- `examples/recipes/Helsinki-NLP_opus-mt-en-ru/cpu/cpu/translation_fp16_decoder_config.json`
- `examples/recipes/Helsinki-NLP_opus-mt-en-ru/cpu/cpu/translation_fp16_encoder_config.json`
- `examples/recipes/Helsinki-NLP_opus-mt-en-ru/cpu/cpu/translation_fp32_decoder_config.json`
- `examples/recipes/Helsinki-NLP_opus-mt-en-ru/cpu/cpu/translation_fp32_encoder_config.json`
- `src/winml/modelkit/eval/__init__.py`
- `src/winml/modelkit/eval/evaluate.py`
- `src/winml/modelkit/eval/metrics/translation.py`
- `src/winml/modelkit/eval/translation_evaluator.py`
- `src/winml/modelkit/models/winml/encoder_decoder.py`
- `src/winml/modelkit/utils/eval_utils.py`
- `tests/unit/eval/test_translation_evaluator.py`
- `tests/unit/models/winml/test_composite_from_pretrained.py`

All four existing recipes change only `/export/compatibility/transformers_attention` from absent (`null`) to `"eager"`, matching current auto-config; fp16 quantization is preserved. The evaluator registry is additive; translation direction comes from explicit source/reference fields, bounded capacities come from model metadata, metrics are corpus-aggregated using the existing TorchMetrics dependency, failures propagate, and zero evaluated rows fails closed. `examples/recipes/README.md` remains untouched.

### Bug fix explanation

- **Symptom and trigger:** component parity passed, but full greedy generation for two distinct short, right-padded encoder inputs collapsed to the same incorrect token sequence/text in fp32 and fp16.
- **Root cause:** encoder inputs and hidden states were right-padded to the static 512-token width, while `_run_decoder` applied cache-oriented left-padding to every decoder feed. This moved each short encoder attention mask from active source positions `0..30` / `0..47` to `481..511` / `464..511`, so decoder cross-attention ignored the actual source tokens. Already-512-wide one-step parity inputs hid the defect.
- **Fix mechanism:** `WinMLEncoderDecoderModel` now preserves right-padding for the encoder cross-attention mask while retaining left-padding where the static decoder cache requires it; the regression exercises `test_encoder_decoder_preserves_encoder_alignment_across_independent_rows`.
- **Generalization:** the rule follows tensor role and static shape/capacity metadata. It does not inspect checkpoint, organization, language, dataset, or recipe names.
- **Compatibility/blast radius:** export, optimizer, recipe, lock, artifact signatures, cache identity/progression, static batch-one fan-out, and existing evaluator behavior are preserved. The intentional changes are translation Eval support, the explicit recipe compatibility field, and correct mask alignment for short encoder sequences.
- **Regression evidence:** focused test passed; repaired masks remain at `0..30` / `0..47`; two source rows produce distinct encoder states and distinct outputs; full bounded fp32 and fp16 ONNX token sequences and decoded translations exactly match pinned PyTorch.

### PR #1213 overlap

As last checked, microsoft/winml-cli PR #1213 was **OPEN, DRAFT, DIRTY/CONFLICTING** at head `a74eb377a2d43468c047ea10649aa52faec48991`; no Model25 PR existed. It overlaps the generalized evaluator. If #1213 merges first, drop `caa7dfb9`, rebase the recipe/runtime commits onto current `main`, return to Planner for dependency-aware impact analysis, and rerun Eval plus every invalidated check. Do not drop `3f5f321e` unless the merged encoder-decoder runtime proves equivalent encoder-mask alignment.

## 6. Analyze summary — component level and op level

Static rule analysis is **ANALYZE-PARTIAL-SUCCESS**: both all-EP commands emitted complete seven-target JSON, while exit 1 reflects providers without shipped rule data. This is compatibility analysis, not runtime execution.

### Component-level summary

| Artifact | Architecture coverage | Mapping | Actionable EP findings |
|---|---|---|---|
| fp32 encoder | token/position embeddings; encoder layers x6; self-attention and feed-forward regions | 197 nodes / 15 op types mapped through frozen scope-name hierarchy | No actionable partial/unsupported type in shipped TensorRT RTX, QNN, or OpenVINO rules; CUDA, MIGraphX, TensorRT, and DML runtime providers were absent |
| fp32 cached decoder | token/position embeddings; decoder layers x6; self/cross-attention; static KV cache; LM head; runtime generation loop | 378 nodes / 20 op types mapped through frozen scope-name hierarchy | QNN partial: Expand, Cast, Concat; ScatterND unknown for QNN, OpenVINO, and TensorRT RTX; CUDA, MIGraphX, TensorRT, and DML runtime providers were absent |

### Op-level summary

| Artifact | Graph | Dominant operators | EP roll-up |
|---|---|---|---|
| fp32 encoder | 197 operators / 15 types | Reshape 61; Gemm 36; Transpose 24; Add 19; Mul 13; MatMul 12; LayerNormalization 12 | TensorRT RTX, QNN, and OpenVINO rule classifications complete; runtime presence was observed only where reported by the static analyzer and is not an execution claim |
| fp32 cached decoder | 378 operators / 20 types | Reshape 112; Gemm 60; Transpose 54; Add 33; MatMul 25; Mul 20; LayerNormalization 18; ScatterND 13 | QNN partial for Expand/Cast/Concat; ScatterND unknown for QNN/OpenVINO/TensorRT RTX; absent-rule/runtime providers remain unknown rather than unsupported |

Provider absence and missing rule data are distinct from an unsupported verdict. No accelerator runtime support is claimed from static rules.

## 7. Reproduce commands

```powershell
$MODEL='Helsinki-NLP/opus-mt-en-ru'
$OUT='temp/model25-repro'
$RECIPES='examples/recipes/Helsinki-NLP_opus-mt-en-ru/cpu/cpu'

winml build -c "$RECIPES/translation_fp32_encoder_config.json" -m $MODEL -o "$OUT/encoder-fp32"
winml build -c "$RECIPES/translation_fp32_decoder_config.json" -m $MODEL -o "$OUT/decoder-fp32"
winml build -c "$RECIPES/translation_fp16_encoder_config.json" -m $MODEL -o "$OUT/encoder-fp16"
winml build -c "$RECIPES/translation_fp16_decoder_config.json" -m $MODEL -o "$OUT/decoder-fp16"

winml perf -m "$OUT/encoder-fp32/model.onnx" --ep cpu --device cpu
winml perf -m "$OUT/decoder-fp32/model.onnx" --ep cpu --device cpu
winml perf -m "$OUT/encoder-fp16/model.onnx" --ep cpu --device cpu
winml perf -m "$OUT/decoder-fp16/model.onnx" --ep cpu --device cpu

$env:WINMLCLI_RULES_DIR='rules'
winml analyze --model "$OUT/encoder-fp32/model.onnx" --ep all --output "$OUT/analyze-encoder-fp32.json"
winml analyze --model "$OUT/decoder-fp32/model.onnx" --ep all --output "$OUT/analyze-decoder-fp32.json"

winml eval --schema --task translation
python -m pytest tests/unit/eval/test_translation_evaluator.py tests/unit/models/winml/test_composite_from_pretrained.py tests/unit/eval/test_recipes.py tests/unit/recipes --tb=short --no-cov -q --color=no -m "not e2e and not npu and not gpu"
python -m ruff check src/ tests/
python -m mypy -p winml.modelkit
```