### PR TITLE
fix(build): honor CLI optimization bypass

### DIFF
--- a/src/winml/modelkit/commands/build.py
+++ b/src/winml/modelkit/commands/build.py
@@ -2068,6 +2068,7 @@ def _build_hf_pipeline(
 
     max_iters: int = extra_kwargs.pop("hack_max_optim_iterations", 3)
     allow_unsupported_nodes: bool = extra_kwargs.pop("allow_unsupported_nodes", False)
+    skip_optimize: bool = extra_kwargs.pop("skip_optimize", False)
     model_label = model_id or "random-init"
 
     # ── Validate + setup ─────────────────────────────────────────
@@ -2153,6 +2154,7 @@ def _build_hf_pipeline(
         show_io_first=False,
         analyze_output_path=analyze_result_path,
         allow_unsupported_nodes=allow_unsupported_nodes,
+        skip_optimize=skip_optimize or config.skip_optimize,
     )
 
     # Persist config after autoconf
@@ -2209,6 +2211,7 @@ def _build_onnx_pipeline(
 
     max_iters: int = extra_kwargs.pop("hack_max_optim_iterations", 3)
     allow_unsupported_nodes: bool = extra_kwargs.pop("allow_unsupported_nodes", False)
+    skip_optimize: bool = extra_kwargs.pop("skip_optimize", False)
 
     # ── Validate + setup ─────────────────────────────────────────
     if not onnx_path.exists():
@@ -2264,7 +2267,7 @@ def _build_onnx_pipeline(
         show_io_first=True,
         analyze_output_path=analyze_result_path,
         allow_unsupported_nodes=allow_unsupported_nodes,
-        skip_optimize=config.skip_optimize,
+        skip_optimize=skip_optimize or config.skip_optimize,
     )
 
     config_path.write_text(json.dumps(config.to_dict(), indent=2))

--- a/tests/unit/commands/test_build.py
+++ b/tests/unit/commands/test_build.py
@@ -1791,6 +1791,258 @@ class TestBuildNoOptimizeFlag:
         assert "skip_optimize" not in extra
 
 
+class TestBuildPipelineStageControls:
+    """Exercise real CLI sinks and stage control, mocking only expensive payloads."""
+
+    @staticmethod
+    def _write_model(path: Path, graph_kind: str) -> None:
+        import onnx
+        from onnx import TensorProto, helper
+
+        input_type = output_type = TensorProto.FLOAT
+        initializers = []
+        if graph_kind == "raw":
+            nodes = [helper.make_node("Identity", ["x"], ["y"])]
+        elif graph_kind == "qdq":
+            initializers = [
+                helper.make_tensor("scale", TensorProto.FLOAT, [], [0.125]),
+                helper.make_tensor("zero", TensorProto.UINT8, [], [0]),
+            ]
+            nodes = [
+                helper.make_node("QuantizeLinear", ["x", "scale", "zero"], ["q"]),
+                helper.make_node("DequantizeLinear", ["q", "scale", "zero"], ["y"]),
+            ]
+        else:
+            assert graph_kind == "qoperator"
+            input_type, output_type = TensorProto.UINT8, TensorProto.INT32
+            initializers = [helper.make_tensor("weight", TensorProto.UINT8, [1, 1], [1])]
+            # No Q/DQ nodes: detection must recognize the integer operator itself.
+            nodes = [helper.make_node("MatMulInteger", ["x", "weight"], ["y"])]
+        graph = helper.make_graph(
+            nodes,
+            "stage-control-fixture",
+            [helper.make_tensor_value_info("x", input_type, [1, 1])],
+            [helper.make_tensor_value_info("y", output_type, [1, 1])],
+            initializer=initializers,
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+        onnx.checker.check_model(model)
+        onnx.save(model, path)
+
+    @staticmethod
+    def _config(input_kind: str, quant_mode: str, config_skip: bool = False) -> dict:
+        return {
+            "loader": {"task": "feature-extraction"},
+            "export": {"opset_version": 17} if input_kind == "hf" else None,
+            "optim": {},
+            "quant": {
+                "mode": quant_mode,
+                "samples": 1,
+                "task": "feature-extraction",
+                "model_id": "test-model",
+            },
+            "compile": {"execution_provider": "cpu", "enable_ep_context": False},
+            "auto": True,
+            "skip_optimize": config_skip,
+        }
+
+    @pytest.fixture
+    def payloads(self):
+        from winml.modelkit.analyze import AnalyzeResult, LintResult
+        from winml.modelkit.onnx import copy_onnx_model
+        from winml.modelkit.optim import WinMLOptimizationConfig
+
+        def export_payload(*, model, output_path, **kwargs):
+            copy_onnx_model(model, output_path)
+
+        def optimize_payload(*, model, output, **kwargs):
+            copy_onnx_model(model, output)
+
+        def convert_payload(*, model_path, output_path, **kwargs):
+            copy_onnx_model(model_path, output_path)
+            return MagicMock(success=True, output_path=output_path, errors=[])
+
+        optim = WinMLOptimizationConfig()
+        analysis = AnalyzeResult(
+            lint=LintResult(
+                errors=0,
+                warnings=0,
+                info=0,
+                passed=True,
+                error_patterns=[],
+                warning_patterns=[],
+                information=[],
+                optimization_config=optim,
+            ),
+            optimization_config=optim,
+        )
+        with (
+            patch("winml.modelkit.build.hf._load_model") as load,
+            patch("winml.modelkit.export.export_onnx", side_effect=export_payload) as export,
+            patch(
+                "winml.modelkit.build.common.optimize_onnx", side_effect=optimize_payload
+            ) as optimize,
+            patch("winml.modelkit.build.common.analyze_onnx", return_value=analysis) as analyze,
+            patch("winml.modelkit.quant.quantize_onnx", side_effect=convert_payload) as quantize,
+            patch("winml.modelkit.compiler.compile_onnx", side_effect=convert_payload) as compile_,
+            patch("winml.modelkit.utils.console.StageLive"),
+            patch(
+                "winml.modelkit.session.resolve_device",
+                return_value=EPDeviceTarget(ep="CPUExecutionProvider", device="cpu"),
+            ),
+        ):
+            yield {
+                "load": load,
+                "export": export,
+                "optimize": optimize,
+                "analyze": analyze,
+                "quantize": quantize,
+                "compile": compile_,
+            }
+
+    def _invoke_pipeline(
+        self,
+        tmp_path: Path,
+        payloads: dict,
+        input_kind: str,
+        quant_mode: str,
+        flags: tuple[str, ...],
+        *,
+        config_skip: bool = False,
+        graph_kind: str = "raw",
+    ) -> Path:
+        from winml.modelkit.onnx import is_quantized_onnx
+
+        model_path = tmp_path / "input.onnx"
+        self._write_model(model_path, graph_kind)
+        assert is_quantized_onnx(model_path) is (graph_kind != "raw")
+        payloads["load"].return_value = model_path
+        config_path = tmp_path / "config.json"
+        config_path.write_text(json.dumps(self._config(input_kind, quant_mode, config_skip)))
+        output_dir = tmp_path / "out"
+        result = _invoke(
+            [
+                "-c",
+                str(config_path),
+                "-m",
+                "test-model" if input_kind == "hf" else str(model_path),
+                "-o",
+                str(output_dir),
+                "--ep",
+                "cpu",
+                "--export-type",
+                "generic",
+                *flags,
+            ]
+        )
+        assert result.exit_code == 0, result.output
+        return output_dir
+
+    @pytest.mark.parametrize("input_kind", ["hf", "onnx"])
+    @pytest.mark.parametrize("quant_mode", ["fp16", "static"])
+    @pytest.mark.parametrize(
+        ("flags", "config_skip"),
+        [
+            pytest.param((), False, id="default"),
+            pytest.param(("--optimize",), False, id="explicit-optimize"),
+            pytest.param(("--no-optimize",), False, id="cli-skip"),
+            pytest.param((), True, id="config-skip"),
+            pytest.param(("--optimize",), True, id="config-skip-with-cli-optimize"),
+            pytest.param(
+                ("--no-optimize", "--max-optim-iterations", "5"),
+                False,
+                id="cli-skip-with-autoconf",
+            ),
+        ],
+    )
+    def test_raw_pipeline_preserves_optimization_and_quantization_controls(
+        self, tmp_path: Path, payloads, input_kind, quant_mode, flags, config_skip
+    ) -> None:
+        output_dir = self._invoke_pipeline(
+            tmp_path, payloads, input_kind, quant_mode, flags, config_skip=config_skip
+        )
+
+        skip = config_skip or "--no-optimize" in flags
+        assert payloads["optimize"].call_count == (0 if skip else 1)
+        assert payloads["analyze"].call_count == (0 if skip else 2)
+        assert payloads["export"].call_count == (1 if input_kind == "hf" else 0)
+        payloads["quantize"].assert_called_once()
+        assert payloads["quantize"].call_args.kwargs["config"].mode == quant_mode
+        payloads["compile"].assert_called_once()
+        assert (
+            payloads["compile"].call_args.kwargs["model_path"]
+            == payloads["quantize"].call_args.kwargs["output_path"]
+        )
+        saved = json.loads((output_dir / "winml_build_config.json").read_text())
+        assert saved["quant"]["mode"] == quant_mode
+        # Explicit bypass is not evidence of prequantization: do not force-stamp it.
+        assert saved.get("skip_optimize", False) is config_skip
+        optimized_name = "optimized.onnx" if input_kind == "hf" else "input_optimized.onnx"
+        assert (output_dir / optimized_name).is_file()
+        assert (output_dir / "model.onnx").is_file()
+
+    @pytest.mark.parametrize("graph_kind", ["qdq", "qoperator"])
+    @pytest.mark.parametrize("quant_mode", ["fp16", "static"])
+    @pytest.mark.parametrize(
+        ("flags", "config_skip"),
+        [((), False), (("--no-optimize",), False), ((), True)],
+        ids=["default", "cli-skip", "config-skip"],
+    )
+    def test_graph_proven_prequantization_suppresses_requantization(
+        self, tmp_path: Path, payloads, graph_kind, quant_mode, flags, config_skip
+    ) -> None:
+        output_dir = self._invoke_pipeline(
+            tmp_path,
+            payloads,
+            "onnx",
+            quant_mode,
+            flags,
+            config_skip=config_skip,
+            graph_kind=graph_kind,
+        )
+
+        for stage in ("export", "optimize", "analyze", "quantize"):
+            payloads[stage].assert_not_called()
+        payloads["compile"].assert_called_once()
+        saved = json.loads((output_dir / "winml_build_config.json").read_text())
+        assert saved["skip_optimize"] is True
+        assert saved["quant"] is None
+        assert (output_dir / "model.onnx").is_file()
+
+    @pytest.mark.parametrize("quant_mode", ["fp16", "static"])
+    @pytest.mark.parametrize("flags", [(), ("--no-optimize",)], ids=["default", "cli-skip"])
+    def test_composite_controls_reach_every_actual_hf_sink(
+        self, tmp_path: Path, payloads, quant_mode, flags
+    ) -> None:
+        from winml.modelkit.config import WinMLBuildConfig
+
+        components = dict.fromkeys(("part_a", "part_b"), "feature-extraction")
+
+        def component_config(_model_id, *, task, **kwargs):
+            data = self._config("hf", quant_mode)
+            data["loader"]["task"] = task
+            return WinMLBuildConfig.from_dict(data)
+
+        with (
+            patch(
+                "winml.modelkit.loader.resolution.resolve_composite_components",
+                return_value=components,
+            ),
+            patch("winml.modelkit.config.generate_build_config", side_effect=component_config),
+        ):
+            output_dir = self._invoke_pipeline(tmp_path, payloads, "hf", quant_mode, flags)
+
+        assert payloads["optimize"].call_count == (0 if flags else 2)
+        assert payloads["analyze"].call_count == (0 if flags else 4)
+        for stage in ("load", "export", "quantize", "compile"):
+            assert payloads[stage].call_count == len(components)
+        quant_configs = [call.kwargs["config"] for call in payloads["quantize"].call_args_list]
+        assert quant_configs[0] is not quant_configs[1]
+        assert all(config.mode == quant_mode for config in quant_configs)
+        for name in components:
+            assert (output_dir / f"{name}_model.onnx").is_file()
+
+
 # =============================================================================
 # _run_compile_stage UNIT TESTS
 # =============================================================================


### PR DESCRIPTION
## Summary

CLI-only control-correctness fix; no recipes, model-specific logic, new graph optimization pass, or speedup claim.

- Consume `skip_optimize` at the actual single-model HF and direct-ONNX CLI sinks, then pass `CLI skip OR config.skip_optimize` to the existing `_run_optimize_stage` helper.
- Retain the helper and its intermediate-copy/config behavior. The existing shared loop suppresses optimization and analyzer/autoconf re-optimization when bypass is requested.
- Preserve configured raw-model FP16/static quantization, compilation, and finalization. Direct-ONNX prequantization remains graph-driven (QDQ/QOperator); an ordinary bypass does not mark a raw model prequantized or clear its quantization config.

Exactly two changed paths: the CLI build command (+4/-1) and its regression tests (+252). No library, recipe, dependency, lockfile, or skill changes.

## Validation

- Reviewed and shipped commit: `4da82cde6c93894199f00e108f80be13f5dfe3bd`; parent/base: `dcad2f4a29cb34af71d7b138bcafc4276a70a4ed`. Fetched `origin/main` still matched this base before shipment; no rebase or new commit.
- Retained causal regression evidence: **14 failed / 26 passed -> 40 passed**, with identical selected test identities. Retained committed affected-scope JUnit/logs: **358 passed, 0 failures/errors/skips**; rechecked against the exact reviewed source/test blobs and case set.
- Fresh shipment check at the same commit: **40 passed, 115 deselected in 8.54 s**, with no failures/errors/skips and the same 40 regression identities. Read-only Ruff check, Ruff format check, and Git whitespace checks passed.
- Explicit Python 3.11.16, verified worktree source origins, existing package/overlay environment, offline mode, and no new dependencies. The tests use actual Click dispatch and stage helpers with tiny pytest-generated raw/QDQ/QOperator graphs; expensive payloads and host/UI boundaries are mocked.
- Independent local assessment: **LOCAL_READY**, no critical/important introduced-code defect. Nonblocking artifact-finalization test-hardening feedback remains; this is not a GitHub approval. Independent post-PR review is still required.

## Scope and limits

- Composite **CLI-flag** fan-out is covered. Array/module CLI mode, outer composite **config-only** inheritance, and optimized-bundle generic controls are pre-existing exclusions, not fixed or claimed supported here.
- No full-repository suite, real-model export/calibration/inference, numerical-quality, provider/hardware, or performance validation is claimed. This PR does not establish unrelated VitPose recipe quality or latency, and does not certify FP16/static-quantized model outputs.

## Overlap and integration

Overlaps the CLI portion of #1370 by @ssss141414 (observed head `3cd22269dfbfaac8baef63cb221c44c9e803af91`). That draft combines multilingual recipes with a repair that bypasses the entire optimize-stage helper; this standalone fix instead preserves the existing helper contract.

**Proposed disposition, if this fix is adopted:** use this as the canonical CLI repair in place of #1370's overlapping code/test change, while keeping its model recipes separate or adapting them to depend on the canonical repair. This acknowledges the prior overlapping work; it does not claim agreement from that author or declare #1370 superseded. #1370 has not been edited, commented on, closed, rebased, or pushed by this shipment.

Coordinate ownership before landing either overlapping implementation; **do not merge both unchanged**. Keep this PR **draft** pending independent post-PR review and integration coordination.