### PR TITLE
Fix image to text evaluator

### DIFF
--- a/src/winml/modelkit/eval/image_to_text_evaluator.py
+++ b/src/winml/modelkit/eval/image_to_text_evaluator.py
@@ -73,7 +73,7 @@ class WinMLImageToTextEvaluator(WinMLEvaluator):
                 continue
 
             try:
-                out = self.pipe(image, text="")
+                out = self.pipe(image)
             except Exception as e:
                 logger.warning("Pipeline call failed (skipping): %s", e)
                 skipped += 1

--- a/tests/unit/eval/test_image_to_text_evaluator.py
+++ b/tests/unit/eval/test_image_to_text_evaluator.py
@@ -7,7 +7,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 from winml.modelkit.eval.image_to_text_evaluator import WinMLImageToTextEvaluator
 from winml.modelkit.inference.pipeline import _HF_PIPELINE_TASK_MAP
@@ -110,7 +110,7 @@ class TestCompute:
 
         result = ev.compute()
 
-        ev.pipe.assert_any_call("img1", text="")
+        assert ev.pipe.call_args_list == [call(sample["image"]) for sample in ev.data]
         assert result["cer"] == 0.0
         assert result["n_samples"] == 2
         assert "cider" in result


### PR DESCRIPTION
## Summary
Fix image-to-text evaluation skipping all samples and returning `cer=None`.

## Root Cause
In Transformers **4.57.6**, the `image-to-text` task’s `ImageToTextPipeline` does not support the `text` keyword argument. The evaluator passed `text=""`, causing parameter validation to fail for every sample.

Remove this unsupported argument and update the existing unit test to verify image-only calls.

## Validation
- 11 unit tests and the BLIP FP16 E2E test passed after `uv sync`.
- All 10 evaluation samples processed successfully.
- Ruff checks passed.