### PR TITLE
Make E2E timeouts download-aware and prioritize model execution

### DIFF
--- a/scripts/e2e_eval/README.md
+++ b/scripts/e2e_eval/README.md
@@ -120,7 +120,8 @@ uv run python scripts/e2e_eval/run_eval.py --update-baseline --eval-type accurac
 | `--group` | — | Filter by group (e.g. `Foundry Toolkit`) |
 | `--device` | `auto` | Target device |
 | `--ep` | — | Execution provider (e.g. `qnn`, `dml`, `openvino`); applied at perf/eval time |
-| `--timeout` | 600 | Per-subprocess timeout (seconds) |
+| `--timeout` | 600 | Per-subprocess execution timeout (seconds). Observable Hugging Face download time is excluded; the full timeout restarts when the download completes. |
+| `--hf-download-stall-timeout` | 600 | Fail as `HF_FETCH_FAIL` when a Hugging Face partial download has no size/mtime progress for this many seconds. |
 | `--clean-cache [TARGET ...]` | off | Clean caches after each job. `TARGET`: `winml`, `huggingface`, `others` (others = VitisAI cache + temp/cwd leaked scratch files). Use `--clean-cache` without TARGET to clear all (legacy behavior). |
 | `--update-baseline` | off | Offline mode: refresh `cache/baseline_cache.json` via the PyTorch baseline, then exit (no build/perf/eval) |
 | `--list` | off | List models and exit |

--- a/scripts/e2e_eval/run_eval.py
+++ b/scripts/e2e_eval/run_eval.py
@@ -623,19 +623,34 @@ def _kill_process_tree(pid: int) -> None:
             pass  # Process already exited; nothing to kill
 
 
+def _expand_cache_path(path: str | os.PathLike[str]) -> Path:
+    return Path(os.path.expandvars(os.fspath(path))).expanduser()
+
+
+def _hf_cache_roots(env: dict[str, str]) -> tuple[Path, Path, Path]:
+    """Resolve cache roots using Hugging Face's environment precedence."""
+    if "HF_HOME" in env:
+        hf_home = _expand_cache_path(env["HF_HOME"])
+    else:
+        xdg_cache = _expand_cache_path(env.get("XDG_CACHE_HOME", Path.home() / ".cache"))
+        hf_home = xdg_cache / "huggingface"
+
+    hub_cache_value = env.get("HF_HUB_CACHE")
+    if hub_cache_value is None:
+        hub_cache_value = env.get("HUGGINGFACE_HUB_CACHE")
+    hub_cache = _expand_cache_path(hub_cache_value or hf_home / "hub")
+    datasets_cache = _expand_cache_path(env.get("HF_DATASETS_CACHE") or hf_home / "datasets")
+    xet_cache = _expand_cache_path(env.get("HF_XET_CACHE") or hf_home / "xet")
+    return hub_cache, datasets_cache, xet_cache
+
+
 def _snapshot_hf_downloads(env: dict[str, str]) -> dict[Path, tuple[int, int]]:
     """Return observable Hugging Face partial downloads as size/mtime pairs."""
-    hf_home = Path(env.get("HF_HOME", Path.home() / ".cache" / "huggingface")).expanduser()
-    hub_cache = Path(
-        env.get("HF_HUB_CACHE")
-        or env.get("HUGGINGFACE_HUB_CACHE")
-        or hf_home / "hub"
-    ).expanduser()
-    datasets_cache = Path(env.get("HF_DATASETS_CACHE") or hf_home / "datasets").expanduser()
+    hub_cache, datasets_cache, xet_cache = _hf_cache_roots(env)
     searches = (
         (hub_cache, ("*/blobs/*.incomplete", "*.incomplete")),
         (datasets_cache, ("downloads/*.incomplete",)),
-        (hf_home / "xet", ("**/*.incomplete",)),
+        (xet_cache, ("**/*.incomplete",)),
     )
     snapshot: dict[Path, tuple[int, int]] = {}
     for root, patterns in searches:
@@ -655,24 +670,63 @@ def _snapshot_hf_downloads(env: dict[str, str]) -> dict[Path, tuple[int, int]]:
     return snapshot
 
 
+def _normalized_path(path: str | os.PathLike[str]) -> str:
+    return os.path.normcase(os.path.realpath(os.fspath(path)))
+
+
+def _process_tree_open_paths(pid: int) -> set[str]:
+    """Return normalized paths opened by a process and its descendants."""
+    try:
+        import psutil
+    except ImportError:
+        return set()
+
+    try:
+        root = psutil.Process(pid)
+    except psutil.Error:
+        return set()
+
+    processes = [root]
+    with contextlib.suppress(psutil.Error):
+        processes.extend(root.children(recursive=True))
+
+    paths: set[str] = set()
+    for process in processes:
+        try:
+            open_files = process.open_files()
+        except psutil.Error:
+            continue
+        paths.update(_normalized_path(open_file.path) for open_file in open_files)
+    return paths
+
+
 class _HfDownloadTracker:
-    """Detect active Hub downloads from growing ``*.incomplete`` cache files."""
+    """Detect downloads owned by the monitored subprocess tree."""
 
     def __init__(self, env: dict[str, str], now: float) -> None:
         self._env = env
         self._previous = _snapshot_hf_downloads(env)
         self._active_paths: set[Path] = set()
+        self._pid: int | None = None
         self.last_progress = now
+
+    def bind(self, pid: int) -> None:
+        self._pid = pid
 
     def poll(self, now: float) -> bool:
         current = _snapshot_hf_downloads(self._env)
+        open_paths = _process_tree_open_paths(self._pid) if self._pid is not None else set()
         progressed = {
-            path for path, state in current.items() if self._previous.get(path) != state
+            path
+            for path, state in current.items()
+            if self._previous.get(path) != state and _normalized_path(path) in open_paths
         }
         if progressed:
             self._active_paths.update(progressed)
             self.last_progress = now
-        self._active_paths.intersection_update(current)
+        self._active_paths.intersection_update(
+            path for path in current if _normalized_path(path) in open_paths
+        )
         self._previous = current
         return bool(self._active_paths)
 
@@ -717,6 +771,7 @@ def _run_subprocess(args: list[str], timeout: int) -> dict:
     else:
         popen_kwargs["start_new_session"] = True
     proc = subprocess.Popen(args, **popen_kwargs)  # noqa: S603
+    download_tracker.bind(proc.pid)
 
     # Read pipes in background threads so communicate() timeout works even
     # when grandchild processes keep pipe handles alive (Windows issue).

--- a/scripts/e2e_eval/run_eval.py
+++ b/scripts/e2e_eval/run_eval.py
@@ -99,6 +99,10 @@ EVAL_DATASETS_CACHE = Path.home() / ".cache" / "winml" / "eval_datasets"
 TIMEOUT_SKIP_LIST_PATH = Path(__file__).parent / "cache" / "timeout_skip_list.json"
 _DEFAULT_SAMPLES = 1000
 _DEFAULT_PRECISION_NPU = "w8a16"
+_DEFAULT_HF_DOWNLOAD_STALL_TIMEOUT = 600
+_HF_DOWNLOAD_STALL_TIMEOUT = float(_DEFAULT_HF_DOWNLOAD_STALL_TIMEOUT)
+_SUBPROCESS_POLL_INTERVAL = 0.25
+_PRIORITY_RANK = {f"P{index}": index for index in range(4)}
 _RETRY_FAILED_TYPES = (
     *(failure_type.value for failure_type in FailureType),
     "FAIL",
@@ -619,22 +623,89 @@ def _kill_process_tree(pid: int) -> None:
             pass  # Process already exited; nothing to kill
 
 
-def _run_subprocess(args: list[str], timeout: int) -> dict:
-    """Run a subprocess with three-layer timeout protection.
+def _snapshot_hf_downloads(env: dict[str, str]) -> dict[Path, tuple[int, int]]:
+    """Return observable Hugging Face partial downloads as size/mtime pairs."""
+    hf_home = Path(env.get("HF_HOME", Path.home() / ".cache" / "huggingface")).expanduser()
+    hub_cache = Path(
+        env.get("HF_HUB_CACHE")
+        or env.get("HUGGINGFACE_HUB_CACHE")
+        or hf_home / "hub"
+    ).expanduser()
+    datasets_cache = Path(env.get("HF_DATASETS_CACHE") or hf_home / "datasets").expanduser()
+    searches = (
+        (hub_cache, ("*/blobs/*.incomplete", "*.incomplete")),
+        (datasets_cache, ("downloads/*.incomplete",)),
+        (hf_home / "xet", ("**/*.incomplete",)),
+    )
+    snapshot: dict[Path, tuple[int, int]] = {}
+    for root, patterns in searches:
+        if not root.is_dir():
+            continue
+        for pattern in patterns:
+            try:
+                candidates = root.glob(pattern)
+                for path in candidates:
+                    try:
+                        stat = path.stat()
+                    except OSError:
+                        continue
+                    snapshot[path] = (stat.st_size, stat.st_mtime_ns)
+            except OSError:
+                continue
+    return snapshot
 
-    Returns a dict with: stdout, stderr, exit_code, elapsed, timeout, command.
+
+class _HfDownloadTracker:
+    """Detect active Hub downloads from growing ``*.incomplete`` cache files."""
+
+    def __init__(self, env: dict[str, str], now: float) -> None:
+        self._env = env
+        self._previous = _snapshot_hf_downloads(env)
+        self._active_paths: set[Path] = set()
+        self.last_progress = now
+
+    def poll(self, now: float) -> bool:
+        current = _snapshot_hf_downloads(self._env)
+        progressed = {
+            path for path, state in current.items() if self._previous.get(path) != state
+        }
+        if progressed:
+            self._active_paths.update(progressed)
+            self.last_progress = now
+        self._active_paths.intersection_update(current)
+        self._previous = current
+        return bool(self._active_paths)
+
+
+def _run_subprocess(args: list[str], timeout: int) -> dict:
+    """Run a subprocess with execution and HF-download-stall timeouts.
+
+    ``timeout`` starts normally when no Hugging Face download is observed. If a
+    Hub download starts, the execution budget is suspended and reset to its
+    full value after the download completes. Downloads get an independent
+    inactivity budget: if an ``*.incomplete`` cache file stops changing for
+    ``_HF_DOWNLOAD_STALL_TIMEOUT`` seconds, the process is terminated as an HF
+    fetch failure.
 
     Windows fix: On Windows, child processes can inherit pipe handles, causing
-    ``proc.communicate()`` to block indefinitely even after ``taskkill`` kills
-    the process tree.  We work around this by:
+    pipe reads to block indefinitely even after ``taskkill`` kills the process
+    tree. We work around this by:
     1. Using ``CREATE_NO_WINDOW`` to prevent console inheritance issues.
-    2. Reading stdout/stderr in background threads so the main thread can
-       enforce the timeout independently of pipe EOF.
-    3. Using a hard watchdog timer that forcefully closes pipes.
+    2. Reading stdout/stderr in background threads.
+    3. Polling process state independently of pipe EOF.
     """
-    env = {**os.environ, "PYTHONIOENCODING": "utf-8"}
+    env = {
+        **os.environ,
+        "PYTHONIOENCODING": "utf-8",
+        "HF_HUB_DOWNLOAD_TIMEOUT": str(int(_HF_DOWNLOAD_STALL_TIMEOUT)),
+    }
     start = time.perf_counter()
     timed_out = False
+    hf_download_stalled = False
+    execution_elapsed = 0.0
+    last_poll = start
+    download_tracker = _HfDownloadTracker(env, start)
+    download_was_active = False
 
     popen_kwargs: dict = {
         "stdout": subprocess.PIPE,
@@ -667,46 +738,57 @@ def _run_subprocess(args: list[str], timeout: int) -> dict:
     stdout_thread.start()
     stderr_thread.start()
 
-    def _watchdog() -> None:
-        try:
-            _kill_process_tree(proc.pid)
-            proc.kill()
-            for pipe in (proc.stdout, proc.stderr):
-                if pipe:
-                    try:
-                        pipe.close()
-                    except OSError:
-                        pass  # Pipe already closed
-        except Exception:
-            pass  # Best-effort cleanup; ignore all errors in watchdog
-
-    watchdog = threading.Timer(timeout + 30, _watchdog)
-    watchdog.daemon = True
-    watchdog.start()
-
     try:
-        proc.wait(timeout=timeout)
-        exit_code = proc.returncode
+        while True:
+            remaining = max(0.01, timeout - execution_elapsed)
+            try:
+                proc.wait(timeout=min(_SUBPROCESS_POLL_INTERVAL, remaining))
+                now = time.perf_counter()
+                download_active = download_tracker.poll(now)
+                if download_was_active and not download_active:
+                    execution_elapsed = 0.0
+                elif not download_active:
+                    execution_elapsed += now - last_poll
+                exit_code = proc.returncode
+                break
+            except subprocess.TimeoutExpired:
+                now = time.perf_counter()
+                download_active = download_tracker.poll(now)
+                if download_active:
+                    download_was_active = True
+                    if now - download_tracker.last_progress >= _HF_DOWNLOAD_STALL_TIMEOUT:
+                        hf_download_stalled = True
+                else:
+                    if download_was_active:
+                        execution_elapsed = 0.0
+                        download_was_active = False
+                    else:
+                        execution_elapsed += now - last_poll
+                    if execution_elapsed >= timeout:
+                        timed_out = True
+                last_poll = now
+
+                if not timed_out and not hf_download_stalled:
+                    continue
+
+                _kill_process_tree(proc.pid)
+                with contextlib.suppress(OSError):
+                    proc.kill()
+                exit_code = -1
+                break
+
         # Give reader threads a moment to finish draining
         stdout_thread.join(timeout=10)
         stderr_thread.join(timeout=10)
-    except subprocess.TimeoutExpired:
-        _kill_process_tree(proc.pid)
-        proc.kill()
-        # Give threads a short time to drain after kill
-        stdout_thread.join(timeout=5)
-        stderr_thread.join(timeout=5)
-        exit_code = -1
-        timed_out = True
     except KeyboardInterrupt:
         safe_print("\n  [Ctrl+C] Killing subprocess...")
         _kill_process_tree(proc.pid)
-        proc.kill()
+        with contextlib.suppress(OSError):
+            proc.kill()
         stdout_thread.join(timeout=5)
         stderr_thread.join(timeout=5)
         raise
     finally:
-        watchdog.cancel()
         # Force-close pipes to unblock any stuck reader threads
         for pipe in (proc.stdout, proc.stderr):
             if pipe:
@@ -723,6 +805,12 @@ def _run_subprocess(args: list[str], timeout: int) -> dict:
 
     stdout = b"".join(stdout_chunks).decode("utf-8", errors="replace")
     stderr = b"".join(stderr_chunks).decode("utf-8", errors="replace")
+    if hf_download_stalled:
+        stderr += (
+            "\nError while downloading from https://huggingface.co: "
+            f"no cache progress for {_HF_DOWNLOAD_STALL_TIMEOUT:g} seconds "
+            "(Hugging Face download stalled).\n"
+        )
     elapsed = round(time.perf_counter() - start, 1)
 
     result = {
@@ -731,6 +819,7 @@ def _run_subprocess(args: list[str], timeout: int) -> dict:
         "exit_code": exit_code,
         "elapsed": elapsed,
         "timeout": timed_out,
+        "hf_download_stalled": hf_download_stalled,
         "command": " ".join(str(a) for a in args),
     }
 
@@ -2705,6 +2794,14 @@ class EvalJob:
         return self.fallback_precision or self.entry.precision
 
 
+def _model_sort_key(entry: ModelEntry) -> tuple[int, str]:
+    """Sort P0-P3 models by priority, then case-insensitive model ID."""
+    return (
+        _PRIORITY_RANK.get(entry.priority.upper(), len(_PRIORITY_RANK)),
+        entry.hf_id.casefold(),
+    )
+
+
 def _is_quantized_precision(precision: str) -> bool:
     """True if a recipe precision implies quantization.
 
@@ -2783,7 +2880,10 @@ def _build_jobs(
             )
         else:
             jobs.append(EvalJob(entry, None))
-    return jobs
+    return sorted(
+        jobs,
+        key=lambda job: _model_sort_key(job.entry),
+    )
 
 
 def _build_for_job(
@@ -3023,6 +3123,16 @@ def parse_args() -> argparse.Namespace:
         "--timeout", type=int, default=600, help="Per-subprocess timeout in seconds (default: 600)"
     )
     parser.add_argument(
+        "--hf-download-stall-timeout",
+        type=int,
+        default=_DEFAULT_HF_DOWNLOAD_STALL_TIMEOUT,
+        help=(
+            "Hugging Face download inactivity timeout in seconds; active download "
+            "time is excluded and --timeout restarts after download completion "
+            "(default: 600)"
+        ),
+    )
+    parser.add_argument(
         "--clean-cache",
         dest="clean_cache",
         nargs="*",
@@ -3097,7 +3207,12 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     """Run E2E evaluation pipeline."""
+    global _HF_DOWNLOAD_STALL_TIMEOUT
+
     args = parse_args()
+    if args.hf_download_stall_timeout <= 0:
+        raise ValueError("--hf-download-stall-timeout must be positive")
+    _HF_DOWNLOAD_STALL_TIMEOUT = float(args.hf_download_stall_timeout)
     clean_cache_targets = _resolve_clean_cache_targets(args.clean_cache)
     args.clean_cache_targets = clean_cache_targets
 
@@ -3146,6 +3261,7 @@ def main() -> None:
     if not entries:
         safe_print("No models matched the filters.")
         sys.exit(1)
+    entries.sort(key=_model_sort_key)
 
     # Register dataset configs from registry entries as fallback
     register_from_registry(entries)

--- a/scripts/e2e_eval/run_eval.py
+++ b/scripts/e2e_eval/run_eval.py
@@ -714,8 +714,8 @@ class _HfDownloadTracker:
         self._pid = pid
 
     def poll(self, now: float) -> bool:
-        current = _snapshot_hf_downloads(self._env)
         open_paths = _process_tree_open_paths(self._pid) if self._pid is not None else set()
+        current = _snapshot_hf_downloads(self._env)
         progressed = {
             path
             for path, state in current.items()

--- a/scripts/e2e_eval/utils/classifier.py
+++ b/scripts/e2e_eval/utils/classifier.py
@@ -45,6 +45,7 @@ _HF_FETCH_RETRY_PATTERNS = (
     "winerror 10060",
     "we couldn't connect to 'https://huggingface.co'",
     "thrown while requesting head https://huggingface.co",
+    "hugging face download stalled",
 )
 
 

--- a/tests/unit/eval/test_run_eval_script.py
+++ b/tests/unit/eval/test_run_eval_script.py
@@ -17,6 +17,7 @@ import argparse
 import importlib.util
 import json
 import sys
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -226,6 +227,25 @@ class TestKillProcessTree:
 
 
 class TestRunSubprocessTimeouts:
+    _HF_CACHE_ENV_VARS = (
+        "HF_HOME",
+        "HF_HUB_CACHE",
+        "HUGGINGFACE_HUB_CACHE",
+        "HF_DATASETS_CACHE",
+        "HF_XET_CACHE",
+        "XDG_CACHE_HOME",
+    )
+
+    @classmethod
+    def _cache_env(cls, run_eval, **overrides):
+        env = {
+            name: value
+            for name, value in run_eval.os.environ.items()
+            if name not in cls._HF_CACHE_ENV_VARS
+        }
+        env.update({name: str(value) for name, value in overrides.items()})
+        return patch.dict(run_eval.os.environ, env, clear=True)
+
     @staticmethod
     def _download_script(
         incomplete: Path,
@@ -268,7 +288,7 @@ class TestRunSubprocessTimeouts:
         )
 
         with (
-            patch.dict(run_eval.os.environ, {"HF_HOME": str(tmp_path)}),
+            self._cache_env(run_eval, HF_HOME=tmp_path),
             patch.object(run_eval, "_HF_DOWNLOAD_STALL_TIMEOUT", 1.0),
         ):
             result = run_eval._run_subprocess([sys.executable, "-c", script], timeout=0.5)
@@ -283,7 +303,7 @@ class TestRunSubprocessTimeouts:
         script = self._download_script(incomplete, [5.0])
 
         with (
-            patch.dict(run_eval.os.environ, {"HF_HOME": str(tmp_path)}),
+            self._cache_env(run_eval, HF_HOME=tmp_path),
             patch.object(run_eval, "_HF_DOWNLOAD_STALL_TIMEOUT", 0.5),
         ):
             result = run_eval._run_subprocess([sys.executable, "-c", script], timeout=5)
@@ -298,6 +318,71 @@ class TestRunSubprocessTimeouts:
             classifier.FailureType.HF_FETCH_FAIL
         )
         assert classifier.matches_hf_fetch_retry(result["stderr"]) is True
+
+    def test_unrelated_hf_download_does_not_suspend_execution_timeout(self, run_eval, tmp_path):
+        incomplete = tmp_path / "hub" / "models--acme--model" / "blobs" / "model.incomplete"
+        sibling_script = self._download_script(incomplete, [0.1] * 20)
+
+        with (
+            self._cache_env(run_eval, HF_HOME=tmp_path),
+            patch.object(run_eval, "_HF_DOWNLOAD_STALL_TIMEOUT", 1.0),
+        ):
+            sibling = run_eval.subprocess.Popen([sys.executable, "-c", sibling_script])
+            try:
+                deadline = time.perf_counter() + 2
+                while not incomplete.exists() and time.perf_counter() < deadline:
+                    time.sleep(0.01)
+                assert incomplete.exists()
+
+                result = run_eval._run_subprocess(
+                    [sys.executable, "-c", "import time; time.sleep(1.2)"],
+                    timeout=0.5,
+                )
+            finally:
+                sibling.kill()
+                sibling.wait(timeout=5)
+
+        assert result["exit_code"] == -1
+        assert result["timeout"] is True
+        assert result["hf_download_stalled"] is False
+
+    def test_execution_timeout_restarts_after_xdg_hf_download(self, run_eval, tmp_path):
+        incomplete = (
+            tmp_path / "huggingface" / "hub" / "models--acme--model" / "blobs" / "model.incomplete"
+        )
+        script = self._download_script(
+            incomplete,
+            [0.2] * 5,
+            before_download=0.35,
+            after_download=0.35,
+        )
+
+        with (
+            self._cache_env(run_eval, XDG_CACHE_HOME=tmp_path),
+            patch.object(run_eval, "_HF_DOWNLOAD_STALL_TIMEOUT", 1.0),
+        ):
+            result = run_eval._run_subprocess([sys.executable, "-c", script], timeout=0.5)
+
+        assert result["exit_code"] == 0
+        assert result["elapsed"] >= 1.6
+        assert result["timeout"] is False
+        assert result["hf_download_stalled"] is False
+
+    def test_stalled_xdg_hf_download_uses_independent_timeout(self, run_eval, tmp_path):
+        incomplete = (
+            tmp_path / "huggingface" / "hub" / "models--acme--model" / "blobs" / "model.incomplete"
+        )
+        script = self._download_script(incomplete, [5.0])
+
+        with (
+            self._cache_env(run_eval, XDG_CACHE_HOME=tmp_path),
+            patch.object(run_eval, "_HF_DOWNLOAD_STALL_TIMEOUT", 0.5),
+        ):
+            result = run_eval._run_subprocess([sys.executable, "-c", script], timeout=5)
+
+        assert result["exit_code"] == -1
+        assert result["timeout"] is False
+        assert result["hf_download_stalled"] is True
 
     def test_execution_without_hf_download_uses_original_timeout(self, run_eval):
         with patch.object(run_eval, "_HF_DOWNLOAD_STALL_TIMEOUT", 1.0):

--- a/tests/unit/eval/test_run_eval_script.py
+++ b/tests/unit/eval/test_run_eval_script.py
@@ -225,6 +225,91 @@ class TestKillProcessTree:
         )
 
 
+class TestRunSubprocessTimeouts:
+    @staticmethod
+    def _download_script(
+        incomplete: Path,
+        delays: list[float],
+        *,
+        before_download: float = 0.0,
+        after_download: float = 0.0,
+    ) -> str:
+        return "\n".join(
+            [
+                "import time",
+                "from pathlib import Path",
+                f"path = Path({str(incomplete)!r})",
+                f"time.sleep({before_download})",
+                "path.parent.mkdir(parents=True, exist_ok=True)",
+                "with path.open('wb') as stream:",
+                *[
+                    line
+                    for delay in delays
+                    for line in (
+                        "    stream.write(b'x')",
+                        "    stream.flush()",
+                        f"    time.sleep({delay})",
+                    )
+                ],
+                "path.unlink()",
+                f"time.sleep({after_download})",
+            ]
+        )
+
+    def test_execution_timeout_restarts_after_hf_download(
+        self, run_eval, tmp_path
+    ):
+        incomplete = tmp_path / "hub" / "models--acme--model" / "blobs" / "model.incomplete"
+        script = self._download_script(
+            incomplete,
+            [0.2] * 5,
+            before_download=0.35,
+            after_download=0.35,
+        )
+
+        with (
+            patch.dict(run_eval.os.environ, {"HF_HOME": str(tmp_path)}),
+            patch.object(run_eval, "_HF_DOWNLOAD_STALL_TIMEOUT", 1.0),
+        ):
+            result = run_eval._run_subprocess([sys.executable, "-c", script], timeout=0.5)
+
+        assert result["exit_code"] == 0
+        assert result["elapsed"] >= 1.6
+        assert result["timeout"] is False
+        assert result["hf_download_stalled"] is False
+
+    def test_stalled_hf_download_uses_independent_timeout(self, run_eval, tmp_path):
+        incomplete = tmp_path / "hub" / "models--acme--model" / "blobs" / "model.incomplete"
+        script = self._download_script(incomplete, [5.0])
+
+        with (
+            patch.dict(run_eval.os.environ, {"HF_HOME": str(tmp_path)}),
+            patch.object(run_eval, "_HF_DOWNLOAD_STALL_TIMEOUT", 0.5),
+        ):
+            result = run_eval._run_subprocess([sys.executable, "-c", script], timeout=5)
+
+        assert result["exit_code"] == -1
+        assert result["elapsed"] < 3
+        assert result["timeout"] is False
+        assert result["hf_download_stalled"] is True
+        assert "Hugging Face download stalled" in result["stderr"]
+        classifier = sys.modules["utils.classifier"]
+        assert classifier.classify_failure(result["stderr"], result["exit_code"]) is (
+            classifier.FailureType.HF_FETCH_FAIL
+        )
+        assert classifier.matches_hf_fetch_retry(result["stderr"]) is True
+
+    def test_execution_without_hf_download_uses_original_timeout(self, run_eval):
+        with patch.object(run_eval, "_HF_DOWNLOAD_STALL_TIMEOUT", 1.0):
+            result = run_eval._run_subprocess(
+                [sys.executable, "-c", "import time; time.sleep(5)"], timeout=0.5
+            )
+
+        assert result["exit_code"] == -1
+        assert result["timeout"] is True
+        assert result["hf_download_stalled"] is False
+
+
 def test_curated_target_models_preserve_existing_priorities(run_eval):
     testsets_dir = (
         Path(__file__).resolve().parents[3]
@@ -1716,6 +1801,27 @@ class TestBuildJobs:
         jobs = run_eval._build_jobs([entry], None, "cpu")
         assert len(jobs) == 1
         assert jobs[0].variant is None
+
+    def test_sorts_by_priority_then_model_name(self, run_eval):
+        entries = [
+            _entry("zeta/p0", "text-classification"),
+            _entry("Zulu/p2", "text-classification"),
+            _entry("beta/p1", "text-classification"),
+            _entry("Alpha/p2", "text-classification"),
+            _entry("alpha/p1", "text-classification"),
+        ]
+        for entry, priority in zip(entries, ["P0", "P2", "P1", "P2", "P1"], strict=True):
+            entry.priority = priority
+
+        jobs = run_eval._build_jobs(entries, None, "cpu")
+
+        assert [(job.entry.priority, job.entry.hf_id) for job in jobs] == [
+            ("P0", "zeta/p0"),
+            ("P1", "alpha/p1"),
+            ("P1", "beta/p1"),
+            ("P2", "Alpha/p2"),
+            ("P2", "Zulu/p2"),
+        ]
 
 
 class TestRunRecipeBuild:

--- a/tests/unit/eval/test_run_eval_script.py
+++ b/tests/unit/eval/test_run_eval_script.py
@@ -298,6 +298,33 @@ class TestRunSubprocessTimeouts:
         assert result["timeout"] is False
         assert result["hf_download_stalled"] is False
 
+    def test_execution_timeout_restarts_after_hf_download_with_slow_handle_scan(
+        self, run_eval, tmp_path
+    ):
+        incomplete = tmp_path / "hub" / "models--acme--model" / "blobs" / "model.incomplete"
+        script = self._download_script(
+            incomplete,
+            [0.2] * 5,
+            before_download=0.35,
+            after_download=0.35,
+        )
+        real_open_paths = run_eval._process_tree_open_paths
+
+        def slow_open_paths(pid):
+            time.sleep(0.7)
+            return real_open_paths(pid)
+
+        with (
+            self._cache_env(run_eval, HF_HOME=tmp_path),
+            patch.object(run_eval, "_HF_DOWNLOAD_STALL_TIMEOUT", 2.0),
+            patch.object(run_eval, "_process_tree_open_paths", side_effect=slow_open_paths),
+        ):
+            result = run_eval._run_subprocess([sys.executable, "-c", script], timeout=0.5)
+
+        assert result["exit_code"] == 0
+        assert result["timeout"] is False
+        assert result["hf_download_stalled"] is False
+
     def test_stalled_hf_download_uses_independent_timeout(self, run_eval, tmp_path):
         incomplete = tmp_path / "hub" / "models--acme--model" / "blobs" / "model.incomplete"
         script = self._download_script(incomplete, [5.0])


### PR DESCRIPTION
## Summary

- monitor Hugging Face `.incomplete` cache files and exclude active downloads from the normal subprocess timeout
- restart the full execution timeout after a Hugging Face download completes
- fail downloads after 600 seconds without progress by default and classify them as `HF_FETCH_FAIL` for retry selection
- schedule E2E models by P0, P1, P2, P3, then by case-insensitive model ID
- document the new timeout option and add regression tests

## Testing

- `D:\Dev\MKs\ModelKit\.venv\Scripts\python.exe -m pytest tests/unit/eval/test_run_eval_script.py -q` (182 passed)
- `D:\Dev\MKs\ModelKit\.venv\Scripts\python.exe -m ruff check scripts/e2e_eval/run_eval.py scripts/e2e_eval/utils/classifier.py tests/unit/eval/test_run_eval_script.py`
- `git diff --check`

Fixes #1399